### PR TITLE
Linux Makefile Updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DIR_SRC		=	./src
 DIR_OBJ		=	./obj
 DIR_BIN		=	./lib
 
-CFLAGS		+=	-g -Wall -I${DIR_INC} `sdl-config --cflags`
+CFLAGS		+=	-g -Wall -I${DIR_INC} `sdl2-config --cflags`
 LDFLAGS		+=	-lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGLU -lGL
 
 SRC			=	$(shell find ${DIR_SRC} -name "*.cpp")

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,17 @@ install-deps-arch:
 .PHONY:install-deps-ubuntu
 install-deps-ubuntu:
 	apt install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev glee-dev libphysfs-dev
+
+# CentOS
+
+.PHONY:install-repos-centos
+install-repos-centos:
+	# For SDL2
+	yum install epel-release
+	# For GLee (-y answers "yes" to prompts)
+	yum install -y http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-1.el7.nux.noarch.rpm
+
+.PHONY:install-deps-centos
+install-deps-centos:
+	# Install development packages (-y answers "yes" to prompts)
+	yum -y install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel physfs-devel GLee-devel

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,9 @@ clean:
 .PHONY:install-deps-arch
 install-deps-arch:
 	pacman -S sdl2 sdl2_mixer sdl2_image sdl2_ttf glew glee physfs
+
+# Ubuntu
+
+.PHONY:install-deps-ubuntu
+install-deps-ubuntu:
+	apt install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev glee-dev libphysfs-dev

--- a/Makefile
+++ b/Makefile
@@ -29,28 +29,42 @@ clean:
 
 
 
-# Arch Linux
+### Linux development package dependencies ###
+# This section contains install rules to aid setup and compiling on Linux.
+# Only a few common Linux distributions are covered. Other distributions
+# should be similar.
+
+
+## Arch Linux ##
 
 .PHONY:install-deps-arch
 install-deps-arch:
 	pacman -S sdl2 sdl2_mixer sdl2_image sdl2_ttf glew glee physfs
 
-# Ubuntu
+
+## Ubuntu ##
 
 .PHONY:install-deps-ubuntu
 install-deps-ubuntu:
 	apt install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev glee-dev libphysfs-dev
 
-# CentOS
+
+## CentOS ##
 
 .PHONY:install-repos-centos
 install-repos-centos:
-	# For SDL2
+	# Default CentOS repositories only contain SDL1
+	# For SDL2 use EPEL repo (EPEL = Extra Packages for Enterprise Linux)
 	yum install epel-release
-	# For GLee (-y answers "yes" to prompts)
+	# For GLee use Nux Dextop repo
+	# **Note**: Nux Dextop might conflict with other extension repositories
+	# GLee manages OpenGL extensions, much like Glew
+	# GLee appears to be old an unmaintained.
+	# (-y answers "yes" to prompts)
 	yum install -y http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-1.el7.nux.noarch.rpm
 
 .PHONY:install-deps-centos
 install-deps-centos:
 	# Install development packages (-y answers "yes" to prompts)
 	yum -y install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel physfs-devel GLee-devel
+

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DIR_SRC		=	./src
 DIR_OBJ		=	./obj
 DIR_BIN		=	./lib
 
-CFLAGS		+=	-g -Wall -I${DIR_INC} `sdl2-config --cflags`
+CFLAGS		+=	-std=c++11 -g -Wall -I${DIR_INC} `sdl2-config --cflags`
 LDFLAGS		+=	-lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGLU -lGL
 
 SRC			=	$(shell find ${DIR_SRC} -name "*.cpp")

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,11 @@ ${DIR_OBJ}/%.o: ${DIR_SRC}/%.cpp ${INC_H}
 clean:
 	-rm -fr ${DIR_OBJ}/*
 	-rm -fr ${DIR_BIN}/*
+
+
+
+# Arch Linux
+
+.PHONY:install-deps-arch
+install-deps-arch:
+	pacman -S sdl2 sdl2_mixer sdl2_image sdl2_ttf glew glee physfs


### PR DESCRIPTION
Updates to the Makefile to aid setup and development on Linux. Covers Arch Linux, Ubuntu, and CentOS distributions.

This serves as a starting point to get things compiling. From here warnings and platform specific issues can be addressed.