### PR TITLE
Include normalization

### DIFF
--- a/include/NAS2D/State.h
+++ b/include/NAS2D/State.h
@@ -10,14 +10,6 @@
 
 #pragma once
 
-#ifdef __APPLE__
-#include <SDL2/SDL.h>
-#elif __linux__
-#include "SDL2/SDL.h"
-#else
-#include "SDL.h"
-#endif
-
 #include "NAS2D/EventHandler.h"
 #include "NAS2D/Signal.h"
 

--- a/src/EventHandler.cpp
+++ b/src/EventHandler.cpp
@@ -9,13 +9,7 @@
 // ==================================================================================
 #include "NAS2D/EventHandler.h"
 
-#ifdef __APPLE__
-#include <SDL2/SDL.h>
-#elif __linux__
-#include "SDL2/SDL.h"
-#else
-#include "SDL.h"
-#endif
+#include <SDL.h>
 
 // UGLY ASS HACK for mouse window grabbing
 #include "NAS2D/Renderer/OGL_Renderer.h"

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -11,13 +11,10 @@
 #include "NAS2D/Filesystem.h"
 #include "NAS2D/Exception.h"
 
-#if defined(__linux__)
-#include "physfs.h"
-#elif __APPLE__
-#include "physfs.h"
+#include <physfs.h>
+
+#if defined(__APPLE__)
 #include <CoreFoundation/CoreFoundation.h>
-#else
-#include "physfs.h"
 #endif
 
 #include <climits>

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -10,13 +10,7 @@
 
 #include "NAS2D/FpsCounter.h"
 
-#ifdef __APPLE__
-#include <SDL2/SDL.h>
-#elif __linux__
-#include "SDL2/SDL.h"
-#else
-#include "SDL.h"
-#endif
+#include <SDL.h>
 
 using namespace NAS2D;
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -18,6 +18,7 @@
 #include "NAS2D/Mixer/Mixer_SDL.h"
 #include "NAS2D/Renderer/OGL_Renderer.h"
 
+#include <SDL.h>
 
 #include <iostream>
 

--- a/src/Mixer/Mixer_SDL.cpp
+++ b/src/Mixer/Mixer_SDL.cpp
@@ -20,16 +20,8 @@
 #include <iostream>
 #include <functional>
 
-#ifdef __APPLE__
-#include <SDL2/SDL.h>
-#include "SDL2_mixer/SDL_mixer.h"
-#elif __linux__
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_mixer.h"
-#elif WINDOWS
-#include "SDL.h"
-#include "SDL_mixer.h"
-#endif
+#include <SDL.h>
+#include <SDL_mixer.h>
 
 using namespace NAS2D;
 using namespace NAS2D::Exception;

--- a/src/Renderer/OGL_Renderer.cpp
+++ b/src/Renderer/OGL_Renderer.cpp
@@ -11,18 +11,12 @@
 #ifdef WINDOWS
 #define NO_SDL_GLEXT
 #include "GL/glew.h"
-#include "SDL.h"
-#include "SDL_image.h"
-#elif __APPLE__
-#include <SDL2/SDL.h>
 #elif __linux__
 #include "GL/glew.h"
-#include "SDL2/SDL.h"
-#include "SDL_image.h"
-//#include "SDL2/SDL_opengl.h"
-#else
-#include "SDL2.h"
 #endif
+
+#include <SDL.h>
+#include <SDL_image.h>
 
 #include "NAS2D/Trig.h"
 #include "NAS2D/Renderer/OGL_Renderer.h"

--- a/src/Resources/Font.cpp
+++ b/src/Resources/Font.cpp
@@ -14,19 +14,15 @@
 #include "NAS2D/Filesystem.h"
 #include "NAS2D/Utility.h"
 
-#ifdef __APPLE__
-#include "SDL2_image/SDL_image.h"
-#include "SDL2_ttf/SDL_ttf.h"
-#elif _WIN32
+#ifdef _WIN32
 #include "GL/glew.h"
 #define NO_SDL_GLEXT
-#include "SDL_image.h"
-#include "SDL_ttf.h"
 #else
 #include "GL/glew.h"
-#include "SDL2/SDL_image.h"
-#include "SDL2/SDL_ttf.h"
 #endif
+
+#include <SDL_image.h>
+#include <SDL_ttf.h>
 
 #include <iostream>
 #include <math.h>

--- a/src/Resources/Image.cpp
+++ b/src/Resources/Image.cpp
@@ -16,16 +16,13 @@
 
 #include "NAS2D/Renderer/Primitives.h"
 
-#ifdef __APPLE__
-#include "SDL2_image/SDL_image.h"
-#elif __linux__
+#ifdef __linux__
 #include "GL/glew.h"
-#include "SDL2/SDL_image.h"
 #elif _WIN32
 #include "GL/glew.h"
 #define NO_SDL_GLEXT
-#include "SDL_image.h"
 #endif
+#include <SDL_image.h>
 
 #include <iostream>
 #include <map>

--- a/src/Resources/Music.cpp
+++ b/src/Resources/Music.cpp
@@ -13,16 +13,8 @@
 #include "NAS2D/Filesystem.h"
 #include "NAS2D/Utility.h"
 
-#ifdef __APPLE__
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_mixer.h>
-#elif __linux__
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_mixer.h"
-#else
-#include "SDL.h"
-#include "SDL_mixer.h"
-#endif
+#include <SDL.h>
+#include <SDL_mixer.h>
 
 #include <iostream>
 #include <string>

--- a/src/Resources/Sound.cpp
+++ b/src/Resources/Sound.cpp
@@ -13,16 +13,8 @@
 #include "NAS2D/Filesystem.h"
 #include "NAS2D/Utility.h"
 
-#ifdef __APPLE__
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_mixer.h>
-#elif __linux__
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_mixer.h"
-#else
-#include "SDL.h"
-#include "SDL_mixer.h"
-#endif
+#include <SDL.h>
+#include <SDL_mixer.h>
 
 using namespace NAS2D;
 

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -10,13 +10,7 @@
 
 #include "NAS2D/Timer.h"
 
-#ifdef __APPLE__
-#include <SDL2/SDL.h>
-#elif __linux__
-#include "SDL2/SDL.h"
-#else
-#include "SDL.h"
-#endif
+#include <SDL.h>
 
 using namespace NAS2D;
 


### PR DESCRIPTION
Normalize includes for SDL2 and physfs.

I'm not normalizing the glew includes for now.

Tested on Linux. This has the potential to break builds on other platforms. Project settings may need to be adjusted to add appropriate include folders.