### PR TITLE
Remove glee package from dependency installation

### DIFF
--- a/makefile
+++ b/makefile
@@ -62,14 +62,14 @@ clean-deps:
 
 .PHONY:install-deps-arch
 install-deps-arch:
-	pacman -S sdl2 sdl2_mixer sdl2_image sdl2_ttf glew glee physfs
+	pacman -S sdl2 sdl2_mixer sdl2_image sdl2_ttf glew physfs
 
 
 ## Ubuntu ##
 
 .PHONY:install-deps-ubuntu
 install-deps-ubuntu:
-	apt install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev glee-dev libphysfs-dev
+	apt install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev libphysfs-dev
 
 
 ## CentOS ##
@@ -79,15 +79,9 @@ install-repos-centos:
 	# Default CentOS repositories only contain SDL1
 	# For SDL2 use EPEL repo (EPEL = Extra Packages for Enterprise Linux)
 	yum install epel-release
-	# For GLee use Nux Dextop repo
-	# **Note**: Nux Dextop might conflict with other extension repositories
-	# GLee manages OpenGL extensions, much like Glew
-	# GLee appears to be old an unmaintained.
-	# (-y answers "yes" to prompts)
-	yum install -y http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-1.el7.nux.noarch.rpm
 
 .PHONY:install-deps-centos
 install-deps-centos:
 	# Install development packages (-y answers "yes" to prompts)
-	yum -y install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel physfs-devel GLee-devel
+	yum -y install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel physfs-devel
 


### PR DESCRIPTION
Legacy GLee package is no longer needed now that src/Resources/Shader.cpp has been commented out.