### PR TITLE
Add simple mouse pointer management

### DIFF
--- a/include/NAS2D/Renderer/OGL_Renderer.h
+++ b/include/NAS2D/Renderer/OGL_Renderer.h
@@ -49,6 +49,8 @@ public:
     void drawText(NAS2D::Font& font, const std::string& text, float x, float y, int r, int g, int b, int a);
 
 	virtual void showSystemPointer(bool);
+	void addCursor(const std::string& filePath, int cursorId, int offx, int offy);
+	void setCursor(int cursorId);
 
 	void clearScreen(int r, int g, int b);
     

--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -108,6 +108,8 @@ public:
 	NAS2D::Signals::Signal0<void>& fadeComplete() const;
 
 	virtual void showSystemPointer(bool);
+	virtual void addCursor(const std::string& filePath, int cursorId, int offx, int offy);
+	virtual void setCursor(int cursorId);
 
 	void clearScreen(const Color_4ub& color);
 	virtual void clearScreen(int r, int g, int b);

--- a/src/Renderer/OGL_Renderer.cpp
+++ b/src/Renderer/OGL_Renderer.cpp
@@ -59,6 +59,9 @@ GLfloat COLOR_VERTEX_ARRAY[24] = { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0
 GLfloat		VERTEX_ARRAY[12]		= {};	/**< Vertex array for quad drawing functions (all blitter functions). */
 GLfloat		TEXTURE_COORD_ARRAY[12]	= {};	/**< Texture coordinate array for quad drawing functions (all blitter functions). */
 
+/** Mouse cursors */
+std::map<int, SDL_Cursor*> CURSORS;
+
 // UGLY ASS HACK!
 // This is required here in order to remove OpenGL implementation details from Image and Font.
 extern std::map<std::string, ImageInfo>	IMAGE_ID_MAP;
@@ -439,6 +442,43 @@ void OGL_Renderer::showSystemPointer(bool _b)
 }
 
 
+void OGL_Renderer::addCursor(const std::string& filePath, int cursorId, int offx, int offy)
+{
+	/* FIXME proper cleanup */
+	File imageFile = Utility<Filesystem>::get().open(filePath);
+	if(imageFile.size() == 0) {
+		std::cout << "OGL_Renderer::addCursor(): '" << name() << "' is empty." << std::endl;
+		return;
+	}
+
+	SDL_Surface* pixels = IMG_Load_RW(SDL_RWFromConstMem(imageFile.raw_bytes(), static_cast<int>(imageFile.size())), 0);
+	if(!pixels) {
+		std::cout << "OGL_Renderer::addCursor(): " << SDL_GetError() << std::endl;
+		return;
+	}
+
+	SDL_Cursor* cur = SDL_CreateColorCursor(pixels, offx, offy);
+	if(!cur) {
+		std::cout << "OGL_Renderer::addCursor(): " << SDL_GetError() << std::endl;
+		return;
+	}
+
+	if (CURSORS.count(cursorId))
+		SDL_FreeCursor(CURSORS[cursorId]);
+
+	CURSORS[cursorId] = cur;
+
+	if (1 == CURSORS.size())
+		setCursor(cursorId);
+}
+
+
+void OGL_Renderer::setCursor(int cursorId)
+{
+	SDL_SetCursor(CURSORS[cursorId]);
+}
+
+
 void OGL_Renderer::clearScreen(int r, int g, int b)
 {
 	glClearColor((GLfloat)r / 255, (GLfloat)g / 255, (GLfloat)b / 255, 0.0 );
@@ -639,7 +679,7 @@ void OGL_Renderer::initVideo(unsigned int resX, unsigned int resY, unsigned int 
 	}
 	#endif
 
-	SDL_ShowCursor(false);
+	SDL_ShowCursor(true);
 	glewInit();
 	initGL();
 

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -657,8 +657,28 @@ void Renderer::showSystemPointer(bool _b)
 
 
 /**
+ * Adds a mouse cursor ready to be displayed
+ * \param	filePath	Self explanatory
+ * \param	cursorId	Identifier used for setCursor, usually from an enum
+ * \param	offx		Offset of the hotspot from the top left corner in pixels
+ * \param	offy		Same as offx but for the vertical coordinate
+ */
+void Renderer::addCursor(const std::string& filePath, int cursorId, int offx, int offy)
+{}
+
+
+/**
+ * Sets the current mouse cursor
+ * \param	cursorId	Identifier for the cursor, as provided
+ *						to addCursor.
+ */
+void Renderer::setCursor(int cursorId)
+{}
+
+
+/**
  * Sets fullscreen mode.
- * 
+ *
  * \param	fs			True for fullscreen, false for windowed mode.
  * \param	maintain	Boolean flag indicating whether or not resolution from
  *						windowed mode should be maintained or if the native


### PR DESCRIPTION
The cursors are simply kept track of by a global std::map in
OGL_Renderer.cpp. When a cursor is added, an Id is passed to addCursor,
this Id can then subsequentely by be used to set the current currsor via
setCursor.

When the first cursor is added, it is automatically set as the current
cursor. Overwriting an Id should happen without memory leaking.