### PR TITLE
SDL2 Source Install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ compiler:
 addons:
   apt:
     packages:
-    - libsdl2-dev
+    - libsdl2-dev # Need sdl2-config. Ubuntu repos only have 2.0.4 available
     - libsdl2-mixer-dev
     - libsdl2-image-dev
     - libsdl2-ttf-dev
@@ -26,7 +26,10 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf glew physfs; fi
 
 script:
-  - make -k   # Use -k to continue after errors. This will allow more errors to be caught and listed in the logs
+  # Build SDL2 from source to ensure up-to-date 2.0.5 package
+  - make install-deps-source-sdl2
+  # Use -k to continue after errors, ensuring full build log with all errors
+  - make -k ADDITIONAL_INCLUDES=build/sdl2/SDL2-2.0.5/include/
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
     - libsdl2-image-dev
     - libsdl2-ttf-dev
     - libglew-dev
-    - glee-dev
     - libphysfs-dev
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,12 @@ addons:
     - libphysfs-dev
 
 before_install:
+  # OSX: Install packages using brew
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf glew physfs; fi
+  # Linux: Build SDL2 from source to ensure up-to-date 2.0.5 package
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make install-deps-source-sdl2; fi
 
 script:
-  # Build SDL2 from source to ensure up-to-date 2.0.5 package
-  - make install-deps-source-sdl2
   # Use -k to continue after errors, ensuring full build log with all errors
   - make -k ADDITIONAL_INCLUDES=build/sdl2/SDL2-2.0.5/include/
 

--- a/makefile
+++ b/makefile
@@ -100,7 +100,7 @@ install-deps-source-sdl2:
 	# Download source archive
 	wget --no-clobber --directory-prefix=$(SdlDir) $(SdlUrl)
 	# Unpack archive
-	cd $(SdlDir) && tar -xzvf $(SdlArchive)
+	cd $(SdlDir) && tar -xzf $(SdlArchive)
 	# Compile package
-	cd $(SdlDir)/$(SdlVer) && ./configure --enable-mir-shared=no && make
+	cd $(SdlDir)/$(SdlVer) && ./configure --enable-mir-shared=no --quiet && make
 

--- a/makefile
+++ b/makefile
@@ -91,16 +91,19 @@ install-deps-centos:
 SdlVer := SDL2-2.0.5
 SdlArchive := $(SdlVer).tar.gz
 SdlUrl := "https://www.libsdl.org/release/$(SdlArchive)"
-SdlDir := $(BUILDDIR)/sdl2
+SdlPackageDir := $(BUILDDIR)/sdl2
+SdlDir := $(SdlPackageDir)/$(SdlVer)
 
 .PHONY:install-deps-source-sdl2
 install-deps-source-sdl2:
 	# Create source build folder
 	mkdir -p $(SdlDir)
 	# Download source archive
-	wget --no-clobber --directory-prefix=$(SdlDir) $(SdlUrl)
+	wget --no-clobber --directory-prefix=$(SdlPackageDir) $(SdlUrl)
 	# Unpack archive
-	cd $(SdlDir) && tar -xzf $(SdlArchive)
+	cd $(SdlPackageDir) && tar -xzf $(SdlArchive)
+	# Configure package
+	cd $(SdlDir) && ./configure --quiet --enable-mir-shared=no
 	# Compile package
-	cd $(SdlDir)/$(SdlVer) && ./configure --enable-mir-shared=no --quiet && make
+	cd $(SdlDir) && make
 

--- a/makefile
+++ b/makefile
@@ -85,3 +85,22 @@ install-deps-centos:
 	# Install development packages (-y answers "yes" to prompts)
 	yum -y install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel physfs-devel
 
+
+## Generic SDL2 source build ##
+
+SdlVer := SDL2-2.0.5
+SdlArchive := $(SdlVer).tar.gz
+SdlUrl := "https://www.libsdl.org/release/$(SdlArchive)"
+SdlDir := $(BUILDDIR)/sdl2
+
+.PHONY:install-deps-source-sdl2
+install-deps-source-sdl2:
+	# Create source build folder
+	mkdir -p $(SdlDir)
+	# Download source archive
+	wget --no-clobber --directory-prefix=$(SdlDir) $(SdlUrl)
+	# Unpack archive
+	cd $(SdlDir) && tar -xzvf $(SdlArchive)
+	# Compile package
+	cd $(SdlDir)/$(SdlVer) && ./configure --enable-mir-shared=no && make
+

--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@ OBJDIR := $(BUILDDIR)/obj
 DEPDIR := $(BUILDDIR)/deps
 EXE := $(BINDIR)/libnas2d.a
 
-CFLAGS := -std=c++11 -g -Wall -I$(INCDIR) $(shell sdl2-config --cflags)
+CFLAGS := -std=c++11 -g -Wall -I$(INCDIR) -I$(ADDITIONAL_INCLUDES) $(shell sdl2-config --cflags)
 LDFLAGS := -lstdc++ -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGLU -lGL
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td


### PR DESCRIPTION
Makefile rule for SDL2 source build, plus Travis updates to compile SDL2 from source on Linux.

Changes get Linux builds working on Travis.
