### PR TITLE
Normalize glew includes

### DIFF
--- a/src/Renderer/OGL_Renderer.cpp
+++ b/src/Renderer/OGL_Renderer.cpp
@@ -8,12 +8,7 @@
 // = Acknowledgement of your use of NAS2D is appriciated but is not required.
 // ==================================================================================
 
-#ifdef WINDOWS
-#define NO_SDL_GLEXT
 #include "GL/glew.h"
-#elif __linux__
-#include "GL/glew.h"
-#endif
 
 #include <SDL.h>
 #include <SDL_image.h>

--- a/src/Resources/Font.cpp
+++ b/src/Resources/Font.cpp
@@ -14,12 +14,7 @@
 #include "NAS2D/Filesystem.h"
 #include "NAS2D/Utility.h"
 
-#ifdef _WIN32
-#include "GL/glew.h"
-#define NO_SDL_GLEXT
-#else
-#include "GL/glew.h"
-#endif
+#include <GL/glew.h>
 
 #include <SDL_image.h>
 #include <SDL_ttf.h>

--- a/src/Resources/Image.cpp
+++ b/src/Resources/Image.cpp
@@ -16,12 +16,7 @@
 
 #include "NAS2D/Renderer/Primitives.h"
 
-#ifdef __linux__
-#include "GL/glew.h"
-#elif _WIN32
-#include "GL/glew.h"
-#define NO_SDL_GLEXT
-#endif
+#include <GL/glew.h>
 #include <SDL_image.h>
 
 #include <iostream>


### PR DESCRIPTION
Removed platform specific checks around identical glew.h includes.

Use of NO_SDL_GLEXT only appears relevant to SDL_opengl.h. The last use of SDL_opengl.h was in Shader.cpp, which has  been commented out. As such NO_SDL_GLEXT has been removed.