### PR TITLE
Remove gl/glew include

### DIFF
--- a/include/NAS2D/Configuration.h
+++ b/include/NAS2D/Configuration.h
@@ -9,15 +9,6 @@
 // ==================================================================================
 #pragma once
 
-#ifdef __APPLE__
-#include <OpenGL/gl.h>
-#elif WINDOWS
-#include "GL/glew.h"
-#define NO_SDL_GLEXT
-#else
-#include <GL/gl.h>
-#endif
-
 #include <map>
 
 #include "Common.h"


### PR DESCRIPTION
Remove gl/glew include from header which doesn't appear to use them.

If an implementation file needs those headers, they should be included there. Additionally, removing this can speed up compile times for client code that doesn't need the headers.

I should also point out that the inconsistency of the includes across platforms suggests the includes were wrong to begin with.