### PR TITLE
Fix makefile include for dependencies

### DIFF
--- a/makefile
+++ b/makefile
@@ -48,7 +48,7 @@ build-folder:
 $(DEPDIR)/%.d: ;
 .PRECIOUS: $(DEPDIR)/%.d
 
-include $(wildcard $(patsubst %,$(DEPDIR)/%.d,$(basename $(SRCS))))
+include $(patsubst $(SRCDIR)/%.cpp,$(DEPDIR)/%.d,$(SRCS))
 
 .PHONY:clean, clean-deps, clean-sdl, clean-sdl-all, clean-all
 clean:


### PR DESCRIPTION
This was broken when the dependencies folder was moved, causing files to
not be rebuilt when a dependency was updated. This fix resolves that
issue.