### PR TITLE
Add missing includes for <string>

### DIFF
--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -19,6 +19,7 @@
 
 #include <climits>
 #include <cstring>
+#include <string>
 #include <iostream>
 #include <sstream>
 

--- a/src/Xml/XmlParser.cpp
+++ b/src/Xml/XmlParser.cpp
@@ -27,6 +27,7 @@
 #include <cctype>
 #include <fstream>
 #include <cstring>
+#include <string>
 
 
 //#define DEBUG_PARSER


### PR DESCRIPTION
Before using std::string, the <string> header should be included. This
can be included implicitly, in platform dependent ways, by including
other headers that include <string>. As such, the code may compile on
some platforms but not others, unless they include <string> explicitly.

Interestingly, these files included <cstring>, but not <string>. The
<cstring> header contains functions for working with null terminated
strings, such as 'strlen'. <cstring> does not include the 'string' class.