### PR TITLE
Add Dockerfile for Ubuntu-18.04 base image

### DIFF
--- a/docker/Ubuntu-18.04.BuildEnv.Dockerfile
+++ b/docker/Ubuntu-18.04.BuildEnv.Dockerfile
@@ -29,6 +29,6 @@ WORKDIR /code
 # The MAINTAINER tag was deprecated in Docker 1.13. The alternative is to use a LABEL tag.
 # This is probably better off not being in the Dockerfile at all though for open source projects.
 # Specifying maintainers in source files is known to discourage other people from making updates.
-LABEL maintainer="WhoEverWantsToEdit <anybody@anywhere.com>"
+MAINTAINER "WhoEverWantsToEdit <anybody@anywhere.com>"
 
 CMD ["make", "-k"]

--- a/docker/Ubuntu-18.04.BuildEnv.Dockerfile
+++ b/docker/Ubuntu-18.04.BuildEnv.Dockerfile
@@ -1,7 +1,12 @@
 # Build from the root project folder with:
 #   docker build docker/ --file docker/Ubuntu-18.04.BuildEnv.Dockerfile --tag ubuntu-18.04-gcc-sdl2
-# Run the resulting image with:
+# Run the resulting image to compile source with:
 #   docker run --rm --tty --volume `pwd`:/code ubuntu-18.04-gcc-sdl2
+
+# Debug build environment interactively as normal user with:
+#   docker run --rm --tty --volume `pwd`:/code --interactive ubuntu-18.04-gcc-sdl2 bash
+# Debug build environment interactively as root with:
+#   docker run --rm --tty --volume `pwd`:/code --interactive --user=0 ubuntu-18.04-gcc-sdl2 bash
 
 FROM ubuntu:18.04
 

--- a/docker/Ubuntu-18.04.BuildEnv.Dockerfile
+++ b/docker/Ubuntu-18.04.BuildEnv.Dockerfile
@@ -11,13 +11,13 @@
 FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    g++ \
-    libglew-dev \
-    libphysfs-dev \
-    libsdl2-dev \
-    libsdl2-image-dev \
-    libsdl2-mixer-dev \
-    libsdl2-ttf-dev \
+    g++=4:7.3.0-* \
+    libglew-dev=2.0.0-* \
+    libphysfs-dev=3.0.1-* \
+    libsdl2-dev=2.0.8+* \
+    libsdl2-image-dev=2.0.3+* \
+    libsdl2-mixer-dev=2.0.2+* \
+    libsdl2-ttf-dev=2.0.14+* \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash user

--- a/docker/Ubuntu-18.04.BuildEnv.Dockerfile
+++ b/docker/Ubuntu-18.04.BuildEnv.Dockerfile
@@ -1,0 +1,24 @@
+# Build from the root project folder with:
+#   docker build docker/ --file docker/Ubuntu-18.04.BuildEnv.Dockerfile --tag ubuntu-18.04-gcc-sdl2
+# Run the resulting image with:
+#   docker run --rm --tty --volume `pwd`:/code ubuntu-18.04-gcc-sdl2
+
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    libglew-dev \
+    libphysfs-dev \
+    libsdl2-dev \
+    libsdl2-image-dev \
+    libsdl2-mixer-dev \
+    libsdl2-ttf-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash user
+USER user
+
+VOLUME /code
+WORKDIR /code
+
+CMD ["make", "-k"]

--- a/docker/Ubuntu-18.04.BuildEnv.Dockerfile
+++ b/docker/Ubuntu-18.04.BuildEnv.Dockerfile
@@ -26,4 +26,9 @@ USER user
 VOLUME /code
 WORKDIR /code
 
+# The MAINTAINER tag was deprecated in Docker 1.13. The alternative is to use a LABEL tag.
+# This is probably better off not being in the Dockerfile at all though for open source projects.
+# Specifying maintainers in source files is known to discourage other people from making updates.
+LABEL maintainer="WhoEverWantsToEdit <anybody@anywhere.com>"
+
 CMD ["make", "-k"]


### PR DESCRIPTION
This allows Docker to build an image based on Ubuntu-18.04 with the g++
compiler installed, along with necessary dependencies, such as GLEW,
physfs, SDL2, and SDL2 modules for Image, Mixer, and TTF.

Default command for this image is to run "make" to build the code.

Example build and run commands are given in the header comments of the
Dockerfile.