### PR TITLE
Ternary updates

### DIFF
--- a/src/Renderer/OGL_Renderer.cpp
+++ b/src/Renderer/OGL_Renderer.cpp
@@ -743,7 +743,7 @@ GLuint generate_fbo(Image& image)
 	glGenTextures(1, &textureColorbuffer);
 	glBindTexture(GL_TEXTURE_2D, textureColorbuffer);
 	GLenum textureFormat = 0;
-	SDL_BYTEORDER == SDL_BIG_ENDIAN ? textureFormat = GL_BGRA : textureFormat = GL_RGBA;
+	textureFormat = SDL_BYTEORDER == SDL_BIG_ENDIAN ? GL_BGRA : GL_RGBA;
 
 	glTexImage2D(GL_TEXTURE_2D, 0, textureFormat, image.width(), image.height(), 0, textureFormat, GL_UNSIGNED_BYTE, NULL);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);

--- a/src/Resources/Image.cpp
+++ b/src/Resources/Image.cpp
@@ -370,10 +370,10 @@ unsigned int generateTexture(void *buffer, int bytesPerPixel, int width, int hei
 	switch (bytesPerPixel)
 	{
 	case 4:
-		SDL_BYTEORDER == SDL_BIG_ENDIAN ? textureFormat = GL_BGRA : textureFormat = GL_RGBA;
+		textureFormat = SDL_BYTEORDER == SDL_BIG_ENDIAN ? GL_BGRA : GL_RGBA;
 		break;
 	case 3:
-		SDL_BYTEORDER == SDL_BIG_ENDIAN ? textureFormat = GL_BGR : textureFormat = GL_RGB;
+		textureFormat = SDL_BYTEORDER == SDL_BIG_ENDIAN ? GL_BGR : GL_RGB;
 		break;
 
 	default:


### PR DESCRIPTION
Use the result of a ternary expression in an assignment statement (direct effect), rather then discard results of ternary expression and performing assignment as a side effect.
