### PR TITLE
Cleanup filesystem code

### DIFF
--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -8,6 +8,10 @@
 // = Acknowledgement of your use of NAS2D is appriciated but is not required.
 // ==================================================================================
 
+#if !(defined(WINDOWS) || defined(__APPLE__) || defined(__linux__))
+#error Filesystem support for this platform has not been developed.
+#endif
+
 #include "NAS2D/Filesystem.h"
 #include "NAS2D/Exception.h"
 
@@ -25,7 +29,6 @@
 
 using namespace NAS2D;
 using namespace NAS2D::Exception;
-
 
 bool FILESYSTEM_INITIALIZED = false;
 
@@ -80,8 +83,6 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 	PHYSFS_setWriteDir(userDir.c_str());
 	// Create directory if it does not exist
 	PHYSFS_mkdir(appUserDataDir.c_str());
-#else
-#error Filesystem support for this platform has not been developed.
 #endif
 
 	PHYSFS_setWriteDir(mDataPath.c_str());
@@ -117,7 +118,6 @@ bool Filesystem::addToSearchPath(const std::string& path) const
 		return false;
 	}
 
-#if defined(WINDOWS) || defined(__APPLE__) || defined(__linux__)
 	std::string searchPath(mDataPath + path);
 
 	if (PHYSFS_addToSearchPath(searchPath.c_str(), 1) == 0)
@@ -125,9 +125,6 @@ bool Filesystem::addToSearchPath(const std::string& path) const
 		std::cout << "Couldn't add '" << path << "' to search path. " << PHYSFS_getLastError() << "." << std::endl;
 		return false;
 	}
-#else
-#error Filesystem support for this platform has not been developed.
-#endif
 
 	if (mVerbose) { std::cout << "Added '" << path << "' to search path." << std::endl; }
 

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -68,10 +68,10 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 #if defined(WINDOWS) || defined(__APPLE__)
 	std::string basePath = PHYSFS_getBaseDir();
 
-	mDataPath = basePath;
-	if (mStartPath.size() > 0)
+	mDataPath = basePath + mStartPath;
+	if (mDataPath.back() != mDirSeparator)
 	{
-		mDataPath += mStartPath + mDirSeparator;
+		mDataPath += mDirSeparator;
 	}
 
 #elif defined(__linux__)

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -81,7 +81,7 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 
 	if (PHYSFS_addToSearchPath(mDataPath.c_str(), 0) == 0)
 	{
-		std::cout << std::endl << "Couldn't find data path '" << mDataPath << "'. " << PHYSFS_getLastError() << "." << std::endl;
+		std::cout << std::endl << "(FSYS) Couldn't find data path '" << mDataPath << "'. " << PHYSFS_getLastError() << "." << std::endl;
 	}
 
 #elif defined(__linux__)
@@ -101,7 +101,7 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 	if (PHYSFS_addToSearchPath(mDataPath.c_str(), 0) == 0)
 	{
 		//mErrorMessages.push_back(PHYSFS_getLastError());
-		std::cout << "(FSYS) Couldn't find data path '" << mDataPath << "'. " << PHYSFS_getLastError() << "." << std::endl;
+		std::cout << std::endl << "(FSYS) Couldn't find data path '" << mDataPath << "'. " << PHYSFS_getLastError() << "." << std::endl;
 	}
 
 #else

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -68,13 +68,10 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 #if defined(WINDOWS) || defined(__APPLE__)
 	std::string basePath = PHYSFS_getBaseDir();
 
-	if (mStartPath.size() < 1)
+	mDataPath = basePath;
+	if (mStartPath.size() > 0)
 	{
-		mDataPath = basePath;
-	}
-	else
-	{
-		mDataPath = basePath + mStartPath + mDirSeparator;
+		mDataPath += mStartPath + mDirSeparator;
 	}
 
 #elif defined(__linux__)

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -68,11 +68,8 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 #if defined(WINDOWS) || defined(__APPLE__)
 	std::string basePath = PHYSFS_getBaseDir();
 
-	mDataPath = basePath + mStartPath;
-	if (mDataPath.back() != mDirSeparator)
-	{
-		mDataPath += mDirSeparator;
-	}
+	// Note: Multiple trailing dir separators are safely ignored
+	mDataPath = basePath + mStartPath + mDirSeparator;
 
 #elif defined(__linux__)
 	std::string userDir = PHYSFS_getUserDir();

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -63,10 +63,10 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 	}
 
 	mStartPath = startPath;
+	mDirSeparator = PHYSFS_getDirSeparator();
 
 #if defined(WINDOWS) || defined(__APPLE__)
 	std::string basePath = PHYSFS_getBaseDir();
-	mDirSeparator = PHYSFS_getDirSeparator();
 
 	if (mStartPath.size() < 1)
 	{

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -78,14 +78,16 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 	}
 
 #elif defined(__linux__)
-	std::string mTempWritePath = PHYSFS_getUserDir();
-	std::string mDirName = ".lom/data/";
-	mDataPath = mTempWritePath + mDirName;
+	std::string userDir = PHYSFS_getUserDir();
+	std::string appUserDataDir = ".lom/data/";
+	mDataPath = userDir + appUserDataDir;
 
+	// Create write directory if it does not exist
 	if (PHYSFS_exists(mDataPath.c_str()) == 0)
 	{
-		PHYSFS_setWriteDir(mTempWritePath.c_str());
-		PHYSFS_mkdir(mDirName.c_str());
+		// Must set write directory before we can modify filesystem
+		PHYSFS_setWriteDir(userDir.c_str());
+		PHYSFS_mkdir(appUserDataDir.c_str());
 	}
 #else
 #error Filesystem support for this platform has not been developed.

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -8,10 +8,6 @@
 // = Acknowledgement of your use of NAS2D is appriciated but is not required.
 // ==================================================================================
 
-#if !(defined(WINDOWS) || defined(__APPLE__) || defined(__linux__))
-#error Filesystem support for this platform has not been developed.
-#endif
-
 #include "NAS2D/Filesystem.h"
 #include "NAS2D/Exception.h"
 

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -82,10 +82,9 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 	std::string mDirName = ".lom/data/";
 	mDataPath = mTempWritePath + mDirName;
 
-	PHYSFS_setWriteDir(mTempWritePath.c_str());
-
 	if (PHYSFS_exists(mDataPath.c_str()) == 0)
 	{
+		PHYSFS_setWriteDir(mTempWritePath.c_str());
 		PHYSFS_mkdir(mDirName.c_str());
 	}
 #else

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -77,13 +77,6 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 		mDataPath = basePath + mStartPath + mDirSeparator;
 	}
 
-	PHYSFS_setWriteDir(mDataPath.c_str());
-
-	if (PHYSFS_addToSearchPath(mDataPath.c_str(), 0) == 0)
-	{
-		std::cout << std::endl << "(FSYS) Couldn't find data path '" << mDataPath << "'. " << PHYSFS_getLastError() << "." << std::endl;
-	}
-
 #elif defined(__linux__)
 	std::string mTempWritePath = PHYSFS_getUserDir();
 	std::string mDirName = ".lom/data/";
@@ -95,6 +88,9 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 	{
 		PHYSFS_mkdir(mDirName.c_str());
 	}
+#else
+#error Filesystem support for this platform has not been developed.
+#endif
 
 	PHYSFS_setWriteDir(mDataPath.c_str());
 
@@ -103,10 +99,6 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 		//mErrorMessages.push_back(PHYSFS_getLastError());
 		std::cout << std::endl << "(FSYS) Couldn't find data path '" << mDataPath << "'. " << PHYSFS_getLastError() << "." << std::endl;
 	}
-
-#else
-#error Filesystem support for this platform has not been developed.
-#endif
 
 	FILESYSTEM_INITIALIZED = true;
 

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -82,13 +82,10 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 	std::string appUserDataDir = ".lom/data/";
 	mDataPath = userDir + appUserDataDir;
 
-	// Create write directory if it does not exist
-	if (PHYSFS_exists(mDataPath.c_str()) == 0)
-	{
-		// Must set write directory before we can modify filesystem
-		PHYSFS_setWriteDir(userDir.c_str());
-		PHYSFS_mkdir(appUserDataDir.c_str());
-	}
+	// Must set write directory before we can modify filesystem
+	PHYSFS_setWriteDir(userDir.c_str());
+	// Create directory if it does not exist
+	PHYSFS_mkdir(appUserDataDir.c_str());
 #else
 #error Filesystem support for this platform has not been developed.
 #endif

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -77,12 +77,12 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 		mDataPath = basePath + mStartPath + mDirSeparator;
 	}
 
+	PHYSFS_setWriteDir(mDataPath.c_str());
+
 	if (PHYSFS_addToSearchPath(mDataPath.c_str(), 0) == 0)
 	{
 		std::cout << std::endl << "Couldn't find data path '" << mDataPath << "'. " << PHYSFS_getLastError() << "." << std::endl;
 	}
-
-	PHYSFS_setWriteDir(mDataPath.c_str());
 
 #elif defined(__linux__)
 	std::string mTempWritePath = PHYSFS_getUserDir();


### PR DESCRIPTION
I made some simplifications to the filesystem initialization code. You may want to double check the Windows portion. In particular, make sure that multiple trailing directory separators really are safely ignored on Windows.

Hopefully this cleanup will make it easier to address upgrading to the newer simpler methods in the more recent versions of Physfs.
