### PR TITLE
Reduce Physfs deprecation warnings

### DIFF
--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -83,7 +83,7 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 
 	PHYSFS_setWriteDir(mDataPath.c_str());
 
-	if (PHYSFS_addToSearchPath(mDataPath.c_str(), 0) == 0)
+	if (PHYSFS_mount(mDataPath.c_str(), "", 0) == 0)
 	{
 		//mErrorMessages.push_back(PHYSFS_getLastError());
 		std::cout << std::endl << "(FSYS) Couldn't find data path '" << mDataPath << "'. " << PHYSFS_getLastError() << "." << std::endl;
@@ -116,7 +116,7 @@ bool Filesystem::addToSearchPath(const std::string& path) const
 
 	std::string searchPath(mDataPath + path);
 
-	if (PHYSFS_addToSearchPath(searchPath.c_str(), 1) == 0)
+	if (PHYSFS_mount(searchPath.c_str(), "", 1) == 0)
 	{
 		std::cout << "Couldn't add '" << path << "' to search path. " << PHYSFS_getLastError() << "." << std::endl;
 		return false;


### PR DESCRIPTION
Convert `addToSearchPath` to `mount`.

This is the only method with a deprecation warning that can be updated while still using the stock Ubuntu 16.04 package for Physfs, which includes Physfs 2.0.3. Most methods with a deprecation warning in Physfs 3 didn't have their replacement introduced until Physfs 2.1.

This relates to Issue #84.