### PR TITLE
Normalize copyright symbol

### DIFF
--- a/include/NAS2D/Delegate.h
+++ b/include/NAS2D/Delegate.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Documentation.h
+++ b/include/NAS2D/Documentation.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software as long under the terms of the zlib license.

--- a/include/NAS2D/Resources/FontInfo.h
+++ b/include/NAS2D/Resources/FontInfo.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Resources/ImageInfo.h
+++ b/include/NAS2D/Resources/ImageInfo.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Resources/MusicInfo.h
+++ b/include/NAS2D/Resources/MusicInfo.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Signal.h
+++ b/include/NAS2D/Signal.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Xml/XmlAttribute.h
+++ b/include/NAS2D/Xml/XmlAttribute.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Xml/XmlAttributeSet.h
+++ b/include/NAS2D/Xml/XmlAttributeSet.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Xml/XmlBase.h
+++ b/include/NAS2D/Xml/XmlBase.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Xml/XmlComment.h
+++ b/include/NAS2D/Xml/XmlComment.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Xml/XmlElement.h
+++ b/include/NAS2D/Xml/XmlElement.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Xml/XmlHandle.h
+++ b/include/NAS2D/Xml/XmlHandle.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Xml/XmlMemoryBuffer.h
+++ b/include/NAS2D/Xml/XmlMemoryBuffer.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Xml/XmlNode.h
+++ b/include/NAS2D/Xml/XmlNode.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Xml/XmlText.h
+++ b/include/NAS2D/Xml/XmlText.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Xml/XmlUnknown.h
+++ b/include/NAS2D/Xml/XmlUnknown.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Xml/XmlVisitor.h
+++ b/include/NAS2D/Xml/XmlVisitor.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Renderer/Primitives.cpp
+++ b/src/Renderer/Primitives.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Resources/Resource.cpp
+++ b/src/Resources/Resource.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Xml/XmlAttribute.cpp
+++ b/src/Xml/XmlAttribute.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Xml/XmlAttributeSet.cpp
+++ b/src/Xml/XmlAttributeSet.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Xml/XmlBase.cpp
+++ b/src/Xml/XmlBase.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Xml/XmlComment.cpp
+++ b/src/Xml/XmlComment.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Xml/XmlDocument.cpp
+++ b/src/Xml/XmlDocument.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Xml/XmlElement.cpp
+++ b/src/Xml/XmlElement.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Xml/XmlHandle.cpp
+++ b/src/Xml/XmlHandle.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Xml/XmlMemoryBuffer.cpp
+++ b/src/Xml/XmlMemoryBuffer.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Xml/XmlNode.cpp
+++ b/src/Xml/XmlNode.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Xml/XmlParser.cpp
+++ b/src/Xml/XmlParser.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Xml/XmlText.cpp
+++ b/src/Xml/XmlText.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Xml/XmlUnknown.cpp
+++ b/src/Xml/XmlUnknown.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2017 New Age Software
+// = Copyright Â© 2008 - 2017 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.


### PR DESCRIPTION
Previously some files used an ASCII encoded copyright symbol (hex code A9). As this is beyond code 127 (hex code 7F), this means the byte encoding differs between ASCII and UTF-8. Most modern code editors assume UTF-8 encoding. As such, the symbol was being interpreted and displayed incorrectly in some editors.

Side note, those characters were showing up oddly in Git diffs due to the encoding problem.