### PR TITLE
Normalize order for user and system includes

### DIFF
--- a/include/NAS2D/Common.h
+++ b/include/NAS2D/Common.h
@@ -9,11 +9,11 @@
 // ==================================================================================
 #pragma once
 
+#include "NAS2D/Renderer/Primitives.h"
+
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "NAS2D/Renderer/Primitives.h"
 
 namespace NAS2D {
 

--- a/include/NAS2D/Configuration.h
+++ b/include/NAS2D/Configuration.h
@@ -9,10 +9,10 @@
 // ==================================================================================
 #pragma once
 
-#include <map>
-
 #include "Common.h"
 #include "Exception.h"
+
+#include <map>
 
 namespace NAS2D {
 

--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -11,10 +11,8 @@
 #pragma once
 
 #include "Common.h"
-
-#include <string>
-
 #include "File.h"
+#include <string>
 
 namespace NAS2D {
 

--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -10,12 +10,12 @@
 
 #pragma once
 
-#include <string>
-
 #include "NAS2D/Signal.h"
 #include "NAS2D/Renderer/Primitives.h"
 #include "NAS2D/Resources/Image.h"
 #include "NAS2D/Resources/Font.h"
+
+#include <string>
 
 namespace NAS2D {
 

--- a/src/EventHandler.cpp
+++ b/src/EventHandler.cpp
@@ -9,10 +9,10 @@
 // ==================================================================================
 #include "NAS2D/EventHandler.h"
 
-#include <SDL.h>
-
 // UGLY ASS HACK for mouse window grabbing
 #include "NAS2D/Renderer/OGL_Renderer.h"
+
+#include <SDL.h>
 
 #include <iostream>
 

--- a/src/Renderer/OGL_Renderer.cpp
+++ b/src/Renderer/OGL_Renderer.cpp
@@ -8,11 +8,6 @@
 // = Acknowledgement of your use of NAS2D is appriciated but is not required.
 // ==================================================================================
 
-#include <GL/glew.h>
-
-#include <SDL.h>
-#include <SDL_image.h>
-
 #include "NAS2D/Trig.h"
 #include "NAS2D/Renderer/OGL_Renderer.h"
 
@@ -24,6 +19,10 @@
 #include "NAS2D/Resources/ImageInfo.h"
 #include "NAS2D/Utility.h"
 
+#include <GL/glew.h>
+
+#include <SDL.h>
+#include <SDL_image.h>
 
 #include <iostream>
 #include <math.h>

--- a/src/Xml/XmlAttribute.cpp
+++ b/src/Xml/XmlAttribute.cpp
@@ -9,9 +9,9 @@
 // ==================================================================================
 // = Originally based on TinyXML. See Xml.h for additional details.
 // ==================================================================================
-#include <stdexcept>
 
 #include "NAS2D/Xml/XmlAttribute.h"
+#include <stdexcept>
 
 using namespace std;
 using namespace NAS2D::Xml;


### PR DESCRIPTION
Most of the project already put project includes before system includes.
This order helps catch missing system header dependencies.

If the order were reversed, it would be possible to include a needed
system dependency in a source file, then include the project header
which depended on it, and have it silently work. Meanwhile, another
program could be written which includes the same project header, and
fails to compile because of a missing system dependency.

Technically there is no order than can guarantee all needed dependencies
are properly included. However, no system header will ever include a
project specific header, so putting project headers first is most likely
to catch missing dependencies.