### PR TITLE
Move Linux build folder to ".build/"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 [Rr]eleases/
 x64/
 x86/
-build/
+.build/
 bld/
 lib/
 [Bb]in/

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ TopLevelFolder := $(abspath $(dir $(lastword ${MAKEFILE_LIST})))
 
 SRCDIR := src
 INCDIR := include
-BUILDDIR := build
+BUILDDIR := .build
 BINDIR := lib
 OBJDIR := $(BUILDDIR)/obj
 DEPDIR := $(BUILDDIR)/deps


### PR DESCRIPTION
Trying to be consistent across all the projects I'm working on. The leading "." in the name makes a hidden directory on Linux, so the intermediate build folder isn't displayed by default in directory listings.
