### PR TITLE
Update Utility

### DIFF
--- a/include/NAS2D/Utility.h
+++ b/include/NAS2D/Utility.h
@@ -122,7 +122,7 @@ public:
 	 *			created object or deallocating the object will yield
 	 *			undefined behavior.
 	 */
-	[[deprecated]]
+	[[deprecated("Consider using Utility::init instead")]]
 	static void instantiateDerived(T* t)
 	{
 		if (mInstance == t)

--- a/include/NAS2D/Utility.h
+++ b/include/NAS2D/Utility.h
@@ -90,10 +90,14 @@ public:
 	 *
 	 * \param	args	A list of arguments to be forwarded to the \c Type objects's constructor
 	 *
+	 * \return Reference to the newly created object as \c Type.
+	 * This allows further method calls to complete initialization or setup
+	 * of the object, using the full interface of the derived type.
+	 *
 	 * \note	This method should be called before <tt>Utility::get()</tt>.
 	 */
 	template<typename Type = T, typename... Args>
-	static void init(Args&&... args)
+	static Type& init(Args&&... args)
 	{
 		// Instantiate a new object with forwarded constructor arguments
 		auto newInstance = new Type(std::forward<Args>(args)...);
@@ -104,6 +108,7 @@ public:
 		}
 
 		mInstance = newInstance;
+		return *newInstance;
 	}
 
 

--- a/include/NAS2D/Utility.h
+++ b/include/NAS2D/Utility.h
@@ -122,6 +122,7 @@ public:
 	 *			created object or deallocating the object will yield
 	 *			undefined behavior.
 	 */
+	[[deprecated]]
 	static void instantiateDerived(T* t)
 	{
 		if (mInstance == t)

--- a/include/NAS2D/Utility.h
+++ b/include/NAS2D/Utility.h
@@ -102,10 +102,7 @@ public:
 		// Instantiate a new object with forwarded constructor arguments
 		auto newInstance = new Type(std::forward<Args>(args)...);
 
-		if (mInstance)
-		{
-			delete mInstance;
-		}
+		delete mInstance;
 
 		mInstance = newInstance;
 		return *newInstance;

--- a/include/NAS2D/Utility.h
+++ b/include/NAS2D/Utility.h
@@ -65,6 +65,49 @@ public:
 
 
 	/**
+	 * Creates a \c Utility<T> interface for a newly created object of type
+	 * \c Type. \c Type must be derived from type \c T specified in the
+	 * template class argument list, and defaults to \c T if not explicitly
+	 * specified.
+	 *
+	 * \c Type should be explicitly specified when instantiating a derived type
+	 * and polymorphic behavior is desired.
+	 *
+	 * \code{.cpp}
+	 * // Instantiate Mixer (default Type is Mixer)
+	 * Utility<Mixer>::init();
+	 * \endcode
+	 *
+	 * \code{.cpp}
+	 * // Instantiate derived type Mixer_SDL, of base type Mixer
+	 * Utility<Mixer>::init<Mixer_SDL>();
+	 * \endcode
+	 *
+	 * \code{.cpp}
+	 * // Instantiate derived type with constructor arguments, as base type reference
+	 * Utility<Base>::init<Derived>(arg1, arg2, arg3);
+	 * \endcode
+	 *
+	 * \param	args	A list of arguments to be forwarded to the \c Type objects's constructor
+	 *
+	 * \note	This method should be called before <tt>Utility::get()</tt>.
+	 */
+	template<typename Type = T, typename... Args>
+	static void init(Args&&... args)
+	{
+		// Instantiate a new object with forwarded constructor arguments
+		auto newInstance = new Type(std::forward<Args>(args)...);
+
+		if (mInstance)
+		{
+			delete mInstance;
+		}
+
+		mInstance = newInstance;
+	}
+
+
+	/**
 	 * Creates a \c Utility<T> interface using a derived type \c T* for
 	 * derived implementation. This is useful when you need polymorphic
 	 * behavior in an object that you need global access to.

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -48,12 +48,12 @@ Game::Game(const std::string& title, const std::string& argv_0, const std::strin
 
 	try
 	{
-		Utility<Mixer>::instantiateDerived(new Mixer_SDL());
+		Utility<Mixer>::init<Mixer_SDL>();
 	}
 	catch (std::exception& e)
 	{
 		std::cout << "Unable to create SDL Audio Mixer: " << e.what() << ". Setting NULL driver." << std::endl;
-		Utility<Mixer>::instantiateDerived(new Mixer());
+		Utility<Mixer>::init();
 	}
 	catch (...)
 	{
@@ -64,7 +64,7 @@ Game::Game(const std::string& title, const std::string& argv_0, const std::strin
 	Utility<EventHandler>::get();
 	std::cout << "done." << std::endl << std::endl;
 
-	Utility<Renderer>::instantiateDerived(new OGL_Renderer(title));
+	Utility<Renderer>::init<OGL_Renderer>(title);
 
 	std::cout << std::endl << "Subsystems initialized." << std::endl << std::endl;
 	std::cout << "===================================" << std::endl << std::endl;


### PR DESCRIPTION
I took a bit of inspiration from [`std::make_unique`](https://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique) on this one.

The `Utility::instantiateDerived(T* t)` method didn't actually instantiate the derived class. It just took an already instantiated object as a parameter. As such, the name wasn't entirely accurate, though I figure that was due to implementation difficulties, rather than lack of spirit. I saw two difficulties with being able to actually instantiate derived objects. One was knowing what derived class the caller wanted. The other was forwarding of constructor arguments to be able to construct arbitrary non-trivial types.

Both of the above problems were nicely solved by `std::make_unique` method for creating `unique_ptr` instances. I thought I'd borrow the method.
