### PR TITLE
Update PhysFS dependency in local build Dockerfile

### DIFF
--- a/docker/Ubuntu-16.04.BuildEnv.Dockerfile
+++ b/docker/Ubuntu-16.04.BuildEnv.Dockerfile
@@ -13,6 +13,7 @@ FROM ubuntu:16.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
     g++=4:5.3.1-* \
     make=4.1-6 \
+    cmake=3.5.1-* \
     wget=1.17.1-* \
     bzip2=1.0.6-8 \
     ca-certificates=* \
@@ -25,6 +26,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY Makefile /buildDependencies/build/
 RUN cd /buildDependencies/build/ && make compile-sdl2 && make install-sdl2 && make clean-all-sdl2
 RUN cd /buildDependencies/build/ && make compile-sdl2-modules && make install-sdl2-modules && make clean-all-sdl2-modules
+RUN cd /buildDependencies/build/ \
+  && make compile-physfs PhysfsPackageUrl="https://icculus.org/physfs/downloads/physfs-2.0.3.tar.bz2" \
+  && make install-physfs PhysfsPackageUrl="https://icculus.org/physfs/downloads/physfs-2.0.3.tar.bz2" \
+  && make clean-physfs PhysfsPackageUrl="https://icculus.org/physfs/downloads/physfs-2.0.3.tar.bz2"
 
 RUN useradd user
 USER user

--- a/docker/Ubuntu-16.04.BuildEnv.Dockerfile
+++ b/docker/Ubuntu-16.04.BuildEnv.Dockerfile
@@ -26,10 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY Makefile /buildDependencies/build/
 RUN cd /buildDependencies/build/ && make compile-sdl2 && make install-sdl2 && make clean-all-sdl2
 RUN cd /buildDependencies/build/ && make compile-sdl2-modules && make install-sdl2-modules && make clean-all-sdl2-modules
-RUN cd /buildDependencies/build/ \
-  && make compile-physfs PhysfsPackageUrl="https://icculus.org/physfs/downloads/physfs-2.0.3.tar.bz2" \
-  && make install-physfs PhysfsPackageUrl="https://icculus.org/physfs/downloads/physfs-2.0.3.tar.bz2" \
-  && make clean-physfs PhysfsPackageUrl="https://icculus.org/physfs/downloads/physfs-2.0.3.tar.bz2"
+RUN cd /buildDependencies/build/ && make compile-physfs && make install-physfs && make clean-physfs
 
 RUN useradd user
 USER user

--- a/makefile
+++ b/makefile
@@ -132,10 +132,10 @@ install-deps-source-sdl2:
 DockerFolder := ${TopLevelFolder}/docker
 
 build-image-ubuntu-16.04:
-	docker build ${DockerFolder}/ --file ${DockerFolder}/Ubuntu-16.04.BuildEnv.Dockerfile --tag ubuntu-16.04-gcc-sdl2-physfs
+	docker build ${DockerFolder}/ --file ${DockerFolder}/Ubuntu-16.04.BuildEnv.Dockerfile --tag outpostuniverse/ubuntu-16.04-gcc-sdl2-physfs
 compile-on-ubuntu-16.04:
-	docker run --rm --tty --volume ${TopLevelFolder}:/code ubuntu-16.04-gcc-sdl2-physfs
+	docker run --rm --tty --volume ${TopLevelFolder}:/code outpostuniverse/ubuntu-16.04-gcc-sdl2-physfs
 debug-image-ubuntu-16.04:
-	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive ubuntu-16.04-gcc-sdl2-physfs bash
+	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive outpostuniverse/ubuntu-16.04-gcc-sdl2-physfs bash
 root-debug-image-ubuntu-16.04:
-	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive --user=0 ubuntu-16.04-gcc-sdl2-physfs bash
+	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive --user=0 outpostuniverse/ubuntu-16.04-gcc-sdl2-physfs bash

--- a/makefile
+++ b/makefile
@@ -132,10 +132,10 @@ install-deps-source-sdl2:
 DockerFolder := ${TopLevelFolder}/docker
 
 build-image-ubuntu-16.04:
-	docker build ${DockerFolder}/ --file ${DockerFolder}/Ubuntu-16.04.BuildEnv.Dockerfile --tag ubuntu-16.04-gcc-sdl2
+	docker build ${DockerFolder}/ --file ${DockerFolder}/Ubuntu-16.04.BuildEnv.Dockerfile --tag ubuntu-16.04-gcc-sdl2-physfs
 compile-on-ubuntu-16.04:
-	docker run --rm --tty --volume ${TopLevelFolder}:/code ubuntu-16.04-gcc-sdl2
+	docker run --rm --tty --volume ${TopLevelFolder}:/code ubuntu-16.04-gcc-sdl2-physfs
 debug-image-ubuntu-16.04:
-	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive ubuntu-16.04-gcc-sdl2 bash
+	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive ubuntu-16.04-gcc-sdl2-physfs bash
 root-debug-image-ubuntu-16.04:
-	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive --user=0 ubuntu-16.04-gcc-sdl2 bash
+	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive --user=0 ubuntu-16.04-gcc-sdl2-physfs bash


### PR DESCRIPTION
This includes updates to the Ubuntu 16.04 Docker image used for building NAS2D.

This first changed the PhysFS install from a package version to a source install, while maintaining the same version. Then it updated the source install to use the newer version of PhysFS.

Supports work for Issue #85.
