### PR TITLE
Update CircleCI Dockerfile

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -15,7 +15,7 @@
 FROM outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs
 
 USER root
-# Install CircleCI tools needed for primary CircleCI containers
+# Install tools needed for primary CircleCI containers
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git=1:2.17.1-* \
     ssh=1:7.6p1-* \

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,19 +1,21 @@
 # Based on Ubuntu 18.04, with tools needed to run on CircleCI, and dependencies for NAS2D
 
 # Build from the root project folder with:
-#   docker build .circleci/ --tag outpostuniverse/ubuntu-18.04-circleci-gcc-sdl2
+#   docker build .circleci/ --tag outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs-circleci
 # Push image to DockerHub with:
 #   docker login
-#   docker push outpostuniverse/outposthd-buildenv
+#   docker push outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs-circleci
 
 # Run locally using the CircleCI command line interface:
 #   circleci build
 # Validate .circleci/config.yml file with:
 #   circleci config validate
 
-FROM ubuntu:18.04
+# Depend on local build image
+FROM outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs
 
-# Install CircleCI tools needed for primary containers
+USER root
+# Install CircleCI tools needed for primary CircleCI containers
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git=1:2.17.1-* \
     ssh=1:7.6p1-* \
@@ -21,17 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gzip=1.6-* \
     ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
-
-# Install NAS2D specific dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    g++=4:7.3.0-* \
-    libglew-dev=2.0.0-* \
-    libphysfs-dev=3.0.1-* \
-    libsdl2-dev=2.0.8+* \
-    libsdl2-image-dev=2.0.3+* \
-    libsdl2-mixer-dev=2.0.2+* \
-    libsdl2-ttf-dev=2.0.14+* \
-  && rm -rf /var/lib/apt/lists/*
+USER user
 
 # Code linter complains about missing MAINTAINER tag.
 # The MAINTAINER tag was deprecated in Docker 1.13. The alternative is to use a LABEL tag.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: outpostuniverse/ubuntu-18.04-circleci-gcc-sdl2
+      - image: outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs-circleci
     steps:
       - checkout
       - run: make -k

--- a/makefile
+++ b/makefile
@@ -151,3 +151,15 @@ debug-image-ubuntu-18.04:
 	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs bash
 root-debug-image-ubuntu-18.04:
 	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive --user=0 outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs bash
+
+
+#### CircleCI related build rules ####
+
+.PHONY: build-image-circleci push-image-circleci circleci-build
+
+build-image-circleci:
+	docker build .circleci/ --tag outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs-circleci
+push-image-circleci:
+	docker push outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs-circleci
+circleci-build:
+	circleci build

--- a/makefile
+++ b/makefile
@@ -155,11 +155,13 @@ root-debug-image-ubuntu-18.04:
 
 #### CircleCI related build rules ####
 
-.PHONY: build-image-circleci push-image-circleci circleci-build
+.PHONY: build-image-circleci push-image-circleci circleci-validate circleci-build
 
 build-image-circleci:
 	docker build .circleci/ --tag outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs-circleci
 push-image-circleci:
 	docker push outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs-circleci
+circleci-validate:
+	circleci config validate
 circleci-build:
 	circleci build

--- a/makefile
+++ b/makefile
@@ -129,6 +129,9 @@ install-deps-source-sdl2:
 .PHONY: build-image-ubuntu-16.04 compile-on-ubuntu-16.04
 .PHONY: debug-image-ubuntu-16.04 root-debug-image-ubuntu-16.04
 
+.PHONY: build-image-ubuntu-18.04 compile-on-ubuntu-18.04
+.PHONY: debug-image-ubuntu-18.04 root-debug-image-ubuntu-18.04
+
 DockerFolder := ${TopLevelFolder}/docker
 
 build-image-ubuntu-16.04:
@@ -139,3 +142,12 @@ debug-image-ubuntu-16.04:
 	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive ubuntu-16.04-gcc-sdl2 bash
 root-debug-image-ubuntu-16.04:
 	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive --user=0 ubuntu-16.04-gcc-sdl2 bash
+
+build-image-ubuntu-18.04:
+	docker build ${DockerFolder}/ --file ${DockerFolder}/Ubuntu-18.04.BuildEnv.Dockerfile --tag outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs
+compile-on-ubuntu-18.04:
+	docker run --rm --tty --volume ${TopLevelFolder}:/code outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs
+debug-image-ubuntu-18.04:
+	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs bash
+root-debug-image-ubuntu-18.04:
+	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive --user=0 outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs bash


### PR DESCRIPTION
Adds top level make rules to build with Ubuntu-18.04 and using the local CircleCI tool. Updates CircleCI config so Dockerfile now depends on the local build images. This should make updates and keeping things in sync easier.
