### PR TITLE
Game init changes

### DIFF
--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -28,7 +28,7 @@ public:
 	Filesystem();
 	~Filesystem();
 
-	void init(const std::string& argv_0, const std::string& dataPath);
+	void init(const std::string& argv_0, const std::string& appName, const std::string& organizationName, const std::string& dataPath);
 
 	std::string userPath() const;
 	std::string dataPath() const;

--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -28,7 +28,7 @@ public:
 	Filesystem();
 	~Filesystem();
 
-	void init(const std::string& argv_0, const std::string& startPath);
+	void init(const std::string& argv_0, const std::string& dataPath);
 
 	std::string userPath() const;
 	std::string dataPath() const;

--- a/include/NAS2D/Game.h
+++ b/include/NAS2D/Game.h
@@ -38,7 +38,7 @@ namespace NAS2D {
  * {
  *	try
  *	{
- *		Game game("My NAS2D Application", argv[0]);
+ *		Game game("My NAS2D Application", "ApplicationName", "OrganizationName", argv[0]);
  *		game.mount("gfx.zip");
  *		game.go(new MyState());
  *	}
@@ -56,7 +56,7 @@ namespace NAS2D {
 class Game
 {
 public:
-	Game(const std::string& appTitle, const std::string& argv_0, const std::string& configPath = "config.xml", const std::string& dataPath = "data");
+	Game(const std::string& title, const std::string& appName, const std::string& organizationName, const std::string& argv_0, const std::string& configPath = "config.xml", const std::string& dataPath = "data");
 	~Game();
 
 	void mount(const std::string& path);

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -50,7 +50,7 @@ Filesystem::~Filesystem()
 /**
  * Shuts down PhysFS and cleans up.
  */
-void Filesystem::init(const std::string& argv_0, const std::string& dataPath)
+void Filesystem::init(const std::string& argv_0, const std::string& appName, const std::string& organizationName, const std::string& dataPath)
 {
 	if (FILESYSTEM_INITIALIZED) { throw filesystem_already_initialized(); }
 

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -50,7 +50,7 @@ Filesystem::~Filesystem()
 /**
  * Shuts down PhysFS and cleans up.
  */
-void Filesystem::init(const std::string& argv_0, const std::string& startPath)
+void Filesystem::init(const std::string& argv_0, const std::string& dataPath)
 {
 	if (FILESYSTEM_INITIALIZED) { throw filesystem_already_initialized(); }
 
@@ -61,7 +61,7 @@ void Filesystem::init(const std::string& argv_0, const std::string& startPath)
 		throw filesystem_backend_init_failure(PHYSFS_getLastError());
 	}
 
-	mStartPath = startPath;
+	mStartPath = dataPath;
 	mDirSeparator = PHYSFS_getDirSeparator();
 
 #if defined(WINDOWS) || defined(__APPLE__)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -30,11 +30,13 @@ using namespace NAS2D;
  * setting up any default values should they be needed.
  *
  * \param	title		The title that should be used for the game window.
+ * \param appName		The name of the app (used to create an app data write path)
+ * \param organiationName		The name of the organization (used to create an app data write path)
  * \param	argv_0		argv[0] from main()'s argument list. Necessary for Linux compatibility.
  * \param	configPath	Path to the Config file. Defaults to 'config.xml'.
  * \param	dataPath	Intitial data path. Defaults to 'data'.
  */
-Game::Game(const std::string& title, const std::string& argv_0, const std::string& configPath, const std::string& dataPath)
+Game::Game(const std::string& title, const std::string& appName, const std::string& organizationName, const std::string& argv_0, const std::string& configPath, const std::string& dataPath)
 {
 	std::cout << "NAS2D BUILD: " << __DATE__ << " | " << __TIME__ << std::endl;
 	std::cout << "NAS2D VERSION: " << NAS2D::versionString() << std::endl << std::endl;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -43,7 +43,7 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 
 	std::cout << "Initializing subsystems..." << std::endl << std::endl;
 
-	Utility<Filesystem>::get().init(argv_0, dataPath);
+	Utility<Filesystem>::get().init(argv_0, appName, organizationName, dataPath);
 
 	Configuration& cf = Utility<Configuration>::get();
 	cf.load(configPath);


### PR DESCRIPTION
This adds the `appName` and `organizationName` parameters that will be needed by `PHYSFS_setSaneConfig`. Using this method is one of the major advantages of upgrading to the newer PhysFS version.

Hopefully this change should be minimal enough that it won't create merge conflicts with other open pull requests. I have more changes ready to throw on top of this.
