### PR TITLE
Remove useless delete checks

### DIFF
--- a/include/NAS2D/Utility.h
+++ b/include/NAS2D/Utility.h
@@ -130,12 +130,8 @@ public:
 		if (mInstance == t)
 			return;
 
-		if (mInstance)
-		{
-			delete mInstance;
-			mInstance = 0;
-		}
-		
+		delete mInstance;
+
 		mInstance = t;
 	}
 

--- a/include/NAS2D/Utility.h
+++ b/include/NAS2D/Utility.h
@@ -144,11 +144,8 @@ public:
 	 */
 	static void clear()
 	{
-		if (mInstance)
-		{
-			delete mInstance;
-			mInstance = nullptr;
-		}
+		delete mInstance;
+		mInstance = nullptr;
 	}
 
 private:

--- a/src/StateManager.cpp
+++ b/src/StateManager.cpp
@@ -62,11 +62,7 @@ void StateManager::setState(State* state)
 
 	if (mForceStopAudio) { Utility<Mixer>::get().stopAllAudio(); }
 
-	if (mActiveState != nullptr)
-	{
-		delete mActiveState;
-		mActiveState = nullptr;
-	}
+	delete mActiveState;
 
 	// Initialize the new one
 	mActiveState = state;


### PR DESCRIPTION
It is safe to delete `nullptr`. It's also safe to skip setting a deleted pointer to `nullptr` when it is being set to a new value immediately afterwards.
