### PR TITLE
Use setSaneConfig

### DIFF
--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -58,7 +58,7 @@ private:
 	bool closeFile(void *file) const;
 
 private:
-	std::string			mDataPath;			/**< Data path string. Specific to each platform. */
+	std::string			mDataPath;			/**< Data path string. This will typically be 'data/'. */
 	mutable bool		mVerbose;			/**< Displays lots of messages when true. Otherwise only critical messages are displayed. */
 };
 

--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -59,13 +59,6 @@ private:
 
 private:
 	std::string			mDataPath;			/**< Data path string. Specific to each platform. */
-	std::string			mStartPath;			/**< Path to start in. This will typically be 'data/'. */
-	std::string			mDirSeparator;		/**< Platform dependant directory separator. */
-
-	#ifdef __APPLE__
-	std::string			mBundlePath;		/**< Apple Bundle Directory. */
-	#endif
-
 	mutable bool		mVerbose;			/**< Displays lots of messages when true. Otherwise only critical messages are displayed. */
 };
 

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -67,28 +67,12 @@ void Filesystem::init(const std::string& argv_0, const std::string& appName, con
 		throw filesystem_backend_init_failure(PHYSFS_getLastError());
 	}
 
-	mStartPath = dataPath;
-	mDirSeparator = PHYSFS_getDirSeparator();
+	if (PHYSFS_setSaneConfig(organizationName.c_str(), appName.c_str(), nullptr, false, false) == 0)
+	{
+		std::cout << std::endl << "(FSYS) Error setting sane config. " << PHYSFS_getLastError() << "." << std::endl;
+	}
 
-#if defined(WINDOWS) || defined(__APPLE__)
-	std::string basePath = PHYSFS_getBaseDir();
-
-	// Note: Multiple trailing dir separators are safely ignored
-	mDataPath = basePath + mStartPath + mDirSeparator;
-
-#elif defined(__linux__)
-	std::string userDir = PHYSFS_getUserDir();
-	std::string appUserDataDir = ".lom/data/";
-	mDataPath = userDir + appUserDataDir;
-
-	// Must set write directory before we can modify filesystem
-	PHYSFS_setWriteDir(userDir.c_str());
-	// Create directory if it does not exist
-	PHYSFS_mkdir(appUserDataDir.c_str());
-#endif
-
-	PHYSFS_setWriteDir(mDataPath.c_str());
-
+	mDataPath = dataPath;
 	if (PHYSFS_mount(mDataPath.c_str(), "/", MountPosition::MOUNT_PREPEND) == 0)
 	{
 		std::cout << std::endl << "(FSYS) Couldn't find data path '" << mDataPath << "'. " << PHYSFS_getLastError() << "." << std::endl;

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -91,7 +91,6 @@ void Filesystem::init(const std::string& argv_0, const std::string& appName, con
 
 	if (PHYSFS_mount(mDataPath.c_str(), "/", MountPosition::MOUNT_PREPEND) == 0)
 	{
-		//mErrorMessages.push_back(PHYSFS_getLastError());
 		std::cout << std::endl << "(FSYS) Couldn't find data path '" << mDataPath << "'. " << PHYSFS_getLastError() << "." << std::endl;
 	}
 


### PR DESCRIPTION
Bug fixes. In particular, this fixes Linux. A stock OutpostHD build with this fix will now work without strange path hacks or copying data around to non-standard locations.

This also eliminates a lot of the platform differences, removing platform specific code blocks.

Removes setting the `dataPath` as a write folder. The `dataPath` was typically used for read-only resources packaged with games. Instead it now uses a platform appropriate write folder, which will be located somewhere under the user's profile data.

Closes #85. Relates to #84.
