### PR TITLE
Remove bad check before mount

### DIFF
--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -114,12 +114,6 @@ bool Filesystem::addToSearchPath(const std::string& path) const
 
 	if (mVerbose) { std::cout << "Adding '" << path << "' to search path." << std::endl; }
 
-	if (PHYSFS_exists(path.c_str()) == 0)
-	{
-		std::cout << "File '" << path << "' does not exist as specified." << std::endl;
-		return false;
-	}
-
 	std::string searchPath(mDataPath + path);
 
 	if (PHYSFS_mount(searchPath.c_str(), "/", MountPosition::MOUNT_APPEND) == 0)


### PR DESCRIPTION
The `PHYSFS_exists` method takes a platform independent path which it searches the virtual filesystem for. Here the method is being used on a platform dependent path, which is likely outside the virtual filesystem, as it is about to be mounted into the virtual filesystem.

Additionally, the error reporting if a `PHYSFS_mount` call fails should already be enough to diagnose the problem.
