### PR TITLE
Rename `addToSearchPath` to `mount`

### DIFF
--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -34,7 +34,7 @@ public:
 	std::string dataPath() const;
 	std::string workingPath(const std::string& filename) const;
 	StringList searchPath() const;
-	bool addToSearchPath(const std::string& path) const;
+	bool mount(const std::string& path) const;
 
 	StringList directoryList(const std::string& dir) const;
 	StringList directoryList(const std::string& dir, const std::string& filter) const;

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -108,7 +108,7 @@ void Filesystem::init(const std::string& argv_0, const std::string& appName, con
  *
  * \return Returns \c true if successful. Otherwise, returns \c false.
  */
-bool Filesystem::addToSearchPath(const std::string& path) const
+bool Filesystem::mount(const std::string& path) const
 {
 	if (!FILESYSTEM_INITIALIZED) { throw filesystem_not_initialized(); }
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -103,7 +103,7 @@ Game::~Game()
  */
 void Game::mount(const std::string& path)
 {
-	Utility<Filesystem>::get().addToSearchPath(path);
+	Utility<Filesystem>::get().mount(path);
 }
 
 


### PR DESCRIPTION
Both the higher level component (`Game`) and the lower level component (PhysFS) use `mount`. It makes sense to be consistent here.

This is a breaking change. Granted a simple one, and easy to fix for library users. I think it's worth it.
