### PR TITLE
Fix memory leak using `PHYSFS_getSearchPath`

### DIFF
--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -120,10 +120,12 @@ StringList Filesystem::searchPath() const
 
 	StringList searchPath;
 
-	for (char **i = PHYSFS_getSearchPath(); *i != nullptr; i++)
+	auto searchPathList = PHYSFS_getSearchPath();
+	for (char **i = searchPathList; *i != nullptr; ++i)
 	{
 		searchPath.push_back(*i);
 	}
+	PHYSFS_freeList(searchPathList);
 
 	return searchPath;
 }


### PR DESCRIPTION
As per the documentation here:
https://icculus.org/physfs/docs-devel/html/physfs_8h.html#ac738531e9c7e5ca3797b64985c103cf4
The memory returned should be disposed of with `PHYSFS_freeList()`.

Note: This only fixes the happy path. It does not make the code exception safe. In particular, the `StringList` could throw an out of memory exception while building the list. In that case, the exception would cause the cleanup to be skipped.
