### PR TITLE
Remove redundant `directoryList` method

### DIFF
--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -36,8 +36,7 @@ public:
 	StringList searchPath() const;
 	bool mount(const std::string& path) const;
 
-	StringList directoryList(const std::string& dir) const;
-	StringList directoryList(const std::string& dir, const std::string& filter) const;
+	StringList directoryList(const std::string& dir, const std::string& filter = "") const;
 
 	File open(const std::string& filename) const;
 	bool write(const File& file, bool overwrite = true) const;

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -133,19 +133,6 @@ StringList Filesystem::searchPath() const
  * Returns a list of files within a given directory.
  *
  * \param	dir	Directory to search within the searchpath.
- *
- * \note	This function will also return the names of any directories in a specified search path
- */
-StringList Filesystem::directoryList(const std::string& dir) const
-{
-	return directoryList(dir, std::string(""));
-}
-
-
-/**
- * Returns a list of files within a given directory.
- *
- * \param	dir	Directory to search within the searchpath.
  * \param	filter		Optional extension filter. Only use the extension without a wildcard (*) character or period (e.g., 'png' vs '*.png' or '.png').
  *
  * \note	This function will also return the names of any directories in a specified search path


### PR DESCRIPTION
The same effect can be achieved by specifying a default parameter value in the header file.