### PR TITLE
Delete default copy constructor and copy assignment operator

### DIFF
--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -52,8 +52,8 @@ public:
 	void toggleVerbose() const;
 
 private:
-	Filesystem(const Filesystem&);				// Intentionally left undefined.
-	Filesystem& operator= (const Filesystem&);	// Intentionally left undefined.
+	Filesystem(const Filesystem&) = delete;
+	Filesystem& operator= (const Filesystem&) = delete;
 
 	bool closeFile(void *file) const;
 


### PR DESCRIPTION
Explicitly deleting the methods, rather than simply declaring them private and leaving them undefined, is perhaps more self documenting. Additionally, if a method within the class (with access to private members) tries to call either of them, it will be reported earlier as a compiler error rather than a linker error.
