### PR TITLE
Remove redundant log message

### DIFF
--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -105,8 +105,6 @@ bool Filesystem::mount(const std::string& path) const
 		return false;
 	}
 
-	if (mVerbose) { std::cout << "Added '" << path << "' to search path." << std::endl; }
-
 	return true;
 }
 


### PR DESCRIPTION
This exact message is output earlier in the same function. Additionally, there is a failure message, which also outputs sufficient debug information to determine cause of any problems.
