### PR TITLE
Reduce PhysFS warnings

### DIFF
--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -56,6 +56,7 @@ private:
 	Filesystem& operator= (const Filesystem&);	// Intentionally left undefined.
 
 	bool closeFile(void *file) const;
+	const char* getLastPhysfsError() const;
 
 private:
 	std::string			mDataPath;			/**< Data path string. This will typically be 'data/'. */

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -454,3 +454,9 @@ std::string Filesystem::extension(const std::string& path)
 		return std::string();
 	}
 }
+
+
+const char* Filesystem::getLastPhysfsError() const
+{
+	return PHYSFS_getLastError();
+}

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -64,18 +64,18 @@ void Filesystem::init(const std::string& argv_0, const std::string& appName, con
 
 	if (PHYSFS_init(argv_0.c_str()) == 0)
 	{
-		throw filesystem_backend_init_failure(PHYSFS_getLastError());
+		throw filesystem_backend_init_failure(getLastPhysfsError());
 	}
 
 	if (PHYSFS_setSaneConfig(organizationName.c_str(), appName.c_str(), nullptr, false, false) == 0)
 	{
-		std::cout << std::endl << "(FSYS) Error setting sane config. " << PHYSFS_getLastError() << "." << std::endl;
+		std::cout << std::endl << "(FSYS) Error setting sane config. " << getLastPhysfsError() << "." << std::endl;
 	}
 
 	mDataPath = dataPath;
 	if (PHYSFS_mount(mDataPath.c_str(), "/", MountPosition::MOUNT_PREPEND) == 0)
 	{
-		std::cout << std::endl << "(FSYS) Couldn't find data path '" << mDataPath << "'. " << PHYSFS_getLastError() << "." << std::endl;
+		std::cout << std::endl << "(FSYS) Couldn't find data path '" << mDataPath << "'. " << getLastPhysfsError() << "." << std::endl;
 	}
 
 	FILESYSTEM_INITIALIZED = true;
@@ -101,7 +101,7 @@ bool Filesystem::mount(const std::string& path) const
 
 	if (PHYSFS_mount(searchPath.c_str(), "/", MountPosition::MOUNT_APPEND) == 0)
 	{
-		std::cout << "Couldn't add '" << path << "' to search path. " << PHYSFS_getLastError() << "." << std::endl;
+		std::cout << "Couldn't add '" << path << "' to search path. " << getLastPhysfsError() << "." << std::endl;
 		return false;
 	}
 
@@ -197,7 +197,7 @@ bool Filesystem::del(const std::string& filename) const
 
 	if (PHYSFS_delete(filename.c_str()) == 0)
 	{
-		std::cout << "Unable to delete '" << filename << "':" << PHYSFS_getLastError() << std::endl;
+		std::cout << "Unable to delete '" << filename << "':" << getLastPhysfsError() << std::endl;
 		return false;
 	}
 
@@ -221,7 +221,7 @@ File Filesystem::open(const std::string& filename) const
 	PHYSFS_file* myFile = PHYSFS_openRead(filename.c_str());
 	if (!myFile)
 	{
-		std::cout << "Unable to load '" << filename << "'. " << PHYSFS_getLastError() << "." << std::endl;
+		std::cout << "Unable to load '" << filename << "'. " << getLastPhysfsError() << "." << std::endl;
 		closeFile(myFile);
 		return File();
 	}
@@ -242,7 +242,7 @@ File Filesystem::open(const std::string& filename) const
 	// If we read less then the file length, return an empty File object, log a message and free any used memory.
 	if (PHYSFS_readBytes(myFile, fileBuffer, fileLength) < fileLength)
 	{
-		std::cout << "Unable to load '" << filename << "'. " << PHYSFS_getLastError() << "." << std::endl;
+		std::cout << "Unable to load '" << filename << "'. " << getLastPhysfsError() << "." << std::endl;
 		delete[] fileBuffer;
 		closeFile(myFile);
 		return File();
@@ -328,7 +328,7 @@ bool Filesystem::closeFile(void* file) const
 
 	if (PHYSFS_close(static_cast<PHYSFS_File*>(file)) != 0) { return true; }
 
-	throw filesystem_file_handle_still_open(PHYSFS_getLastError());
+	throw filesystem_file_handle_still_open(getLastPhysfsError());
 }
 
 
@@ -359,13 +359,13 @@ bool Filesystem::write(const File& file, bool overwrite) const
 	PHYSFS_file* myFile = PHYSFS_openWrite(file.filename().c_str());
 	if (!myFile)
 	{
-		if (mVerbose) { std::cout << "Couldn't open '" << file.filename() << "' for writing: " << PHYSFS_getLastError() << std::endl; }
+		if (mVerbose) { std::cout << "Couldn't open '" << file.filename() << "' for writing: " << getLastPhysfsError() << std::endl; }
 		return false;
 	}
 
 	if (PHYSFS_writeBytes(myFile, file.bytes().c_str(), static_cast<PHYSFS_uint32>(file.size())) < static_cast<PHYSFS_sint64>(file.size()))
 	{
-		if (mVerbose) { std::cout << "Error occured while writing to file '" << file.filename() << "': " << PHYSFS_getLastError() << std::endl; }
+		if (mVerbose) { std::cout << "Error occured while writing to file '" << file.filename() << "': " << getLastPhysfsError() << std::endl; }
 		closeFile(myFile);
 		return false;
 	}

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -458,5 +458,5 @@ std::string Filesystem::extension(const std::string& path)
 
 const char* Filesystem::getLastPhysfsError() const
 {
-	return PHYSFS_getLastError();
+	return PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());
 }


### PR DESCRIPTION
This substantially reduces the number of deprecation warnings for PhysFS related messages. It routes all uses of `PHYSFS_getLastError()` through a private method, reducing the direct calls. It then swaps out `PHYSFS_getLastError()` for `PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())` to eliminate the warning.

Only one warning left. Addresses most of what's left of Issue #84. Related: Issue #83.
