### PR TITLE
Have TravisCI do source install of PhysFS 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ compiler:
   - gcc
   - clang
 
+dist: xenial
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   # Linux: Build SDL2 from source to ensure up-to-date 2.0.5 package
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make install-deps-source-sdl2; fi
   # Linux: Build PhysFS from source to ensure up-to-date 3.0.1 package
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make -C docker/ install-physfs; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make -C docker/ compile-physfs && sudo make -C docker/ install-physfs; fi
 
 script:
   # Use -k to continue after errors, ensuring full build log with all errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 
 language: cpp
 
-sudo: false
-
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,14 @@ addons:
     - libsdl2-image-dev
     - libsdl2-ttf-dev
     - libglew-dev
-    - libphysfs-dev
 
 before_install:
   # OSX: Install packages using brew
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install sdl2 sdl2_image sdl2_mixer sdl2_ttf glew physfs; fi
   # Linux: Build SDL2 from source to ensure up-to-date 2.0.5 package
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make install-deps-source-sdl2; fi
+  # Linux: Build PhysFS from source to ensure up-to-date 3.0.1 package
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make -C docker/ install-physfs; fi
 
 script:
   # Use -k to continue after errors, ensuring full build log with all errors


### PR DESCRIPTION
This should fix the Linux TravisCI build.

The system packaged versions of PhysFS were too old. This update does a source install of PhysFS to the build environment before building NAS2D.

----

I noticed TravisCI build statuses haven't been showing up on GitHub recently. They are still running though. Seems the TravisCI builds have been broken for days, ever since the PhysFS upgrade.
