### PR TITLE
Utility constexpr-if

### DIFF
--- a/include/NAS2D/Utility.h
+++ b/include/NAS2D/Utility.h
@@ -11,6 +11,7 @@
 
 #include <utility>
 #include <type_traits>
+#include <stdexcept>
 
 
 namespace NAS2D {
@@ -63,8 +64,14 @@ public:
 	{
 		if (!mInstance)
 		{
-			static_assert(std::is_default_constructible<T>::value, "Type must be default constructible");
-			mInstance = new T();
+			if constexpr(std::is_default_constructible<T>::value)
+			{
+				mInstance = new T();
+			}
+			else
+			{
+				throw std::runtime_error("Type must be default constructible or initialized with `init`");
+			}
 		}
 
 		return *mInstance;

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ SdlDir := $(SdlPackageDir)/$(SdlVer)
 # (Must be searched before system folder returned by sdl2-config)
 SdlInc := $(SdlDir)/include
 
-CXXFLAGS := -std=c++11 -g -Wall -I$(INCDIR) -I$(SdlInc) $(shell sdl2-config --cflags)
+CXXFLAGS := -std=c++17 -g -Wall -I$(INCDIR) -I$(SdlInc) $(shell sdl2-config --cflags)
 LDLIBS := -lstdc++ -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGLU -lGL
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td

--- a/test/Utility.test.cpp
+++ b/test/Utility.test.cpp
@@ -9,7 +9,6 @@ TEST(Utility, DefaultConstructibleType) {
 	EXPECT_NO_THROW(NAS2D::Utility<DefaultConstructible>::get());
 }
 
-/*
 TEST(Utility, NonDefaultConstructibleType) {
 	struct NonDefaultConstructible {
 		NonDefaultConstructible() = delete;
@@ -19,4 +18,3 @@ TEST(Utility, NonDefaultConstructibleType) {
 	NAS2D::Utility<NonDefaultConstructible>::init(0);
 	NAS2D::Utility<NonDefaultConstructible>::get();
 }
-*/


### PR DESCRIPTION
This expands the scope of the `Utility` class so it's able to handle non-default-constructible types too.

For non-default-constructible types (and only for those types), the code throws an exception at runtime if `get` is called before `init`. As the type is non-default-constructible, the method can't simply create an object on demand. It would need to call a non-default constructor and pass actual arguments which the method doesn't have.

Upon `nullptr`, the decision to either construct a new value (default constructible) or throw an exception (non-default-constructible) is made at compile time. There is no run-time check for this. The proper code is compiled in as part of template method selection.

The [`constexpr-if`](https://en.cppreference.com/w/cpp/language/if) feature used here is a C++17 feature. Compiler/project settings may need to be adjusted to enable it.
