### PR TITLE
Replace constexpr-if with `enable_if`

### DIFF
--- a/include/NAS2D/Utility.h
+++ b/include/NAS2D/Utility.h
@@ -59,19 +59,35 @@ public:
 	/**
 	 * Gets a reference to a global instance of the specified type
 	 * \c T. If an instance doesn't exist, one is created.
+	 * Type \c T must be default constructible to use this overload.
 	 */
-	static T& get()
+	template<typename Type = T>
+	static
+	std::enable_if_t<std::is_default_constructible<Type>::value, T&>
+	get()
 	{
 		if (!mInstance)
 		{
-			if constexpr(std::is_default_constructible<T>::value)
-			{
-				mInstance = new T();
-			}
-			else
-			{
-				throw std::runtime_error("Type must be default constructible or initialized with `init`");
-			}
+			mInstance = new T();
+		}
+
+		return *mInstance;
+	}
+
+
+	/**
+	 * Gets a reference to a global instance of the specified type
+	 * \c T. If an instance doesn't exist, an exception is thrown.
+	 * Type \c T is not default constructible for this overload.
+	 */
+	template<typename Type = T>
+	static
+	std::enable_if_t<!std::is_default_constructible<Type>::value, T&>
+	get()
+	{
+		if (!mInstance)
+		{
+			throw std::runtime_error("Type must be default constructible or initialized with `init`");
 		}
 
 		return *mInstance;

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ SdlDir := $(SdlPackageDir)/$(SdlVer)
 # (Must be searched before system folder returned by sdl2-config)
 SdlInc := $(SdlDir)/include
 
-CXXFLAGS := -std=c++17 -g -Wall -I$(INCDIR) -I$(SdlInc) $(shell sdl2-config --cflags)
+CXXFLAGS := -std=c++14 -g -Wall -I$(INCDIR) -I$(SdlInc) $(shell sdl2-config --cflags)
 LDLIBS := -lstdc++ -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGLU -lGL
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td


### PR DESCRIPTION
This drops language requirements from C++17 to C++14. It's possible to drop further to C++11 using more verbose syntax.

This should fix the TravisCI GCC build. The TravisCI environment uses an outdated version of GCC without support for constexpr-if. Upgrading GCC (for every build on TravisCI) would be prohibitively expensive for build time. By using earlier primitives that existed in prior versions of C++, the code can be made to work on earlier compiler versions.
