### PR TITLE
Clang-format integration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,8 +3,6 @@ configuration: Release
 platform:
   - x86
   - x64
-before_build:
-  - nuget restore proj/vc17
+before_build: nuget restore proj/vc17
 build:
-  project:
-    - proj/vc17/NAS2D.sln
+  project: proj/vc17/NAS2D.sln

--- a/_clang-format
+++ b/_clang-format
@@ -1,0 +1,93 @@
+Language: Cpp
+AlignTrailingComments: true
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: true
+
+#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
+#AllowShortLambdasOnASingleLine: All
+
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: false
+#BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom #Allman, but not quite
+BraceWrapping:
+    AfterClass: true
+    AfterControlStatement: true
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    AfterStruct: true
+    AfterUnion: true
+    AfterExternBlock: true
+    BeforeCatch: true
+    BeforeElse: true
+    IndentBraces: false
+    SplitEmptyFunction: false
+    SplitEmptyRecord: false
+    SplitEmptyNamespace: false
+
+BreakBeforeBinaryOperators: NonAssignment
+BreakConstructorInitializers: BeforeComma
+ColumnLimit: 0
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 0
+FixNamespaceComments: true
+IncludeBlocks: Regroup
+IncludeCategories:
+# Prefer project-specific includes first
+#i.e. Prefer "my" includes before other libraries
+#First local multi-folder (usually not in the same directory) includes
+# e.g. #include "NAS2D/Renderer/Renderer.h"
+    - Regex: '\"([[:alnum:]_]+\/)+[[:alnum:]_]+\.(h|c)(pp)?\"'
+    - Priority: 4
+#Then local project-specific includes
+# e.g. #include "Mixer.h" in Mixer_SDL.h file
+    - Regex: '\"[[:alnum:]_]+\.(h|c)(pp)?\"'
+    - Priority: 3
+#Followed by global STL and Library headers
+# e.g. #include <iostream>
+    - Regex: '\<[[:alnum:]_]+\>'
+    - Priority: 2
+#Lastly, global linked libraries and C and OS-specific headers.
+# e.g. #include <windows.h>
+    - Regex: '\<[[:alnum:]_]+\.h(pp)?\>'
+    - Priority: 1
+
+IndentCaseLabels: false
+#Unsupported in VS-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
+#IndentPPDirectives: BeforeHash
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+NamespaceIndentation: All
+PointerAlignment: Left
+ReflowComments: false
+SortIncludes : true
+SortUsingDeclarations: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+
+#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
+#SpaceBeforeCpp11BracedList: false
+
+#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
+#SpaceBeforeCtorInitializerColon: true
+
+#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
+#SpaceBeforeInheritanceColon: true
+
+SpaceBeforeParens: Never
+
+#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
+#SpaceBeforeRangeBasedForLoopColon: false
+
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+TabWidth: 4
+UseTab: Always

--- a/proj/vc17/NAS2D.sln
+++ b/proj/vc17/NAS2D.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.572
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NAS2D", "NAS2D.vcxproj", "{3350562D-6204-42FC-898A-C85FD62E04E8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release Gold|x64 = Release Gold|x64
+		Release Gold|x86 = Release Gold|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+		Release-Analysis|x64 = Release-Analysis|x64
+		Release-Analysis|x86 = Release-Analysis|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Debug|x64.ActiveCfg = Debug|x64
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Debug|x64.Build.0 = Debug|x64
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Debug|x86.ActiveCfg = Debug|Win32
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Debug|x86.Build.0 = Debug|Win32
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Release Gold|x64.ActiveCfg = Release Gold|x64
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Release Gold|x64.Build.0 = Release Gold|x64
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Release Gold|x86.ActiveCfg = Release Gold|Win32
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Release Gold|x86.Build.0 = Release Gold|Win32
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Release|x64.ActiveCfg = Release Gold|x64
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Release|x64.Build.0 = Release Gold|x64
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Release|x86.ActiveCfg = Release Gold|Win32
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Release|x86.Build.0 = Release Gold|Win32
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Release-Analysis|x64.ActiveCfg = Release|x64
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Release-Analysis|x64.Build.0 = Release|x64
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Release-Analysis|x86.ActiveCfg = Release|Win32
+		{3350562D-6204-42FC-898A-C85FD62E04E8}.Release-Analysis|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {15085ABC-405F-490F-ACD9-1D013C557676}
+	EndGlobalSection
+EndGlobal

--- a/proj/vc17/NAS2D.vcxproj
+++ b/proj/vc17/NAS2D.vcxproj
@@ -1,0 +1,366 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release Gold|Win32">
+      <Configuration>Release Gold</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release Gold|x64">
+      <Configuration>Release Gold</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{3350562D-6204-42FC-898A-C85FD62E04E8}</ProjectGuid>
+    <RootNamespace>NAS2D</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Gold|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Gold|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release Gold|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release Gold|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IncludePath>C:\API\glew-1.13.0\include;C:\API\physfs-2.0.3\;C:\API\SDL2-2.0.5\include;C:\API\SDL2_image-2.0.0\include;C:\API\SDL2_mixer-2.0.0\include;C:\API\SDL2_ttf-2.0.12\include;..\..\include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\API\glew-1.13.0\lib\Release\x64;C:\API\physfs-2.0.3\lib\x64;C:\API\SDL2-2.0.5\lib\x64;C:\API\SDL2_image-2.0.0\lib\x64;C:\API\SDL2_mixer-2.0.0\lib\x64;C:\API\SDL2_ttf-2.0.12\lib\x64;$(LibraryPath)</LibraryPath>
+    <TargetName>$(ProjectName)_d</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>C:\API\glew-1.13.0\include;C:\API\physfs-2.0.3\;C:\API\SDL2-2.0.5\include;C:\API\SDL2_image-2.0.0\include;C:\API\SDL2_mixer-2.0.0\include;C:\API\SDL2_ttf-2.0.12\include;..\..\include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\API\glew-1.13.0\lib\Release\x64;C:\API\physfs-2.0.3\lib\x64;C:\API\SDL2-2.0.5\lib\x64;C:\API\SDL2_image-2.0.0\lib\x64;C:\API\SDL2_mixer-2.0.0\lib\x64;C:\API\SDL2_ttf-2.0.12\lib\x64;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Gold|x64'">
+    <IncludePath>C:\API\glew-1.13.0\include;C:\API\physfs-2.0.3\;C:\API\SDL2-2.0.5\include;C:\API\SDL2_image-2.0.0\include;C:\API\SDL2_mixer-2.0.0\include;C:\API\SDL2_ttf-2.0.12\include;..\..\include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\API\glew-1.13.0\lib\Release\x64;C:\API\physfs-2.0.3\lib\x64;C:\API\SDL2-2.0.5\lib\x64;C:\API\SDL2_image-2.0.0\lib\x64;C:\API\SDL2_mixer-2.0.0\lib\x64;C:\API\SDL2_ttf-2.0.12\lib\x64;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <IncludePath>C:\API\glew-1.13.0\include;C:\API\physfs-2.0.3\;C:\API\SDL2-2.0.5\include;C:\API\SDL2_image-2.0.0\include;C:\API\SDL2_mixer-2.0.0\include;C:\API\SDL2_ttf-2.0.12\include;..\..\include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\API\glew-1.13.0\lib\Release\Win32;C:\API\physfs-2.0.3\lib\x86;C:\API\SDL2-2.0.5\lib\x86;C:\API\SDL2_image-2.0.0\lib\x86;C:\API\SDL2_mixer-2.0.0\lib\x86;C:\API\SDL2_ttf-2.0.12\lib\x86;$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>$(ProjectName)_d</TargetName>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>C:\Program Files (x86)\Microsoft Visual Studio 14.0\Team Tools\Static Analysis Tools\Rule Sets\NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <IncludePath>C:\API\glew-1.13.0\include;C:\API\physfs-2.0.3\;C:\API\SDL2-2.0.5\include;C:\API\SDL2_image-2.0.0\include;C:\API\SDL2_mixer-2.0.0\include;C:\API\SDL2_ttf-2.0.12\include;..\..\include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\API\glew-1.13.0\lib\Release\Win32;C:\API\physfs-2.0.3\lib\x86;C:\API\SDL2-2.0.5\lib\x86;C:\API\SDL2_image-2.0.0\lib\x86;C:\API\SDL2_mixer-2.0.0\lib\x86;C:\API\SDL2_ttf-2.0.12\lib\x86;$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <CodeAnalysisRuleSet>C:\Program Files (x86)\Microsoft Visual Studio 14.0\Team Tools\Static Analysis Tools\Rule Sets\NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Gold|Win32'">
+    <IncludePath>C:\API\glew-1.13.0\include;C:\API\physfs-2.0.3\;C:\API\SDL2-2.0.5\include;C:\API\SDL2_image-2.0.0\include;C:\API\SDL2_mixer-2.0.0\include;C:\API\SDL2_ttf-2.0.12\include;..\..\include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\API\glew-1.13.0\lib\Release\Win32;C:\API\physfs-2.0.3\lib\x86;C:\API\SDL2-2.0.5\lib\x86;C:\API\SDL2_image-2.0.0\lib\x86;C:\API\SDL2_mixer-2.0.0\lib\x86;C:\API\SDL2_ttf-2.0.12\lib\x86;$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <EnablePREfast>false</EnablePREfast>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>glew32s.lib;physfs.lib;sdl2.lib;sdl2_image.lib;sdl2_mixer.lib;sdl2_ttf.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINDOWS;TIXML_USE_STL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <EnablePREfast>true</EnablePREfast>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>glew32s.lib;physfs.lib;sdl2.lib;sdl2_image.lib;sdl2_mixer.lib;sdl2_ttf.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Gold|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Full</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <OmitFramePointers>true</OmitFramePointers>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>glew32s.lib;physfs.lib;sdl2.lib;sdl2_image.lib;sdl2_mixer.lib;sdl2_ttf.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINDOWS;TIXML_USE_STL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Gold|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>MinSpace</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINDOWS;TIXML_USE_STL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\Common.cpp" />
+    <ClCompile Include="..\..\src\Configuration.cpp" />
+    <ClCompile Include="..\..\src\EventHandler.cpp" />
+    <ClCompile Include="..\..\src\Exception.cpp" />
+    <ClCompile Include="..\..\src\Filesystem.cpp" />
+    <ClCompile Include="..\..\src\FpsCounter.cpp" />
+    <ClCompile Include="..\..\src\Game.cpp" />
+    <ClCompile Include="..\..\src\Mixer\Mixer.cpp" />
+    <ClCompile Include="..\..\src\Mixer\Mixer_SDL.cpp" />
+    <ClCompile Include="..\..\src\Renderer\OGL_Renderer.cpp" />
+    <ClCompile Include="..\..\src\Renderer\Primitives.cpp" />
+    <ClCompile Include="..\..\src\Renderer\Renderer.cpp" />
+    <ClCompile Include="..\..\src\Resources\Font.cpp" />
+    <ClCompile Include="..\..\src\Resources\Image.cpp" />
+    <ClCompile Include="..\..\src\Resources\Music.cpp" />
+    <ClCompile Include="..\..\src\Resources\Resource.cpp" />
+    <ClCompile Include="..\..\src\Resources\Sound.cpp" />
+    <ClCompile Include="..\..\src\Resources\Sprite.cpp" />
+    <ClCompile Include="..\..\src\StateManager.cpp" />
+    <ClCompile Include="..\..\src\Timer.cpp" />
+    <ClCompile Include="..\..\src\Trig.cpp" />
+    <ClCompile Include="..\..\src\Xml\XmlNode.cpp" />
+    <ClCompile Include="..\..\src\Xml\XmlAttribute.cpp" />
+    <ClCompile Include="..\..\src\Xml\XmlAttributeSet.cpp" />
+    <ClCompile Include="..\..\src\Xml\XmlBase.cpp" />
+    <ClCompile Include="..\..\src\Xml\XmlComment.cpp" />
+    <ClCompile Include="..\..\src\Xml\XmlDocument.cpp" />
+    <ClCompile Include="..\..\src\Xml\XmlElement.cpp" />
+    <ClCompile Include="..\..\src\Xml\XmlHandle.cpp" />
+    <ClCompile Include="..\..\src\Xml\XmlMemoryBuffer.cpp" />
+    <ClCompile Include="..\..\src\Xml\XmlParser.cpp" />
+    <ClCompile Include="..\..\src\Xml\XmlText.cpp" />
+    <ClCompile Include="..\..\src\Xml\XmlUnknown.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\NAS2D\BuildConfig.h" />
+    <ClInclude Include="..\..\include\NAS2D\Common.h" />
+    <ClInclude Include="..\..\include\NAS2D\Configuration.h" />
+    <ClInclude Include="..\..\include\NAS2D\Delegate.h" />
+    <ClInclude Include="..\..\include\NAS2D\Documentation.h" />
+    <ClInclude Include="..\..\include\NAS2D\EventHandler.h" />
+    <ClInclude Include="..\..\include\NAS2D\Exception.h" />
+    <ClInclude Include="..\..\include\NAS2D\File.h" />
+    <ClInclude Include="..\..\include\NAS2D\Filesystem.h" />
+    <ClInclude Include="..\..\include\NAS2D\FpsCounter.h" />
+    <ClInclude Include="..\..\include\NAS2D\Game.h" />
+    <ClInclude Include="..\..\include\NAS2D\Mixer\Mixer.h" />
+    <ClInclude Include="..\..\include\NAS2D\Mixer\Mixer_SDL.h" />
+    <ClInclude Include="..\..\include\NAS2D\NAS2D.h" />
+    <ClInclude Include="..\..\include\NAS2D\Renderer\OGL_Renderer.h" />
+    <ClInclude Include="..\..\include\NAS2D\Renderer\Primitives.h" />
+    <ClInclude Include="..\..\include\NAS2D\Renderer\Renderer.h" />
+    <ClInclude Include="..\..\include\NAS2D\Resources\Font.h" />
+    <ClInclude Include="..\..\include\NAS2D\Resources\FontInfo.h" />
+    <ClInclude Include="..\..\include\NAS2D\Resources\Image.h" />
+    <ClInclude Include="..\..\include\NAS2D\Resources\ImageInfo.h" />
+    <ClInclude Include="..\..\include\NAS2D\Resources\Music.h" />
+    <ClInclude Include="..\..\include\NAS2D\Resources\MusicInfo.h" />
+    <ClInclude Include="..\..\include\NAS2D\Resources\Resource.h" />
+    <ClInclude Include="..\..\include\NAS2D\Resources\Sound.h" />
+    <ClInclude Include="..\..\include\NAS2D\Resources\Sprite.h" />
+    <ClInclude Include="..\..\include\NAS2D\Signal.h" />
+    <ClInclude Include="..\..\include\NAS2D\State.h" />
+    <ClInclude Include="..\..\include\NAS2D\StateManager.h" />
+    <ClInclude Include="..\..\include\NAS2D\Timer.h" />
+    <ClInclude Include="..\..\include\NAS2D\Trig.h" />
+    <ClInclude Include="..\..\include\NAS2D\Utility.h" />
+    <ClInclude Include="..\..\include\NAS2D\Xml\Xml.h" />
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlAttribute.h" />
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlAttributeSet.h" />
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlBase.h" />
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlComment.h" />
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlDocument.h" />
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlElement.h" />
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlHandle.h" />
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlMemoryBuffer.h" />
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlNode.h" />
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlText.h" />
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlUnknown.h" />
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlVisitor.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\_clang-format" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="packages\physfs.v140.2.0.3.1\build\native\physfs.v140.targets" Condition="Exists('packages\physfs.v140.2.0.3.1\build\native\physfs.v140.targets')" />
+    <Import Project="packages\glew.redist.1.9.0.1\build\native\glew.redist.targets" Condition="Exists('packages\glew.redist.1.9.0.1\build\native\glew.redist.targets')" />
+    <Import Project="packages\glew.1.9.0.1\build\native\glew.targets" Condition="Exists('packages\glew.1.9.0.1\build\native\glew.targets')" />
+    <Import Project="packages\sdl2.redist.2.0.5\build\native\sdl2.redist.targets" Condition="Exists('packages\sdl2.redist.2.0.5\build\native\sdl2.redist.targets')" />
+    <Import Project="packages\sdl2.2.0.5\build\native\sdl2.targets" Condition="Exists('packages\sdl2.2.0.5\build\native\sdl2.targets')" />
+    <Import Project="packages\sdl2.v140.redist.2.0.4\build\native\sdl2.v140.redist.targets" Condition="Exists('packages\sdl2.v140.redist.2.0.4\build\native\sdl2.v140.redist.targets')" />
+    <Import Project="packages\sdl2.new.redist.2.0.8\build\native\sdl2.new.redist.targets" Condition="Exists('packages\sdl2.new.redist.2.0.8\build\native\sdl2.new.redist.targets')" />
+    <Import Project="packages\sdl2.new.2.0.8\build\native\sdl2.new.targets" Condition="Exists('packages\sdl2.new.2.0.8\build\native\sdl2.new.targets')" />
+    <Import Project="packages\vii.SDL2_image.redist.2.0.3\build\native\vii.SDL2_image.redist.targets" Condition="Exists('packages\vii.SDL2_image.redist.2.0.3\build\native\vii.SDL2_image.redist.targets')" />
+    <Import Project="packages\vii.SDL2_image.2.0.3\build\native\vii.SDL2_image.targets" Condition="Exists('packages\vii.SDL2_image.2.0.3\build\native\vii.SDL2_image.targets')" />
+    <Import Project="packages\ikkepop.sdl2_ttf.redist.2.0.14\build\native\ikkepop.sdl2_ttf.redist.targets" Condition="Exists('packages\ikkepop.sdl2_ttf.redist.2.0.14\build\native\ikkepop.sdl2_ttf.redist.targets')" />
+    <Import Project="packages\ikkepop.sdl2_ttf.2.0.14\build\native\ikkepop.sdl2_ttf.targets" Condition="Exists('packages\ikkepop.sdl2_ttf.2.0.14\build\native\ikkepop.sdl2_ttf.targets')" />
+    <Import Project="packages\vii.SDL2_mixer.redist.2.0.2\build\native\vii.SDL2_mixer.redist.targets" Condition="Exists('packages\vii.SDL2_mixer.redist.2.0.2\build\native\vii.SDL2_mixer.redist.targets')" />
+    <Import Project="packages\vii.SDL2_mixer.2.0.2\build\native\vii.SDL2_mixer.targets" Condition="Exists('packages\vii.SDL2_mixer.2.0.2\build\native\vii.SDL2_mixer.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\physfs.v140.2.0.3.1\build\native\physfs.v140.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\physfs.v140.2.0.3.1\build\native\physfs.v140.targets'))" />
+    <Error Condition="!Exists('packages\glew.redist.1.9.0.1\build\native\glew.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\glew.redist.1.9.0.1\build\native\glew.redist.targets'))" />
+    <Error Condition="!Exists('packages\glew.1.9.0.1\build\native\glew.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\glew.1.9.0.1\build\native\glew.targets'))" />
+    <Error Condition="!Exists('packages\sdl2.redist.2.0.5\build\native\sdl2.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2.redist.2.0.5\build\native\sdl2.redist.targets'))" />
+    <Error Condition="!Exists('packages\sdl2.2.0.5\build\native\sdl2.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2.2.0.5\build\native\sdl2.targets'))" />
+    <Error Condition="!Exists('packages\sdl2.v140.redist.2.0.4\build\native\sdl2.v140.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2.v140.redist.2.0.4\build\native\sdl2.v140.redist.targets'))" />
+    <Error Condition="!Exists('packages\sdl2.new.redist.2.0.8\build\native\sdl2.new.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2.new.redist.2.0.8\build\native\sdl2.new.redist.targets'))" />
+    <Error Condition="!Exists('packages\sdl2.new.2.0.8\build\native\sdl2.new.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2.new.2.0.8\build\native\sdl2.new.targets'))" />
+    <Error Condition="!Exists('packages\vii.SDL2_image.redist.2.0.3\build\native\vii.SDL2_image.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\vii.SDL2_image.redist.2.0.3\build\native\vii.SDL2_image.redist.targets'))" />
+    <Error Condition="!Exists('packages\vii.SDL2_image.2.0.3\build\native\vii.SDL2_image.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\vii.SDL2_image.2.0.3\build\native\vii.SDL2_image.targets'))" />
+    <Error Condition="!Exists('packages\ikkepop.sdl2_ttf.redist.2.0.14\build\native\ikkepop.sdl2_ttf.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\ikkepop.sdl2_ttf.redist.2.0.14\build\native\ikkepop.sdl2_ttf.redist.targets'))" />
+    <Error Condition="!Exists('packages\ikkepop.sdl2_ttf.2.0.14\build\native\ikkepop.sdl2_ttf.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\ikkepop.sdl2_ttf.2.0.14\build\native\ikkepop.sdl2_ttf.targets'))" />
+    <Error Condition="!Exists('packages\vii.SDL2_mixer.redist.2.0.2\build\native\vii.SDL2_mixer.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\vii.SDL2_mixer.redist.2.0.2\build\native\vii.SDL2_mixer.redist.targets'))" />
+    <Error Condition="!Exists('packages\vii.SDL2_mixer.2.0.2\build\native\vii.SDL2_mixer.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\vii.SDL2_mixer.2.0.2\build\native\vii.SDL2_mixer.targets'))" />
+  </Target>
+</Project>

--- a/proj/vc17/NAS2D.vcxproj.filters
+++ b/proj/vc17/NAS2D.vcxproj.filters
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\Mixer">
+      <UniqueIdentifier>{38850f27-88ca-4a9f-8398-c4fc4063e7d2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Renderer">
+      <UniqueIdentifier>{1b4aff9c-81d5-485b-bdc7-1b5850a90ff9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Resources">
+      <UniqueIdentifier>{abe87a21-5242-47d5-a2e5-cd4d11c06440}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Mixer">
+      <UniqueIdentifier>{e726c591-8921-4e48-bcd1-b31f16365f75}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Renderer">
+      <UniqueIdentifier>{f835e375-3047-4a58-8cf1-a8c2ac3a580c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Resources">
+      <UniqueIdentifier>{8fc63a46-a921-4817-8885-8e16d6d47335}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Xml">
+      <UniqueIdentifier>{7d97d5b5-2a02-45fa-b77b-5421848a65aa}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Xml">
+      <UniqueIdentifier>{f77ff9a8-6639-4ae0-8705-c016859865d9}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\Common.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Configuration.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\EventHandler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Filesystem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\FpsCounter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Game.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\StateManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Timer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Trig.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Resources\Font.cpp">
+      <Filter>Source Files\Resources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Resources\Image.cpp">
+      <Filter>Source Files\Resources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Resources\Music.cpp">
+      <Filter>Source Files\Resources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Resources\Resource.cpp">
+      <Filter>Source Files\Resources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Resources\Sound.cpp">
+      <Filter>Source Files\Resources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Resources\Sprite.cpp">
+      <Filter>Source Files\Resources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Renderer\OGL_Renderer.cpp">
+      <Filter>Source Files\Renderer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Renderer\Primitives.cpp">
+      <Filter>Source Files\Renderer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Renderer\Renderer.cpp">
+      <Filter>Source Files\Renderer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Mixer\Mixer_SDL.cpp">
+      <Filter>Source Files\Mixer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Exception.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Xml\XmlParser.cpp">
+      <Filter>Source Files\Xml</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Xml\XmlBase.cpp">
+      <Filter>Source Files\Xml</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Xml\XmlMemoryBuffer.cpp">
+      <Filter>Source Files\Xml</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Xml\XmlHandle.cpp">
+      <Filter>Source Files\Xml</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Xml\XmlAttributeSet.cpp">
+      <Filter>Source Files\Xml</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Xml\XmlUnknown.cpp">
+      <Filter>Source Files\Xml</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Xml\XmlElement.cpp">
+      <Filter>Source Files\Xml</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Xml\XmlText.cpp">
+      <Filter>Source Files\Xml</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Xml\XmlComment.cpp">
+      <Filter>Source Files\Xml</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Xml\XmlAttribute.cpp">
+      <Filter>Source Files\Xml</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Xml\XmlDocument.cpp">
+      <Filter>Source Files\Xml</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Xml\XmlNode.cpp">
+      <Filter>Source Files\Xml</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Mixer\Mixer.cpp">
+      <Filter>Source Files\Mixer</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\NAS2D\Common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Configuration.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Delegate.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Documentation.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\EventHandler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Exception.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\File.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Filesystem.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\FpsCounter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Game.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\NAS2D.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Signal.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\State.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\StateManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Timer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Trig.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Utility.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Mixer\Mixer.h">
+      <Filter>Header Files\Mixer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Resources\Font.h">
+      <Filter>Header Files\Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Resources\Image.h">
+      <Filter>Header Files\Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Resources\Music.h">
+      <Filter>Header Files\Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Resources\Resource.h">
+      <Filter>Header Files\Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Resources\Sound.h">
+      <Filter>Header Files\Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Resources\Sprite.h">
+      <Filter>Header Files\Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Renderer\OGL_Renderer.h">
+      <Filter>Header Files\Renderer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Renderer\Primitives.h">
+      <Filter>Header Files\Renderer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Renderer\Renderer.h">
+      <Filter>Header Files\Renderer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Mixer\Mixer_SDL.h">
+      <Filter>Header Files\Mixer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Resources\ImageInfo.h">
+      <Filter>Header Files\Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Resources\MusicInfo.h">
+      <Filter>Header Files\Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Resources\FontInfo.h">
+      <Filter>Header Files\Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Xml\Xml.h">
+      <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlVisitor.h">
+      <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlBase.h">
+      <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlNode.h">
+      <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlAttribute.h">
+      <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlAttributeSet.h">
+      <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlElement.h">
+      <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlComment.h">
+      <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlText.h">
+      <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlUnknown.h">
+      <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlDocument.h">
+      <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlHandle.h">
+      <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Xml\XmlMemoryBuffer.h">
+      <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\BuildConfig.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="..\..\_clang-format" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Integrated VS2017-included _clang-format support for easier time with coding conventions, especially tabs and braces;

I tried to follow CONVENTIONS.md as close as possible but there were some differences in what VS2017's provided v6.0 clang-format supported. Unsupported key/value pairs are commented out for future use. Maybe VS2019's v7.0 will support more of them (but certainly not all.)

https://devblogs.microsoft.com/cppblog/clangformat-support-in-visual-studio-2017-15-7-preview-1/
Edit > Advanced > Format Document or Format Selection
or
Ctrl+K, Ctrl+D and Ctrl+K, Ctrl+F respectively
to activate.

(The article is a little out of date as the current version of VS2017 supports clang-format v6.0 and VS2019 supports v7.0)

One thing that is a little annoying is if clang-format messes something up it will happily leave it that way. Even after changing the rules. Easier to just re-checkout the file to wipe changes and edit at the format file again.