### PR TITLE
Clang format integration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,93 @@
+Language: Cpp
+AlignTrailingComments: true
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: true
+
+#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
+#AllowShortLambdasOnASingleLine: All
+
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: false
+#BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom #Allman, but not quite
+BraceWrapping:
+    AfterClass: true
+    AfterControlStatement: true
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    AfterStruct: true
+    AfterUnion: true
+    AfterExternBlock: true
+    BeforeCatch: true
+    BeforeElse: true
+    IndentBraces: false
+    SplitEmptyFunction: false
+    SplitEmptyRecord: false
+    SplitEmptyNamespace: false
+
+BreakBeforeBinaryOperators: NonAssignment
+BreakConstructorInitializers: BeforeComma
+ColumnLimit: 0
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 0
+FixNamespaceComments: true
+IncludeBlocks: Regroup
+IncludeCategories:
+# Prefer project-specific includes first
+#i.e. Prefer "my" includes before other libraries
+#First local multi-folder (usually not in the same directory) includes
+# e.g. #include "NAS2D/Renderer/Renderer.h"
+    - Regex: '\"([[:alnum:]_]+\/)+[[:alnum:]_]+\.(h|c)(pp)?\"'
+    - Priority: 4
+#Then local project-specific includes
+# e.g. #include "Mixer.h" in Mixer_SDL.h file
+    - Regex: '\"[[:alnum:]_]+\.(h|c)(pp)?\"'
+    - Priority: 3
+#Followed by global STL and Library headers
+# e.g. #include <iostream>
+    - Regex: '\<[[:alnum:]_]+\>'
+    - Priority: 2
+#Lastly, global linked libraries and C and OS-specific headers.
+# e.g. #include <windows.h>
+    - Regex: '\<[[:alnum:]_]+\.h(pp)?\>'
+    - Priority: 1
+
+IndentCaseLabels: false
+#Unsupported in VS-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
+#IndentPPDirectives: BeforeHash
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+NamespaceIndentation: All
+PointerAlignment: Left
+ReflowComments: false
+SortIncludes : true
+SortUsingDeclarations: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+
+#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
+#SpaceBeforeCpp11BracedList: false
+
+#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
+#SpaceBeforeCtorInitializerColon: true
+
+#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
+#SpaceBeforeInheritanceColon: true
+
+SpaceBeforeParens: Never
+
+#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
+#SpaceBeforeRangeBasedForLoopColon: false
+
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+TabWidth: 4
+UseTab: Always

--- a/proj/vs2017/NAS2D.vcxproj
+++ b/proj/vs2017/NAS2D.vcxproj
@@ -301,6 +301,7 @@
     <ClInclude Include="..\..\include\NAS2D\Xml\XmlVisitor.h" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\.clang-format" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/proj/vs2017/NAS2D.vcxproj.filters
+++ b/proj/vs2017/NAS2D.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -272,5 +272,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="..\..\.clang-format" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I loaded a new page and lost all my notes so I'm not going to re-type it all >.<

Suffice to say, clang-format is supported in VS2017 (v6.0) and VS2019 (v7.0). I added the files necessary to uphold the coding conventions documented in CONVENTIONS.md as close as possible. Deviations are commented and commented out for when using the tool in later VS versions.

This will be especially helpful with tabs and brace styles.

See VS blog: https://devblogs.microsoft.com/cppblog/clangformat-support-in-visual-studio-2017-15-7-preview-1/ for more info.