### PR TITLE
Use vcpkg for PhysFS

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,7 @@ platform:
 cache:
   - C:\tools\vcpkg\installed\
   - C:\projects\nas2d-core\proj\vc14\packages -> proj\vc14\packages.config
-before_build: nuget restore proj/vc14
+install:
+  - nuget restore proj/vc14
 build:
   project: proj/vc14/NAS2D.sln

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,9 @@ configuration: Release
 platform:
   - x86
   - x64
+cache:
+  - C:\tools\vcpkg\installed\
+  - C:\projects\nas2d-core\proj\vc14\packages -> proj\vc14\packages.config
 before_build: nuget restore proj/vc14
 build:
   project: proj/vc14/NAS2D.sln

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,7 @@ cache:
   - C:\tools\vcpkg\installed\
   - C:\projects\nas2d-core\proj\vc14\packages -> proj\vc14\packages.config
 install:
+  - vcpkg integrate install
   - vcpkg install physfs:x86-windows
   - vcpkg install physfs:x64-windows
   - nuget restore proj/vc14

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,8 @@ cache:
   - C:\tools\vcpkg\installed\
   - C:\projects\nas2d-core\proj\vc14\packages -> proj\vc14\packages.config
 install:
+  - vcpkg install physfs:x86-windows
+  - vcpkg install physfs:x64-windows
   - nuget restore proj/vc14
 build:
   project: proj/vc14/NAS2D.sln


### PR DESCRIPTION
Install PhysFS 3.0.2 on AppVeyor using `vcpkg`.

----

Note: Any project specific NuGet package installs are likely to override the general environment `vcpkg` installs. As such, you'll want to remove the PhysFS NuGet package from a project to make use of the environment install. That makes this branch dependent on project file updates.

----

I tried removing the PhysFS package from the project in the `vc14/` folder. The AppVeyor build was having trouble finding the `vcpkg` installed version of PhysFS. Locally I was able to build, though was required to also update the targeted platform and toolset. That didn't seem appropriate for this branch, so I left it out, though may explain the difference.
