### PR TITLE
Cache macOS CircleCI installed dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,35 @@
-version: 2.0
-jobs:
-  build:
+version: 2.1
+executors:
+  docker-executor:
     docker:
       - image: outpostuniverse/ubuntu-18.04-gcc-sdl2-physfs-circleci
+  macos-executor:
+    macos:
+      xcode: "10.0.0"
+jobs:
+  build-linux:
+    executor: docker-executor
     steps:
       - checkout
       - run: make -k
+  build-macos:
+    executor: macos-executor
+    steps:
+      - checkout
+      - restore_cache:
+          key: deps-v2-NAS2D-{{ arch }}
+      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf glew
+      - run: brew link physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf glew
+      - run: make -k
+      - save_cache:
+          paths:
+            - /Users/distiller/Library/Caches/Homebrew
+            - /usr/local/Cellar
+          key: deps-v2-NAS2D-{{ arch }}
+          name: Caching brew install deps
+workflows:
+  version: 2
+  linux_macos_build:
+    jobs:
+      - build-linux
+      - build-macos


### PR DESCRIPTION
Successfully cached macOS dependencies.

Build time is now 1 minute or less.

Note, this will not trigger a circleCI build until merged into master because nothing changed between the last commit and the PR creation.

Here's the circleCI macos-build log (along with super fast cached timings!) to verify it works:
https://circleci.com/gh/cugone/nas2d-core/144
