### PR TITLE
Add BuildConfig

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -118,7 +118,7 @@ void someFunction(int foo)
 
 ```
 
-Please note that in all cases braces are used including for simple single line if/for/while blocks. While somewhat verbose this is intended to avoid common mistakes mistakes that are easy to overlook. For example:
+Please note that in all cases braces are used including for simple single line if/for/while blocks. While somewhat verbose this is intended to avoid common mistakes that are easy to overlook. For example:
 
 ```cpp
 

--- a/include/NAS2D/BuildConfig.h
+++ b/include/NAS2D/BuildConfig.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#if defined(__clang__)
+#define PLATFORM_CLANG
+#define PLATFORM_LINUX
+#elif defined(__GNUC__) || defined(__GNUG__)
+#define PLATFORM_GNUC
+#define PLATFORM_LINUX
+#endif
+
+#if defined(__APPLE__)
+#undef PLATFORM_LINUX
+#define PLATFORM_APPLE
+#elif defined(_MSC_VER) || defined(_WIN32) || defined(_WIN64)
+#define PLATFORM_WINDOWS
+#endif

--- a/proj/vs2017/NAS2D.vcxproj
+++ b/proj/vs2017/NAS2D.vcxproj
@@ -136,7 +136,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>../../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -149,7 +149,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -167,7 +167,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Gold|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -187,7 +187,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -204,7 +204,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Gold|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MinSpace</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>false</IntrinsicFunctions>
@@ -255,6 +255,7 @@
     <ClCompile Include="..\..\src\Xml\XmlUnknown.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\include\NAS2D\BuildConfig.h" />
     <ClInclude Include="..\..\include\NAS2D\Common.h" />
     <ClInclude Include="..\..\include\NAS2D\Configuration.h" />
     <ClInclude Include="..\..\include\NAS2D\Delegate.h" />

--- a/proj/vs2017/NAS2D.vcxproj.filters
+++ b/proj/vs2017/NAS2D.vcxproj.filters
@@ -269,6 +269,9 @@
     <ClInclude Include="..\..\include\NAS2D\Xml\XmlMemoryBuffer.h">
       <Filter>Header Files\Xml</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\BuildConfig.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Renderer/OGL_Renderer.cpp
+++ b/src/Renderer/OGL_Renderer.cpp
@@ -235,7 +235,9 @@ void OGL_Renderer::drawImageToImage(Image& source, Image& destination, const Poi
 
 	// Ignore the call if the detination point is outside the bounds of destination image.
 	if (!isRectInRect(dstPoint.x(), dstPoint.y(), source.width(), source.height(), 0, 0, destination.width(), destination.height()))
+	{
 		return;
+	}
 
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 	glBindTexture(GL_TEXTURE_2D, IMAGE_ID_MAP[destination.name()].texture_id);


### PR DESCRIPTION
Added a build config file.

---

This allows for commonly used preproc defines to live in one place.
Examples include:

```
UNUSED:
 - Unused variable does not throw a warning.
 - More explicit and verbose than commenting out
   formal argument names in function implementations.
PLATFORM_LINUX: Linux-specific code
PLATFORM_WINDOWS: Windows-specific code
PLATFORM_APPLE: macOS specific code
TOKEN_STRINGIZE and TOKEN_STRINGIZE_SIMPLE:
 - Easy stringization of nested macros.
 - Useful for __FUNCTION__ and __LINE__ stringize and type names.
TOKEN_PASTE and TOKEN_PASTE_SIMPLE:
 - Concatenation of names and __LINE__ or __FUNCTION__ macros.
SUBSYSTEM_DEBUG:
 - Compiling out subsystem debug code in release builds
   such as AUDIO_DEBUG, RENDER_DEBUG, etc.
 - Compile-time choosing of memory tracking. e.g.
   TRACK_MEMORY/TRACK_MEMORY_VERBOSE/TRACK_MEMORY_BASIC.
   Useful for finding memory leaks in Debug/Release builds
   prior to pushing to Gold or Master build.
```

Right now only the platform-specific defines have been implemented.
