### PR TITLE
Mark constructor as explicit

### DIFF
--- a/test/Utility.test.cpp
+++ b/test/Utility.test.cpp
@@ -12,7 +12,7 @@ TEST(Utility, DefaultConstructibleType) {
 TEST(Utility, NonDefaultConstructibleType) {
 	struct NonDefaultConstructible {
 		NonDefaultConstructible() = delete;
-		NonDefaultConstructible(int) {}
+		explicit NonDefaultConstructible(int) {}
 	};
 
 	NAS2D::Utility<NonDefaultConstructible>::init(0);


### PR DESCRIPTION
Codacy requires constructors with 1 parameter to be marked as explicit.

Normally an `explicit` constructor is to prevent automatic conversions from calling the constructor, such as assigning a new object from an `int`. Admittedly it not of much relevance for the test object here.

----

Side note: I created an account at [Codacy](https://www.codacy.com/) so that my pushes will now trigger Codacy runs. That should help prevent lint warnings from sneaking in without warning.
