### PR TITLE
Add `test` target to Makefile to build unit tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -73,7 +73,7 @@ clean-all:
 
 ## Unit Test project ##
 
-.PHONY: gtest gmock check
+.PHONY: gtest gmock test check
 
 # Either of these should be a complete combined package. Only build one.
 GTESTSRCDIR := /usr/src/gtest/
@@ -113,7 +113,8 @@ TESTDEPFLAGS = -MT $@ -MMD -MP -MF $(TESTOBJDIR)/$*.Td
 TESTCOMPILE.cpp = $(CXX) $(TESTCPPFLAGS) $(TESTDEPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
 TESTPOSTCOMPILE = @mv -f $(TESTOBJDIR)/$*.Td $(TESTOBJDIR)/$*.d && touch $@
 
-check: $(TESTOUTPUT)
+test: $(TESTOUTPUT)
+check: | test
 	cd test && ../$(TESTOUTPUT)
 
 $(TESTOUTPUT): $(TESTOBJS) $(OUTPUT)


### PR DESCRIPTION
This allows building of the test project (`test`) to be separate from running of the unit tests (`check`).

With separate steps the CircleCI run details can create separate output sections. This can become important to separate out as test output grows.
