### PR TITLE
Enable MacOS unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ commands:
   build-and-test:
     steps:
       - run: make --keep-going
+      - run: make --keep-going test
       - run: make --keep-going check
 jobs:
   build-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       - build-googletest
       - checkout
       - run: make --keep-going
-      - run: echo "Testing disabled" || make --keep-going check
+      - run: make --keep-going check
 workflows:
   build_and_test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,21 +59,23 @@ commands:
       - run:
           name: "Install Google Test system wide"
           command: cp -r << parameters.buildPrefix >> << parameters.installPrefix >>
+  build-and-test:
+    steps:
+      - run: make --keep-going
+      - run: make --keep-going check
 jobs:
   build-linux:
     executor: docker-executor
     steps:
       - checkout
-      - run: make --keep-going
-      - run: make --keep-going check
+      - build-and-test
   build-macos:
     executor: macos-executor
     steps:
       - brew-install
       - build-googletest
       - checkout
-      - run: make --keep-going
-      - run: make --keep-going check
+      - build-and-test
 workflows:
   build_and_test:
     jobs:

--- a/makefile
+++ b/makefile
@@ -101,7 +101,7 @@ TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
 TESTCPPFLAGS := -I$(INCDIR) -I$(GMOCKSRCDIR)/gtest/include
 TESTLDFLAGS := -L$(BINDIR) -L$(GMOCKDIR) -L$(GMOCKDIR)/gtest/ -L$(GTESTDIR)
-TESTLIBS := -lnas2d -lgtest -lgtest_main -lpthread -lstdc++fs $(LDLIBS)
+TESTLIBS := -lnas2d -lgtest -lgtest_main -lpthread $(LDLIBS)
 TESTOUTPUT := $(BUILDDIR)/testBin/runTests
 # Conditionally add GMock if we built it separately
 # This is conditional to avoid errors in case the library is not found

--- a/makefile
+++ b/makefile
@@ -24,7 +24,7 @@ SdlDir := $(SdlPackageDir)/$(SdlVer)
 SdlInc := $(SdlDir)/include
 
 CXXFLAGS := -std=c++14 -g -Wall -I$(INCDIR) -I$(SdlInc) $(shell sdl2-config --cflags)
-LDLIBS := -lstdc++ -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGLU -lGL
+LDLIBS := -lstdc++ -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGL
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td
 

--- a/makefile
+++ b/makefile
@@ -24,7 +24,7 @@ SdlDir := $(SdlPackageDir)/$(SdlVer)
 SdlInc := $(SdlDir)/include
 
 CXXFLAGS := -std=c++14 -g -Wall -I$(INCDIR) -I$(SdlInc) $(shell sdl2-config --cflags)
-LDLIBS := -lstdc++ -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lphysfs -lGL
+LDLIBS := -lstdc++ -lphysfs # -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lGL
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td
 


### PR DESCRIPTION
Closes #110. All platforms now run unit tests on CI.
