### PR TITLE
Disable TravisCI branch builds except for master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 
 language: cpp
 
+branches:
+  only:
+    - master
+
 os:
   - linux
   - osx


### PR DESCRIPTION
This should save testing time. The branch builds are already covered by CircleCI. We should probably still build master though, just to keep history of any breaks on master.

Partially addresses #137.
