### PR TITLE
Cache less on MacOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ commands:
           name: Caching brew dependencies
           key: deps-v2-NAS2D-{{ arch }}
           paths:
-            - /Users/distiller/Library/Caches/Homebrew
             - /usr/local/Cellar
       - run: brew link physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf glew
   build-googletest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,11 @@ commands:
     steps:
       - restore_cache:
           name: Restoring brew dependencies
-          key: deps-v2-NAS2D-{{ arch }}
+          key: deps-v3-NAS2D-{{ arch }}
       - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf glew
       - save_cache:
           name: Caching brew dependencies
-          key: deps-v2-NAS2D-{{ arch }}
+          key: deps-v3-NAS2D-{{ arch }}
           paths:
             - /usr/local/Cellar
       - run: brew link physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf glew


### PR DESCRIPTION
Don't cache the package download directory. Only cache the built package directory. This should help reduce cache size, which may speed up the build due to smaller caches and faster cache restore.

One downside is that adjusting the installed package list means all packages have to be re-downloaded and compiled again. This however should be a relatively rare occurrence.
