### PR TITLE
Convert Mixer to Abstract Data Type

### DIFF
--- a/include/NAS2D/Mixer/Mixer.h
+++ b/include/NAS2D/Mixer/Mixer.h
@@ -34,34 +34,34 @@ public:
 	/**
 	 * C'Tor
 	 */
-	Mixer() {}
+	Mixer();
 
 	/**
 	 * D'tor
 	 */
-	virtual ~Mixer() {}
+	virtual ~Mixer() = 0;
 
 	/**
 	 * Plays a sound on the first available sound channel.
 	 *
 	 * \param	sound	A reference to a Sound Resource.
 	 */
-	virtual void playSound(Sound& sound) {}
+	virtual void playSound(Sound& sound);
 
 	/**
 	 * Stops playing all sounds on all channels.
 	 */
-	virtual void stopSound() {}
+	virtual void stopSound();
 
 	/**
 	 * Pauses sound on all channels.
 	 */
-	virtual void pauseSound() {}
+	virtual void pauseSound();
 
 	/**
 	 * Resumes sound on all channels.
 	 */
-	virtual void resumeSound() {}
+	virtual void resumeSound();
 
 	/**
 	 * Starts playing a Music track.
@@ -69,24 +69,24 @@ public:
 	 * \param music	Reference to a Music Resource.
 	 * \param loops	Number of times to repeat the music.
 	 */
-	void playMusic(Music& music, int loops = Mixer::CONTINUOUS) { fadeInMusic(music, loops, 0); }
+	void playMusic(Music& music, int loops = Mixer::CONTINUOUS);
 
 	/**
 	 * Stops all playing music.
 	 */
-	virtual void stopMusic() {}
+	virtual void stopMusic();
 
 	/**
 	 * Pauses the currently playing Music.
 	 */
-	virtual void pauseMusic() {}
+	virtual void pauseMusic();
 
 	/**
 	 * Resumes the currently paused Music.
 	 *
 	 * \note	It is safe to call this function if the music is stopped or already playing.
 	 */
-	virtual void resumeMusic() {}
+	virtual void resumeMusic();
 
 	/**
 	 * Starts a Music track and fades it in to the current Music volume.
@@ -95,71 +95,71 @@ public:
 	 * \param	loops	Number of times the Music should be repeated. -1 for continuous loop.
 	 * \param	time	Time, in miliseconds, for the fade to last. Default is 500.
 	 */
-	virtual void fadeInMusic(Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) {}
+	virtual void fadeInMusic(Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME);
 
 	/**
 	 * Fades out the currently playing Music track.
 	 *
 	 * \param	time	Time, in miliseconds, for the fade to last. Default is 500.
 	 */
-	virtual void fadeOutMusic(int time = Mixer::DEFAULT_FADE_TIME) {}
+	virtual void fadeOutMusic(int time = Mixer::DEFAULT_FADE_TIME);
 
 	/**
 	 * Gets whether or not music is currently playing.
 	 */
-	virtual bool musicPlaying() const { return false; }
+	virtual bool musicPlaying() const;
 
 	/**
 	 * Mutes all audio.
 	 */
-	virtual void mute() {}
+	virtual void mute();
 
 	/**
 	 * Unmutes all audio.
 	 */
-	virtual void unmute() {}
+	virtual void unmute();
 
 	/**
 	 * Stops all music and sound.
 	 */
-	void stopAllAudio() { stopMusic(); stopSound(); }
+	void stopAllAudio();
 
 	/**
 	 * Pauses all music and sound.
 	 */
-	void pauseAllAudio() { pauseMusic(); pauseSound(); }
+	void pauseAllAudio();
 
 	/**
 	 * Resumes all paused music and sound.
 	 */
-	void resumeAllAudio() { resumeMusic(); resumeSound(); }
+	void resumeAllAudio();
 
 	/**
 	 * Sets the sound volume.
 	 *
 	 * \param	level	Volume level to set. Valid values are 0 - 128.
 	 */
-	virtual void soundVolume(int level) {};
+	virtual void soundVolume(int level);;
 
 	/**
 	 * Sets the music volume.
 	 *
 	 * \param	level	Volume level to set. Valid values are 0 - 128.
 	 */
-	virtual void musicVolume(int level) {};
+	virtual void musicVolume(int level);;
 
 	/**
 	 * Gets the name of the Mixer.
 	 *
 	 * \return	A /c std::string containing the name of the Mixer.
 	 */
-	const std::string& name() const { return mName; }
+	const std::string& name() const;
 
 	/**
 	 * Gets a reference to a NAS2D::Signals::Signal0<void>, a signal raised
 	 * when a Music track has finished playing.
 	 */
-	NAS2D::Signals::Signal0<void>& musicComplete() { return _music_complete; }
+	NAS2D::Signals::Signal0<void>& musicComplete();
 
 protected:
 	/**
@@ -167,11 +167,9 @@ protected:
 	 *
 	 * This c'tor is not public and can't be invoked externally.
 	 */
-	Mixer(const std::string& name) : mName(name)
-	{}
+	Mixer(const std::string& name);
 
-protected:
-	NAS2D::Signals::Signal0<void>	_music_complete; /**< Callback used when music finished playing. */
+    NAS2D::Signals::Signal0<void>	_music_complete; /**< Callback used when music finished playing. */
 
 private:
 	// No default copy constructor or copy operator
@@ -179,8 +177,7 @@ private:
 	Mixer(const Mixer&) = delete;
 	Mixer& operator=(const Mixer&) = delete;
 
-private:
-	std::string		mName;		/**< Internal name of the Renderer. */
+    std::string		mName;		/**< Internal name of the Renderer. */
 };
 
 } // namespace

--- a/include/NAS2D/Mixer/NullMixer.h
+++ b/include/NAS2D/Mixer/NullMixer.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "NAS2D/Mixer/Mixer.h"
+
+namespace NAS2D
+{
+
+	class NullMixer : public Mixer
+	{
+	  public:
+		NullMixer() = default;
+		NullMixer(const NullMixer& other) = default;
+		NullMixer(NullMixer&& other) = default;
+		NullMixer& operator=(const NullMixer& other) = default;
+		NullMixer& operator=(NullMixer&& other) = default;
+		virtual ~NullMixer() = default;
+
+
+virtual void playSound(Sound& sound) override;
+
+
+virtual void stopSound() override;
+
+
+virtual void pauseSound() override;
+
+
+virtual void resumeSound() override;
+
+
+virtual void stopMusic() override;
+
+
+virtual void pauseMusic() override;
+
+
+virtual void resumeMusic() override;
+
+
+virtual void fadeInMusic(Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) override;
+
+
+virtual void fadeOutMusic(int time = Mixer::DEFAULT_FADE_TIME) override;
+
+
+virtual bool musicPlaying() const override;
+
+
+virtual void mute() override;
+
+
+virtual void unmute() override;
+
+
+virtual void soundVolume(int level) override;
+
+
+virtual void musicVolume(int level) override;
+
+protected:
+private:
+	};
+
+} // namespace NAS2D

--- a/include/NAS2D/Mixer/NullMixer.h
+++ b/include/NAS2D/Mixer/NullMixer.h
@@ -15,50 +15,36 @@ namespace NAS2D
 		NullMixer& operator=(NullMixer&& other) = default;
 		virtual ~NullMixer() = default;
 
+		virtual void playSound(Sound& sound) override;
 
-virtual void playSound(Sound& sound) override;
+		virtual void stopSound() override;
 
+		virtual void pauseSound() override;
 
-virtual void stopSound() override;
+		virtual void resumeSound() override;
 
+		virtual void stopMusic() override;
 
-virtual void pauseSound() override;
+		virtual void pauseMusic() override;
 
+		virtual void resumeMusic() override;
 
-virtual void resumeSound() override;
+		virtual void fadeInMusic(Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) override;
 
+		virtual void fadeOutMusic(int time = Mixer::DEFAULT_FADE_TIME) override;
 
-virtual void stopMusic() override;
+		virtual bool musicPlaying() const override;
 
+		virtual void mute() override;
 
-virtual void pauseMusic() override;
+		virtual void unmute() override;
 
+		virtual void soundVolume(int level) override;
 
-virtual void resumeMusic() override;
+		virtual void musicVolume(int level) override;
 
-
-virtual void fadeInMusic(Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) override;
-
-
-virtual void fadeOutMusic(int time = Mixer::DEFAULT_FADE_TIME) override;
-
-
-virtual bool musicPlaying() const override;
-
-
-virtual void mute() override;
-
-
-virtual void unmute() override;
-
-
-virtual void soundVolume(int level) override;
-
-
-virtual void musicVolume(int level) override;
-
-protected:
-private:
+	  protected:
+	  private:
 	};
 
 } // namespace NAS2D

--- a/proj/vs2019/NAS2D.vcxproj
+++ b/proj/vs2019/NAS2D.vcxproj
@@ -234,7 +234,9 @@
     <ClCompile Include="..\..\src\Filesystem.cpp" />
     <ClCompile Include="..\..\src\FpsCounter.cpp" />
     <ClCompile Include="..\..\src\Game.cpp" />
+    <ClCompile Include="..\..\src\Mixer\Mixer.cpp" />
     <ClCompile Include="..\..\src\Mixer\Mixer_SDL.cpp" />
+    <ClCompile Include="..\..\src\Mixer\NullMixer.cpp" />
     <ClCompile Include="..\..\src\Renderer\OGL_Renderer.cpp" />
     <ClCompile Include="..\..\src\Renderer\Primitives.cpp" />
     <ClCompile Include="..\..\src\Renderer\Renderer.cpp" />
@@ -273,6 +275,7 @@
     <ClInclude Include="..\..\include\NAS2D\Game.h" />
     <ClInclude Include="..\..\include\NAS2D\Mixer\Mixer.h" />
     <ClInclude Include="..\..\include\NAS2D\Mixer\Mixer_SDL.h" />
+    <ClInclude Include="..\..\include\NAS2D\Mixer\NullMixer.h" />
     <ClInclude Include="..\..\include\NAS2D\NAS2D.h" />
     <ClInclude Include="..\..\include\NAS2D\Renderer\OGL_Renderer.h" />
     <ClInclude Include="..\..\include\NAS2D\Renderer\Primitives.h" />

--- a/proj/vs2019/NAS2D.vcxproj.filters
+++ b/proj/vs2019/NAS2D.vcxproj.filters
@@ -135,6 +135,12 @@
     <ClCompile Include="..\..\src\Xml\XmlNode.cpp">
       <Filter>Source Files\Xml</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Mixer\Mixer.cpp">
+      <Filter>Source Files\Mixer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Mixer\NullMixer.cpp">
+      <Filter>Source Files\Mixer</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\NAS2D\Common.h">
@@ -268,6 +274,9 @@
     </ClInclude>
     <ClInclude Include="..\..\include\NAS2D\Xml\XmlMemoryBuffer.h">
       <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Mixer\NullMixer.h">
+      <Filter>Header Files\Mixer</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -15,6 +15,7 @@
 #include "NAS2D/Game.h"
 #include "NAS2D/Utility.h"
 
+#include "NAS2D/Mixer/NullMixer.h"
 #include "NAS2D/Mixer/Mixer_SDL.h"
 #include "NAS2D/Renderer/OGL_Renderer.h"
 
@@ -55,7 +56,7 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 	catch (std::exception& e)
 	{
 		std::cout << "Unable to create SDL Audio Mixer: " << e.what() << ". Setting NULL driver." << std::endl;
-		Utility<Mixer>::init();
+		Utility<Mixer>::init<NullMixer>();
 	}
 	catch (...)
 	{

--- a/src/Mixer/Mixer.cpp
+++ b/src/Mixer/Mixer.cpp
@@ -1,0 +1,109 @@
+#include "NAS2D/Mixer/Mixer.h"
+
+namespace NAS2D
+{
+
+	Mixer::Mixer(const std::string& name)
+	: mName(name)
+	{
+	}
+
+	Mixer::Mixer()
+	{
+	}
+
+	Mixer::~Mixer()
+	{
+	}
+
+	void Mixer::playSound(Sound& /*sound*/)
+	{
+	}
+
+	void Mixer::stopSound()
+	{
+	}
+
+	void Mixer::pauseSound()
+	{
+	}
+
+	void Mixer::resumeSound()
+	{
+	}
+
+	void Mixer::playMusic(Music& music, int loops /*= Mixer::CONTINUOUS*/)
+	{
+		fadeInMusic(music, loops, 0);
+	}
+
+	void Mixer::stopMusic()
+	{
+	}
+
+	void Mixer::pauseMusic()
+	{
+	}
+
+	void Mixer::resumeMusic()
+	{
+	}
+
+	void Mixer::fadeInMusic(Music& /*music*/, int /*loops*/ /*= Mixer::CONTINUOUS*/, int /*time*/ /*= Mixer::DEFAULT_FADE_TIME*/)
+	{
+	}
+
+	void Mixer::fadeOutMusic(int /*time*/ /*= Mixer::DEFAULT_FADE_TIME*/)
+	{
+	}
+
+	bool Mixer::musicPlaying() const
+	{
+		return false;
+	}
+
+	void Mixer::mute()
+	{
+	}
+
+	void Mixer::unmute()
+	{
+	}
+
+	void Mixer::stopAllAudio()
+	{
+		stopMusic();
+		stopSound();
+	}
+
+	void Mixer::pauseAllAudio()
+	{
+		pauseMusic();
+		pauseSound();
+	}
+
+	void Mixer::resumeAllAudio()
+	{
+		resumeMusic();
+		resumeSound();
+	}
+
+	void Mixer::soundVolume(int /*level*/)
+	{
+	}
+
+	void Mixer::musicVolume(int /*level*/)
+	{
+	}
+
+	const std::string& Mixer::name() const
+	{
+		return mName;
+	}
+
+	Signals::Signal0<void>& Mixer::musicComplete()
+	{
+		return _music_complete;
+	}
+
+} // namespace NAS2D

--- a/src/Mixer/NullMixer.cpp
+++ b/src/Mixer/NullMixer.cpp
@@ -1,0 +1,50 @@
+#include "NAS2D/Mixer/NullMixer.h"
+
+namespace NAS2D
+{
+
+	void NullMixer::playSound(Sound& /*sound*/)
+	{}
+
+	void NullMixer::stopSound()
+	{}
+
+	void NullMixer::pauseSound()
+	{}
+
+	void NullMixer::resumeSound()
+	{}
+
+	void NullMixer::stopMusic()
+	{}
+
+	void NullMixer::pauseMusic()
+	{}
+
+	void NullMixer::resumeMusic()
+	{}
+
+	void NullMixer::fadeInMusic(Music& /*music*/, int /*loops*/ /*= Mixer::CONTINUOUS*/, int /*time*/ /*= Mixer::DEFAULT_FADE_TIME*/)
+	{}
+
+	void NullMixer::fadeOutMusic(int /*time*/ /*= Mixer::DEFAULT_FADE_TIME*/)
+	{}
+
+	bool NullMixer::musicPlaying() const
+	{
+		return false;
+	}
+
+	void NullMixer::mute()
+	{}
+
+	void NullMixer::unmute()
+	{}
+
+	void NullMixer::soundVolume(int /*level*/)
+	{}
+
+	void NullMixer::musicVolume(int /*level*/)
+	{}
+
+} // namespace NAS2D


### PR DESCRIPTION
Converted Mixer to an Abstract Data Type.
It contains data and non-virtual member functions
so calling it an "interface" is a misnomer.

Derived NullMixer from Mixer ADT

Updated Non-compiling usage of plain Mixer to
NullMixer when audio driver fails to load.

Added NullMixer header and implementation to project files.