### PR TITLE
Resolve delegate warnings

### DIFF
--- a/include/NAS2D/Delegate.h
+++ b/include/NAS2D/Delegate.h
@@ -348,7 +348,7 @@ public:
 #else
 
 	template<class DerivedClass>
-	inline void CopyFrom(DerivedClass *pParent, const DelegateMemento &right) { SetMementoFrom(right); }
+	inline void CopyFrom(DerivedClass*, const DelegateMemento &right) { SetMementoFrom(right); }
 
 	template <class DerivedClass, class ParentInvokerSig>
 	inline void bindstaticfunc(DerivedClass *pParent, ParentInvokerSig static_function_invoker, StaticFuncPtr function_to_bind)

--- a/include/NAS2D/Delegate.h
+++ b/include/NAS2D/Delegate.h
@@ -330,7 +330,7 @@ public:
 #if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
 
 public:
-	template< lass DerivedClass>
+	template<class DerivedClass>
 	inline void CopyFrom(DerivedClass *pParent, const DelegateMemento &x)
 	{
 		SetMementoFrom(x);


### PR DESCRIPTION
Removed unused parameter name to resolve Warning C4100.

Also noticed an apparent typo in a non-active `#if` block. That's one of the dangers of `#if`. Code inside them is not seen nor checked by the compiler.
