### PR TITLE
Cherry pick Mixer changes from cugone's work

### DIFF
--- a/include/NAS2D/Mixer/Mixer.h
+++ b/include/NAS2D/Mixer/Mixer.h
@@ -69,7 +69,7 @@ public:
 	 * \param music	Reference to a Music Resource.
 	 * \param loops	Number of times to repeat the music.
 	 */
-	void playMusic(Music& music, int loops = Mixer::CONTINUOUS) { fadeInMusic(music, loops, 0); }
+	void playMusic(Music& music, int loops = Mixer::CONTINUOUS);
 
 	/**
 	 * Stops all playing music.
@@ -122,17 +122,17 @@ public:
 	/**
 	 * Stops all music and sound.
 	 */
-	void stopAllAudio() { stopMusic(); stopSound(); }
+	void stopAllAudio();
 
 	/**
 	 * Pauses all music and sound.
 	 */
-	void pauseAllAudio() { pauseMusic(); pauseSound(); }
+	void pauseAllAudio();
 
 	/**
 	 * Resumes all paused music and sound.
 	 */
-	void resumeAllAudio() { resumeMusic(); resumeSound(); }
+	void resumeAllAudio();
 
 	/**
 	 * Sets the sound volume.
@@ -153,13 +153,13 @@ public:
 	 *
 	 * \return	A /c std::string containing the name of the Mixer.
 	 */
-	const std::string& name() const { return mName; }
+	const std::string& name() const;
 
 	/**
 	 * Gets a reference to a NAS2D::Signals::Signal0<void>, a signal raised
 	 * when a Music track has finished playing.
 	 */
-	NAS2D::Signals::Signal0<void>& musicComplete() { return _music_complete; }
+	NAS2D::Signals::Signal0<void>& musicComplete();
 
 protected:
 	/**
@@ -167,8 +167,7 @@ protected:
 	 *
 	 * This c'tor is not public and can't be invoked externally.
 	 */
-	Mixer(const std::string& name) : mName(name)
-	{}
+	Mixer(const std::string& name);
 
 protected:
 	NAS2D::Signals::Signal0<void>	_music_complete; /**< Callback used when music finished playing. */

--- a/include/NAS2D/Mixer/MixerNull.h
+++ b/include/NAS2D/Mixer/MixerNull.h
@@ -21,27 +21,27 @@ public:
 	~MixerNull() = default;
 
 	// Sound Functions
-	void playSound(Sound&) override {}
-	void stopSound() override {}
-	void pauseSound() override {}
-	void resumeSound() override {}
+	void playSound(Sound& sound) override;
+	void stopSound() override;
+	void pauseSound() override;
+	void resumeSound() override;
 
 	// Music Functions
-	void stopMusic() override {}
-	void pauseMusic() override {}
-	void resumeMusic() override {}
+	void stopMusic() override;
+	void pauseMusic() override;
+	void resumeMusic() override;
 
-	void fadeInMusic(Music&, int, int) override {}
-	void fadeOutMusic(int) override {}
+	void fadeInMusic(Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) override;
+	void fadeOutMusic(int time = Mixer::DEFAULT_FADE_TIME) override;
 
-	bool musicPlaying() const override { return false; }
+	bool musicPlaying() const override;
 
 	// Global Functions
-	void soundVolume(int) override {}
-	void musicVolume(int) override {}
+	void soundVolume(int level) override;
+	void musicVolume(int level) override;
 
-	void mute() override {}
-	void unmute() override {}
+	void mute() override;
+	void unmute() override;
 };
 
 }

--- a/proj/vs2017/NAS2D.vcxproj
+++ b/proj/vs2017/NAS2D.vcxproj
@@ -228,6 +228,8 @@
     <ClCompile Include="..\..\src\Filesystem.cpp" />
     <ClCompile Include="..\..\src\FpsCounter.cpp" />
     <ClCompile Include="..\..\src\Game.cpp" />
+    <ClCompile Include="..\..\src\Mixer\Mixer.cpp" />
+    <ClCompile Include="..\..\src\Mixer\MixerNull.cpp" />
     <ClCompile Include="..\..\src\Mixer\Mixer_SDL.cpp" />
     <ClCompile Include="..\..\src\Renderer\OGL_Renderer.cpp" />
     <ClCompile Include="..\..\src\Renderer\Primitives.cpp" />

--- a/proj/vs2017/NAS2D.vcxproj.filters
+++ b/proj/vs2017/NAS2D.vcxproj.filters
@@ -135,6 +135,12 @@
     <ClCompile Include="..\..\src\Xml\XmlNode.cpp">
       <Filter>Source Files\Xml</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Mixer\Mixer.cpp">
+      <Filter>Source Files\Mixer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Mixer\MixerNull.cpp">
+      <Filter>Source Files\Mixer</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\NAS2D\Common.h">

--- a/proj/vs2019/NAS2D.vcxproj
+++ b/proj/vs2019/NAS2D.vcxproj
@@ -234,6 +234,8 @@
     <ClCompile Include="..\..\src\Filesystem.cpp" />
     <ClCompile Include="..\..\src\FpsCounter.cpp" />
     <ClCompile Include="..\..\src\Game.cpp" />
+    <ClCompile Include="..\..\src\Mixer\Mixer.cpp" />
+    <ClCompile Include="..\..\src\Mixer\MixerNull.cpp" />
     <ClCompile Include="..\..\src\Mixer\Mixer_SDL.cpp" />
     <ClCompile Include="..\..\src\Renderer\OGL_Renderer.cpp" />
     <ClCompile Include="..\..\src\Renderer\Primitives.cpp" />

--- a/proj/vs2019/NAS2D.vcxproj.filters
+++ b/proj/vs2019/NAS2D.vcxproj.filters
@@ -135,6 +135,12 @@
     <ClCompile Include="..\..\src\Xml\XmlNode.cpp">
       <Filter>Source Files\Xml</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Mixer\Mixer.cpp">
+      <Filter>Source Files\Mixer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Mixer\MixerNull.cpp">
+      <Filter>Source Files\Mixer</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\NAS2D\Common.h">
@@ -271,6 +277,9 @@
     </ClInclude>
     <ClInclude Include="..\..\include\NAS2D\Xml\XmlMemoryBuffer.h">
       <Filter>Header Files\Xml</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Mixer\MixerNull.h">
+      <Filter>Header Files\Mixer</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Mixer/Mixer.cpp
+++ b/src/Mixer/Mixer.cpp
@@ -1,0 +1,42 @@
+#include "NAS2D/Mixer/Mixer.h"
+
+using namespace NAS2D;
+
+
+Mixer::Mixer(const std::string& name)
+: mName(name)
+{
+}
+
+void Mixer::playMusic(Music& music, int loops /*= Mixer::CONTINUOUS*/)
+{
+	fadeInMusic(music, loops, 0);
+}
+
+void Mixer::stopAllAudio()
+{
+	stopMusic();
+	stopSound();
+}
+
+void Mixer::pauseAllAudio()
+{
+	pauseMusic();
+	pauseSound();
+}
+
+void Mixer::resumeAllAudio()
+{
+	resumeMusic();
+	resumeSound();
+}
+
+const std::string& Mixer::name() const
+{
+	return mName;
+}
+
+Signals::Signal0<void>& Mixer::musicComplete()
+{
+	return _music_complete;
+}

--- a/src/Mixer/MixerNull.cpp
+++ b/src/Mixer/MixerNull.cpp
@@ -1,0 +1,48 @@
+#include "NAS2D/Mixer/MixerNull.h"
+
+using namespace NAS2D;
+
+
+void MixerNull::playSound(Sound& /*sound*/)
+{}
+
+void MixerNull::stopSound()
+{}
+
+void MixerNull::pauseSound()
+{}
+
+void MixerNull::resumeSound()
+{}
+
+void MixerNull::stopMusic()
+{}
+
+void MixerNull::pauseMusic()
+{}
+
+void MixerNull::resumeMusic()
+{}
+
+void MixerNull::fadeInMusic(Music& /*music*/, int /*loops*/ /*= Mixer::CONTINUOUS*/, int /*time*/ /*= Mixer::DEFAULT_FADE_TIME*/)
+{}
+
+void MixerNull::fadeOutMusic(int /*time*/ /*= Mixer::DEFAULT_FADE_TIME*/)
+{}
+
+bool MixerNull::musicPlaying() const
+{
+	return false;
+}
+
+void MixerNull::mute()
+{}
+
+void MixerNull::unmute()
+{}
+
+void MixerNull::soundVolume(int /*level*/)
+{}
+
+void MixerNull::musicVolume(int /*level*/)
+{}


### PR DESCRIPTION
This copies the separation of Mixer into .h and .cpp files. This also brings back the parameter names in the .h file.

Point taken that the Mixer base type contains some non-virtual member functions, so isn't really a true "interface".

I've edited the work to account for my naming difference, plus some style updates so the code more closely matches existing style (for better or worse). It's possible I've introduced some unintended errors, though I did try to check carefully, and local tests were passing.

Original work is from PR #166, and has been based on top of #167. This is an attempt to (subjectively) merge the best of both.

----

The new .cpp files don't currently have a copyright header. I'm not sure it's appropriate for me to edit that, so I leave it to @cugone or @ldicker83 to decide what to do there.
