### PR TITLE
Add filesystem unit tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,8 @@ install:
   - vcpkg install physfs:x64-windows
   - vcpkg install glew:x86-windows
   - vcpkg install glew:x64-windows
+  - vcpkg install gtest:x86-windows
+  - vcpkg install gtest:x64-windows
   - nuget restore proj/vs2019
 build:
   project: proj/vs2019/NAS2D.sln

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,4 +18,5 @@ install:
 build:
   project: proj/vs2019/NAS2D.sln
 test_script:
+  - cd %APPVEYOR_BUILD_FOLDER%\test
   - '%APPVEYOR_BUILD_FOLDER%\test\%PLATFORM%\%CONFIGURATION%\test.exe'

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -47,7 +47,6 @@ Filesystem::Filesystem(): mVerbose(false)
 Filesystem::~Filesystem()
 {
 	if (PHYSFS_isInit()) { PHYSFS_deinit(); }
-	std::cout << "Filesystem Terminated." << std::endl;
 }
 
 
@@ -57,8 +56,6 @@ Filesystem::~Filesystem()
 void Filesystem::init(const std::string& argv_0, const std::string& appName, const std::string& organizationName, const std::string& dataPath)
 {
 	if (PHYSFS_isInit()) { throw filesystem_already_initialized(); }
-
-	std::cout << "Initializing Filesystem... ";
 
 	if (PHYSFS_init(argv_0.c_str()) == 0)
 	{
@@ -75,8 +72,6 @@ void Filesystem::init(const std::string& argv_0, const std::string& appName, con
 	{
 		std::cout << std::endl << "(FSYS) Couldn't find data path '" << mDataPath << "'. " << getLastPhysfsError() << "." << std::endl;
 	}
-
-	std::cout << "done." << std::endl;
 }
 
 

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -85,3 +85,19 @@ TEST_F(FilesystemTest, writeReadDeleteExists) {
 	fs.del(testFilename);
 	EXPECT_FALSE(fs.exists(testFilename));
 }
+
+TEST_F(FilesystemTest, isDirectoryMakeDirectory) {
+	const std::string fileName = "file.txt";
+	const std::string folderName = "subfolder/";
+
+	EXPECT_TRUE(fs.exists(fileName));
+	EXPECT_FALSE(fs.isDirectory(fileName));
+
+	fs.makeDirectory(folderName);
+	EXPECT_TRUE(fs.exists(folderName));
+	EXPECT_TRUE(fs.isDirectory(folderName));
+
+	fs.del(folderName);
+	EXPECT_FALSE(fs.exists(folderName));
+	EXPECT_FALSE(fs.isDirectory(folderName));
+}

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -48,7 +48,31 @@ TEST_F(FilesystemTest, directoryList) {
 	EXPECT_THAT(pathList, Contains(testing::StrEq("file.txt")));
 }
 
+TEST_F(FilesystemTest, exists) {
+	EXPECT_TRUE(fs.exists("file.txt"));
+}
+
 TEST_F(FilesystemTest, open) {
 	const auto file = fs.open("file.txt");
 	EXPECT_EQ("Test data\n", file.bytes());
+}
+
+// Test a few related methods. Some don't test well standalone.
+TEST_F(FilesystemTest, writeReadDeleteExists) {
+	const std::string testFilename = "TestFile.txt";
+	const std::string testData = "Test file contents";
+	const auto file = NAS2D::File(testData, testFilename);
+
+	EXPECT_TRUE(fs.write(file));
+	EXPECT_TRUE(fs.exists(testFilename));
+
+	// Try to overwrite file, with and without permission
+	EXPECT_TRUE(fs.write(file));
+	EXPECT_FALSE(fs.write(file, false));
+
+	const auto fileRead = fs.open(testFilename);
+	EXPECT_EQ(testData, fileRead.bytes());
+
+	fs.del(testFilename);
+	EXPECT_FALSE(fs.exists(testFilename));
 }

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -33,8 +33,9 @@ TEST_F(FilesystemTest, extension) {
 	EXPECT_EQ("txt", fs.extension("file.txt"));
 	EXPECT_EQ("reallyLongExtensionName", fs.extension("file.reallyLongExtensionName"));
 	EXPECT_EQ("a", fs.extension("file.a"));
-	EXPECT_EQ("", fs.extension("file."));
 	EXPECT_EQ("file", fs.extension(".file"));
+	EXPECT_EQ("", fs.extension("file."));
+	EXPECT_EQ("", fs.extension("file"));
 }
 
 TEST_F(FilesystemTest, workingPath) {

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -28,6 +28,15 @@ TEST_F(FilesystemTest, dataPath) {
 	EXPECT_EQ("data/", fs.dataPath());
 }
 
+TEST_F(FilesystemTest, extension) {
+	EXPECT_EQ("txt", fs.extension("subdir/file.txt"));
+	EXPECT_EQ("txt", fs.extension("file.txt"));
+	EXPECT_EQ("reallyLongExtensionName", fs.extension("file.reallyLongExtensionName"));
+	EXPECT_EQ("a", fs.extension("file.a"));
+	EXPECT_EQ("", fs.extension("file."));
+	EXPECT_EQ("file", fs.extension(".file"));
+}
+
 TEST_F(FilesystemTest, workingPath) {
 	EXPECT_EQ("data/", fs.workingPath("data/file.extension"));
 	EXPECT_EQ("data/subfolder/", fs.workingPath("data/subfolder/file.extension"));

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -1,5 +1,6 @@
 #include "NAS2D/Filesystem.h"
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 
 TEST(Filesystem, ConstructDestruct) {
@@ -32,4 +33,17 @@ TEST_F(FilesystemTest, workingPath) {
 	EXPECT_EQ("data/subfolder/", fs.workingPath("data/subfolder/file.extension"));
 	EXPECT_EQ("anotherFolder/", fs.workingPath("anotherFolder/file.extension"));
 	EXPECT_EQ("", fs.workingPath("file.extension"));
+}
+
+TEST_F(FilesystemTest, searchPath) {
+	auto pathList = fs.searchPath();
+	EXPECT_EQ(3, pathList.size());
+	EXPECT_THAT(pathList, Contains(testing::HasSubstr("NAS2DUnitTests/")));
+	EXPECT_THAT(pathList, Contains(testing::HasSubstr("data/")));
+}
+
+TEST_F(FilesystemTest, directoryList) {
+	auto pathList = fs.directoryList("");
+	EXPECT_LE(1, pathList.size());
+	EXPECT_THAT(pathList, Contains(testing::StrEq("file.txt")));
 }

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -48,7 +48,7 @@ TEST_F(FilesystemTest, workingPath) {
 TEST_F(FilesystemTest, searchPath) {
 	auto pathList = fs.searchPath();
 	EXPECT_EQ(3, pathList.size());
-	EXPECT_THAT(pathList, Contains(testing::HasSubstr("NAS2DUnitTests/")));
+	EXPECT_THAT(pathList, Contains(testing::HasSubstr("NAS2DUnitTests")));
 	EXPECT_THAT(pathList, Contains(testing::HasSubstr("data/")));
 }
 

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -101,3 +101,15 @@ TEST_F(FilesystemTest, isDirectoryMakeDirectory) {
 	EXPECT_FALSE(fs.exists(folderName));
 	EXPECT_FALSE(fs.isDirectory(folderName));
 }
+
+TEST_F(FilesystemTest, mount) {
+	const std::string extraMount = "extraData/";
+	const std::string extraFile = "extraFile.txt";
+
+	EXPECT_FALSE(fs.exists(extraFile));
+	EXPECT_TRUE(fs.mount(extraMount));
+	EXPECT_THAT(fs.searchPath(), Contains(testing::HasSubstr(extraMount)));
+	EXPECT_TRUE(fs.exists(extraFile));
+
+	EXPECT_FALSE(fs.mount("nonExistentPath/"));
+}

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -11,3 +11,25 @@ TEST(Filesystem, Init) {
 	NAS2D::Filesystem fs;
 	EXPECT_NO_THROW(fs.init("", "NAS2DUnitTests", "LairWorks", "./"));
 }
+
+
+class FilesystemTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		fs.init("", "NAS2DUnitTests", "LairWorks", "data/");
+	}
+
+	NAS2D::Filesystem fs;
+};
+
+
+TEST_F(FilesystemTest, dataPath) {
+	EXPECT_EQ("data/", fs.dataPath());
+}
+
+TEST_F(FilesystemTest, workingPath) {
+	EXPECT_EQ("data/", fs.workingPath("data/file.extension"));
+	EXPECT_EQ("data/subfolder/", fs.workingPath("data/subfolder/file.extension"));
+	EXPECT_EQ("anotherFolder/", fs.workingPath("anotherFolder/file.extension"));
+	EXPECT_EQ("", fs.workingPath("file.extension"));
+}

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -47,3 +47,8 @@ TEST_F(FilesystemTest, directoryList) {
 	EXPECT_LE(1, pathList.size());
 	EXPECT_THAT(pathList, Contains(testing::StrEq("file.txt")));
 }
+
+TEST_F(FilesystemTest, open) {
+	const auto file = fs.open("file.txt");
+	EXPECT_EQ("Test data\n", file.bytes());
+}

--- a/test/data/extraData/extraFile.txt
+++ b/test/data/extraData/extraFile.txt
@@ -1,0 +1,1 @@
+Some extra test data

--- a/test/data/file.txt
+++ b/test/data/file.txt
@@ -1,0 +1,1 @@
+Test data

--- a/test/packages.config
+++ b/test/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1" targetFramework="native" />
-</packages>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -51,30 +51,24 @@
     <ClCompile Include="Utility.test.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\proj\vs2019\NAS2D.vcxproj">
       <Project>{3350562d-6204-42fc-898a-c85fd62e04e8}</Project>
     </ProjectReference>
   </ItemGroup>
   <ItemDefinitionGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\proj\vs2017\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\proj\vs2017\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
-    <Import Project="..\proj\vs2019\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\proj\vs2019\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
-  </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>GTEST_LINKED_AS_SHARED_LIBRARY;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
+      <AdditionalDependencies>gtest.lib;gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -82,7 +76,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>GTEST_LINKED_AS_SHARED_LIBRARY;X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -90,6 +84,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
+      <AdditionalDependencies>gtest.lib;gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -97,13 +92,14 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>GTEST_LINKED_AS_SHARED_LIBRARY;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
+      <AdditionalDependencies>gtest.lib;gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -112,7 +108,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>GTEST_LINKED_AS_SHARED_LIBRARY;X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -121,16 +117,11 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
+      <AdditionalDependencies>gtest.lib;gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
   </ItemDefinitionGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\proj\vs2019\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\proj\vs2019\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
-  </Target>
 </Project>


### PR DESCRIPTION
This closes #175.

Note that in the last test added for `mount`, I believe the behavior is buggy. I added the test to describe the current behavior. We should consider updating it to reflect intended behavior. I believe it should allow mounting of any arbitrary additional folder from the filesystem, rather than being restricted to a subfolder of the initial data folder (which is already a subfolder of the executable's folder).

In general, we should start a discussion on what we want from the Filesystem layer.

I'm actually wondering if perhaps it should be split to separate out real filesystem concerns from virtual filesystem concerns. For example, the executable's path/name, or the application write folder for the current platform would be real filesystem concerns. They affect the choice of mount points. Whereas reading and writing withing the data folders is a virtual filesystem concern.

----

Another thought I had, is the verbose logging should probably be removed, and instead replaced by unit tests or exceptions. Some seem to be debugging related, and just provide textual confirmation of what is happening. These should become unit tests. Some are for feedback to the caller, and are often associated with an error code. These should be converted to exceptions.
