### PR TITLE
Add String utility functions

### DIFF
--- a/include/NAS2D/Common.h
+++ b/include/NAS2D/Common.h
@@ -36,8 +36,8 @@ int divideUp(int to_divide, int divisor);
 
 
 // String functions & types
-std::string toLowercase(const std::string& str);
-std::string toUppercase(const std::string& str);
+std::string toLowercase(std::string str);
+std::string toUppercase(std::string str);
 std::vector<std::string> split(std::string str, char delim = ',', bool skip_empty = true);
 std::string join(std::vector<std::string> strs, char delim, bool skip_empty = true);
 std::string join(std::vector<std::string> strs, bool skip_empty = true);

--- a/include/NAS2D/Common.h
+++ b/include/NAS2D/Common.h
@@ -47,6 +47,8 @@ std::string join(std::vector<std::string> strs, bool skip_empty = true);
 std::string trimWhitespace(std::string string);
 bool startsWith(const std::string& string, const std::string& start);
 bool endsWith(const std::string& string, const std::string& end);
+bool startsWith(const std::string& string, char start);
+bool endsWith(const std::string& string, char end);
 
 /**
  * Simple helper function to provide a printf like function.

--- a/include/NAS2D/Common.h
+++ b/include/NAS2D/Common.h
@@ -39,6 +39,8 @@ int divideUp(int to_divide, int divisor);
 std::string toLowercase(const std::string& str);
 std::string toUppercase(const std::string& str);
 std::vector<std::string> split(std::string str, char delim = ',', bool skip_empty = true);
+std::string join(std::vector<std::string> strs, char delim, bool skip_empty = true);
+std::string join(std::vector<std::string> strs, bool skip_empty = true);
 
 /**
  * Simple helper function to provide a printf like function.

--- a/include/NAS2D/Common.h
+++ b/include/NAS2D/Common.h
@@ -45,8 +45,8 @@ std::pair<std::string, std::string> splitOnLast(const std::string& str, char del
 std::string join(std::vector<std::string> strs, char delim, bool skip_empty = true);
 std::string join(std::vector<std::string> strs, bool skip_empty = true);
 std::string trimWhitespace(std::string string);
-bool startsWith(const std::string& string, const std::string& start);
-bool endsWith(const std::string& string, const std::string& end);
+bool startsWith(const std::string& string, const std::string& start) noexcept;
+bool endsWith(const std::string& string, const std::string& end) noexcept;
 bool startsWith(const std::string& string, char start);
 bool endsWith(const std::string& string, char end);
 

--- a/include/NAS2D/Common.h
+++ b/include/NAS2D/Common.h
@@ -62,6 +62,6 @@ std::string string_format(const std::string& format, Args ... args)
  * The StringList is provided primarily as a convenience typedef
  * but is also used by some of NAS2D's functions.
  */
-typedef std::vector<std::string> StringList;
+using StringList = std::vector<std::string>;
 
 }

--- a/include/NAS2D/Common.h
+++ b/include/NAS2D/Common.h
@@ -45,6 +45,8 @@ std::pair<std::string, std::string> splitOnLast(const std::string& str, char del
 std::string join(std::vector<std::string> strs, char delim, bool skip_empty = true);
 std::string join(std::vector<std::string> strs, bool skip_empty = true);
 std::string trimWhitespace(std::string string);
+bool startsWith(const std::string& string, const std::string& start);
+bool endsWith(const std::string& string, const std::string& end);
 
 /**
  * Simple helper function to provide a printf like function.

--- a/include/NAS2D/Common.h
+++ b/include/NAS2D/Common.h
@@ -44,6 +44,7 @@ std::pair<std::string, std::string> splitOnFirst(const std::string& str, char de
 std::pair<std::string, std::string> splitOnLast(const std::string& str, char delim);
 std::string join(std::vector<std::string> strs, char delim, bool skip_empty = true);
 std::string join(std::vector<std::string> strs, bool skip_empty = true);
+std::string trimWhitespace(std::string string);
 
 /**
  * Simple helper function to provide a printf like function.

--- a/include/NAS2D/Common.h
+++ b/include/NAS2D/Common.h
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace NAS2D {
@@ -39,6 +40,8 @@ int divideUp(int to_divide, int divisor);
 std::string toLowercase(std::string str);
 std::string toUppercase(std::string str);
 std::vector<std::string> split(std::string str, char delim = ',', bool skip_empty = true);
+std::pair<std::string, std::string> splitOnFirst(const std::string& str, char delim);
+std::pair<std::string, std::string> splitOnLast(const std::string& str, char delim);
 std::string join(std::vector<std::string> strs, char delim, bool skip_empty = true);
 std::string join(std::vector<std::string> strs, bool skip_empty = true);
 

--- a/include/NAS2D/Common.h
+++ b/include/NAS2D/Common.h
@@ -38,6 +38,7 @@ int divideUp(int to_divide, int divisor);
 // String functions & types
 std::string toLowercase(const std::string& str);
 std::string toUppercase(const std::string& str);
+std::vector<std::string> split(std::string str, char delim = ',', bool skip_empty = true);
 
 /**
  * Simple helper function to provide a printf like function.

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -9,15 +9,13 @@
 // ==================================================================================
 #include "NAS2D/Common.h"
 
-#include <cctype>
 #include <algorithm>
+#include <cctype>
 #include <sstream>
-
 
 const int NAS2D_MAJOR_VERSION = 1;
 const int NAS2D_MINOR_VERSION = 4;
 const int NAS2D_PATCH_VERSION = 2;
-
 
 /**
  * Gets a string containing the version of NAS2D being used.
@@ -29,7 +27,6 @@ std::string NAS2D::versionString()
 	return ss.str();
 }
 
-
 /**
  * Gets version major.
  */
@@ -37,7 +34,6 @@ int NAS2D::versionMajor()
 {
 	return NAS2D_MAJOR_VERSION;
 }
-
 
 /**
  * Gets version minor.
@@ -47,7 +43,6 @@ int NAS2D::versionMinor()
 	return NAS2D_MINOR_VERSION;
 }
 
-
 /**
  * Gets version patch.
  */
@@ -55,7 +50,6 @@ int NAS2D::versionPatch()
 {
 	return NAS2D_PATCH_VERSION;
 }
-
 
 /**
  * \fn isPointInRect(int pointX, int pointY, int rectX, int rectY, int rectW, int rectH)
@@ -76,7 +70,6 @@ bool NAS2D::isPointInRect(int pointX, int pointY, int rectX, int rectY, int rect
 	return (pointX >= rectX && pointX <= rectX + rectW && pointY >= rectY && pointY <= rectY + rectH);
 }
 
-
 /**
  * \fn isPointInRect(const Point_2d& point, const Rectangle_2d& rect)
  *
@@ -91,7 +84,6 @@ bool NAS2D::isPointInRect(const Point_2d& point, const Rectangle_2d& rect)
 {
 	return (point.x() >= rect.x() && point.x() <= rect.x() + rect.width() && point.y() >= rect.y() && point.y() <= rect.y() + rect.height());
 }
-
 
 /**
  * \fn isRectInRect(int aX, int aY, int aX2, int aY2, int bX, int bY, int bX2, int bY2)
@@ -114,7 +106,6 @@ bool NAS2D::isRectInRect(int aX, int aY, int aX2, int aY2, int bX, int bY, int b
 	return (aX <= bX2 && aX2 >= bX && aY <= bY2 && aY2 >= bY);
 }
 
-
 /**
  * \fn isRectInRect(const Rectangle_2d& a, const Rectangle_2d& b)
  *
@@ -130,7 +121,6 @@ bool NAS2D::isRectInRect(const Rectangle_2d& a, const Rectangle_2d& b)
 	return (a.x() <= (b.x() + b.width()) && (a.x() + a.width()) >= b.x() && a.y() <= (b.y() + b.height()) && (a.y() + a.height()) >= b.y());
 }
 
-
 /**
  * \fn toLowercase(const std::string& str)
  *
@@ -143,10 +133,9 @@ bool NAS2D::isRectInRect(const Rectangle_2d& a, const Rectangle_2d& b)
 std::string NAS2D::toLowercase(const std::string& str)
 {
 	std::string transformStr(str);
-	std::transform(transformStr.begin(), transformStr.end(), transformStr.begin(), (int(*)(int))std::tolower);
+	std::transform(transformStr.begin(), transformStr.end(), transformStr.begin(), (int (*)(int))std::tolower);
 	return transformStr;
 }
-
 
 /**
  * \fn toUppercase(const std::string& str)
@@ -160,10 +149,30 @@ std::string NAS2D::toLowercase(const std::string& str)
 std::string NAS2D::toUppercase(const std::string& str)
 {
 	std::string transformStr(str);
-	std::transform(transformStr.begin(), transformStr.end(), transformStr.begin(), (int(*)(int))std::toupper);
+	std::transform(transformStr.begin(), transformStr.end(), transformStr.begin(), (int (*)(int))std::toupper);
 	return transformStr;
 }
 
+std::vector<std::string> NAS2D::split(std::string str, char delim /*= ','*/, bool skip_empty /*= true*/)
+{
+	const auto potential_count = 1 + std::count(std::begin(str), std::end(str), delim);
+	NAS2D::StringList result{};
+	result.reserve(potential_count);
+
+	std::stringstream ss{};
+	ss.str(str);
+	ss.seekg(0);
+	ss.seekp(0);
+	ss.clear();
+
+	std::string curString{};
+    while(std::getline(ss, curString, delim)) {
+        if(skip_empty && curString.empty()) { continue; }
+		result.push_back(curString);
+    }
+	result.shrink_to_fit();
+	return result;
+}
 
 /**
  * \fn clamp(int x, int a, int b)
@@ -181,7 +190,6 @@ int NAS2D::clamp(int x, int min, int max)
 	return x < min ? min : (x > max ? max : x);
 }
 
-
 /**
  * \fn float clamp(float x, float a, float b)
  *
@@ -197,7 +205,6 @@ float NAS2D::clamp(float x, float min, float max)
 {
 	return x < min ? min : (x > max ? max : x);
 }
-
 
 /**
  * \fn int divideUp(int a, int b)

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -228,11 +228,13 @@ bool NAS2D::endsWith(const std::string& string, const std::string& end) noexcept
 
 bool NAS2D::startsWith(const std::string& string, char start)
 {
+	if (string.empty()) { return false; }
 	return *std::begin(string) == start;
 }
 
 bool NAS2D::endsWith(const std::string& string, char end)
 {
+	if (string.empty()) { return false; }
 	return *(std::end(string) - 1) == end;
 }
 

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -229,13 +229,13 @@ bool NAS2D::endsWith(const std::string& string, const std::string& end) noexcept
 bool NAS2D::startsWith(const std::string& string, char start)
 {
 	if (string.empty()) { return false; }
-	return *std::begin(string) == start;
+	return string.front() == start;
 }
 
 bool NAS2D::endsWith(const std::string& string, char end)
 {
 	if (string.empty()) { return false; }
-	return *(std::end(string) - 1) == end;
+	return string.back() == end;
 }
 
 std::string NAS2D::join(std::vector<std::string> strs, bool skip_empty /*= true*/)

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -226,6 +226,16 @@ bool NAS2D::endsWith(const std::string& string, const std::string& end)
 	return found_loc != std::string::npos && found_loc == string.size() - end.size();
 }
 
+bool NAS2D::startsWith(const std::string& string, char start)
+{
+	return *std::begin(string) == start;
+}
+
+bool NAS2D::endsWith(const std::string& string, char end)
+{
+	return *(std::end(string) - 1) == end;
+}
+
 std::string NAS2D::join(std::vector<std::string> strs, bool skip_empty /*= true*/)
 {
 	const auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + std::size_t{1u} + b.size(); };

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -207,6 +207,21 @@ std::string NAS2D::join(std::vector<std::string> strs, char delim, bool skip_emp
 	return result;
 }
 
+std::string NAS2D::join(std::vector<std::string> strs, bool skip_empty /*= true*/)
+{
+	const auto acc_op = [](const std::size_t& a, const std::string& b) noexcept->std::size_t { return a + std::size_t{1u} + b.size(); };
+	auto total_size = std::accumulate(std::begin(strs), std::end(strs), std::size_t{0u}, acc_op);
+	std::string result;
+	result.reserve(total_size);
+	for (const auto& s : strs)
+	{
+		if (skip_empty && s.empty()) { continue; }
+		result += s;
+	}
+	result.shrink_to_fit();
+	return result;
+}
+
 std::string NAS2D::trimWhitespace(std::string string)
 {
 	const auto first_non_space = string.find_first_not_of(" \r\n\t\v\f");
@@ -236,21 +251,6 @@ bool NAS2D::endsWith(const std::string& string, char end)
 {
 	if (string.empty()) { return false; }
 	return string.back() == end;
-}
-
-std::string NAS2D::join(std::vector<std::string> strs, bool skip_empty /*= true*/)
-{
-	const auto acc_op = [](const std::size_t& a, const std::string& b) noexcept -> std::size_t { return a + std::size_t{1u} + b.size(); };
-	auto total_size = std::accumulate(std::begin(strs), std::end(strs), std::size_t{0u}, acc_op);
-	std::string result;
-	result.reserve(total_size);
-	for (const auto& s : strs)
-	{
-		if (skip_empty && s.empty()) { continue; }
-		result += s;
-	}
-	result.shrink_to_fit();
-	return result;
 }
 
 /**

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -188,7 +188,7 @@ std::pair<std::string, std::string> NAS2D::splitOnLast(const std::string& str, c
 
 std::string NAS2D::join(std::vector<std::string> strs, char delim, bool skip_empty /*= true*/)
 {
-	const auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + std::size_t{1u} + b.size(); };
+	const auto acc_op = [](const std::size_t& a, const std::string& b) noexcept -> std::size_t { return a + std::size_t{1u} + b.size(); };
 	auto total_size = std::accumulate(std::begin(strs), std::end(strs), std::size_t{0u}, acc_op);
 	std::string result;
 	result.reserve(total_size);
@@ -209,20 +209,20 @@ std::string NAS2D::join(std::vector<std::string> strs, char delim, bool skip_emp
 
 std::string NAS2D::trimWhitespace(std::string string)
 {
-	auto first_non_space = string.find_first_not_of(" \r\n\t\v\f");
-	auto last_non_space = string.find_last_not_of(" \r\n\t\v\f");
+	const auto first_non_space = string.find_first_not_of(" \r\n\t\v\f");
+	const auto last_non_space = string.find_last_not_of(" \r\n\t\v\f");
 	return string.substr(first_non_space, last_non_space - first_non_space + 1);
 }
 
-bool NAS2D::startsWith(const std::string& string, const std::string& start)
+bool NAS2D::startsWith(const std::string& string, const std::string& start) noexcept
 {
-	auto found_loc = string.find(start);
+	const auto found_loc = string.find(start);
 	return found_loc != std::string::npos && found_loc == 0;
 }
 
-bool NAS2D::endsWith(const std::string& string, const std::string& end)
+bool NAS2D::endsWith(const std::string& string, const std::string& end) noexcept
 {
-	auto found_loc = string.rfind(end);
+	const auto found_loc = string.rfind(end);
 	return found_loc != std::string::npos && found_loc == string.size() - end.size();
 }
 
@@ -238,7 +238,7 @@ bool NAS2D::endsWith(const std::string& string, char end)
 
 std::string NAS2D::join(std::vector<std::string> strs, bool skip_empty /*= true*/)
 {
-	const auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + std::size_t{1u} + b.size(); };
+	const auto acc_op = [](const std::size_t& a, const std::string& b) noexcept -> std::size_t { return a + std::size_t{1u} + b.size(); };
 	auto total_size = std::accumulate(std::begin(strs), std::end(strs), std::size_t{0u}, acc_op);
 	std::string result;
 	result.reserve(total_size);

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <clocale>
 #include <locale>
 #include <numeric>
 #include <sstream>

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -189,8 +189,8 @@ std::pair<std::string, std::string> NAS2D::splitOnLast(const std::string& str, c
 
 std::string NAS2D::join(std::vector<std::string> strs, char delim, bool skip_empty /*= true*/)
 {
-	const auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + static_cast<std::size_t>(1u) + b.size(); };
-	auto total_size = std::accumulate(std::begin(strs), std::end(strs), static_cast<std::size_t>(0u), acc_op);
+	const auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + std::size_t{1u} + b.size(); };
+	auto total_size = std::accumulate(std::begin(strs), std::end(strs), std::size_t{0u}, acc_op);
 	std::string result;
 	result.reserve(total_size);
 
@@ -211,8 +211,8 @@ std::string NAS2D::join(std::vector<std::string> strs, char delim, bool skip_emp
 
 std::string NAS2D::join(std::vector<std::string> strs, bool skip_empty /*= true*/)
 {
-	const auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + static_cast<std::size_t>(1u) + b.size(); };
-	auto total_size = std::accumulate(std::begin(strs), std::end(strs), static_cast<std::size_t>(0u), acc_op);
+	const auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + std::size_t{1u} + b.size(); };
+	auto total_size = std::accumulate(std::begin(strs), std::end(strs), std::size_t{0u}, acc_op);
 	std::string result;
 	result.reserve(total_size);
 	for (const auto& s : strs)

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -214,6 +214,18 @@ std::string NAS2D::trimWhitespace(std::string string)
 	return string.substr(first_non_space, last_non_space - first_non_space + 1);
 }
 
+bool NAS2D::startsWith(const std::string& string, const std::string& start)
+{
+	auto found_loc = string.find(start);
+	return found_loc != std::string::npos && found_loc == 0;
+}
+
+bool NAS2D::endsWith(const std::string& string, const std::string& end)
+{
+	auto found_loc = string.rfind(end);
+	return found_loc != std::string::npos && found_loc == string.size() - end.size();
+}
+
 std::string NAS2D::join(std::vector<std::string> strs, bool skip_empty /*= true*/)
 {
 	const auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + std::size_t{1u} + b.size(); };

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -133,7 +133,7 @@ bool NAS2D::isRectInRect(const Rectangle_2d& a, const Rectangle_2d& b)
  */
 std::string NAS2D::toLowercase(std::string str)
 {
-	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) -> unsigned char { return static_cast<unsigned char>(::tolower(c)); });
+	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept -> unsigned char { return static_cast<unsigned char>(::tolower(c)); });
 	return str;
 }
 
@@ -148,7 +148,7 @@ std::string NAS2D::toLowercase(std::string str)
  */
 std::string NAS2D::toUppercase(std::string str)
 {
-	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) -> unsigned char { return static_cast<unsigned char>(::toupper(c)); });
+	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept -> unsigned char { return static_cast<unsigned char>(::toupper(c)); });
 	return str;
 }
 

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -11,8 +11,6 @@
 
 #include <algorithm>
 #include <cctype>
-#include <clocale>
-#include <locale>
 #include <numeric>
 #include <sstream>
 
@@ -135,7 +133,7 @@ bool NAS2D::isRectInRect(const Rectangle_2d& a, const Rectangle_2d& b)
  */
 std::string NAS2D::toLowercase(std::string str)
 {
-	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) -> unsigned char { return std::tolower(c, std::locale("")); });
+	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) -> unsigned char { return static_cast<unsigned char>(::tolower(c)); });
 	return str;
 }
 
@@ -150,7 +148,7 @@ std::string NAS2D::toLowercase(std::string str)
  */
 std::string NAS2D::toUppercase(std::string str)
 {
-	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) -> unsigned char { return std::toupper(c, std::locale("")); });
+	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) -> unsigned char { return static_cast<unsigned char>(::toupper(c)); });
 	return str;
 }
 

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <numeric>
 #include <sstream>
 
 const int NAS2D_MAJOR_VERSION = 1;
@@ -166,10 +167,49 @@ std::vector<std::string> NAS2D::split(std::string str, char delim /*= ','*/, boo
 	ss.clear();
 
 	std::string curString{};
-    while(std::getline(ss, curString, delim)) {
-        if(skip_empty && curString.empty()) { continue; }
+	while (std::getline(ss, curString, delim))
+	{
+		if (skip_empty && curString.empty()) { continue; }
 		result.push_back(curString);
-    }
+	}
+	result.shrink_to_fit();
+	return result;
+}
+
+
+std::string NAS2D::join(std::vector<std::string> strs, char delim, bool skip_empty /*= true*/)
+{
+	auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + static_cast<std::size_t>(1u) + b.size(); };
+	auto total_size = std::accumulate(std::begin(strs), std::end(strs), static_cast<std::size_t>(0u), acc_op);
+	std::string result;
+	result.reserve(total_size);
+
+	for (auto iter = std::begin(strs); iter != std::end(strs); ++iter)
+	{
+		if (skip_empty && (*iter).empty()) { continue; }
+		result += (*iter);
+		if (iter != std::end(strs) - 1)
+		{
+			result.push_back(delim);
+		}
+	}
+
+	result.shrink_to_fit();
+	return result;
+}
+
+
+std::string NAS2D::join(std::vector<std::string> strs, bool skip_empty /*= true*/)
+{
+	auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + static_cast<std::size_t>(1u) + b.size(); };
+	auto total_size = std::accumulate(std::begin(strs), std::end(strs), static_cast<std::size_t>(0u), acc_op);
+	std::string result;
+	result.reserve(total_size);
+	for (const auto& s : strs)
+	{
+		if (skip_empty && s.empty()) { continue; }
+		result += s;
+	}
 	result.shrink_to_fit();
 	return result;
 }

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -189,7 +189,7 @@ std::pair<std::string, std::string> NAS2D::splitOnLast(const std::string& str, c
 
 std::string NAS2D::join(std::vector<std::string> strs, char delim, bool skip_empty /*= true*/)
 {
-	auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + static_cast<std::size_t>(1u) + b.size(); };
+	const auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + static_cast<std::size_t>(1u) + b.size(); };
 	auto total_size = std::accumulate(std::begin(strs), std::end(strs), static_cast<std::size_t>(0u), acc_op);
 	std::string result;
 	result.reserve(total_size);
@@ -211,7 +211,7 @@ std::string NAS2D::join(std::vector<std::string> strs, char delim, bool skip_emp
 
 std::string NAS2D::join(std::vector<std::string> strs, bool skip_empty /*= true*/)
 {
-	auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + static_cast<std::size_t>(1u) + b.size(); };
+	const auto acc_op = [](const std::size_t& a, const std::string& b) -> std::size_t { return a + static_cast<std::size_t>(1u) + b.size(); };
 	auto total_size = std::accumulate(std::begin(strs), std::end(strs), static_cast<std::size_t>(0u), acc_op);
 	std::string result;
 	result.reserve(total_size);

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -175,6 +175,18 @@ std::vector<std::string> NAS2D::split(std::string str, char delim /*= ','*/, boo
 	return result;
 }
 
+std::pair<std::string, std::string> NAS2D::splitOnFirst(const std::string& str, char delim)
+{
+	const auto delim_loc = str.find_first_of(delim);
+	return std::make_pair(str.substr(0, delim_loc), str.substr(delim_loc + 1));
+}
+
+
+std::pair<std::string, std::string> NAS2D::splitOnLast(const std::string& str, char delim)
+{
+	const auto delim_loc = str.find_last_of(delim);
+	return std::make_pair(str.substr(0, delim_loc), str.substr(delim_loc + 1));
+}
 
 std::string NAS2D::join(std::vector<std::string> strs, char delim, bool skip_empty /*= true*/)
 {

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -133,7 +133,7 @@ bool NAS2D::isRectInRect(const Rectangle_2d& a, const Rectangle_2d& b)
  */
 std::string NAS2D::toLowercase(std::string str)
 {
-	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept -> unsigned char { return static_cast<unsigned char>(::tolower(c)); });
+	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept->unsigned char { return static_cast<unsigned char>(::tolower(c)); });
 	return str;
 }
 
@@ -148,7 +148,7 @@ std::string NAS2D::toLowercase(std::string str)
  */
 std::string NAS2D::toUppercase(std::string str)
 {
-	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept -> unsigned char { return static_cast<unsigned char>(::toupper(c)); });
+	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept->unsigned char { return static_cast<unsigned char>(::toupper(c)); });
 	return str;
 }
 
@@ -180,7 +180,6 @@ std::pair<std::string, std::string> NAS2D::splitOnFirst(const std::string& str, 
 	return std::make_pair(str.substr(0, delim_loc), str.substr(delim_loc + 1));
 }
 
-
 std::pair<std::string, std::string> NAS2D::splitOnLast(const std::string& str, char delim)
 {
 	const auto delim_loc = str.find_last_of(delim);
@@ -208,6 +207,12 @@ std::string NAS2D::join(std::vector<std::string> strs, char delim, bool skip_emp
 	return result;
 }
 
+std::string NAS2D::trimWhitespace(std::string string)
+{
+	auto first_non_space = string.find_first_not_of(" \r\n\t\v\f");
+	auto last_non_space = string.find_last_not_of(" \r\n\t\v\f");
+	return string.substr(first_non_space, last_non_space - first_non_space + 1);
+}
 
 std::string NAS2D::join(std::vector<std::string> strs, bool skip_empty /*= true*/)
 {

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <locale>
 #include <numeric>
 #include <sstream>
 
@@ -131,11 +132,10 @@ bool NAS2D::isRectInRect(const Rectangle_2d& a, const Rectangle_2d& b)
  *
  * \return	Returns the converted string.
  */
-std::string NAS2D::toLowercase(const std::string& str)
+std::string NAS2D::toLowercase(std::string str)
 {
-	std::string transformStr(str);
-	std::transform(transformStr.begin(), transformStr.end(), transformStr.begin(), (int (*)(int))std::tolower);
-	return transformStr;
+	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) -> unsigned char { return std::tolower(c, std::locale("")); });
+	return str;
 }
 
 /**
@@ -147,11 +147,10 @@ std::string NAS2D::toLowercase(const std::string& str)
  *
  * \return	Returns the converted string.
  */
-std::string NAS2D::toUppercase(const std::string& str)
+std::string NAS2D::toUppercase(std::string str)
 {
-	std::string transformStr(str);
-	std::transform(transformStr.begin(), transformStr.end(), transformStr.begin(), (int (*)(int))std::toupper);
-	return transformStr;
+	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) -> unsigned char { return std::toupper(c, std::locale("")); });
+	return str;
 }
 
 std::vector<std::string> NAS2D::split(std::string str, char delim /*= ','*/, bool skip_empty /*= true*/)


### PR DESCRIPTION
Adds various string utility functions:

Note: Existing warnings are due to upcoming fixes not yet pushed to master.

`std::vector<std::string> split(std::string str, char delim = ',', bool skip_empty = true);`
Splits a string into a vector of strings based on a given delimiter.

`std::pair<std::string, std::string> splitOnFirst(const std::string& str, char delim);`
Splits a string into a `std::pair` of strings where `.first` is the substring before the first occurrence of the delimiter and `.second` is the rest of the string. Neither result includes the delimiter.

`std::pair<std::string, std::string> splitOnLast(const std::string& str, char delim);`
Splits a string into a `std::pair` of strings where `.second` is the substring after the last occurrence of the delimiter and `.first` is the rest of the string. Neither result includes the delimiter.

`std::string join(std::vector<std::string> strs, char delim, bool skip_empty = true);`
Concatenates a vector of strings separated by `delim`.

`std::string join(std::vector<std::string> strs, bool skip_empty = true);`
Concatenates a vector of strings.

`std::string trimWhitespace(std::string string);`
Removes leading and trailing whitespace from a string.

`bool startsWith(const std::string& string, const std::string& start);`
Checks if a string starts with a given string.

`bool endsWith(const std::string& string, const std::string& end);`
Checks if a string ends with a given string.

`bool startsWith(const std::string& string, char start);`
Checks if a string starts with a given character.

`bool endsWith(const std::string& string, char end);`
Checks if a string ends with a given character.

`std::string toLowercase(std::string str);`
`std::string toUppercase(std::string str);`
Refactored to use lambdas instead of function pointers.

`StringList` is a using declaration instead of a typedef.
