### PR TITLE
Update `stringstream` uses

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -23,7 +23,7 @@ const int NAS2D_PATCH_VERSION = 2;
  */
 std::string NAS2D::versionString()
 {
-	std::stringstream ss;
+	std::ostringstream ss;
 	ss << versionMajor() << "." << versionMinor() << "." << versionPatch();
 	return ss.str();
 }

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -159,11 +159,7 @@ std::vector<std::string> NAS2D::split(std::string str, char delim /*= ','*/, boo
 	NAS2D::StringList result{};
 	result.reserve(potential_count);
 
-	std::stringstream ss{};
-	ss.str(str);
-	ss.seekg(0);
-	ss.seekp(0);
-	ss.clear();
+	std::istringstream ss(str);
 
 	std::string curString{};
 	while (std::getline(ss, curString, delim))

--- a/test/Common.test.cpp
+++ b/test/Common.test.cpp
@@ -1,0 +1,8 @@
+#include "NAS2D/Common.h"
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+
+TEST(Version, versionString) {
+	EXPECT_THAT(NAS2D::versionString(), testing::MatchesRegex("[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+"));
+}

--- a/test/Common.test.cpp
+++ b/test/Common.test.cpp
@@ -6,3 +6,26 @@
 TEST(Version, versionString) {
 	EXPECT_THAT(NAS2D::versionString(), testing::MatchesRegex("[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+"));
 }
+
+TEST(String, split) {
+	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::split("a,b,c"));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split("abc"));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split(",abc"));
+	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::split("a,bc"));
+	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::split("ab,c"));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split("abc,"));
+
+	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::split("a.b.c", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split("abc", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split(".abc", '.'));
+	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::split("a.bc", '.'));
+	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::split("ab.c", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split("abc.", '.'));
+
+	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::split("a,b,c", ',', false));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split("abc", ',', false));
+	EXPECT_EQ((NAS2D::StringList{"", "abc"}), NAS2D::split(",abc", ',', false));
+	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::split("a,bc", ',', false));
+	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::split("ab,c", ',', false));
+	// EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::split("abc,", ',', false));  // Actual: {"abc"}
+}


### PR DESCRIPTION
This PR adds unit tests, and then updates `stringstream` code to use the more targeted classes `ostringstream` and `istringstream`.

----

@cugone, I believe there is a bug in `split` as illustrated by the commented out unit test line. I've opened Issue #198 to track this.
