### PR TITLE
Remove `clamp` in favor of `std::clamp`

### DIFF
--- a/include/NAS2D/Common.h
+++ b/include/NAS2D/Common.h
@@ -31,9 +31,6 @@ bool isPointInRect(const Point_2d& point, const Rectangle_2d& rect);
 bool isRectInRect(int aX, int aY, int aX2, int aY2, int bX, int bY, int bX2, int bY2);
 bool isRectInRect(const Rectangle_2d& a, const Rectangle_2d& b);
 
-int clamp(int x, int min, int max);
-float clamp(float x, float min, float max);
-
 int divideUp(int to_divide, int divisor);
 
 

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -265,38 +265,6 @@ bool NAS2D::endsWith(std::string_view string, char end) noexcept
 }
 
 /**
- * \fn clamp(int x, int a, int b)
- *
- * Clamps an \c int value to a specified range.
- *
- * \param	x	Value to clamp.
- * \param	min	Minimum value to clamp to.
- * \param	max	Maximum value to clamp to.
- *
- * \return	Clamped value.
- */
-int NAS2D::clamp(int x, int min, int max)
-{
-	return x < min ? min : (x > max ? max : x);
-}
-
-/**
- * \fn float clamp(float x, float a, float b)
- *
- * Clamps a \c float value to a specified range.
- *
- * \param	x	Value to clamp.
- * \param	min	Minimum value to clamp to.
- * \param	max	Maximum value to clamp to.
- *
- * \return	Clamped value.
- */
-float NAS2D::clamp(float x, float min, float max)
-{
-	return x < min ? min : (x > max ? max : x);
-}
-
-/**
  * \fn int divideUp(int a, int b)
  *
  * Basic integer division that rounds up to the nearest whole number.

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -14,6 +14,7 @@
 #include "NAS2D/Xml/Xml.h"
 
 #include <iostream>
+#include <algorithm>
 
 using namespace NAS2D;
 using namespace NAS2D::Xml;
@@ -312,7 +313,7 @@ void Configuration::parseAudio(void* _n)
 
 			if (mSfxVolume < AUDIO_SFX_MIN_VOLUME || mSfxVolume > AUDIO_SFX_MAX_VOLUME)
 			{
-				audioSfxVolume(clamp(mSfxVolume, AUDIO_SFX_MIN_VOLUME, AUDIO_SFX_MAX_VOLUME));
+				audioSfxVolume(std::clamp(mSfxVolume, AUDIO_SFX_MIN_VOLUME, AUDIO_SFX_MAX_VOLUME));
 			}
 		}
 		else if (attribute->name() == AUDIO_CFG_MUS_VOLUME)
@@ -321,7 +322,7 @@ void Configuration::parseAudio(void* _n)
 
 			if (mMusicVolume < AUDIO_SFX_MIN_VOLUME || mMusicVolume > AUDIO_SFX_MAX_VOLUME)
 			{
-				audioSfxVolume(clamp(mMusicVolume, AUDIO_SFX_MIN_VOLUME, AUDIO_SFX_MAX_VOLUME));
+				audioSfxVolume(std::clamp(mMusicVolume, AUDIO_SFX_MIN_VOLUME, AUDIO_SFX_MAX_VOLUME));
 			}
 		}
 		else if (attribute->name() == AUDIO_CFG_BUFFER_SIZE)
@@ -329,7 +330,7 @@ void Configuration::parseAudio(void* _n)
 			attribute->queryIntValue(mBufferLength);
 			if (mBufferLength < AUDIO_BUFFER_MIN_SIZE || mBufferLength > AUDIO_BUFFER_MAX_SIZE)
 			{
-				audioBufferSize(clamp(mBufferLength, AUDIO_BUFFER_MIN_SIZE, AUDIO_BUFFER_MAX_SIZE));
+				audioBufferSize(std::clamp(mBufferLength, AUDIO_BUFFER_MIN_SIZE, AUDIO_BUFFER_MAX_SIZE));
 			}
 		}
 		else if (attribute->name() == AUDIO_CFG_MIXER)
@@ -610,7 +611,7 @@ void Configuration::mixer(const std::string& mixer)
  */
 void Configuration::audioStereoChannels(int channels)
 {
-	mStereoChannels = clamp(channels, AUDIO_MONO, AUDIO_STEREO);
+	mStereoChannels = std::clamp(channels, AUDIO_MONO, AUDIO_STEREO);
 	mOptionChanged = true;
 }
 
@@ -622,7 +623,7 @@ void Configuration::audioStereoChannels(int channels)
  */
 void Configuration::audioSfxVolume(int volume)
 {
-	mSfxVolume = clamp(volume, AUDIO_SFX_MIN_VOLUME, AUDIO_SFX_MAX_VOLUME);
+	mSfxVolume = std::clamp(volume, AUDIO_SFX_MIN_VOLUME, AUDIO_SFX_MAX_VOLUME);
 	mOptionChanged = true;
 }
 
@@ -635,7 +636,7 @@ void Configuration::audioSfxVolume(int volume)
  */
 void Configuration::audioMusicVolume(int volume)
 {
-	mMusicVolume = clamp(volume, AUDIO_MUSIC_MIN_VOLUME, AUDIO_MUSIC_MAX_VOLUME);
+	mMusicVolume = std::clamp(volume, AUDIO_MUSIC_MIN_VOLUME, AUDIO_MUSIC_MAX_VOLUME);
 	mOptionChanged = true;
 }
 

--- a/src/Mixer/MixerSDL.cpp
+++ b/src/Mixer/MixerSDL.cpp
@@ -172,13 +172,13 @@ bool MixerSDL::musicPlaying() const
 
 void MixerSDL::soundVolume(int volume)
 {
-	Mix_Volume(-1, clamp(volume, 0, SDL_MIX_MAXVOLUME));
+	Mix_Volume(-1, std::clamp(volume, 0, SDL_MIX_MAXVOLUME));
 }
 
 
 void MixerSDL::musicVolume(int volume)
 {
-	Mix_VolumeMusic(clamp(volume, 0, SDL_MIX_MAXVOLUME));
+	Mix_VolumeMusic(std::clamp(volume, 0, SDL_MIX_MAXVOLUME));
 }
 
 

--- a/src/Mixer/MixerSDL.cpp
+++ b/src/Mixer/MixerSDL.cpp
@@ -17,11 +17,12 @@
 
 #include "NAS2D/Utility.h"
 
-#include <iostream>
-#include <functional>
-
 #include <SDL.h>
 #include <SDL_mixer.h>
+
+#include <iostream>
+#include <functional>
+#include <algorithm>
 
 using namespace NAS2D;
 using namespace NAS2D::Exception;

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -14,6 +14,7 @@
 #include "NAS2D/Timer.h"
 
 #include <iostream>
+#include <algorithm>
 
 using namespace NAS2D;
 
@@ -585,7 +586,7 @@ void Renderer::update()
 
 		if (mCurrentFade < 0.0f || mCurrentFade > 255.0f)
 		{
-			mCurrentFade = clamp(mCurrentFade, 0.0f, 255.0f);
+			mCurrentFade = std::clamp(mCurrentFade, 0.0f, 255.0f);
 			CURRENT_FADE = FADE_NONE;
 			_FADE_COMPLETE();
 		}

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -26,6 +26,7 @@
 
 #include <iostream>
 #include <math.h>
+#include <algorithm>
 
 using namespace NAS2D;
 using namespace NAS2D::Exception;
@@ -453,7 +454,7 @@ void RendererOpenGL::drawText(NAS2D::Font& font, const std::string& text, float 
 	GlyphMetrics gm;
 	for (size_t i = 0; i < text.size(); i++)
 	{
-		gm = gml[clamp(text[i], 0, 255)];
+		gm = gml[std::clamp<std::size_t>(text[i], 0, 255)];
 
 		fillVertexArray(x + offset, y, (float)font.glyphCellWidth(), (float)font.glyphCellHeight());
 		fillTextureArray(gm.uvX, gm.uvY, gm.uvW, gm.uvH);

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -451,10 +451,9 @@ void RendererOpenGL::drawText(NAS2D::Font& font, const std::string& text, float 
 	GlyphMetricsList& gml = FONTMAP[font.name()].metrics;
 	if (gml.empty()) { return; }
 
-	GlyphMetrics gm;
 	for (size_t i = 0; i < text.size(); i++)
 	{
-		gm = gml[std::clamp<std::size_t>(text[i], 0, 255)];
+		GlyphMetrics& gm = gml[std::clamp<std::size_t>(text[i], 0, 255)];
 
 		fillVertexArray(x + offset, y, (float)font.glyphCellWidth(), (float)font.glyphCellHeight());
 		fillTextureArray(gm.uvX, gm.uvY, gm.uvW, gm.uvH);

--- a/src/Resources/Font.cpp
+++ b/src/Resources/Font.cpp
@@ -21,6 +21,7 @@
 
 #include <iostream>
 #include <math.h>
+#include <algorithm>
 
 using namespace NAS2D;
 using namespace NAS2D::Exception;
@@ -182,7 +183,7 @@ int NAS2D::Font::width(const std::string& str) const
 
 	for (size_t i = 0; i < str.size(); i++)
 	{
-		int glyph = clamp(str[i], 0, 255);
+		int glyph = std::clamp<std::size_t>(str[i], 0, 255);
 		width += gml[glyph].advance + gml[glyph].minX;
 	}
 

--- a/src/Resources/Font.cpp
+++ b/src/Resources/Font.cpp
@@ -183,7 +183,7 @@ int NAS2D::Font::width(const std::string& str) const
 
 	for (size_t i = 0; i < str.size(); i++)
 	{
-		int glyph = std::clamp<std::size_t>(str[i], 0, 255);
+		auto glyph = std::clamp<std::size_t>(str[i], 0, 255);
 		width += gml[glyph].advance + gml[glyph].minX;
 	}
 


### PR DESCRIPTION
Explicit template instantiation needs to be used when not all parameters are of the same type. This can happen when indexing a string to find a `const char` data type, while the other literal value parameters `255` are interpreted as `int`. By being explicit with the template instantiation, the compiler will promote values to the selected type.

Closes #195.
