### PR TITLE
Add missing Common.test.cpp to VS project

### DIFF
--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -47,6 +47,7 @@
     <OutDir>$(ProjectDir)$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemGroup>
+    <ClCompile Include="Common.test.cpp" />
     <ClCompile Include="Filesystem.test.cpp" />
     <ClCompile Include="Utility.test.cpp" />
   </ItemGroup>


### PR DESCRIPTION
Common.test.cpp was not added to the test project when it was created.