### PR TITLE
Removes pure virtual declaration on d'tor's for Mixer and Renderer.h.…

### DIFF
--- a/include/NAS2D/Mixer/Mixer.h
+++ b/include/NAS2D/Mixer/Mixer.h
@@ -32,7 +32,7 @@ public:
 
 public:
 	Mixer() = default;
-	virtual ~Mixer() = 0;
+	virtual ~Mixer() = default;
 
 public:
 	/**

--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -47,7 +47,7 @@ class Renderer
 {
 public:
 	Renderer();
-	virtual ~Renderer() = 0;
+	virtual ~Renderer();
 
 	const std::string& name();
 	const std::string& driverName();


### PR DESCRIPTION
… Pure virtual Mixer d'tor caused a compiler issue later on for derived types.