### PR TITLE
Add splitOnUnquoted functions

### DIFF
--- a/include/NAS2D/StringUtils.h
+++ b/include/NAS2D/StringUtils.h
@@ -24,6 +24,9 @@ namespace NAS2D
 	std::vector<std::string> splitSkipEmpty(std::string str, char delim = ',');
 	std::pair<std::string, std::string> splitOnFirst(const std::string& str, char delim);
 	std::pair<std::string, std::string> splitOnLast(const std::string& str, char delim);
+	std::vector<std::string> splitOnUnquoted(const std::string& str, char delim = ',');
+	std::vector<std::string> splitOnUnquotedSkipEmpty(const std::string& str, char delim = ',');
+
 	std::string join(std::vector<std::string> strs);
 	std::string join(std::vector<std::string> strs, char delim);
 	std::string joinSkipEmpty(std::vector<std::string> strs);

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -131,6 +131,14 @@ std::vector<std::string> NAS2D::splitOnUnquoted(const std::string& str, char del
 		}
 		substring_end = iter++;
 		std::string substring(substring_start, substring_end);
+		if (substring.front() == '"')
+		{
+			substring.erase(0, 1);
+		}
+		if (substring.back() == '"')
+		{
+			substring.pop_back();
+		}
 		result.push_back(substring);
 		substring_start = iter;
 	}
@@ -164,10 +172,19 @@ std::vector<std::string> NAS2D::splitOnUnquotedSkipEmpty(const std::string& str,
 		}
 		substring_end = iter++;
 		std::string substring(substring_start, substring_end);
-		if (substring.empty()) { 
-            substring_start = iter;
-            continue;
-        }
+		if (substring.front() == '"')
+		{
+			substring.erase(0, 1);
+		}
+		if (substring.back() == '"')
+		{
+			substring.pop_back();
+		}
+		if (substring.empty())
+		{
+			substring_start = iter;
+			continue;
+		}
 		result.push_back(substring);
 		substring_start = iter;
 	}

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -110,73 +110,79 @@ std::pair<std::string, std::string> NAS2D::splitOnLast(const std::string& str, c
 
 std::vector<std::string> NAS2D::splitOnUnquoted(const std::string& str, char delim /*= ','*/)
 {
-	bool in_quote = false;
+	bool inQuote = false;
 	std::vector<std::string> result{};
-	auto potential_count = 1u + std::count(std::begin(str), std::end(str), delim);
+	std::size_t potential_count = 1u + std::count(std::begin(str), std::end(str), delim);
 	result.reserve(potential_count);
-	auto substring_start = std::begin(str);
-	auto substring_end = std::end(str);
+	auto start = std::begin(str);
+	auto end = std::end(str);
 	for (auto iter = std::begin(str); iter != std::end(str); /* DO NOTHING */)
 	{
 		if (*iter == '"')
 		{
-			in_quote = !in_quote;
+			inQuote = !inQuote;
 			++iter;
 			continue;
 		}
-		if (in_quote || *iter != delim)
+		if (!inQuote)
 		{
-			++iter;
-			continue;
+			if (*iter == delim)
+			{
+				end = iter++;
+				std::string s(start, end);
+				result.push_back(std::string(start, end));
+				start = iter;
+				continue;
+			}
 		}
-		substring_end = iter++;
-		std::string substring(substring_start, substring_end);
-		result.push_back(substring);
-		substring_start = iter;
+		++iter;
 	}
-	substring_end = std::end(str);
-	auto last_string = std::string(substring_start, substring_end);
-	result.push_back(last_string);
+	end = std::end(str);
+	auto last_s = std::string(start, end);
+	result.push_back(std::string(start, end));
 	result.shrink_to_fit();
 	return result;
 }
 
 std::vector<std::string> NAS2D::splitOnUnquotedSkipEmpty(const std::string& str, char delim /*= ','*/)
 {
-	bool in_quote = false;
+	bool inQuote = false;
 	std::vector<std::string> result{};
-	auto potential_count = 1u + std::count(std::begin(str), std::end(str), delim);
+	std::size_t potential_count = 1u + std::count(std::begin(str), std::end(str), delim);
 	result.reserve(potential_count);
-	auto substring_start = std::begin(str);
-	auto substring_end = std::end(str);
+	auto start = std::begin(str);
+	auto end = std::end(str);
 	for (auto iter = std::begin(str); iter != std::end(str); /* DO NOTHING */)
 	{
 		if (*iter == '"')
 		{
-			in_quote = !in_quote;
+			inQuote = !inQuote;
 			++iter;
 			continue;
 		}
-		if (in_quote || *iter != delim)
+		if (!inQuote)
 		{
-			++iter;
-			continue;
+			if (*iter == delim)
+			{
+				end = iter++;
+				std::string s(start, end);
+				if (s.empty())
+				{
+					start = iter;
+					continue;
+				}
+				result.push_back(std::string(start, end));
+				start = iter;
+				continue;
+			}
 		}
-		substring_end = iter++;
-		std::string substring(substring_start, substring_end);
-		if (substring.empty())
-		{
-			substring_start = iter;
-			continue;
-		}
-		result.push_back(substring);
-		substring_start = iter;
+		++iter;
 	}
-	substring_end = std::end(str);
-	auto last_string = std::string(substring_start, substring_end);
-	if (!last_string.empty())
+	end = std::end(str);
+	auto last_s = std::string(start, end);
+	if (!last_s.empty())
 	{
-		result.push_back(last_string);
+		result.push_back(std::string(start, end));
 	}
 	result.shrink_to_fit();
 	return result;

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -131,14 +131,6 @@ std::vector<std::string> NAS2D::splitOnUnquoted(const std::string& str, char del
 		}
 		substring_end = iter++;
 		std::string substring(substring_start, substring_end);
-		if (substring.front() == '"')
-		{
-			substring.erase(0, 1);
-		}
-		if (substring.back() == '"')
-		{
-			substring.pop_back();
-		}
 		result.push_back(substring);
 		substring_start = iter;
 	}
@@ -172,14 +164,6 @@ std::vector<std::string> NAS2D::splitOnUnquotedSkipEmpty(const std::string& str,
 		}
 		substring_end = iter++;
 		std::string substring(substring_start, substring_end);
-		if (substring.front() == '"')
-		{
-			substring.erase(0, 1);
-		}
-		if (substring.back() == '"')
-		{
-			substring.pop_back();
-		}
 		if (substring.empty())
 		{
 			substring_start = iter;

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -130,6 +130,14 @@ std::vector<std::string> NAS2D::splitOnUnquoted(const std::string& str, char del
 			continue;
 		}
 		substring_end = iter++;
+		if (*substring_start == '"')
+		{
+			++substring_start;
+		}
+		if (*(substring_end - 1) == '"')
+		{
+			--substring_end;
+		}
 		std::string substring(substring_start, substring_end);
 		result.push_back(substring);
 		substring_start = iter;
@@ -163,6 +171,14 @@ std::vector<std::string> NAS2D::splitOnUnquotedSkipEmpty(const std::string& str,
 			continue;
 		}
 		substring_end = iter++;
+		if (*substring_start == '"')
+		{
+			++substring_start;
+		}
+		if (*(substring_end - 1) == '"')
+		{
+			--substring_end;
+		}
 		std::string substring(substring_start, substring_end);
 		if (substring.empty()) { continue; }
 		result.push_back(substring);

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -130,20 +130,28 @@ std::vector<std::string> NAS2D::splitOnUnquoted(const std::string& str, char del
 			continue;
 		}
 		substring_end = iter++;
-		if (*substring_start == '"')
-		{
-			++substring_start;
-		}
-		if (*(substring_end - 1) == '"')
-		{
-			--substring_end;
-		}
 		std::string substring(substring_start, substring_end);
+		if (substring.front() == '"')
+		{
+			substring.erase(0, 1);
+		}
+		if (substring.back() == '"')
+		{
+			substring.pop_back();
+		}
 		result.push_back(substring);
 		substring_start = iter;
 	}
 	substring_end = std::end(str);
 	auto last_string = std::string(substring_start, substring_end);
+	if (last_string.front() == '"')
+	{
+		last_string.erase(0, 1);
+	}
+	if (last_string.back() == '"')
+	{
+		last_string.pop_back();
+	}
 	result.push_back(last_string);
 	result.shrink_to_fit();
 	return result;
@@ -171,16 +179,16 @@ std::vector<std::string> NAS2D::splitOnUnquotedSkipEmpty(const std::string& str,
 			continue;
 		}
 		substring_end = iter++;
-		if (*substring_start == '"')
-		{
-			++substring_start;
-		}
-		if (*(substring_end - 1) == '"')
-		{
-			--substring_end;
-		}
 		std::string substring(substring_start, substring_end);
 		if (substring.empty()) { continue; }
+		if (substring.front() == '"')
+		{
+			substring.erase(0, 1);
+		}
+		if (substring.back() == '"')
+		{
+			substring.pop_back();
+		}
 		result.push_back(substring);
 		substring_start = iter;
 	}
@@ -188,6 +196,14 @@ std::vector<std::string> NAS2D::splitOnUnquotedSkipEmpty(const std::string& str,
 	auto last_string = std::string(substring_start, substring_end);
 	if (!last_string.empty())
 	{
+		if (last_string.front() == '"')
+		{
+			last_string.erase(0, 1);
+		}
+		if (last_string.back() == '"')
+		{
+			last_string.pop_back();
+		}
 		result.push_back(last_string);
 	}
 	result.shrink_to_fit();

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -131,27 +131,11 @@ std::vector<std::string> NAS2D::splitOnUnquoted(const std::string& str, char del
 		}
 		substring_end = iter++;
 		std::string substring(substring_start, substring_end);
-		if (substring.front() == '"')
-		{
-			substring.erase(0, 1);
-		}
-		if (substring.back() == '"')
-		{
-			substring.pop_back();
-		}
 		result.push_back(substring);
 		substring_start = iter;
 	}
 	substring_end = std::end(str);
 	auto last_string = std::string(substring_start, substring_end);
-	if (last_string.front() == '"')
-	{
-		last_string.erase(0, 1);
-	}
-	if (last_string.back() == '"')
-	{
-		last_string.pop_back();
-	}
 	result.push_back(last_string);
 	result.shrink_to_fit();
 	return result;
@@ -180,15 +164,10 @@ std::vector<std::string> NAS2D::splitOnUnquotedSkipEmpty(const std::string& str,
 		}
 		substring_end = iter++;
 		std::string substring(substring_start, substring_end);
-		if (substring.empty()) { continue; }
-		if (substring.front() == '"')
-		{
-			substring.erase(0, 1);
-		}
-		if (substring.back() == '"')
-		{
-			substring.pop_back();
-		}
+		if (substring.empty()) { 
+            substring_start = iter;
+            continue;
+        }
 		result.push_back(substring);
 		substring_start = iter;
 	}
@@ -196,14 +175,6 @@ std::vector<std::string> NAS2D::splitOnUnquotedSkipEmpty(const std::string& str,
 	auto last_string = std::string(substring_start, substring_end);
 	if (!last_string.empty())
 	{
-		if (last_string.front() == '"')
-		{
-			last_string.erase(0, 1);
-		}
-		if (last_string.back() == '"')
-		{
-			last_string.pop_back();
-		}
 		result.push_back(last_string);
 	}
 	result.shrink_to_fit();

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -108,6 +108,76 @@ std::pair<std::string, std::string> NAS2D::splitOnLast(const std::string& str, c
 	}
 }
 
+std::vector<std::string> NAS2D::splitOnUnquoted(const std::string& str, char delim /*= ','*/)
+{
+	bool in_quote = false;
+	std::vector<std::string> result{};
+	auto potential_count = 1u + std::count(std::begin(str), std::end(str), delim);
+	result.reserve(potential_count);
+	auto substring_start = std::begin(str);
+	auto substring_end = std::end(str);
+	for (auto iter = std::begin(str); iter != std::end(str); /* DO NOTHING */)
+	{
+		if (*iter == '"')
+		{
+			in_quote = !in_quote;
+			++iter;
+			continue;
+		}
+		if (in_quote || *iter != delim)
+		{
+			++iter;
+			continue;
+		}
+		substring_end = iter++;
+		std::string substring(substring_start, substring_end);
+		result.push_back(substring);
+		substring_start = iter;
+	}
+	substring_end = std::end(str);
+	auto last_string = std::string(substring_start, substring_end);
+	result.push_back(last_string);
+	result.shrink_to_fit();
+	return result;
+}
+
+std::vector<std::string> NAS2D::splitOnUnquotedSkipEmpty(const std::string& str, char delim /*= ','*/)
+{
+	bool in_quote = false;
+	std::vector<std::string> result{};
+	auto potential_count = 1u + std::count(std::begin(str), std::end(str), delim);
+	result.reserve(potential_count);
+	auto substring_start = std::begin(str);
+	auto substring_end = std::end(str);
+	for (auto iter = std::begin(str); iter != std::end(str); /* DO NOTHING */)
+	{
+		if (*iter == '"')
+		{
+			in_quote = !in_quote;
+			++iter;
+			continue;
+		}
+		if (in_quote || *iter != delim)
+		{
+			++iter;
+			continue;
+		}
+		substring_end = iter++;
+		std::string substring(substring_start, substring_end);
+		if (substring.empty()) { continue; }
+		result.push_back(substring);
+		substring_start = iter;
+	}
+	substring_end = std::end(str);
+	auto last_string = std::string(substring_start, substring_end);
+	if (!last_string.empty())
+	{
+		result.push_back(last_string);
+	}
+	result.shrink_to_fit();
+	return result;
+}
+
 std::string NAS2D::join(std::vector<std::string> strs)
 {
 	const auto acc_op = [](const std::size_t& a, const std::string& b) noexcept->std::size_t { return a + b.size(); };

--- a/test/Common.test.cpp
+++ b/test/Common.test.cpp
@@ -40,7 +40,7 @@ TEST(String, splitOnUnquoted)
 	EXPECT_EQ((NAS2D::StringList{"a,b,c", "abc", "def"}), NAS2D::splitOnUnquoted(R"("a,b,c",abc,def)"));
 	EXPECT_EQ((NAS2D::StringList{"abc", "a,b,c", "def"}), NAS2D::splitOnUnquoted(R"(abc,"a,b,c",def)"));
 	EXPECT_EQ((NAS2D::StringList{"abc", "def", "a,b,c"}), NAS2D::splitOnUnquoted(R"(abc,def,"a,b,c")"));
-	EXPECT_EQ((NAS2D::StringList{"", "abc", "def"}), NAS2D::splitOnUnquoted(R"("",abc,def)"));
+	EXPECT_EQ((NAS2D::StringList{"","abc", "def"}), NAS2D::splitOnUnquoted(R"("",abc,def)"));
 	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted(R"(abc,"",def)"));
 	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted(R"(abc,def,"")"));
 
@@ -79,27 +79,34 @@ TEST(String, splitSkipEmpty)
 	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc.", '.'));
 }
 
-TEST(String, splitOnUnquotedSkipEmpty)
+TEST(StringUtils, SplitOnUnquotedSkipEmpty)
 {
-	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitOnUnquotedSkipEmpty("a,b,c"));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquotedSkipEmpty("abc"));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquotedSkipEmpty(",abc"));
-	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquotedSkipEmpty("a,bc"));
-	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquotedSkipEmpty("ab,c"));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquotedSkipEmpty("abc,"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("\"\",abc,def"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("abc,\"\",def"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("abc,def,\"\""));
+	using StringList = std::vector<std::string>;
+	std::string input =
+		R"(
+a=b
 
-	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitOnUnquotedSkipEmpty("a.b.c", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquotedSkipEmpty("abc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquotedSkipEmpty(".abc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquotedSkipEmpty("a.bc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquotedSkipEmpty("ab.c", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquotedSkipEmpty("abc.", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("\"\".abc.def", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("abc.\"\".def", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("abc.def.\"\"", '.'));
-	EXPECT_EQ((NAS2D::StringList{"Hello", " ", "World"}), NAS2D::splitOnUnquotedSkipEmpty("Hello \" \" World", ' '));
-	EXPECT_EQ((NAS2D::StringList{"Hello", "World"}), NAS2D::splitOnUnquotedSkipEmpty("Hello \"\" World", ' '));
+c=d
+e="Hello
+World"
+)";
+	auto a = StringList{"a=b", "c=d", "e=\"Hello\nWorld\""};
+	auto b = NAS2D::splitOnUnquotedSkipEmpty(input, '\n');
+	EXPECT_EQ(a, b);
+}
+
+TEST(StringUtils, SplitOnUnquotedNoSkipEmpty)
+{
+	using StringList = std::vector<std::string>;
+	std::string input =
+		R"(
+a=b
+
+c=d
+e="Hello
+World"
+)";
+	auto a = StringList{"", "a=b", "", "c=d", "e=\"Hello\nWorld\"", ""};
+	auto b = NAS2D::splitOnUnquoted(input, '\n');
+	EXPECT_EQ(a, b);
 }

--- a/test/Common.test.cpp
+++ b/test/Common.test.cpp
@@ -1,9 +1,10 @@
 #include "NAS2D/Common.h"
-#include <gtest/gtest.h>
+
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
-
-TEST(Version, versionString) {
+TEST(Version, versionString)
+{
 #if GTEST_USES_POSIX_RE == 1
 	EXPECT_THAT(NAS2D::versionString(), testing::MatchesRegex(R"([0-9]+\.[0-9]+\.[0-9]+)"));
 #elif GTEST_USES_SIMPLE_RE == 1
@@ -28,6 +29,35 @@ TEST(String, split)
 	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::split("abc.", '.'));
 }
 
+TEST(String, splitOnUnquoted)
+{
+	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitOnUnquoted("a,b,c"));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquoted("abc"));
+	EXPECT_EQ((NAS2D::StringList{"", "abc"}), NAS2D::splitOnUnquoted(",abc"));
+	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquoted("a,bc"));
+	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquoted("ab,c"));
+	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::splitOnUnquoted("abc,"));
+	EXPECT_EQ((NAS2D::StringList{"a,b,c", "abc", "def"}), NAS2D::splitOnUnquoted("\"a,b,c\",abc,def"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "a,b,c", "def"}), NAS2D::splitOnUnquoted("abc,\"a,b,c\",def"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def","a,b,c"}), NAS2D::splitOnUnquoted("abc,def,\"a,b,c\""));
+	EXPECT_EQ((NAS2D::StringList{"", "abc", "def"}), NAS2D::splitOnUnquoted("\"\",abc,def"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted("abc,\"\",def"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted("abc,def,\"\""));
+
+	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitOnUnquoted("a.b.c", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquoted("abc", '.'));
+	EXPECT_EQ((NAS2D::StringList{"", "abc"}), NAS2D::splitOnUnquoted(".abc", '.'));
+	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquoted("a.bc", '.'));
+	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquoted("ab.c", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::splitOnUnquoted("abc.", '.'));
+	EXPECT_EQ((NAS2D::StringList{"a.b.c", "abc", "def"}), NAS2D::splitOnUnquoted("\"a.b.c\".abc.def", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "a.b.c", "def"}), NAS2D::splitOnUnquoted("abc.\"a.b.c\".def", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def", "a.b.c"}), NAS2D::splitOnUnquoted("abc.def.\"a.b.c\"", '.'));
+	EXPECT_EQ((NAS2D::StringList{"", "abc", "def"}), NAS2D::splitOnUnquoted("\"\".abc.def", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted("abc.\"\".def", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted("abc.def.\"\"", '.'));
+}
+
 TEST(String, splitSkipEmpty)
 {
 	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitSkipEmpty("a,b,c"));
@@ -43,4 +73,28 @@ TEST(String, splitSkipEmpty)
 	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitSkipEmpty("a.bc", '.'));
 	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitSkipEmpty("ab.c", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc.", '.'));
+}
+
+TEST(String, splitOnUnquotedSkipEmpty)
+{
+	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitOnUnquotedSkipEmpty("a,b,c"));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquotedSkipEmpty("abc"));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquotedSkipEmpty(",abc"));
+	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquotedSkipEmpty("a,bc"));
+	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquotedSkipEmpty("ab,c"));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquotedSkipEmpty("abc,"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("\"\",abc,def"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("abc,\"\",def"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("abc,def,\"\""));
+
+	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitOnUnquotedSkipEmpty("a.b.c", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquotedSkipEmpty("abc", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquotedSkipEmpty(".abc", '.'));
+	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquotedSkipEmpty("a.bc", '.'));
+	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquotedSkipEmpty("ab.c", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquotedSkipEmpty("abc.", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("\"\".abc.def", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("abc.\"\".def", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("abc.def.\"\"", '.'));
+
 }

--- a/test/Common.test.cpp
+++ b/test/Common.test.cpp
@@ -29,56 +29,6 @@ TEST(String, split)
 	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::split("abc.", '.'));
 }
 
-TEST(String, splitOnUnquoted)
-{
-	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitOnUnquoted("a,b,c"));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquoted("abc"));
-	EXPECT_EQ((NAS2D::StringList{"", "abc"}), NAS2D::splitOnUnquoted(",abc"));
-	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquoted("a,bc"));
-	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquoted("ab,c"));
-	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::splitOnUnquoted("abc,"));
-	EXPECT_EQ((NAS2D::StringList{"a,b,c", "abc", "def"}), NAS2D::splitOnUnquoted(R"("a,b,c",abc,def)"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "a,b,c", "def"}), NAS2D::splitOnUnquoted(R"(abc,"a,b,c",def)"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def", "a,b,c"}), NAS2D::splitOnUnquoted(R"(abc,def,"a,b,c")"));
-	EXPECT_EQ((NAS2D::StringList{"","abc", "def"}), NAS2D::splitOnUnquoted(R"("",abc,def)"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted(R"(abc,"",def)"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted(R"(abc,def,"")"));
-
-	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitOnUnquoted("a.b.c", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquoted("abc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"", "abc"}), NAS2D::splitOnUnquoted(".abc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquoted("a.bc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquoted("ab.c", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::splitOnUnquoted("abc.", '.'));
-	EXPECT_EQ((NAS2D::StringList{"a.b.c", "abc", "def"}), NAS2D::splitOnUnquoted(R"("a.b.c".abc.def)", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "a.b.c", "def"}), NAS2D::splitOnUnquoted(R"(abc."a.b.c".def)", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def", "a.b.c"}), NAS2D::splitOnUnquoted(R"(abc.def."a.b.c")", '.'));
-	EXPECT_EQ((NAS2D::StringList{"", "abc", "def"}), NAS2D::splitOnUnquoted(R"("".abc.def)", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted(R"(abc."".def)", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted(R"(abc.def."")", '.'));
-	EXPECT_EQ((NAS2D::StringList{"Hello", "Hello World", "World"}), NAS2D::splitOnUnquoted(R"(Hello "Hello World" World)", ' '));
-	EXPECT_EQ((NAS2D::StringList{"Hello", " ", "World"}), NAS2D::splitOnUnquoted(R"(Hello " " World)", ' '));
-	EXPECT_EQ((NAS2D::StringList{"Hello", "", "World"}), NAS2D::splitOnUnquoted(R"(Hello "" World)", ' '));
-
-}
-
-TEST(String, splitSkipEmpty)
-{
-	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitSkipEmpty("a,b,c"));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc"));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty(",abc"));
-	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitSkipEmpty("a,bc"));
-	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitSkipEmpty("ab,c"));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc,"));
-
-	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitSkipEmpty("a.b.c", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty(".abc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitSkipEmpty("a.bc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitSkipEmpty("ab.c", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc.", '.'));
-}
-
 TEST(String, SplitOnUnquotedSkipEmpty)
 {
 	using StringList = std::vector<std::string>;

--- a/test/Common.test.cpp
+++ b/test/Common.test.cpp
@@ -79,7 +79,7 @@ TEST(String, splitSkipEmpty)
 	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc.", '.'));
 }
 
-TEST(StringUtils, SplitOnUnquotedSkipEmpty)
+TEST(String, SplitOnUnquotedSkipEmpty)
 {
 	using StringList = std::vector<std::string>;
 	std::string input =
@@ -95,7 +95,7 @@ World"
 	EXPECT_EQ(a, b);
 }
 
-TEST(StringUtils, SplitOnUnquotedNoSkipEmpty)
+TEST(String, SplitOnUnquotedNoSkipEmpty)
 {
 	using StringList = std::vector<std::string>;
 	std::string input =

--- a/test/Common.test.cpp
+++ b/test/Common.test.cpp
@@ -37,12 +37,12 @@ TEST(String, splitOnUnquoted)
 	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquoted("a,bc"));
 	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquoted("ab,c"));
 	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::splitOnUnquoted("abc,"));
-	EXPECT_EQ((NAS2D::StringList{"a,b,c", "abc", "def"}), NAS2D::splitOnUnquoted("\"a,b,c\",abc,def"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "a,b,c", "def"}), NAS2D::splitOnUnquoted("abc,\"a,b,c\",def"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def","a,b,c"}), NAS2D::splitOnUnquoted("abc,def,\"a,b,c\""));
-	EXPECT_EQ((NAS2D::StringList{"", "abc", "def"}), NAS2D::splitOnUnquoted("\"\",abc,def"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted("abc,\"\",def"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted("abc,def,\"\""));
+	EXPECT_EQ((NAS2D::StringList{"a,b,c", "abc", "def"}), NAS2D::splitOnUnquoted(R"("a,b,c",abc,def)"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "a,b,c", "def"}), NAS2D::splitOnUnquoted(R"(abc,"a,b,c",def)"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def","a,b,c"}), NAS2D::splitOnUnquoted(R"(abc,def,"a,b,c")"));
+	EXPECT_EQ((NAS2D::StringList{"", "abc", "def"}), NAS2D::splitOnUnquoted(R"("",abc,def)"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted(R"(abc,"",def)"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted(R"(abc,def,"")"));
 
 	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitOnUnquoted("a.b.c", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitOnUnquoted("abc", '.'));
@@ -50,15 +50,15 @@ TEST(String, splitOnUnquoted)
 	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquoted("a.bc", '.'));
 	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquoted("ab.c", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::splitOnUnquoted("abc.", '.'));
-	EXPECT_EQ((NAS2D::StringList{"a.b.c", "abc", "def"}), NAS2D::splitOnUnquoted("\"a.b.c\".abc.def", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "a.b.c", "def"}), NAS2D::splitOnUnquoted("abc.\"a.b.c\".def", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def", "a.b.c"}), NAS2D::splitOnUnquoted("abc.def.\"a.b.c\"", '.'));
-	EXPECT_EQ((NAS2D::StringList{"", "abc", "def"}), NAS2D::splitOnUnquoted("\"\".abc.def", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted("abc.\"\".def", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted("abc.def.\"\"", '.'));
-	EXPECT_EQ((NAS2D::StringList{"Hello", "Hello World", "World"}), NAS2D::splitOnUnquoted("Hello \"Hello World\" World", ' '));
-	EXPECT_EQ((NAS2D::StringList{"Hello", " ", "World"}), NAS2D::splitOnUnquoted("Hello \" \" World", ' '));
-	EXPECT_EQ((NAS2D::StringList{"Hello", "", "World"}), NAS2D::splitOnUnquoted("Hello \"\" World", ' '));
+	EXPECT_EQ((NAS2D::StringList{"a.b.c", "abc", "def"}), NAS2D::splitOnUnquoted(R"("a.b.c".abc.def)", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "a.b.c", "def"}), NAS2D::splitOnUnquoted(R"(abc."a.b.c".def)", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def", "a.b.c"}), NAS2D::splitOnUnquoted(R"(abc.def."a.b.c")", '.'));
+	EXPECT_EQ((NAS2D::StringList{"", "abc", "def"}), NAS2D::splitOnUnquoted(R"("".abc.def)", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted(R"(abc."".def)", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted(R"(abc.def."")", '.'));
+	EXPECT_EQ((NAS2D::StringList{"Hello", "Hello World", "World"}), NAS2D::splitOnUnquoted(R"(Hello "Hello World" World)", ' '));
+	EXPECT_EQ((NAS2D::StringList{"Hello", " ", "World"}), NAS2D::splitOnUnquoted(R"(Hello " " World)", ' '));
+	EXPECT_EQ((NAS2D::StringList{"Hello", "", "World"}), NAS2D::splitOnUnquoted(R"(Hello "" World)", ' '));
 
 }
 

--- a/test/Common.test.cpp
+++ b/test/Common.test.cpp
@@ -56,6 +56,10 @@ TEST(String, splitOnUnquoted)
 	EXPECT_EQ((NAS2D::StringList{"", "abc", "def"}), NAS2D::splitOnUnquoted("\"\".abc.def", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted("abc.\"\".def", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted("abc.def.\"\"", '.'));
+	EXPECT_EQ((NAS2D::StringList{"Hello", "Hello World", "World"}), NAS2D::splitOnUnquoted("Hello \"Hello World\" World", ' '));
+	EXPECT_EQ((NAS2D::StringList{"Hello", " ", "World"}), NAS2D::splitOnUnquoted("Hello \" \" World", ' '));
+	EXPECT_EQ((NAS2D::StringList{"Hello", "", "World"}), NAS2D::splitOnUnquoted("Hello \"\" World", ' '));
+
 }
 
 TEST(String, splitSkipEmpty)
@@ -96,5 +100,6 @@ TEST(String, splitOnUnquotedSkipEmpty)
 	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("\"\".abc.def", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("abc.\"\".def", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc", "def"}), NAS2D::splitOnUnquotedSkipEmpty("abc.def.\"\"", '.'));
-
+	EXPECT_EQ((NAS2D::StringList{"Hello", " ", "World"}), NAS2D::splitOnUnquotedSkipEmpty("Hello \" \" World", ' '));
+	EXPECT_EQ((NAS2D::StringList{"Hello", "World"}), NAS2D::splitOnUnquotedSkipEmpty("Hello \"\" World", ' '));
 }

--- a/test/Common.test.cpp
+++ b/test/Common.test.cpp
@@ -37,9 +37,9 @@ TEST(String, splitOnUnquoted)
 	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquoted("a,bc"));
 	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquoted("ab,c"));
 	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::splitOnUnquoted("abc,"));
-	EXPECT_EQ((NAS2D::StringList{R"("a,b,c")", "abc", "def"}), NAS2D::splitOnUnquoted(R"("a,b,c",abc,def)"));
-	EXPECT_EQ((NAS2D::StringList{"abc", R"("a,b,c")", "def"}), NAS2D::splitOnUnquoted(R"(abc,"a,b,c",def)"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def", R"("a,b,c")"}), NAS2D::splitOnUnquoted(R"(abc,def,"a,b,c")"));
+	EXPECT_EQ((NAS2D::StringList{"a,b,c", "abc", "def"}), NAS2D::splitOnUnquoted(R"("a,b,c",abc,def)"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "a,b,c", "def"}), NAS2D::splitOnUnquoted(R"(abc,"a,b,c",def)"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def", "a,b,c"}), NAS2D::splitOnUnquoted(R"(abc,def,"a,b,c")"));
 	EXPECT_EQ((NAS2D::StringList{"", "abc", "def"}), NAS2D::splitOnUnquoted(R"("",abc,def)"));
 	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted(R"(abc,"",def)"));
 	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted(R"(abc,def,"")"));
@@ -50,14 +50,14 @@ TEST(String, splitOnUnquoted)
 	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquoted("a.bc", '.'));
 	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquoted("ab.c", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::splitOnUnquoted("abc.", '.'));
-	EXPECT_EQ((NAS2D::StringList{R"("a.b.c")", "abc", "def"}), NAS2D::splitOnUnquoted(R"("a.b.c".abc.def)", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", R"("a.b.c")", "def"}), NAS2D::splitOnUnquoted(R"(abc."a.b.c".def)", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def", R"("a.b.c")"}), NAS2D::splitOnUnquoted(R"(abc.def."a.b.c")", '.'));
+	EXPECT_EQ((NAS2D::StringList{"a.b.c", "abc", "def"}), NAS2D::splitOnUnquoted(R"("a.b.c".abc.def)", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "a.b.c", "def"}), NAS2D::splitOnUnquoted(R"(abc."a.b.c".def)", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def", "a.b.c"}), NAS2D::splitOnUnquoted(R"(abc.def."a.b.c")", '.'));
 	EXPECT_EQ((NAS2D::StringList{"", "abc", "def"}), NAS2D::splitOnUnquoted(R"("".abc.def)", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted(R"(abc."".def)", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted(R"(abc.def."")", '.'));
-	EXPECT_EQ((NAS2D::StringList{"Hello", R"("Hello World")", "World"}), NAS2D::splitOnUnquoted(R"(Hello "Hello World" World)", ' '));
-	EXPECT_EQ((NAS2D::StringList{"Hello", R"(" ")", "World"}), NAS2D::splitOnUnquoted(R"(Hello " " World)", ' '));
+	EXPECT_EQ((NAS2D::StringList{"Hello", "Hello World", "World"}), NAS2D::splitOnUnquoted(R"(Hello "Hello World" World)", ' '));
+	EXPECT_EQ((NAS2D::StringList{"Hello", " ", "World"}), NAS2D::splitOnUnquoted(R"(Hello " " World)", ' '));
 	EXPECT_EQ((NAS2D::StringList{"Hello", "", "World"}), NAS2D::splitOnUnquoted(R"(Hello "" World)", ' '));
 
 }

--- a/test/Common.test.cpp
+++ b/test/Common.test.cpp
@@ -37,9 +37,9 @@ TEST(String, splitOnUnquoted)
 	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquoted("a,bc"));
 	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquoted("ab,c"));
 	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::splitOnUnquoted("abc,"));
-	EXPECT_EQ((NAS2D::StringList{"a,b,c", "abc", "def"}), NAS2D::splitOnUnquoted(R"("a,b,c",abc,def)"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "a,b,c", "def"}), NAS2D::splitOnUnquoted(R"(abc,"a,b,c",def)"));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def","a,b,c"}), NAS2D::splitOnUnquoted(R"(abc,def,"a,b,c")"));
+	EXPECT_EQ((NAS2D::StringList{R"("a,b,c")", "abc", "def"}), NAS2D::splitOnUnquoted(R"("a,b,c",abc,def)"));
+	EXPECT_EQ((NAS2D::StringList{"abc", R"("a,b,c")", "def"}), NAS2D::splitOnUnquoted(R"(abc,"a,b,c",def)"));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def", R"("a,b,c")"}), NAS2D::splitOnUnquoted(R"(abc,def,"a,b,c")"));
 	EXPECT_EQ((NAS2D::StringList{"", "abc", "def"}), NAS2D::splitOnUnquoted(R"("",abc,def)"));
 	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted(R"(abc,"",def)"));
 	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted(R"(abc,def,"")"));
@@ -50,14 +50,14 @@ TEST(String, splitOnUnquoted)
 	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitOnUnquoted("a.bc", '.'));
 	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitOnUnquoted("ab.c", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::splitOnUnquoted("abc.", '.'));
-	EXPECT_EQ((NAS2D::StringList{"a.b.c", "abc", "def"}), NAS2D::splitOnUnquoted(R"("a.b.c".abc.def)", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "a.b.c", "def"}), NAS2D::splitOnUnquoted(R"(abc."a.b.c".def)", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", "def", "a.b.c"}), NAS2D::splitOnUnquoted(R"(abc.def."a.b.c")", '.'));
+	EXPECT_EQ((NAS2D::StringList{R"("a.b.c")", "abc", "def"}), NAS2D::splitOnUnquoted(R"("a.b.c".abc.def)", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", R"("a.b.c")", "def"}), NAS2D::splitOnUnquoted(R"(abc."a.b.c".def)", '.'));
+	EXPECT_EQ((NAS2D::StringList{"abc", "def", R"("a.b.c")"}), NAS2D::splitOnUnquoted(R"(abc.def."a.b.c")", '.'));
 	EXPECT_EQ((NAS2D::StringList{"", "abc", "def"}), NAS2D::splitOnUnquoted(R"("".abc.def)", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc", "", "def"}), NAS2D::splitOnUnquoted(R"(abc."".def)", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc", "def", ""}), NAS2D::splitOnUnquoted(R"(abc.def."")", '.'));
-	EXPECT_EQ((NAS2D::StringList{"Hello", "Hello World", "World"}), NAS2D::splitOnUnquoted(R"(Hello "Hello World" World)", ' '));
-	EXPECT_EQ((NAS2D::StringList{"Hello", " ", "World"}), NAS2D::splitOnUnquoted(R"(Hello " " World)", ' '));
+	EXPECT_EQ((NAS2D::StringList{"Hello", R"("Hello World")", "World"}), NAS2D::splitOnUnquoted(R"(Hello "Hello World" World)", ' '));
+	EXPECT_EQ((NAS2D::StringList{"Hello", R"(" ")", "World"}), NAS2D::splitOnUnquoted(R"(Hello " " World)", ' '));
 	EXPECT_EQ((NAS2D::StringList{"Hello", "", "World"}), NAS2D::splitOnUnquoted(R"(Hello "" World)", ' '));
 
 }


### PR DESCRIPTION
Adds split functions that preserve quoted delimiters. Useful for key-value parsers.