### PR TITLE
Remove trailing semicolons on namespace blocks

### DIFF
--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -61,4 +61,4 @@ private:
 	mutable bool		mVerbose;			/**< Displays lots of messages when true. Otherwise only critical messages are displayed. */
 };
 
-};
+}

--- a/include/NAS2D/Mixer/MixerSDL.h
+++ b/include/NAS2D/Mixer/MixerSDL.h
@@ -61,4 +61,4 @@ private:
 	void music_finished_hook();
 };
 
-};
+}

--- a/include/NAS2D/Trig.h
+++ b/include/NAS2D/Trig.h
@@ -29,4 +29,4 @@ Point_2df getDirectionVector(float angle);
 
 bool lineIntersectsCircle(const Point_2d& p, const Point_2d& q, const Point_2d& c, float r);
 
-};
+}


### PR DESCRIPTION
This was causing quite a few warnings on the Linux builds.
