### PR TITLE
Fix Clang parenthesis warning

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -216,7 +216,7 @@ bool Configuration::readConfig(const std::string& filePath)
 
 		// Start parsing through the Config.xml file.
 		XmlNode *xmlNode = nullptr;
-		while (xmlNode = root->iterateChildren(xmlNode)) // warning C4706: intended
+		while ((xmlNode = root->iterateChildren(xmlNode)))
 		{
 			if (xmlNode->value() == "graphics") { parseGraphics(xmlNode); }
 			else if (xmlNode->value() == "audio") { parseAudio(xmlNode); }
@@ -365,7 +365,7 @@ void Configuration::parseOptions(void* _n)
 	}
 
 	XmlNode *node = nullptr;
-	while (node = element->iterateChildren(node)) // warning C4706: intended
+	while ((node = element->iterateChildren(node)))
 	{
 		if (node->value() == "option")
 		{

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -358,7 +358,7 @@ void Sprite::processImageSheets(void* root)
 
 	XmlNode* node = nullptr;
 	string id, src;
-	while (node = e->iterateChildren(node)) // warning C4706: intended
+	while ((node = e->iterateChildren(node)))
 	{
 		if (node->value() == "imagesheet" && node->toElement())
 		{
@@ -437,7 +437,7 @@ void Sprite::processActions(void* root)
 	XmlElement* element = static_cast<XmlElement*>(root);
 
 	XmlNode* node = nullptr;
-	while (node = element->iterateChildren(node)) // warning C4706: intended
+	while ((node = element->iterateChildren(node)))
 	{
 		if (toLowercase(node->value()) == "action" && node->toElement())
 		{
@@ -483,7 +483,7 @@ void Sprite::processFrames(const std::string& action, void* _node)
 	FrameList frameList;
 
 	XmlNode* frame = nullptr;
-	while (frame = node->iterateChildren(frame)) // warning C4706: intended
+	while ((frame = node->iterateChildren(frame)))
 	{
 		int currentRow = frame->row();
 


### PR DESCRIPTION
Extra parenthesis seems to indicate intent and silence the warning for all compilers.
