### PR TITLE
Fix debug output bug for cursor image of size 0

### DIFF
--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -477,7 +477,7 @@ void RendererOpenGL::addCursor(const std::string& filePath, int cursorId, int of
 	File imageFile = Utility<Filesystem>::get().open(filePath);
 	if (imageFile.size() == 0)
 	{
-		std::cout << "RendererOpenGL::addCursor(): '" << name() << "' is empty." << std::endl;
+		std::cout << "RendererOpenGL::addCursor(): '" << filePath << "' is empty." << std::endl;
 		return;
 	}
 


### PR DESCRIPTION
Closes #249

Replaces nonsensical `name()` output with `filePath`, which is probably what was originally intended.
