### PR TITLE
Changed macOS executor to 11.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
       - image: outpostuniverse/nas2d-circleci:1.1
   macos-executor:
     macos:
-      xcode: "10.0.0"
+      xcode: "11.3.0"
 commands:
   brew-install:
     description: "Brew install MacOS dependencies (or restore from cache)"


### PR DESCRIPTION
Cherry picked from PR #243. I'd like to get this change in now, rather than wait for review and fixes on the original branch.

> Per https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions 11.3.0 is the highest version number that supports macOS 10.15

The new version of MacOS and Xcode comes with the new C++17 `<filesystem>` header.

Original discussion:
https://github.com/lairworks/nas2d-core/issues/179#issuecomment-566124388
Closes #152
