### PR TITLE
Fix `Debug` configuration references to GTest libraries

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,7 @@
 image: Visual Studio 2019 Preview
-configuration: Release
+configuration:
+  - Release
+  - Debug
 platform:
   - x86
   - x64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 image: Visual Studio 2019 Preview
 configuration:
-  - Release
+  # - Release
   - Debug
 platform:
   - x86

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,6 @@
 image: Visual Studio 2019 Preview
 configuration:
-  # - Release
-  - Debug
+  - Release
 platform:
   - x86
   - x64

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -72,7 +72,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gtest.lib;gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtestd.lib;gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -89,7 +89,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gtest.lib;gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtestd.lib;gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>


### PR DESCRIPTION
Closes #184

Seems the debug versions of the GTest libraries have a "d" appended to their names.
