### PR TITLE
Platform specific vcpkg

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,12 +8,9 @@ cache:
   - C:\projects\nas2d-core\proj\vs2019\packages -> proj\vs2019\packages.config
 install:
   - vcpkg integrate install
-  - vcpkg install physfs:x86-windows
-  - vcpkg install physfs:x64-windows
-  - vcpkg install glew:x86-windows
-  - vcpkg install glew:x64-windows
-  - vcpkg install gtest:x86-windows
-  - vcpkg install gtest:x64-windows
+  - vcpkg install physfs:%PLATFORM%-windows
+  - vcpkg install glew:%PLATFORM%-windows
+  - vcpkg install gtest:%PLATFORM%-windows
   - nuget restore proj/vs2019
 build:
   project: proj/vs2019/NAS2D.sln

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,13 +4,11 @@ platform:
   - x86
   - x64
 cache:
-  - C:\tools\vcpkg\installed\
+  - C:\tools\vcpkg\installed\ -> InstallVcpkgDeps.bat
   - C:\projects\nas2d-core\proj\vs2019\packages -> proj\vs2019\packages.config
 install:
   - vcpkg integrate install
-  - vcpkg install physfs:%PLATFORM%-windows
-  - vcpkg install glew:%PLATFORM%-windows
-  - vcpkg install gtest:%PLATFORM%-windows
+  - call InstallVcpkgDeps.bat
   - nuget restore proj/vs2019
   - set APPVEYOR_SAVE_CACHE_ON_ERROR=true
 build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,7 @@ install:
   - vcpkg install glew:%PLATFORM%-windows
   - vcpkg install gtest:%PLATFORM%-windows
   - nuget restore proj/vs2019
+  - set APPVEYOR_SAVE_CACHE_ON_ERROR=true
 build:
   project: proj/vs2019/NAS2D.sln
 test_script:

--- a/InstallVcpkgDeps.bat
+++ b/InstallVcpkgDeps.bat
@@ -1,0 +1,21 @@
+@echo off
+echo "This batch file will install dependencies on Windows with vcpkg"
+
+vcpkg version
+if %ERRORLEVEL% NEQ 0 (
+  echo "The command `vcpkg` is not installed"
+  exit /b
+)
+
+if not defined PLATFORM (
+  set PLATFORM=x86
+  call :Install
+  set PLATFORM=x64
+  call :Install
+  exit /b
+)
+
+:Install
+vcpkg install physfs:%PLATFORM%-windows
+vcpkg install glew:%PLATFORM%-windows
+vcpkg install gtest:%PLATFORM%-windows


### PR DESCRIPTION
Closes #173

Now only packages for the current platform are installed by `vcpkg`. It does this using the AppVeyor `PLATFORM` environment variable.

Once installation completes successfully, installed packages will be cached even if the build later fails. According to AppVeyor documentation, caching is done per Job, so there will be separate caches for different platform configurations.

The package installation was extracted to a batch file. This makes local installation of packages easier. For a local run, the `PLATFORM` environment variable likely won't be set. In this case, the batch file will install both `x86` and `x64` packages, to allow the user to switch between configurations easily.
