### PR TITLE
Update Appveyor to full VS2019

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019 Preview
+image: Visual Studio 2019
 configuration:
   - Release
 platform:


### PR DESCRIPTION
Closes #273 

Appveyor now supports full VS2019 (16.4 as of this PR)