### PR TITLE
Xml const correctness

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -236,7 +236,7 @@ void Configuration::parseGraphics(void* _n)
 		return;
 	}
 
-	XmlAttribute* attribute = element->firstAttribute();
+	const XmlAttribute* attribute = element->firstAttribute();
 	while (attribute)
 	{
 		if (attribute->name() == GRAPHICS_CFG_SCREEN_WIDTH) { attribute->queryIntValue(mScreenWidth); }
@@ -270,7 +270,7 @@ void Configuration::parseAudio(void* _n)
 		return;
 	}
 
-	XmlAttribute* attribute = element->firstAttribute();
+	const XmlAttribute* attribute = element->firstAttribute();
 	while (attribute)
 	{
 		if (attribute->name() == AUDIO_CFG_MIXRATE)
@@ -354,7 +354,7 @@ void Configuration::parseOptions(void* _n)
 	{
 		if (node->value() == "option")
 		{
-			XmlAttribute* attribute = node->toElement()->firstAttribute();
+			const XmlAttribute* attribute = node->toElement()->firstAttribute();
 
 			std::string name, value;
 			while (attribute)

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -10,6 +10,7 @@
 
 #include "NAS2D/Resources/Sprite.h"
 #include "NAS2D/Version.h"
+#include "NAS2D/Xml/Xml.h"
 
 #include <iostream>
 

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -321,7 +321,7 @@ void Sprite::processXml(const std::string& filePath)
 		}
 
 		// Get the Sprite version.
-		XmlAttribute* version = xmlRootElement->firstAttribute();
+		const XmlAttribute* version = xmlRootElement->firstAttribute();
 		if (!version || version->value().empty())
 		{
 			cout << "Root element in sprite file '" << filePath << "' doesn't define a version." << endl;
@@ -363,7 +363,7 @@ void Sprite::processImageSheets(void* root)
 	{
 		if (node->value() == "imagesheet" && node->toElement())
 		{
-			XmlAttribute* attribute = node->toElement()->firstAttribute();
+			const XmlAttribute* attribute = node->toElement()->firstAttribute();
 			while (attribute)
 			{
 				if (toLowercase(attribute->name()) == "id") { id = attribute->value(); }
@@ -444,7 +444,7 @@ void Sprite::processActions(void* root)
 		{
 
 			string action_name;
-			XmlAttribute* attribute = node->toElement()->firstAttribute();
+			const XmlAttribute* attribute = node->toElement()->firstAttribute();
 			while (attribute)
 			{
 				if (toLowercase(attribute->name()) == "name")
@@ -496,7 +496,7 @@ void Sprite::processFrames(const std::string& action, void* _node)
 			int width = 0, height = 0;
 			int anchorx = 0, anchory = 0;
 
-			XmlAttribute* attribute = frame->toElement()->firstAttribute();
+			const XmlAttribute* attribute = frame->toElement()->firstAttribute();
 			while (attribute)
 			{
 				if (toLowercase(attribute->name()) == "sheetid") { sheetId = attribute->value(); }


### PR DESCRIPTION
This addresses part of issue #239.

This improves `const` correctness. It also accounts for a difference in return type for the TinyXML2 library. By improving this now, it can make a potential upgrade easier later.
