### PR TITLE
Adds Pre-Build Event for VS2019

### DIFF
--- a/proj/vs2019/NAS2D.vcxproj
+++ b/proj/vs2019/NAS2D.vcxproj
@@ -104,6 +104,12 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Installing vcpkg dependencies</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -119,6 +125,12 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Installing vcpkg dependencies</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -141,6 +153,12 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Installing vcpkg dependencies</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -163,6 +181,12 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Installing vcpkg dependencies</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\Configuration.cpp" />

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -76,6 +76,12 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Installing Vcpkg dependencies</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -93,6 +99,12 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Installing Vcpkg dependencies</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -111,6 +123,12 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Installing Vcpkg dependencies</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -130,5 +148,11 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Installing Vcpkg dependencies</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
 </Project>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -76,12 +76,8 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
-    <PreBuildEvent>
-      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
-    </PreBuildEvent>
-    <PreBuildEvent>
-      <Message>Installing Vcpkg dependencies</Message>
-    </PreBuildEvent>
+    <PreBuildEvent />
+    <PreBuildEvent />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -99,12 +95,8 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
-    <PreBuildEvent>
-      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
-    </PreBuildEvent>
-    <PreBuildEvent>
-      <Message>Installing Vcpkg dependencies</Message>
-    </PreBuildEvent>
+    <PreBuildEvent />
+    <PreBuildEvent />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -123,12 +115,8 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
-    <PreBuildEvent>
-      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
-    </PreBuildEvent>
-    <PreBuildEvent>
-      <Message>Installing Vcpkg dependencies</Message>
-    </PreBuildEvent>
+    <PreBuildEvent />
+    <PreBuildEvent />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -148,11 +136,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
-    <PreBuildEvent>
-      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
-    </PreBuildEvent>
-    <PreBuildEvent>
-      <Message>Installing Vcpkg dependencies</Message>
-    </PreBuildEvent>
+    <PreBuildEvent />
+    <PreBuildEvent />
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Closes #278 

Runs `($SolutionDir)../../VcpkgDeps.bat` as a Pre-Build Event to install glew/physfs dependencies prior to trying to build.