### PR TITLE
Simplify `Filesystem::extension`

### DIFF
--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -326,14 +326,7 @@ std::string Filesystem::extension(const std::string& path)
 	{
 		return path.substr(pos + 1);
 	}
-	else if (isDirectory(path))
-	{
-		return std::string();
-	}
-	else
-	{
-		return std::string();
-	}
+	return std::string();
 }
 
 


### PR DESCRIPTION
Something we noticed earlier, but was off-topic at the time. Made even more obvious by other recent edits.
