### PR TITLE
Refresh Docker images

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,7 +1,7 @@
 # See Docker and CircleCI section of makefile in root project folder for usage.
 
 # Depend on local build image
-FROM outpostuniverse/nas2d:1.1
+FROM outpostuniverse/nas2d:1.2
 
 USER root
 # Install tools needed for primary CircleCI containers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   docker-executor:
     docker:
-      - image: outpostuniverse/nas2d-circleci:1.1
+      - image: outpostuniverse/nas2d-circleci:1.2
   macos-executor:
     macos:
       xcode: "11.3.0"

--- a/docker/Ubuntu-18.04-gcc-gtest.Dockerfile
+++ b/docker/Ubuntu-18.04-gcc-gtest.Dockerfile
@@ -1,6 +1,6 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM outpostuniverse/ubuntu-18.04-gcc:1.0
+FROM outpostuniverse/ubuntu-18.04-gcc:1.1
 
 # Install Google Test source package
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/nas2d.Dockerfile
+++ b/docker/nas2d.Dockerfile
@@ -1,6 +1,6 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM outpostuniverse/ubuntu-18.04-gcc-gtest:1.0
+FROM outpostuniverse/ubuntu-18.04-gcc-gtest:1.2
 
 # Install NAS2D specific dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/makefile
+++ b/makefile
@@ -206,9 +206,9 @@ root-debug-image-ubuntu-16.04:
 	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive --user=0 outpostuniverse/ubuntu-16.04-gcc-sdl2-physfs bash
 
 build-image-ubuntu-18.04:
-	docker build ${DockerFolder}/ --file ${DockerFolder}/Ubuntu-18.04-gcc.Dockerfile --tag outpostuniverse/ubuntu-18.04-gcc:latest --tag outpostuniverse/ubuntu-18.04-gcc:1.0
-	docker build ${DockerFolder}/ --file ${DockerFolder}/Ubuntu-18.04-gcc-gtest.Dockerfile --tag outpostuniverse/ubuntu-18.04-gcc-gtest:latest --tag outpostuniverse/ubuntu-18.04-gcc-gtest:1.1
-	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d.Dockerfile --tag outpostuniverse/nas2d:latest --tag outpostuniverse/nas2d:1.1
+	docker build ${DockerFolder}/ --file ${DockerFolder}/Ubuntu-18.04-gcc.Dockerfile --tag outpostuniverse/ubuntu-18.04-gcc:latest --tag outpostuniverse/ubuntu-18.04-gcc:1.1
+	docker build ${DockerFolder}/ --file ${DockerFolder}/Ubuntu-18.04-gcc-gtest.Dockerfile --tag outpostuniverse/ubuntu-18.04-gcc-gtest:latest --tag outpostuniverse/ubuntu-18.04-gcc-gtest:1.2
+	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d.Dockerfile --tag outpostuniverse/nas2d:latest --tag outpostuniverse/nas2d:1.2
 compile-on-ubuntu-18.04:
 	docker run --rm --tty --volume ${TopLevelFolder}:/code outpostuniverse/nas2d
 debug-image-ubuntu-18.04:
@@ -222,7 +222,7 @@ root-debug-image-ubuntu-18.04:
 .PHONY: build-image-circleci push-image-circleci circleci-validate circleci-build
 
 build-image-circleci: | build-image-ubuntu-18.04
-	docker build .circleci/ --tag outpostuniverse/nas2d-circleci:latest --tag outpostuniverse/nas2d-circleci:1.1
+	docker build .circleci/ --tag outpostuniverse/nas2d-circleci:latest --tag outpostuniverse/nas2d-circleci:1.2
 push-image-circleci:
 	docker push outpostuniverse/nas2d-circleci
 circleci-validate:


### PR DESCRIPTION
Closes #292

A new Ubuntu base image was pulled, and dependent images rebuilt on top of it. Docker image version numbers have been updated for the new builds.

The new images have been pushed to DockerHub.

Installed Apt package versions are the same. There were no updated versions available when building from the new base image, at least not for the top level packages, to the extent that version numbers have been specified in the Dockerfile.
