### PR TITLE
Converts Point and Rectangle classes to struct

### DIFF
--- a/include/NAS2D/Renderer/Point.h
+++ b/include/NAS2D/Renderer/Point.h
@@ -12,15 +12,15 @@
 
 namespace NAS2D {
 
-class Point_2d;
-class Point_2df;
+struct Point_2d;
+struct Point_2df;
 
 
 /**
  * \class	Point_2d
  * \brief	2D point.
  */
-class Point_2d
+struct Point_2d
 {
 public:
 	Point_2d() = default;
@@ -66,7 +66,7 @@ private:
  * \class	Point_2df
  * \brief	Floating point 2D Point.
  */
-class Point_2df
+struct Point_2df
 {
 public:
 	Point_2df() = default;

--- a/include/NAS2D/Renderer/Rectangle.h
+++ b/include/NAS2D/Renderer/Rectangle.h
@@ -13,15 +13,15 @@
 namespace NAS2D {
 
 
-class Rectangle_2d;
-class Rectangle_2df;
+struct Rectangle_2d;
+struct Rectangle_2df;
 
 
 /**
  * \class	Rectangle_2d
  * \brief	2D rectangle.
  */
-class Rectangle_2d
+struct Rectangle_2d
 {
 public:
 	Rectangle_2d() = default;
@@ -86,7 +86,7 @@ private:
  * \class	Rectangle_2df
  * \brief	Floating point 2D Rectangle.
  */
-class Rectangle_2df
+struct Rectangle_2df
 {
 public:
 	Rectangle_2df() = default;

--- a/include/NAS2D/Trig.h
+++ b/include/NAS2D/Trig.h
@@ -18,8 +18,8 @@ extern const float DEG2RAD;
 extern const float RAD2DEG;
 
 
-class Point_2d;
-class Point_2df;
+struct Point_2d;
+struct Point_2df;
 
 
 float degToRad(float degree);


### PR DESCRIPTION
Closes #268

This is a breaking change to any file that forward declares `Point_2d`, `Point_2df`, `Rectangle_2d`, and `Rectangle_2df` as a `class` instead of `struct`.