### PR TITLE
Update Docker image with newer GoogleTest library

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,7 +1,7 @@
 # See Docker and CircleCI section of makefile in root project folder for usage.
 
 # Depend on local build image
-FROM outpostuniverse/nas2d:1.2
+FROM outpostuniverse/nas2d:1.3
 
 USER root
 # Install tools needed for primary CircleCI containers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   docker-executor:
     docker:
-      - image: outpostuniverse/nas2d-circleci:1.2
+      - image: outpostuniverse/nas2d-circleci:1.3
   macos-executor:
     macos:
       xcode: "11.3.0"

--- a/docker/nas2d.Dockerfile
+++ b/docker/nas2d.Dockerfile
@@ -8,19 +8,35 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake=3.10.2-* \
   && rm -rf /var/lib/apt/lists/*
 
-# Install Google Test source package
+# Install curl (so an updated GoogleTest can be downloaded)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    googletest=1.8.0-* \
+    curl=7.58.0-* \
+    ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
 
-# Compile and install Google Test
+# Download, compile, and install Google Test source package
 WORKDIR /tmp/gtest/
-RUN cmake -DCMAKE_CXX_FLAGS="-std=c++17" /usr/src/googletest/ && \
+RUN curl --location https://github.com/google/googletest/archive/release-1.10.0.tar.gz | \
+  tar -xz && \
+  cmake -DCMAKE_CXX_FLAGS="-std=c++17" googletest-release-1.10.0/ && \
   make && \
-  cp googlemock/gtest/lib*.a /usr/lib && \
-  cp googlemock/lib*.a /usr/lib && \
+  cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DBUILD_SHARED_LIBS=ON googletest-release-1.10.0/ && \
+  make && \
+  cp -r lib/ /usr/local/ && \
+  cp -r \
+    googletest-release-1.10.0/googletest/include/ \
+    googletest-release-1.10.0/googlemock/include/ \
+    /usr/local/ && \
+  cp --parents -r \
+    googletest-release-1.10.0/CMakeLists.txt \
+    googletest-release-1.10.0/googletest/CMakeLists.txt \
+    googletest-release-1.10.0/googletest/cmake/ \
+    googletest-release-1.10.0/googletest/src/ \
+    googletest-release-1.10.0/googlemock/CMakeLists.txt \
+    googletest-release-1.10.0/googlemock/cmake/ \
+    googletest-release-1.10.0/googlemock/src/ \
+    /usr/local/src/ && \
   rm -rf /tmp/gtest/
-WORKDIR /
 
 # Install NAS2D specific dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/makefile
+++ b/makefile
@@ -206,7 +206,7 @@ root-debug-image-ubuntu-16.04:
 	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive --user=0 outpostuniverse/ubuntu-16.04-gcc-sdl2-physfs bash
 
 build-image-ubuntu-18.04:
-	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d.Dockerfile --tag outpostuniverse/nas2d:latest --tag outpostuniverse/nas2d:1.2
+	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d.Dockerfile --tag outpostuniverse/nas2d:latest --tag outpostuniverse/nas2d:1.3
 compile-on-ubuntu-18.04:
 	docker run --rm --tty --volume ${TopLevelFolder}:/code outpostuniverse/nas2d
 debug-image-ubuntu-18.04:
@@ -220,7 +220,7 @@ root-debug-image-ubuntu-18.04:
 .PHONY: build-image-circleci push-image-circleci circleci-validate circleci-build
 
 build-image-circleci: | build-image-ubuntu-18.04
-	docker build .circleci/ --tag outpostuniverse/nas2d-circleci:latest --tag outpostuniverse/nas2d-circleci:1.2
+	docker build .circleci/ --tag outpostuniverse/nas2d-circleci:latest --tag outpostuniverse/nas2d-circleci:1.3
 push-image-circleci:
 	docker push outpostuniverse/nas2d-circleci
 circleci-validate:


### PR DESCRIPTION
This requires doing a source install of GoogleTest. The Apt packaged library is only up to version 1.8, whereas the current release is 1.10.

The 1.10 release introduced the new `MOCK_METHOD` macro. This is much easier to use than the older `MOCK_METHOD0` style macros, where the number of parameters has to be manually counted and specified.

----

Linux only change.
