### PR TITLE
Update `string_format`

### DIFF
--- a/include/NAS2D/StringUtils.h
+++ b/include/NAS2D/StringUtils.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2019 New Age Software
+// = Copyright ï¿½ 2008 - 2019 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.
@@ -37,10 +37,12 @@ namespace NAS2D
 	template<typename... Args>
 	std::string string_format(const std::string& format, Args... args)
 	{
-		std::size_t size = snprintf(nullptr, std::size_t{0u}, format.c_str(), args...) + std::size_t{1u};
-		std::unique_ptr<char[]> buffer(new char[size]);
-		snprintf(buffer.get(), size, format.c_str(), args...);
-		return std::string(buffer.get(), buffer.get() + size - 1);
+		std::string buffer;
+		std::size_t size = snprintf(buffer.data(), buffer.size(), format.c_str(), args...);
+		buffer.resize(size + 1); // Including null (avoid clipping/undefined behavior)
+		snprintf(buffer.data(), buffer.size(), format.c_str(), args...);
+		buffer.resize(size); // Strip null temrinator
+		return buffer;
 	}
 
 	/**

--- a/include/NAS2D/StringUtils.h
+++ b/include/NAS2D/StringUtils.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright � 2008 - 2019 New Age Software
+// = Copyright © 2008 - 2019 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -36,3 +36,26 @@ TEST(String, splitSkipEmpty)
 	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitSkipEmpty("ab.c", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc.", '.'));
 }
+
+TEST(String, string_format)
+{
+	// Numbers
+	EXPECT_EQ("-1", NAS2D::string_format("%d", -1));
+	EXPECT_EQ("0", NAS2D::string_format("%d", 0));
+	EXPECT_EQ("1", NAS2D::string_format("%d", 1));
+
+	// Padded numbers
+	EXPECT_EQ(" 10", NAS2D::string_format("%3d", 10));
+	EXPECT_EQ("010", NAS2D::string_format("%03d", 10));
+	// Negative padded numbers
+	EXPECT_EQ("-10", NAS2D::string_format("%3d", -10));
+	EXPECT_EQ("-10", NAS2D::string_format("%03d", -10));
+	EXPECT_EQ(" -10", NAS2D::string_format("%4d", -10));
+	EXPECT_EQ("-010", NAS2D::string_format("%04d", -10));
+
+	// Strings
+	EXPECT_EQ("Hello World", NAS2D::string_format("Hello %s", "World"));
+
+	// Padded strings
+	EXPECT_EQ("  ABC", NAS2D::string_format("%5s", "ABC"));
+}


### PR DESCRIPTION
Closes #293

GCC no longer complains about null destination buffer.

Eliminates copy from temporary buffer.
