### PR TITLE
Convert copyright symbols to Unicode

### DIFF
--- a/include/NAS2D/MathUtils.h
+++ b/include/NAS2D/MathUtils.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright � 2008 - 2019 New Age Software
+// = Copyright © 2008 - 2019 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/StringUtils.h
+++ b/include/NAS2D/StringUtils.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2019 New Age Software
+// = Copyright Â© 2008 - 2019 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/include/NAS2D/Version.h
+++ b/include/NAS2D/Version.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2019 New Age Software
+// = Copyright Â© 2008 - 2019 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/StringUtils.cpp
+++ b/src/StringUtils.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2019 New Age Software
+// = Copyright Â© 2008 - 2019 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/src/Version.cpp
+++ b/src/Version.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2019 New Age Software
+// = Copyright Â© 2008 - 2019 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.


### PR DESCRIPTION
Closes #313

This changes the encoding of the copyright symbol from ISO-8859 (aka Latin-1) to Unicode UTF-8. This is generally the only high-ASCII symbol used in the source files, and hence the only symbol with a distinct binary encoding between ISO-8859 and UTF-8.
