### PR TITLE
Fix GCC warning about catch by value

### DIFF
--- a/src/Xml/XmlAttribute.cpp
+++ b/src/Xml/XmlAttribute.cpp
@@ -193,7 +193,7 @@ XmlAttribute::QueryResult XmlAttribute::queryIntValue(int& i) const
 	{
 		i = std::stoi(_value);
 	}
-	catch (std::invalid_argument)
+	catch (const std::invalid_argument&)
 	{
 		return QueryResult::XML_WRONG_TYPE;
 	}
@@ -218,7 +218,7 @@ XmlAttribute::QueryResult XmlAttribute::queryDoubleValue(double& d) const
 	{
 		d = std::stod(_value);
 	}
-	catch (std::invalid_argument)
+	catch (const std::invalid_argument&)
 	{
 		return QueryResult::XML_WRONG_TYPE;
 	}


### PR DESCRIPTION
Closes #324

It's recommended to `catch` exceptions by `const &`, rather than by value. Using `&` allows for polymorphic catching of derived types. Using `const &` allows binding of both lvalue references and rvalue references.
