### PR TITLE
Init list formatting

### DIFF
--- a/include/NAS2D/File.h
+++ b/include/NAS2D/File.h
@@ -45,7 +45,9 @@ public:
 	 * \param	stream	A ByteStream representing the file.
 	 * \param	name	The full name of the file including path.
 	 */
-	File(const ByteStream& stream, const std::string& name):	mByteStream(stream), mFileName(name)
+	File(const ByteStream& stream, const std::string& name) :
+		mByteStream(stream),
+		mFileName(name)
 	{}
 
 	/**
@@ -58,7 +60,9 @@ public:
 	/**
 	 * Copy c'tor
 	 */
-	File(const File& _f):	mByteStream(_f.mByteStream), mFileName(_f.mFileName)
+	File(const File& _f) :
+		mByteStream(_f.mByteStream),
+		mFileName(_f.mFileName)
 	{}
 
 

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -26,7 +26,7 @@ NAS2D::Signals::Signal0<void>	fadeCompleteSignal;
  *
  * This c'tor is not public and can't be invoked externally.
  */
-Renderer::Renderer(const std::string& appTitle): mTitle(appTitle)
+Renderer::Renderer(const std::string& appTitle) : mTitle(appTitle)
 {}
 
 

--- a/src/Resources/Music.cpp
+++ b/src/Resources/Music.cpp
@@ -28,7 +28,7 @@ void updateMusicReferenceCount(const std::string& name);
 /**
  * Default c'tor.
  */
-Music::Music():	Resource()
+Music::Music() : Resource()
 {}
 
 
@@ -37,7 +37,7 @@ Music::Music():	Resource()
  *
  * \param filePath	Path of the music file to load.
  */
-Music::Music(const std::string& filePath):	Resource(filePath)
+Music::Music(const std::string& filePath) : Resource(filePath)
 {
 	load();
 }
@@ -46,7 +46,7 @@ Music::Music(const std::string& filePath):	Resource(filePath)
 /**
  * Copy c'tor.
  */
-Music::Music(const Music& rhs): Resource(rhs.name())
+Music::Music(const Music& rhs) : Resource(rhs.name())
 {
 	auto it = MUSIC_REF_MAP.find(name());
 	if (it != MUSIC_REF_MAP.end())

--- a/src/Resources/Resource.cpp
+++ b/src/Resources/Resource.cpp
@@ -15,8 +15,9 @@ using namespace NAS2D;
 /**
  * Default c'tor.
  */
-Resource::Resource():	mResourceName("Default Resource"),
-						mIsLoaded(false)
+Resource::Resource() :
+	mResourceName("Default Resource"),
+	mIsLoaded(false)
 {}
 
 
@@ -25,8 +26,9 @@ Resource::Resource():	mResourceName("Default Resource"),
  *
  * \param filePath Sets the name of the Resource to \c filePath.
  */
-Resource::Resource(const std::string& filePath):	mResourceName(filePath),
-													mIsLoaded(false)
+Resource::Resource(const std::string& filePath) :
+	mResourceName(filePath),
+	mIsLoaded(false)
 {}
 
 

--- a/src/Resources/Sound.cpp
+++ b/src/Resources/Sound.cpp
@@ -21,8 +21,9 @@ using namespace NAS2D;
 /**
  * Default C'tor.
  */
-Sound::Sound(): Resource(),
-				_chunk(nullptr)
+Sound::Sound() :
+	Resource(),
+	_chunk(nullptr)
 {}
 
 /**
@@ -30,8 +31,9 @@ Sound::Sound(): Resource(),
  *
  * \param	filePath	File path of the sound file to load.
  */
-Sound::Sound(const std::string& filePath):	Resource(filePath),
-_chunk(nullptr)
+Sound::Sound(const std::string& filePath) :
+	Resource(filePath),
+	_chunk(nullptr)
 {
 	load();
 }

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -39,12 +39,13 @@ string endTag(int row, const std::string& name)
  * \warning	Generally speaking, Sprites should not be instantiated
  *			with the default c'tor.
  */
-Sprite::Sprite():	mSpriteName("Default Constructed"),
-					mCurrentAction(DEFAULT_ACTION),
-					mCurrentFrame(0),
-					mColor(Color::Normal),
-					mRotationAngle(0.0f),
-					mPaused(false)
+Sprite::Sprite() :
+	mSpriteName("Default Constructed"),
+	mCurrentAction(DEFAULT_ACTION),
+	mCurrentFrame(0),
+	mColor(Color::Normal),
+	mRotationAngle(0.0f),
+	mPaused(false)
 {
 	addDefaultAction();
 }
@@ -55,12 +56,13 @@ Sprite::Sprite():	mSpriteName("Default Constructed"),
  *
  * \param filePath	File path of the Sprite definition file.
  */
-Sprite::Sprite(const std::string& filePath):	mSpriteName(filePath),
-												mCurrentAction(DEFAULT_ACTION),
-												mCurrentFrame(0),
-												mColor(Color::Normal),
-												mRotationAngle(0.0f),
-												mPaused(false)
+Sprite::Sprite(const std::string& filePath) :
+	mSpriteName(filePath),
+	mCurrentAction(DEFAULT_ACTION),
+	mCurrentFrame(0),
+	mColor(Color::Normal),
+	mRotationAngle(0.0f),
+	mPaused(false)
 {
 	processXml(filePath);
 }
@@ -69,14 +71,15 @@ Sprite::Sprite(const std::string& filePath):	mSpriteName(filePath),
 /**
  * Copy C'tor
  */
-Sprite::Sprite(const Sprite &sprite):	mImageSheets(sprite.mImageSheets),
-										mActions(sprite.mActions),
-										mSpriteName(sprite.mSpriteName),
-										mCurrentAction(sprite.mCurrentAction),
-										mCurrentFrame(sprite.mCurrentFrame),
-										mColor(sprite.mColor),
-										mRotationAngle(sprite.mRotationAngle),
-										mPaused(sprite.mPaused)
+Sprite::Sprite(const Sprite &sprite) :
+	mImageSheets(sprite.mImageSheets),
+	mActions(sprite.mActions),
+	mSpriteName(sprite.mSpriteName),
+	mCurrentAction(sprite.mCurrentAction),
+	mCurrentFrame(sprite.mCurrentFrame),
+	mColor(sprite.mColor),
+	mRotationAngle(sprite.mRotationAngle),
+	mPaused(sprite.mPaused)
 {}
 
 
@@ -693,22 +696,24 @@ int Sprite::originY(int y)
  * \param	aY	Y-Axis of the Anchor Point for this spriteFrame.
  * \param	d	Length of time milliseconds to display this spriteFrame during animation playback.
  */
-Sprite::SpriteFrame::SpriteFrame(const std::string& sId, int x, int y, int w, int h, int aX, int aY, int d):	mSheetId(sId),
-																												mFrameDelay(d),
-																												mAnchorX(aX),
-																												mAnchorY(aY),
-																												mRect(x, y, w, h)
+Sprite::SpriteFrame::SpriteFrame(const std::string& sId, int x, int y, int w, int h, int aX, int aY, int d) :
+	mSheetId(sId),
+	mFrameDelay(d),
+	mAnchorX(aX),
+	mAnchorY(aY),
+	mRect(x, y, w, h)
 {}
 
 
 /**
  * Copy C'tor
  */
-Sprite::SpriteFrame::SpriteFrame(const SpriteFrame &sf):	mSheetId(sf.mSheetId),
-															mFrameDelay(sf.mFrameDelay),
-															mAnchorX(sf.mAnchorX),
-															mAnchorY(sf.mAnchorY),
-															mRect(sf.mRect)
+Sprite::SpriteFrame::SpriteFrame(const SpriteFrame &sf) :
+	mSheetId(sf.mSheetId),
+	mFrameDelay(sf.mFrameDelay),
+	mAnchorX(sf.mAnchorX),
+	mAnchorY(sf.mAnchorY),
+	mRect(sf.mRect)
 {}
 
 

--- a/src/StateManager.cpp
+++ b/src/StateManager.cpp
@@ -19,8 +19,9 @@ using namespace NAS2D;
 /**
  * C'tor
  */
-StateManager::StateManager():	mActiveState(nullptr),
-								mActive(true)
+StateManager::StateManager() :
+	mActiveState(nullptr),
+	mActive(true)
 {
 	// Ensure that all quit messages are handled in some way even if a State object doesn't.
 	Utility<EventHandler>::get().quit().connect(this, &StateManager::handleQuit);

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -17,9 +17,10 @@ using namespace NAS2D;
 /**
  * C'tor
  */
-Timer::Timer():	mCurrentTick(0),
-				mLastTick(0),
-				mAccumulator(0)
+Timer::Timer() :
+	mCurrentTick(0),
+	mLastTick(0),
+	mAccumulator(0)
 {
 }
 

--- a/src/Xml/XmlAttribute.cpp
+++ b/src/Xml/XmlAttribute.cpp
@@ -19,10 +19,11 @@ using namespace NAS2D::Xml;
 /**
  * Default c'tor.
  */
-XmlAttribute::XmlAttribute() :	XmlBase(),
-								_document(nullptr),
-								_prev(nullptr),
-								_next(nullptr)
+XmlAttribute::XmlAttribute() :
+	XmlBase(),
+	_document(nullptr),
+	_prev(nullptr),
+	_next(nullptr)
 {}
 
 
@@ -34,12 +35,13 @@ XmlAttribute::XmlAttribute() :	XmlBase(),
  * \param	name	Name of the attribute.
  * \param	value	Value of the attribute.
  */
-XmlAttribute::XmlAttribute(const std::string &name, std::string &value) :	XmlBase(),
-																			_document(nullptr),
-																			_name(name),
-																			_value(value),
-																			_prev(nullptr),
-																			_next(nullptr)
+XmlAttribute::XmlAttribute(const std::string &name, std::string &value) :
+	XmlBase(),
+	_document(nullptr),
+	_name(name),
+	_value(value),
+	_prev(nullptr),
+	_next(nullptr)
 {}
 
 

--- a/src/Xml/XmlDocument.cpp
+++ b/src/Xml/XmlDocument.cpp
@@ -16,9 +16,10 @@ using namespace NAS2D::Xml;
 /**
  * Default c'tor
  */
-XmlDocument::XmlDocument() :	XmlNode(XmlNode::NodeType::XML_DOCUMENT),
-								_errorId(0),
-								_error(false)
+XmlDocument::XmlDocument() :
+	XmlNode(XmlNode::NodeType::XML_DOCUMENT),
+	_errorId(0),
+	_error(false)
 {
 	clearError();
 }
@@ -29,9 +30,10 @@ XmlDocument::XmlDocument() :	XmlNode(XmlNode::NodeType::XML_DOCUMENT),
  *
  * \param documentName	Name of the document.
  */
-XmlDocument::XmlDocument(const std::string& documentName) : XmlNode(XmlNode::NodeType::XML_DOCUMENT),
-															_errorId(0),
-															_error(false)
+XmlDocument::XmlDocument(const std::string& documentName) :
+	XmlNode(XmlNode::NodeType::XML_DOCUMENT),
+	_errorId(0),
+	_error(false)
 {
 	_value = documentName;
 	clearError();
@@ -43,8 +45,8 @@ XmlDocument::XmlDocument(const std::string& documentName) : XmlNode(XmlNode::Nod
  *
  * \param copy XmlDocument to copy.
  */
-XmlDocument::XmlDocument(const XmlDocument& copy)
-: XmlNode(XmlNode::NodeType::XML_DOCUMENT)
+XmlDocument::XmlDocument(const XmlDocument& copy) :
+	XmlNode(XmlNode::NodeType::XML_DOCUMENT)
 {
 	copy.copyTo(this);
 }

--- a/src/Xml/XmlElement.cpp
+++ b/src/Xml/XmlElement.cpp
@@ -23,15 +23,15 @@ using namespace NAS2D::Xml;
 
 const std::string NAS2D_EMPTY_STR = "";
 
-XmlElement::XmlElement(const std::string& value)
-: XmlNode(XmlNode::NodeType::XML_ELEMENT)
+XmlElement::XmlElement(const std::string& value) :
+	XmlNode(XmlNode::NodeType::XML_ELEMENT)
 {
 	_value = value;
 }
 
 
-XmlElement::XmlElement(const XmlElement& copy)
-: XmlNode(XmlNode::NodeType::XML_ELEMENT)
+XmlElement::XmlElement(const XmlElement& copy) :
+	XmlNode(XmlNode::NodeType::XML_ELEMENT)
 {
 	copy.copyTo(this);
 }

--- a/src/Xml/XmlNode.cpp
+++ b/src/Xml/XmlNode.cpp
@@ -19,13 +19,14 @@ using namespace NAS2D::Xml;
 /**
  * Default c'tor.
  */
-XmlNode::XmlNode() :	XmlBase(),
-						_parent(nullptr),
-						_type(NodeType::XML_UNKNOWN),
-						_firstChild(nullptr),
-						_lastChild(nullptr),
-						_prev(nullptr),
-						_next(nullptr)
+XmlNode::XmlNode() :
+	XmlBase(),
+	_parent(nullptr),
+	_type(NodeType::XML_UNKNOWN),
+	_firstChild(nullptr),
+	_lastChild(nullptr),
+	_prev(nullptr),
+	_next(nullptr)
 {}
 
 
@@ -36,13 +37,14 @@ XmlNode::XmlNode() :	XmlBase(),
  *
  * \param	type	Type of the node. See XmlNode::NodeType.
  */
-XmlNode::XmlNode(NodeType type) :	XmlBase(),
-									_parent(nullptr),
-									_type(type),
-									_firstChild(nullptr),
-									_lastChild(nullptr),
-									_prev(nullptr),
-									_next(nullptr)
+XmlNode::XmlNode(NodeType type) :
+	XmlBase(),
+	_parent(nullptr),
+	_type(type),
+	_firstChild(nullptr),
+	_lastChild(nullptr),
+	_prev(nullptr),
+	_next(nullptr)
 {}
 
 

--- a/src/Xml/XmlText.cpp
+++ b/src/Xml/XmlText.cpp
@@ -13,16 +13,16 @@
 
 using namespace NAS2D::Xml;
 
-XmlText::XmlText(const std::string& initValue)
-: XmlNode(XmlNode::NodeType::XML_TEXT)
-, cdata(false)
+XmlText::XmlText(const std::string& initValue) :
+	XmlNode(XmlNode::NodeType::XML_TEXT),
+	cdata(false)
 {
 	value(initValue);
 }
 
 
-XmlText::XmlText(const XmlText& copy)
-: XmlNode(XmlNode::NodeType::XML_TEXT)
+XmlText::XmlText(const XmlText& copy) :
+	XmlNode(XmlNode::NodeType::XML_TEXT)
 {
 	copy.copyTo(this);
 }

--- a/src/Xml/XmlUnknown.cpp
+++ b/src/Xml/XmlUnknown.cpp
@@ -13,8 +13,8 @@
 
 using namespace NAS2D::Xml;
 
-XmlUnknown::XmlUnknown()
-: XmlNode(XmlNode::NodeType::XML_UNKNOWN)
+XmlUnknown::XmlUnknown() :
+	XmlNode(XmlNode::NodeType::XML_UNKNOWN)
 {}
 
 
@@ -22,8 +22,8 @@ XmlUnknown::~XmlUnknown()
 {}
 
 
-XmlUnknown::XmlUnknown(const XmlUnknown& copy)
-: XmlNode(XmlNode::NodeType::XML_UNKNOWN)
+XmlUnknown::XmlUnknown(const XmlUnknown& copy) :
+	XmlNode(XmlNode::NodeType::XML_UNKNOWN)
 {
 	copy.copyTo(this);
 }


### PR DESCRIPTION
This addresses most of #242. Left out are a few cases which I expect to be removed by other edits. In particular `Point` and `Rectangle`, which I expect will eventually have their explicit constructors removed, now that they are `struct`s.
