### PR TITLE
Music Volume config parse bug

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -301,9 +301,9 @@ void Configuration::parseAudio(void* _n)
 		{
 			attribute->queryIntValue(mMusicVolume);
 
-			if (mMusicVolume < AUDIO_SFX_MIN_VOLUME || mMusicVolume > AUDIO_SFX_MAX_VOLUME)
+			if (mMusicVolume < AUDIO_MUSIC_MIN_VOLUME || mMusicVolume > AUDIO_MUSIC_MAX_VOLUME)
 			{
-				audioSfxVolume(std::clamp(mMusicVolume, AUDIO_SFX_MIN_VOLUME, AUDIO_SFX_MAX_VOLUME));
+				audioMusicVolume(std::clamp(mMusicVolume, AUDIO_MUSIC_MIN_VOLUME, AUDIO_MUSIC_MAX_VOLUME));
 			}
 		}
 		else if (attribute->name() == AUDIO_CFG_BUFFER_SIZE)

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -294,7 +294,7 @@ void Configuration::parseAudio(void* _n)
 
 			if (mSfxVolume < AUDIO_SFX_MIN_VOLUME || mSfxVolume > AUDIO_SFX_MAX_VOLUME)
 			{
-				audioSfxVolume(std::clamp(mSfxVolume, AUDIO_SFX_MIN_VOLUME, AUDIO_SFX_MAX_VOLUME));
+				audioSfxVolume(mSfxVolume);
 			}
 		}
 		else if (attribute->name() == AUDIO_CFG_MUS_VOLUME)
@@ -303,7 +303,7 @@ void Configuration::parseAudio(void* _n)
 
 			if (mMusicVolume < AUDIO_MUSIC_MIN_VOLUME || mMusicVolume > AUDIO_MUSIC_MAX_VOLUME)
 			{
-				audioMusicVolume(std::clamp(mMusicVolume, AUDIO_MUSIC_MIN_VOLUME, AUDIO_MUSIC_MAX_VOLUME));
+				audioMusicVolume(mMusicVolume);
 			}
 		}
 		else if (attribute->name() == AUDIO_CFG_BUFFER_SIZE)


### PR DESCRIPTION
I noticed what appears to be a bug in the music volume config parse code. Looks like a copy/paste error, where SFX volume values were being used.

Both cases were also doing double clamping of values, both at the point of call, and within the set method itself.
