### PR TITLE
Default `Timer` constructor

### DIFF
--- a/include/NAS2D/Timer.h
+++ b/include/NAS2D/Timer.h
@@ -56,7 +56,7 @@ namespace NAS2D {
 class Timer
 {
 public:
-	Timer();
+	Timer() = default;
 
 	unsigned int tick() const;
 	unsigned int delta();
@@ -68,8 +68,8 @@ public:
 
 private:
 
-	unsigned int	mCurrentTick;
-	unsigned int	mAccumulator;
+	unsigned int	mCurrentTick = 0;
+	unsigned int	mAccumulator = 0;
 };
 
 } // namespace

--- a/include/NAS2D/Timer.h
+++ b/include/NAS2D/Timer.h
@@ -69,8 +69,6 @@ public:
 private:
 
 	unsigned int	mCurrentTick;
-	unsigned int	mLastTick;
-
 	unsigned int	mAccumulator;
 };
 

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -19,7 +19,6 @@ using namespace NAS2D;
  */
 Timer::Timer() :
 	mCurrentTick(0),
-	mLastTick(0),
 	mAccumulator(0)
 {
 }
@@ -38,7 +37,7 @@ unsigned int Timer::tick() const
  */
 unsigned int Timer::delta()
 {
-	mLastTick = mCurrentTick;
+	unsigned int mLastTick = mCurrentTick;
 	mCurrentTick = SDL_GetTicks();
 
 	return mCurrentTick - mLastTick;

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -15,15 +15,6 @@
 using namespace NAS2D;
 
 /**
- * C'tor
- */
-Timer::Timer() :
-	mCurrentTick(0),
-	mAccumulator(0)
-{
-}
-
-/**
  * Gets the current tick.
  */
 unsigned int Timer::tick() const


### PR DESCRIPTION
This addresses the member field and constructor aspect of issue #334.
