### PR TITLE
Remove unused assignment flagged by Codacy

### DIFF
--- a/src/Resources/Font.cpp
+++ b/src/Resources/Font.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <math.h>
 #include <algorithm>
+#include <cstddef>
 
 using namespace NAS2D;
 using namespace NAS2D::Exception;
@@ -319,7 +320,7 @@ bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int gl
 	{
 		for (int col = 0; col < GLYPH_MATRIX_SIZE; col++)
 		{
-			int glyph = (row * GLYPH_MATRIX_SIZE) + col;
+			const std::size_t glyph = (row * GLYPH_MATRIX_SIZE) + col;
 
 			glm[glyph].uvX = (float)(col * glyphWidth) / (float)glyphMap->w;
 			glm[glyph].uvY = (float)(row * glyphHeight) / (float)glyphMap->h;

--- a/src/Resources/Font.cpp
+++ b/src/Resources/Font.cpp
@@ -315,12 +315,11 @@ bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int gl
 		glm[i].minX = glyphWidth;
 	}
 
-	int glyph = 0;
 	for (int row = 0; row < GLYPH_MATRIX_SIZE; row++)
 	{
 		for (int col = 0; col < GLYPH_MATRIX_SIZE; col++)
 		{
-			glyph = (row * GLYPH_MATRIX_SIZE) + col;
+			int glyph = (row * GLYPH_MATRIX_SIZE) + col;
 
 			glm[glyph].uvX = (float)(col * glyphWidth) / (float)glyphMap->w;
 			glm[glyph].uvY = (float)(row * glyphHeight) / (float)glyphMap->h;


### PR DESCRIPTION
This variable is better scoped within the for loops.