### PR TITLE
Reenables now-working tests

### DIFF
--- a/test/Delegate.test.cpp
+++ b/test/Delegate.test.cpp
@@ -12,8 +12,7 @@ namespace {
 }
 
 
-// Disabled due to GoogleMock crashes on Windows
-TEST(Delegate, DISABLED_DelegateCall) {
+TEST(Delegate, DelegateCall) {
 	MockHandler handler;
 	auto delegate = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
 	EXPECT_CALL(handler, MockMethod(0));
@@ -22,8 +21,7 @@ TEST(Delegate, DISABLED_DelegateCall) {
 	delegate(1);
 }
 
-// Disabled due to GoogleMock crashes on Windows
-TEST(Delegate, DISABLED_DelegateCallConst) {
+TEST(Delegate, DelegateCallConst) {
 	const MockHandler handler;
 	auto delegate = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
 	EXPECT_CALL(handler, MockMethod(0));

--- a/test/Signal.test.cpp
+++ b/test/Signal.test.cpp
@@ -21,9 +21,8 @@ TEST(Signal, ConnectEmitDisconnect) {
 	signal.connect(delegate);
 	EXPECT_FALSE(signal.empty());
 
-	// Disabled due to GoogleMock crashes on Windows
-	// EXPECT_CALL(handler, MockMethod());
-	// signal.emit();
+	EXPECT_CALL(handler, MockMethod());
+	signal.emit();
 
 	signal.disconnect(delegate);
 	EXPECT_TRUE(signal.empty());


### PR DESCRIPTION
Microsoft pushed update 16.4.3 today and google mock no longer crashes.

Note: This will continue to crash on AppVeyor because they are still using 16.4.2. Since we have two Windows developers local to the project that can manually review windows changes, this can be safely ignored.

---

This also sets the test project as the startup project so starting a debug session via F5 or the Play button doesn't complain that NAS2D.lib is not a valid Win32 application.
