### PR TITLE
Add Rectangle `contains` and `overlaps` methods

### DIFF
--- a/include/NAS2D/Renderer/Rectangle.h
+++ b/include/NAS2D/Renderer/Rectangle.h
@@ -10,6 +10,9 @@
 
 #pragma once
 
+#include "Point.h"
+
+
 namespace NAS2D {
 
 
@@ -46,6 +49,14 @@ struct Rectangle
 			static_cast<NewBaseType>(mW),
 			static_cast<NewBaseType>(mH)
 		};
+	}
+
+	// Start point inclusive (x, y), endpoint exclusive (x + width, y + height)
+	// Area in interval notation: [x .. x + width), [y .. y + height)
+	bool contains(const Point<BaseType>& point) const {
+		auto px = point.x();
+		auto py = point.y();
+		return ((mX <= px) && (px < mX + mW)) && ((mY <= py) && (py < mY + mH));
 	}
 
 	void x(BaseType x) {

--- a/include/NAS2D/Renderer/Rectangle.h
+++ b/include/NAS2D/Renderer/Rectangle.h
@@ -59,6 +59,12 @@ struct Rectangle
 		return ((mX <= px) && (px < mX + mW)) && ((mY <= py) && (py < mY + mH));
 	}
 
+	// Start point inclusive (x, y), endpoint exclusive (x + width, y + height)
+	// Area in interval notation: [x .. x + width), [y .. y + height)
+	bool overlaps(const Rectangle& rect) const {
+		return ((mX < rect.mX + rect.mW) && (rect.mX < mX + mW)) && ((mY < rect.mY + rect.mH) && (rect.mY < mY + mH));
+	}
+
 	void x(BaseType x) {
 		mX = x;
 	}

--- a/test/Renderer/Rectangle.test.cpp
+++ b/test/Renderer/Rectangle.test.cpp
@@ -1,0 +1,24 @@
+#include "NAS2D/Renderer/Rectangle.h"
+#include <gtest/gtest.h>
+
+
+TEST(Rectangle, contains) {
+	NAS2D::Rectangle rect = {1, 1, 2, 2};
+
+	// Start point inclusive, and interior
+	EXPECT_TRUE(rect.contains(NAS2D::Point{1, 1}));
+	EXPECT_TRUE(rect.contains(NAS2D::Point{1, 2}));
+	EXPECT_TRUE(rect.contains(NAS2D::Point{2, 1}));
+	EXPECT_TRUE(rect.contains(NAS2D::Point{2, 2}));
+
+	// Endpoint exclusive
+	EXPECT_FALSE(rect.contains(NAS2D::Point{1, 3}));
+	EXPECT_FALSE(rect.contains(NAS2D::Point{3, 1}));
+	EXPECT_FALSE(rect.contains(NAS2D::Point{3, 3}));
+
+	// Far out of bounds
+	EXPECT_FALSE(rect.contains(NAS2D::Point{0, 0}));
+	EXPECT_FALSE(rect.contains(NAS2D::Point{0, 4}));
+	EXPECT_FALSE(rect.contains(NAS2D::Point{4, 0}));
+	EXPECT_FALSE(rect.contains(NAS2D::Point{4, 4}));
+}

--- a/test/Renderer/Rectangle.test.cpp
+++ b/test/Renderer/Rectangle.test.cpp
@@ -22,3 +22,41 @@ TEST(Rectangle, contains) {
 	EXPECT_FALSE(rect.contains(NAS2D::Point{4, 0}));
 	EXPECT_FALSE(rect.contains(NAS2D::Point{4, 4}));
 }
+
+TEST(Rectangle, overlaps) {
+	NAS2D::Rectangle rect = {1, 1, 2, 2};
+
+	// Identical overlap, and interior
+	EXPECT_TRUE(rect.overlaps(NAS2D::Rectangle{1, 1, 2, 2}));
+	EXPECT_TRUE(rect.overlaps(NAS2D::Rectangle{1, 1, 1, 1}));
+	EXPECT_TRUE(rect.overlaps(NAS2D::Rectangle{1, 2, 1, 1}));
+	EXPECT_TRUE(rect.overlaps(NAS2D::Rectangle{2, 1, 1, 1}));
+	EXPECT_TRUE(rect.overlaps(NAS2D::Rectangle{2, 2, 1, 1}));
+
+	// Partial overlap
+	EXPECT_TRUE(rect.overlaps(NAS2D::Rectangle{0, 0, 2, 2}));
+	EXPECT_TRUE(rect.overlaps(NAS2D::Rectangle{0, 2, 2, 2}));
+	EXPECT_TRUE(rect.overlaps(NAS2D::Rectangle{2, 0, 2, 2}));
+	EXPECT_TRUE(rect.overlaps(NAS2D::Rectangle{2, 2, 2, 2}));
+
+	// Touching, with no overlap, 8 surrounding boxes
+	// Corner points (bottom left, top left, bottom right, top right)
+	EXPECT_FALSE(rect.overlaps(NAS2D::Rectangle{0, 0, 1, 1}));
+	EXPECT_FALSE(rect.overlaps(NAS2D::Rectangle{0, 3, 1, 1}));
+	EXPECT_FALSE(rect.overlaps(NAS2D::Rectangle{3, 0, 1, 1}));
+	EXPECT_FALSE(rect.overlaps(NAS2D::Rectangle{3, 3, 1, 1}));
+	// Side edges (bottom, top, left, right)
+	EXPECT_FALSE(rect.overlaps(NAS2D::Rectangle{1, 0, 2, 1}));
+	EXPECT_FALSE(rect.overlaps(NAS2D::Rectangle{1, 3, 2, 1}));
+	EXPECT_FALSE(rect.overlaps(NAS2D::Rectangle{0, 1, 1, 2}));
+	EXPECT_FALSE(rect.overlaps(NAS2D::Rectangle{3, 1, 1, 2}));
+
+	// Disjoint
+	EXPECT_FALSE(rect.overlaps(NAS2D::Rectangle{-1, -1, 1, 1}));
+	EXPECT_FALSE(rect.overlaps(NAS2D::Rectangle{-1, 4, 1, 1}));
+	EXPECT_FALSE(rect.overlaps(NAS2D::Rectangle{4, -1, 1, 1}));
+	EXPECT_FALSE(rect.overlaps(NAS2D::Rectangle{4, 4, 1, 1}));
+
+	// No overlap for zero area, even if start point matches
+	EXPECT_FALSE((NAS2D::Rectangle{0, 0, 0, 0}.overlaps(NAS2D::Rectangle{0, 0, 0, 0})));
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -47,6 +47,7 @@
     <OutDir>$(ProjectDir)$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemGroup>
+    <ClCompile Include="Renderer/Rectangle.test.cpp" />
     <ClCompile Include="Delegate.test.cpp" />
     <ClCompile Include="Filesystem.test.cpp" />
     <ClCompile Include="MathUtils.test.cpp" />


### PR DESCRIPTION
This is support work for issue #235.

Note there is a change in specification between these methods and the existing methods from `MathUtils`. The original methods were inclusive of both start point and endpoint. The new methods are start point inclusive, and end point exclusive. I believe the end point exclusive behaviour is more correct for most uses of the `overlaps` test. In particular, the new methods are consistent with 0-based array indexing, and are suitable for testing overlap of images with dimensions given in pixels.
