### PR TITLE
Update vcpkg install rule

### DIFF
--- a/proj/vs2019/NAS2D.vcxproj
+++ b/proj/vs2019/NAS2D.vcxproj
@@ -107,7 +107,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
+      <Command>$(ProjectDir)../../InstallVcpkgDeps.bat</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Installing vcpkg dependencies</Message>
@@ -128,7 +128,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
+      <Command>$(ProjectDir)../../InstallVcpkgDeps.bat</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Installing vcpkg dependencies</Message>
@@ -156,7 +156,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PreBuildEvent>
-      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
+      <Command>$(ProjectDir)../../InstallVcpkgDeps.bat</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Installing vcpkg dependencies</Message>
@@ -184,7 +184,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PreBuildEvent>
-      <Command>$(SolutionDir)../../InstallVcpkgDeps.bat</Command>
+      <Command>$(ProjectDir)../../InstallVcpkgDeps.bat</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Installing vcpkg dependencies</Message>


### PR DESCRIPTION
This should be relative to the project file, rather than the solution. That way the project can be embedded in other solution files, without the relative path being wrong.

Edit:
The AppVeyor build of downstream project op2-landlord is broken due to not finding `InstallVcpkgDeps.bat`. There is no AppVeyor build for OPHD.

How does this affect people's local builds? I assume it would have failed locally as well? Or is the error not noticed because packages are already installed locally?
