### PR TITLE
Deprecate Point operations

### DIFF
--- a/include/NAS2D/Renderer/Point.h
+++ b/include/NAS2D/Renderer/Point.h
@@ -31,23 +31,27 @@ struct Point {
 		return !(*this == point);
 	}
 
+	[[deprecated("Please use Vector class instead")]]
 	Point& operator+=(const Point& point) {
 		mX += point.mX;
 		mY += point.mY;
 		return *this;
 	}
+	[[deprecated("Please use Vector class instead")]]
 	Point& operator-=(const Point& point) {
 		mX -= point.mX;
 		mY -= point.mY;
 		return *this;
 	}
 
+	[[deprecated("Please use Vector class instead")]]
 	Point operator+(const Point& point) const {
 		return {
 			mX + point.mX,
 			mY + point.mY
 		};
 	}
+	[[deprecated("Please use Vector class instead")]]
 	Point operator-(const Point& point) const {
 		return {
 			mX - point.mX,

--- a/include/NAS2D/Renderer/Point.h
+++ b/include/NAS2D/Renderer/Point.h
@@ -31,34 +31,6 @@ struct Point {
 		return !(*this == point);
 	}
 
-	[[deprecated("Please use Vector class instead")]]
-	Point& operator+=(const Point& point) {
-		mX += point.mX;
-		mY += point.mY;
-		return *this;
-	}
-	[[deprecated("Please use Vector class instead")]]
-	Point& operator-=(const Point& point) {
-		mX -= point.mX;
-		mY -= point.mY;
-		return *this;
-	}
-
-	[[deprecated("Please use Vector class instead")]]
-	Point operator+(const Point& point) const {
-		return {
-			mX + point.mX,
-			mY + point.mY
-		};
-	}
-	[[deprecated("Please use Vector class instead")]]
-	Point operator-(const Point& point) const {
-		return {
-			mX - point.mX,
-			mY - point.mY
-		};
-	}
-
 	template <typename NewBaseType>
 	operator Point<NewBaseType>() const {
 		return {

--- a/test/Renderer/Point.test.cpp
+++ b/test/Renderer/Point.test.cpp
@@ -1,0 +1,25 @@
+#include "NAS2D/Renderer/Point.h"
+#include <gtest/gtest.h>
+
+
+TEST(Point, DefaultConstructibleZeroInit) {
+	EXPECT_EQ((NAS2D::Point<int>{0, 0}), NAS2D::Point<int>{});
+}
+
+TEST(Point, OperatorEqualNotEqual) {
+	EXPECT_EQ((NAS2D::Point<int>{1, 1}), (NAS2D::Point<int>{1, 1}));
+	EXPECT_EQ((NAS2D::Point<int>{2, 2}), (NAS2D::Point<int>{2, 2}));
+
+	EXPECT_NE((NAS2D::Point<int>{1, 1}), (NAS2D::Point<int>{1, 2}));
+	EXPECT_NE((NAS2D::Point<int>{1, 1}), (NAS2D::Point<int>{2, 1}));
+}
+
+TEST(Point, Conversion) {
+	// Allow explicit conversion
+	EXPECT_EQ((NAS2D::Point<int>{1, 1}), static_cast<NAS2D::Point<int>>(NAS2D::Point<float>{1.0, 1.0}));
+	EXPECT_EQ((NAS2D::Point<float>{1.0, 1.0}), static_cast<NAS2D::Point<float>>(NAS2D::Point<int>{1, 1}));
+
+	// Allow implicit conversion (may be deprecated in the future)
+	EXPECT_EQ((NAS2D::Point<int>{1, 1}), (NAS2D::Point<float>{1.0, 1.0}));
+	EXPECT_EQ((NAS2D::Point<float>{1.0, 1.0}), (NAS2D::Point<int>{1, 1}));
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -47,6 +47,7 @@
     <OutDir>$(ProjectDir)$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemGroup>
+    <ClCompile Include="Renderer/Point.test.cpp" />
     <ClCompile Include="Renderer/Rectangle.test.cpp" />
     <ClCompile Include="Delegate.test.cpp" />
     <ClCompile Include="Filesystem.test.cpp" />


### PR DESCRIPTION
This deprecates operations on the `Point` struct that should really only be part of the `Vector` struct.

See PR #352 for the new `Vector` template struct.
