### PR TITLE
Add Rectangle factory functions

### DIFF
--- a/include/NAS2D/Renderer/Rectangle.h
+++ b/include/NAS2D/Renderer/Rectangle.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "Point.h"
+#include "Vector.h"
 
 
 namespace NAS2D {
@@ -29,6 +30,26 @@ struct Rectangle
 		mW(width),
 		mH(height)
 	{}
+
+	// Factory method
+	static Rectangle<BaseType> Create(Point<BaseType> startPoint, Vector<BaseType> size) {
+		return {
+			startPoint.x(),
+			startPoint.y(),
+			size.x,
+			size.y
+		};
+	}
+
+	// Factory method
+	static Rectangle<BaseType> Create(Point<BaseType> startPoint, Point<BaseType> endPoint) {
+		return {
+			startPoint.x(),
+			startPoint.y(),
+			endPoint.x() - startPoint.x(),
+			endPoint.y() - startPoint.y()
+		};
+	}
 
 	bool operator==(const Rectangle& rect) const {
 		return (mX == rect.mX) && (mY == rect.mY) && (mW == rect.mW) && (mH == rect.mH);

--- a/include/NAS2D/Renderer/Vector.h
+++ b/include/NAS2D/Renderer/Vector.h
@@ -1,0 +1,52 @@
+#pragma once
+
+namespace NAS2D {
+
+
+template <typename BaseType>
+struct Vector {
+	BaseType x = 0;
+	BaseType y = 0;
+
+	bool operator==(const Vector& vector) const {
+		return (x == vector.x) && (y == vector.y);
+	}
+	bool operator!=(const Vector& vector) const {
+		return !(*this == vector);
+	}
+
+	Vector& operator+=(const Vector& vector) {
+		x += vector.x;
+		y += vector.y;
+		return *this;
+	}
+	Vector& operator-=(const Vector& vector) {
+		x -= vector.x;
+		y -= vector.y;
+		return *this;
+	}
+
+	Vector operator+(const Vector& vector) const {
+		return {
+			x + vector.x,
+			y + vector.y
+		};
+	}
+	Vector operator-(const Vector& vector) const {
+		return {
+			x - vector.x,
+			y - vector.y
+		};
+	}
+
+	template <typename NewBaseType>
+	operator Vector<NewBaseType>() const {
+		return {
+			static_cast<NewBaseType>(x),
+			static_cast<NewBaseType>(y)
+		};
+	}
+
+};
+
+}

--- a/proj/vs2019/NAS2D.vcxproj
+++ b/proj/vs2019/NAS2D.vcxproj
@@ -249,6 +249,7 @@
     <ClInclude Include="..\..\include\NAS2D\Renderer\RendererNull.h" />
     <ClInclude Include="..\..\include\NAS2D\Renderer\Color.h" />
     <ClInclude Include="..\..\include\NAS2D\Renderer\Point.h" />
+    <ClInclude Include="..\..\include\NAS2D\Renderer\Vector.h" />
     <ClInclude Include="..\..\include\NAS2D\Renderer\Rectangle.h" />
     <ClInclude Include="..\..\include\NAS2D\Renderer\Renderer.h" />
     <ClInclude Include="..\..\include\NAS2D\Renderer\RendererOpenGL.h" />

--- a/proj/vs2019/NAS2D.vcxproj.filters
+++ b/proj/vs2019/NAS2D.vcxproj.filters
@@ -236,6 +236,9 @@
     <ClInclude Include="..\..\include\NAS2D\Renderer\Point.h">
       <Filter>Header Files\Renderer</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\NAS2D\Renderer\Vector.h">
+      <Filter>Header Files\Renderer</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\NAS2D\Renderer\Rectangle.h">
       <Filter>Header Files\Renderer</Filter>
     </ClInclude>

--- a/test/Renderer/Rectangle.test.cpp
+++ b/test/Renderer/Rectangle.test.cpp
@@ -2,6 +2,16 @@
 #include <gtest/gtest.h>
 
 
+TEST(Rectangle, CreatePointVector) {
+	EXPECT_EQ((NAS2D::Rectangle{0, 0, 1, 1}), NAS2D::Rectangle<int>::Create(NAS2D::Point<int>{0, 0}, NAS2D::Vector<int>{1, 1}));
+	EXPECT_EQ((NAS2D::Rectangle{1, 1, 2, 3}), NAS2D::Rectangle<int>::Create(NAS2D::Point<int>{1, 1}, NAS2D::Vector<int>{2, 3}));
+}
+
+TEST(Rectangle, CreatePointPoint) {
+	EXPECT_EQ((NAS2D::Rectangle{0, 0, 1, 1}), NAS2D::Rectangle<int>::Create(NAS2D::Point<int>{0, 0}, NAS2D::Point<int>{1, 1}));
+	EXPECT_EQ((NAS2D::Rectangle{1, 1, 1, 2}), NAS2D::Rectangle<int>::Create(NAS2D::Point<int>{1, 1}, NAS2D::Point<int>{2, 3}));
+}
+
 TEST(Rectangle, contains) {
 	NAS2D::Rectangle rect = {1, 1, 2, 2};
 

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -1,0 +1,45 @@
+#include "NAS2D/Renderer/Vector.h"
+#include <gtest/gtest.h>
+
+
+TEST(Vector, DefaultConstructible) {
+	EXPECT_EQ((NAS2D::Vector<int>{0, 0}), NAS2D::Vector<int>{});
+}
+
+TEST(Vector, OperatorEqualNotEqual) {
+	EXPECT_EQ((NAS2D::Vector<int>{1, 1}), (NAS2D::Vector<int>{1, 1}));
+	EXPECT_EQ((NAS2D::Vector<int>{2, 2}), (NAS2D::Vector<int>{2, 2}));
+
+	EXPECT_NE((NAS2D::Vector<int>{1, 1}), (NAS2D::Vector<int>{1, 2}));
+	EXPECT_NE((NAS2D::Vector<int>{1, 1}), (NAS2D::Vector<int>{2, 1}));
+}
+
+TEST(Vector, Conversion) {
+	// Allow explicit conversion
+	EXPECT_EQ((NAS2D::Vector<int>{1, 1}), static_cast<NAS2D::Vector<int>>(NAS2D::Vector<float>{1.0, 1.0}));
+	EXPECT_EQ((NAS2D::Vector<float>{1.0, 1.0}), static_cast<NAS2D::Vector<float>>(NAS2D::Vector<int>{1, 1}));
+
+	// Allow implicit conversion (may be deprecated in the future)
+	EXPECT_EQ((NAS2D::Vector<int>{1, 1}), (NAS2D::Vector<float>{1.0, 1.0}));
+	EXPECT_EQ((NAS2D::Vector<float>{1.0, 1.0}), (NAS2D::Vector<int>{1, 1}));
+}
+
+TEST(Vector, SelfAdd) {
+	NAS2D::Vector<int> vector{1, 1};
+	EXPECT_EQ(&vector, &(vector += NAS2D::Vector<int>{1, 2}));
+	EXPECT_EQ((NAS2D::Vector<int>{2, 3}), vector);
+}
+
+TEST(Vector, SelfSubtract) {
+	NAS2D::Vector<int> vector{2, 3};
+	EXPECT_EQ(&vector, &(vector -= NAS2D::Vector<int>{1, 2}));
+	EXPECT_EQ((NAS2D::Vector<int>{1, 1}), vector);
+}
+
+TEST(Vector, Add) {
+	EXPECT_EQ((NAS2D::Vector<int>{2, 3}), (NAS2D::Vector<int>{1, 1}) + (NAS2D::Vector<int>{1, 2}));
+}
+
+TEST(Vector, Subtract) {
+	EXPECT_EQ((NAS2D::Vector<int>{1, 1}), (NAS2D::Vector<int>{2, 3}) - (NAS2D::Vector<int>{1, 2}));
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -48,6 +48,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="Renderer/Rectangle.test.cpp" />
+    <ClCompile Include="Renderer/Vector.test.cpp" />
     <ClCompile Include="Delegate.test.cpp" />
     <ClCompile Include="Filesystem.test.cpp" />
     <ClCompile Include="MathUtils.test.cpp" />


### PR DESCRIPTION
Based on PR #352 (Add `Vector`). (Only the last commit is new).

Adds factory methods to create a `Rectangle` from either a `Point` and a `Vector`, or from two `Point`s.
