### PR TITLE
Add graphics libraries to MacOS CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
     executor: macos-executor
     steps:
       - brew-install:
-          packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf glew cmake
+          packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew cmake
       - build-googletest
       - checkout
       - build-and-test

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ OpenGL_LIBS := $($(OS)_OpenGL_LIBS)
 CPPFLAGS := $(CPPFLAGS.EXTRA) -Iinclude/
 CXXFLAGS := -std=c++17 -g -Wall -Wpedantic $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS.EXTRA)
-LDLIBS := -lstdc++ -lphysfs -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(OpenGL_LIBS)
+LDLIBS := -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td
 

--- a/makefile
+++ b/makefile
@@ -13,10 +13,17 @@ OBJDIR := $(BUILDDIR)/obj
 DEPDIR := $(BUILDDIR)/deps
 OUTPUT := $(BINDIR)/libnas2d.a
 
+# Determine OS (Linux, Darwin, ...)
+OS := $(shell uname 2>/dev/null || echo Unknown)
+
+Linux_OpenGL_LIBS := -lGLEW -lGL
+Darwin_OpenGL_LIBS := -lGLEW -framework OpenGL
+OpenGL_LIBS := $($(OS)_OpenGL_LIBS)
+
 CPPFLAGS := $(CPPFLAGS.EXTRA) -Iinclude/
 CXXFLAGS := -std=c++17 -g -Wall -Wpedantic $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS.EXTRA)
-LDLIBS := -lstdc++ -lphysfs # -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lGL
+LDLIBS := -lstdc++ -lphysfs -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(OpenGL_LIBS)
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td
 


### PR DESCRIPTION
This is in preparing to adding unit test code for NAS2D features that depend on the graphics libraries.

Currently, no NAS2D features using the graphics libraries are tested. That means the linker will cut out any code that references the graphics libraries, and effectively prunes those dependencies. As we extend unit testing, this will no longer be true. As such, we'll need a proper set of static libraries during the link step to compile the unit test project.

Further, we'll need access to runtime dynamic link libraries for the unit test executable to load and run. This is covered by updates to the `brew install`/`brew link` step.
