### PR TITLE
Add `Vector<int> Image::size()` method

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,11 +6,9 @@ platform:
   - x64
 cache:
   - C:\tools\vcpkg\installed\ -> InstallVcpkgDeps.bat
-  - C:\projects\nas2d-core\proj\vs2019\packages -> proj\vs2019\packages.config
 install:
   - vcpkg integrate install
   - call InstallVcpkgDeps.bat
-  - nuget restore proj/vs2019
   - set APPVEYOR_SAVE_CACHE_ON_ERROR=true
 build:
   project: proj/vs2019/NAS2D.sln

--- a/InstallVcpkgDeps.bat
+++ b/InstallVcpkgDeps.bat
@@ -18,4 +18,8 @@ if not defined PLATFORM (
 :Install
 vcpkg install physfs:%PLATFORM%-windows
 vcpkg install glew:%PLATFORM%-windows
+vcpkg install SDL2:%PLATFORM%-windows
+vcpkg install SDL2-mixer:%PLATFORM%-windows
+vcpkg install SDL2-image:%PLATFORM%-windows
+vcpkg install SDL2-ttf:%PLATFORM%-windows
 vcpkg install gtest:%PLATFORM%-windows

--- a/include/NAS2D/Resources/Image.h
+++ b/include/NAS2D/Resources/Image.h
@@ -11,6 +11,7 @@
 
 #include "Resource.h"
 #include "../Renderer/Color.h"
+#include "../Renderer/Vector.h"
 
 #include <vector>
 #include <utility>
@@ -48,6 +49,8 @@ public:
 	Image& operator=(const Image& rhs);
 
 	~Image();
+
+	Vector<int> size() const;
 
 	int width() const;
 	int height() const;

--- a/proj/vs2019/NAS2D.vcxproj
+++ b/proj/vs2019/NAS2D.vcxproj
@@ -53,16 +53,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="Shared">
-    <Import Project="packages\sdl2.nuget.redist.2.0.10\build\native\sdl2.nuget.redist.targets" Condition="Exists('packages\sdl2.nuget.redist.2.0.10\build\native\sdl2.nuget.redist.targets')" />
-    <Import Project="packages\sdl2.nuget.2.0.10\build\native\sdl2.nuget.targets" Condition="Exists('packages\sdl2.nuget.2.0.10\build\native\sdl2.nuget.targets')" />
-    <Import Project="packages\sdl2_image.nuget.redist.2.0.5\build\native\sdl2_image.nuget.redist.targets" Condition="Exists('packages\sdl2_image.nuget.redist.2.0.5\build\native\sdl2_image.nuget.redist.targets')" />
-    <Import Project="packages\sdl2_image.nuget.2.0.5\build\native\sdl2_image.nuget.targets" Condition="Exists('packages\sdl2_image.nuget.2.0.5\build\native\sdl2_image.nuget.targets')" />
-    <Import Project="packages\sdl2_mixer.nuget.redist.2.0.4\build\native\sdl2_mixer.nuget.redist.targets" Condition="Exists('packages\sdl2_mixer.nuget.redist.2.0.4\build\native\sdl2_mixer.nuget.redist.targets')" />
-    <Import Project="packages\sdl2_mixer.nuget.2.0.4\build\native\sdl2_mixer.nuget.targets" Condition="Exists('packages\sdl2_mixer.nuget.2.0.4\build\native\sdl2_mixer.nuget.targets')" />
-    <Import Project="packages\sdl2_ttf.nuget.redist.2.0.15\build\native\sdl2_ttf.nuget.redist.targets" Condition="Exists('packages\sdl2_ttf.nuget.redist.2.0.15\build\native\sdl2_ttf.nuget.redist.targets')" />
-    <Import Project="packages\sdl2_ttf.nuget.2.0.15\build\native\sdl2_ttf.nuget.targets" Condition="Exists('packages\sdl2_ttf.nuget.2.0.15\build\native\sdl2_ttf.nuget.targets')" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -286,20 +276,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\.clang-format" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\sdl2.nuget.redist.2.0.10\build\native\sdl2.nuget.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2.nuget.redist.2.0.10\build\native\sdl2.nuget.redist.targets'))" />
-    <Error Condition="!Exists('packages\sdl2.nuget.2.0.10\build\native\sdl2.nuget.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2.nuget.2.0.10\build\native\sdl2.nuget.targets'))" />
-    <Error Condition="!Exists('packages\sdl2_image.nuget.redist.2.0.5\build\native\sdl2_image.nuget.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2_image.nuget.redist.2.0.5\build\native\sdl2_image.nuget.redist.targets'))" />
-    <Error Condition="!Exists('packages\sdl2_image.nuget.2.0.5\build\native\sdl2_image.nuget.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2_image.nuget.2.0.5\build\native\sdl2_image.nuget.targets'))" />
-    <Error Condition="!Exists('packages\sdl2_mixer.nuget.redist.2.0.4\build\native\sdl2_mixer.nuget.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2_mixer.nuget.redist.2.0.4\build\native\sdl2_mixer.nuget.redist.targets'))" />
-    <Error Condition="!Exists('packages\sdl2_mixer.nuget.2.0.4\build\native\sdl2_mixer.nuget.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2_mixer.nuget.2.0.4\build\native\sdl2_mixer.nuget.targets'))" />
-    <Error Condition="!Exists('packages\sdl2_ttf.nuget.redist.2.0.15\build\native\sdl2_ttf.nuget.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2_ttf.nuget.redist.2.0.15\build\native\sdl2_ttf.nuget.redist.targets'))" />
-    <Error Condition="!Exists('packages\sdl2_ttf.nuget.2.0.15\build\native\sdl2_ttf.nuget.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\sdl2_ttf.nuget.2.0.15\build\native\sdl2_ttf.nuget.targets'))" />
-  </Target>
 </Project>

--- a/proj/vs2019/NAS2D.vcxproj.filters
+++ b/proj/vs2019/NAS2D.vcxproj.filters
@@ -314,6 +314,5 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\.clang-format" />
-    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/src/EventHandler.cpp
+++ b/src/EventHandler.cpp
@@ -8,7 +8,7 @@
 // = Acknowledgement of your use of NAS2D is appriciated but is not required.
 // ==================================================================================
 #include "NAS2D/EventHandler.h"
-#include <SDL.h>
+#include <SDL2/SDL.h>
 #include <iostream>
 
 // UGLY ASS HACK!

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -10,7 +10,7 @@
 
 #include "NAS2D/FpsCounter.h"
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 using namespace NAS2D;
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -21,7 +21,7 @@
 #include "NAS2D/Renderer/RendererOpenGL.h"
 #include "NAS2D/Renderer/RendererNull.h"
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 #include <iostream>
 

--- a/src/Mixer/MixerSDL.cpp
+++ b/src/Mixer/MixerSDL.cpp
@@ -14,8 +14,8 @@
 #include "NAS2D/Resources/MusicInfo.h"
 #include "NAS2D/Utility.h"
 
-#include <SDL.h>
-#include <SDL_mixer.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_mixer.h>
 
 #include <iostream>
 #include <functional>

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -22,8 +22,8 @@
 
 #include <GL/glew.h>
 
-#include <SDL.h>
-#include <SDL_image.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
 
 #include <iostream>
 #include <algorithm>

--- a/src/Resources/Font.cpp
+++ b/src/Resources/Font.cpp
@@ -16,8 +16,8 @@
 
 #include <GL/glew.h>
 
-#include <SDL_image.h>
-#include <SDL_ttf.h>
+#include <SDL2/SDL_image.h>
+#include <SDL2/SDL_ttf.h>
 
 #include <iostream>
 #include <cmath>

--- a/src/Resources/Image.cpp
+++ b/src/Resources/Image.cpp
@@ -223,6 +223,15 @@ void Image::load()
 
 
 /**
+ * Gets the dimensions in pixels of the image.
+ */
+Vector<int> Image::size() const
+{
+	return {_size.first, _size.second};
+}
+
+
+/**
  * Gets the width in pixels of the image.
  */
 int Image::width() const

--- a/src/Resources/Image.cpp
+++ b/src/Resources/Image.cpp
@@ -15,7 +15,7 @@
 #include "NAS2D/Utility.h"
 
 #include <GL/glew.h>
-#include <SDL_image.h>
+#include <SDL2/SDL_image.h>
 
 #include <iostream>
 #include <map>

--- a/src/Resources/Music.cpp
+++ b/src/Resources/Music.cpp
@@ -13,8 +13,8 @@
 #include "NAS2D/Filesystem.h"
 #include "NAS2D/Utility.h"
 
-#include <SDL.h>
-#include <SDL_mixer.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_mixer.h>
 
 #include <iostream>
 #include <string>

--- a/src/Resources/Sound.cpp
+++ b/src/Resources/Sound.cpp
@@ -13,8 +13,8 @@
 #include "NAS2D/Filesystem.h"
 #include "NAS2D/Utility.h"
 
-#include <SDL.h>
-#include <SDL_mixer.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_mixer.h>
 
 using namespace NAS2D;
 

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -10,7 +10,7 @@
 
 #include "NAS2D/Timer.h"
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 using namespace NAS2D;
 

--- a/test/Resources/Image.test.cpp
+++ b/test/Resources/Image.test.cpp
@@ -1,0 +1,8 @@
+#include "NAS2D/Resources/Image.h"
+#include <gtest/gtest.h>
+
+
+TEST(Image, size) {
+	EXPECT_EQ((NAS2D::Vector<int>{1, 1}), NAS2D::Image(1, 1).size());
+	EXPECT_EQ((NAS2D::Vector<int>{4, 2}), NAS2D::Image(4, 2).size());
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -77,7 +77,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gtestd.lib;gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtestd.lib;gtest_maind.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -96,7 +96,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gtestd.lib;gtest_maind.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtestd.lib;gtest_maind.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -114,7 +114,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gtest.lib;gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtest.lib;gtest_main.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -135,7 +135,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gtest.lib;gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtest.lib;gtest_main.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -50,6 +50,7 @@
     <ClCompile Include="Renderer/Point.test.cpp" />
     <ClCompile Include="Renderer/Rectangle.test.cpp" />
     <ClCompile Include="Renderer/Vector.test.cpp" />
+    <ClCompile Include="Resources/Image.test.cpp" />
     <ClCompile Include="Delegate.test.cpp" />
     <ClCompile Include="Filesystem.test.cpp" />
     <ClCompile Include="MathUtils.test.cpp" />


### PR DESCRIPTION
This is based on PR #371. (Only the last 2 commits are new).

The project configuration changes from PR #371 PR #364 are needed to run the new unit test introduced here. The unit test is for the `Image` class, which makes use of SDL and OpenGL code. For that test to compile and link, the unit test project needs access to those graphics libraries, which is covered by those PRs.
