### PR TITLE
Makefile cross compile support

### DIFF
--- a/makefile
+++ b/makefile
@@ -27,6 +27,9 @@ CXXFLAGS := -std=c++17 -g -Wall -Wpedantic $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS.EXTRA)
 LDLIBS := -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
 
+Windows_RUN_PREFIX := wine
+RUN_PREFIX := $($(TARGET_OS)_RUN_PREFIX)
+
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td
 
 COMPILE.cpp = $(CXX) $(DEPFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
@@ -104,7 +107,7 @@ TESTPOSTCOMPILE = @mv -f $(TESTOBJDIR)/$*.Td $(TESTOBJDIR)/$*.d && touch $@
 
 test: $(TESTOUTPUT)
 check: | test
-	cd test && ../$(TESTOUTPUT)
+	cd test && $(RUN_PREFIX) ../$(TESTOUTPUT)
 
 $(TESTOUTPUT): $(TESTOBJS) $(OUTPUT)
 	@mkdir -p ${@D}

--- a/makefile
+++ b/makefile
@@ -19,6 +19,7 @@ TARGET_OS ?= $(CURRENT_OS)
 
 Linux_OpenGL_LIBS := -lGLEW -lGL
 Darwin_OpenGL_LIBS := -lGLEW -framework OpenGL
+Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS.EXTRA) -Iinclude/

--- a/makefile
+++ b/makefile
@@ -14,11 +14,12 @@ DEPDIR := $(BUILDDIR)/deps
 OUTPUT := $(BINDIR)/libnas2d.a
 
 # Determine OS (Linux, Darwin, ...)
-OS := $(shell uname 2>/dev/null || echo Unknown)
+CURRENT_OS := $(shell uname 2>/dev/null || echo Unknown)
+TARGET_OS ?= $(CURRENT_OS)
 
 Linux_OpenGL_LIBS := -lGLEW -lGL
 Darwin_OpenGL_LIBS := -lGLEW -framework OpenGL
-OpenGL_LIBS := $($(OS)_OpenGL_LIBS)
+OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS.EXTRA) -Iinclude/
 CXXFLAGS := -std=c++17 -g -Wall -Wpedantic $(shell sdl2-config --cflags)


### PR DESCRIPTION
This adds a bit of `makefile` support so NAS2D can be cross compiled from Linux for Windows, using the Mingw-w64 toolchain.

Mostly this is renaming a few required library includes, and prefixing the unit test running with `wine`.

The real work was in getting a build environment setup. A Dockerfile for the build environment will follow a little later.
