### PR TITLE
Merge Init to constructor of MixerSDL

### DIFF
--- a/include/NAS2D/Mixer/MixerSDL.h
+++ b/include/NAS2D/Mixer/MixerSDL.h
@@ -57,7 +57,6 @@ public:
 	void unmute() override;
 
 private:
-	void init();
 	void music_finished_hook();
 };
 

--- a/src/Mixer/MixerSDL.cpp
+++ b/src/Mixer/MixerSDL.cpp
@@ -40,34 +40,6 @@ void MIXER_HOOK() { MIXER_HOOK_CALLBACK_SIGNAL(); }
  */
 MixerSDL::MixerSDL()
 {
-	init();
-}
-
-
-/*
- * D'tor.
- */
-MixerSDL::~MixerSDL()
-{
-	// Save current volume levels in the Configuration.
-	Utility<Configuration>::get().audioSfxVolume(Mix_Volume(-1, -1));
-	Utility<Configuration>::get().audioMusicVolume(Mix_VolumeMusic(-1));
-
-	stopAllAudio();
-
-	Mix_CloseAudio();
-
-	MIXER_HOOK_CALLBACK_SIGNAL.disconnect(this, &MixerSDL::music_finished_hook);
-	Mix_HookMusicFinished(nullptr);
-
-	SDL_QuitSubSystem(SDL_INIT_AUDIO);
-
-	std::cout << "Mixer Terminated." << std::endl;
-}
-
-
-void MixerSDL::init()
-{
 	std::cout << "Initializing Mixer... ";
 
 	if (SDL_Init(SDL_INIT_AUDIO) < 0)
@@ -91,6 +63,27 @@ void MixerSDL::init()
 	std::cout << "done." << std::endl;
 }
 
+
+/*
+ * D'tor.
+ */
+MixerSDL::~MixerSDL()
+{
+	// Save current volume levels in the Configuration.
+	Utility<Configuration>::get().audioSfxVolume(Mix_Volume(-1, -1));
+	Utility<Configuration>::get().audioMusicVolume(Mix_VolumeMusic(-1));
+
+	stopAllAudio();
+
+	Mix_CloseAudio();
+
+	MIXER_HOOK_CALLBACK_SIGNAL.disconnect(this, &MixerSDL::music_finished_hook);
+	Mix_HookMusicFinished(nullptr);
+
+	SDL_QuitSubSystem(SDL_INIT_AUDIO);
+
+	std::cout << "Mixer Terminated." << std::endl;
+}
 
 void MixerSDL::music_finished_hook()
 {


### PR DESCRIPTION
Moves implementation of trivial init() function into the Ctor and removes init function as it was private anyway.

Reference: https://github.com/lairworks/nas2d-core/pull/389#pullrequestreview-348356805
