### PR TITLE
Makefile - extract docker variables

### DIFF
--- a/makefile
+++ b/makefile
@@ -168,16 +168,20 @@ install-deps-centos:
 .PHONY: debug-image-ubuntu root-debug-image-ubuntu
 
 DockerFolder := ${TopLevelFolder}/docker
+DockerRunFlags := --volume ${TopLevelFolder}:/code
+DockerRepository := outpostuniverse
+
+ImageName := nas2d
+ImageVersion := 1.3
 
 build-image-ubuntu:
-	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d.Dockerfile --tag outpostuniverse/nas2d:latest --tag outpostuniverse/nas2d:1.3
+	docker build ${DockerFolder}/ --file ${DockerFolder}/${ImageName}.Dockerfile --tag ${DockerRepository}/${ImageName}:latest --tag ${DockerRepository}/${ImageName}:${ImageVersion}
 compile-on-ubuntu:
-	docker run --rm --tty --volume ${TopLevelFolder}:/code outpostuniverse/nas2d
+	docker run ${DockerRunFlags} --rm --tty ${DockerRepository}/${ImageName}
 debug-image-ubuntu:
-	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive outpostuniverse/nas2d bash
+	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerRepository}/${ImageName} bash
 root-debug-image-ubuntu:
-	docker run --rm --tty --volume ${TopLevelFolder}:/code --interactive --user=0 outpostuniverse/nas2d bash
-
+	docker run ${DockerRunFlags} --rm --tty --interactive --user=0 ${DockerRepository}/${ImageName} bash
 
 #### CircleCI related build rules ####
 

--- a/makefile
+++ b/makefile
@@ -188,6 +188,10 @@ debug-image-ubuntu:
 root-debug-image-ubuntu:
 	docker run ${DockerRunFlags} --rm --tty --interactive --user=0 ${DockerRepository}/${ImageName} bash
 
+.PHONY: push-image-ubuntu
+push-image-ubuntu:
+	docker push ${DockerRepository}/${ImageName}
+
 #### CircleCI related build rules ####
 
 .PHONY: build-image-circleci push-image-circleci circleci-validate circleci-build

--- a/makefile
+++ b/makefile
@@ -164,8 +164,6 @@ install-deps-centos:
 #### Docker related build rules ####
 
 # Build rules relating to Docker images
-.PHONY: build-image-ubuntu compile-on-ubuntu
-.PHONY: debug-image-ubuntu root-debug-image-ubuntu
 
 DockerFolder := ${TopLevelFolder}/docker
 DockerRunFlags := --volume ${TopLevelFolder}:/code
@@ -174,12 +172,19 @@ DockerRepository := outpostuniverse
 ImageName := nas2d
 ImageVersion := 1.3
 
+.PHONY: build-image-ubuntu
 build-image-ubuntu:
 	docker build ${DockerFolder}/ --file ${DockerFolder}/${ImageName}.Dockerfile --tag ${DockerRepository}/${ImageName}:latest --tag ${DockerRepository}/${ImageName}:${ImageVersion}
+
+.PHONY: compile-on-ubuntu
 compile-on-ubuntu:
 	docker run ${DockerRunFlags} --rm --tty ${DockerRepository}/${ImageName}
+
+.PHONY: debug-image-ubuntu
 debug-image-ubuntu:
 	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerRepository}/${ImageName} bash
+
+.PHONY: root-debug-image-ubuntu
 root-debug-image-ubuntu:
 	docker run ${DockerRunFlags} --rm --tty --interactive --user=0 ${DockerRepository}/${ImageName} bash
 

--- a/makefile
+++ b/makefile
@@ -176,8 +176,8 @@ ImageVersion := 1.3
 build-image-ubuntu:
 	docker build ${DockerFolder}/ --file ${DockerFolder}/${ImageName}.Dockerfile --tag ${DockerRepository}/${ImageName}:latest --tag ${DockerRepository}/${ImageName}:${ImageVersion}
 
-.PHONY: compile-on-ubuntu
-compile-on-ubuntu:
+.PHONY: run-image-ubuntu
+run-image-ubuntu:
 	docker run ${DockerRunFlags} --rm --tty ${DockerRepository}/${ImageName}
 
 .PHONY: debug-image-ubuntu


### PR DESCRIPTION
Makefile only change.

This separates the variable portion from the fixed portion of the Docker image rules. These changes help support being able to build multiple Docker images, such as a Clang or Mingw-w64 image.
