### PR TITLE
Add Mingw-w64 build to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,5 @@
 version: 2.1
 
-executors:
-  docker-executor:
-    docker:
-      - image: outpostuniverse/nas2d:1.4
-  macos-executor:
-    macos:
-      xcode: "11.3.0"
-
 commands:
   brew-install:
     description: "Brew install MacOS dependencies (or restore from cache)"
@@ -71,7 +63,8 @@ commands:
 
 jobs:
   build-macos:
-    executor: macos-executor
+    macos:
+      xcode: "11.3.0"
     steps:
       - brew-install:
           packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew cmake
@@ -79,7 +72,8 @@ jobs:
       - checkout
       - build-and-test
   build-linux:
-    executor: docker-executor
+    docker:
+      - image: outpostuniverse/nas2d:1.4
     steps:
       - checkout
       - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,16 @@ jobs:
     steps:
       - checkout
       - build-and-test
+  build-linux-mingw:
+    docker:
+      - image: outpostuniverse/nas2d-mingw:1.2
+    steps:
+      - checkout
+      - build-and-test
 
 workflows:
   build_and_test:
     jobs:
       - build-macos
       - build-linux
+      - build-linux-mingw

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 version: 2.1
+
 executors:
   docker-executor:
     docker:
@@ -6,6 +7,7 @@ executors:
   macos-executor:
     macos:
       xcode: "11.3.0"
+
 commands:
   brew-install:
     description: "Brew install MacOS dependencies (or restore from cache)"
@@ -66,12 +68,8 @@ commands:
       - run: make --keep-going
       - run: make --keep-going test
       - run: make --keep-going check
+
 jobs:
-  build-linux:
-    executor: docker-executor
-    steps:
-      - checkout
-      - build-and-test
   build-macos:
     executor: macos-executor
     steps:
@@ -80,8 +78,14 @@ jobs:
       - build-googletest
       - checkout
       - build-and-test
+  build-linux:
+    executor: docker-executor
+    steps:
+      - checkout
+      - build-and-test
+
 workflows:
   build_and_test:
     jobs:
-      - build-linux
       - build-macos
+      - build-linux

--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -144,4 +144,9 @@ WORKDIR /code
 # Pre-setup Wine to save startup time later
 RUN wineboot
 
+# Set default extra C pre-processor flags
+# This makes proper rebuilding easier in a debug session
+ENV CPPFLAGS.EXTRA=-D"GLEW_STATIC"
+
+# Be explicit about the extra flags with the default command
 CMD ["make", "--keep-going", "check", "CPPFLAGS.EXTRA=-DGLEW_STATIC"]

--- a/makefile
+++ b/makefile
@@ -173,7 +173,7 @@ ImageName := nas2d
 ImageVersion := 1.4
 
 ImageName_mingw := nas2d-mingw
-ImageVersion_mingw := 1.1
+ImageVersion_mingw := 1.2
 
 .PHONY: build-image
 build-image:


### PR DESCRIPTION
Adds a Mingw-w64 build to CircleCI. This build will cross compile a Windows executable from Linux.

Linux only change.

Not sure if anyone wants to review the code, or comment on the new build.
