### PR TITLE
Add clang docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,12 @@ jobs:
     steps:
       - checkout
       - build-and-test
+  build-linux-clang:
+    docker:
+      - image: outpostuniverse/nas2d-clang:1.0
+    steps:
+      - checkout
+      - build-and-test
   build-linux-mingw:
     docker:
       - image: outpostuniverse/nas2d-mingw:1.2
@@ -89,4 +95,5 @@ workflows:
     jobs:
       - build-macos
       - build-linux
+      - build-linux-clang
       - build-linux-mingw

--- a/docker/nas2d-clang.Dockerfile
+++ b/docker/nas2d-clang.Dockerfile
@@ -1,0 +1,62 @@
+# See Docker section of makefile in root project folder for usage commands.
+
+FROM ubuntu:18.04
+
+# Install base development tools
+# Includes tools to build download, unpack, and build source packages
+# Includes tools needed for primary CircleCI containers
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential=12.4* \
+    clang=1:6.0-* \
+    cmake=3.10.2-* \
+    curl=7.58.0-* \
+    git=1:2.17.1-* \
+    ssh=1:7.6p1-* \
+    tar=1.29b-* \
+    gzip=1.6-* \
+    ca-certificates=* \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV CXX=clang++
+ENV  CC=clang
+
+# Download, compile, and install Google Test source package
+WORKDIR /tmp/gtest/
+RUN curl --location https://github.com/google/googletest/archive/release-1.10.0.tar.gz | tar -xz && \
+  cmake -DCMAKE_CXX_FLAGS="-std=c++17" googletest-release-1.10.0/ && \
+  make && \
+  cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DBUILD_SHARED_LIBS=ON googletest-release-1.10.0/ && \
+  make && \
+  cp -r lib/ /usr/local/ && \
+  cp -r \
+    googletest-release-1.10.0/googletest/include/ \
+    googletest-release-1.10.0/googlemock/include/ \
+    /usr/local/ && \
+  cp --parents -r \
+    googletest-release-1.10.0/CMakeLists.txt \
+    googletest-release-1.10.0/googletest/CMakeLists.txt \
+    googletest-release-1.10.0/googletest/cmake/ \
+    googletest-release-1.10.0/googletest/src/ \
+    googletest-release-1.10.0/googlemock/CMakeLists.txt \
+    googletest-release-1.10.0/googlemock/cmake/ \
+    googletest-release-1.10.0/googlemock/src/ \
+    /usr/local/src/ && \
+  rm -rf /tmp/gtest/
+
+# Install NAS2D specific dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libglew-dev=2.0.0-* \
+    libphysfs-dev=3.0.1-* \
+    libsdl2-dev=2.0.8+* \
+    libsdl2-image-dev=2.0.3+* \
+    libsdl2-mixer-dev=2.0.2+* \
+    libsdl2-ttf-dev=2.0.14+* \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash user
+USER user
+
+VOLUME /code
+WORKDIR /code
+
+CMD ["make", "--keep-going", "check"]

--- a/makefile
+++ b/makefile
@@ -172,6 +172,9 @@ DockerRepository := outpostuniverse
 ImageName := nas2d
 ImageVersion := 1.4
 
+ImageName_clang := nas2d-clang
+ImageVersion_clang := 1.0
+
 ImageName_mingw := nas2d-mingw
 ImageVersion_mingw := 1.2
 
@@ -194,6 +197,23 @@ root-debug-image:
 .PHONY: push-image
 push-image:
 	docker push ${DockerRepository}/${ImageName}
+
+.PHONY: build-image-clang
+build-image-clang: ImageName := ${ImageName_clang}
+build-image-clang: ImageVersion := ${ImageVersion_clang}
+build-image-clang: | build-image
+.PHONY: run-image-clang
+run-image-clang: ImageName := ${ImageName_clang}
+run-image-clang: | run-image
+.PHONY: debug-image-clang
+debug-image-clang: ImageName := ${ImageName_clang}
+debug-image-clang: | debug-image
+.PHONY: root-debug-image-clang
+root-debug-image-clang: ImageName := ${ImageName_clang}
+root-debug-image-clang: | root-debug-image
+.PHONY: push-image-clang
+push-image-clang: ImageName := ${ImageName_clang}
+push-image-clang: | push-image
 
 .PHONY: build-image-mingw
 build-image-mingw: ImageName := ${ImageName_mingw}


### PR DESCRIPTION
Add Clang docker image and CircleCI config for a Linux Clang build.

If these start to be too slow, we can disable some of the builds, or only enable them on branches where it matters for testing. Currently though, the 4 builds done on CircleCI are still faster than the 2 builds done on AppVeyor.
