### PR TITLE
Enable warnings as errors for Linux and MacOS

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS.EXTRA) -Iinclude/
-CXXFLAGS := -std=c++17 -g -Wall -Wpedantic $(shell sdl2-config --cflags)
+CXXFLAGS := -std=c++17 -g -Wall -Wpedantic -Werror $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS.EXTRA)
 LDLIBS := -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
 


### PR DESCRIPTION
Looks like the NAS2D builds for Linux and MacOS are all clean. Should try to keep them that way.
