### PR TITLE
Allow consistent specification of EXTRA flags

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,9 +23,9 @@ Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS.EXTRA) -Iinclude/
-CXXFLAGS := -std=c++17 -g -Wall -Wpedantic -Werror $(shell sdl2-config --cflags)
+CXXFLAGS := $(CXXFLAGS.EXTRA) -std=c++17 -g -Wall -Wpedantic -Werror $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS.EXTRA)
-LDLIBS := -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
+LDLIBS := $(LDLIBS.EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
 
 Windows_RUN_PREFIX := wine
 RUN_PREFIX := $($(TARGET_OS)_RUN_PREFIX)


### PR DESCRIPTION
This fills out the Makefile pattern which allows for consistent specification of `EXTRA` flags.

----

I'm starting to experiment with code coverage. To enable this, GCC needs extra flags passed to the compiler and an extra library passed to the linker. Having these extra flag variables makes it easy to compile the code with support for coverage reports.

Example:
```
make check CXXFLAGS.EXTRA="-fprofile-arcs -ftest-coverage" LDLIBS.EXTRA="-lgcov"
```

This compiles the code with coverage support, and then runs the unit tests to create coverage data. The resulting files can be analysed to determine which lines of source code were run by the unit tests.

Eventually this can be done as part of CI, with coverage reports being produced much like the code analysis and linting tools.
