### PR TITLE
Change `Filesystem::extension` specification

### DIFF
--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -47,7 +47,7 @@ public:
 	void del(const std::string& path) const;
 	bool exists(const std::string& filename) const;
 
-	std::string extension(const std::string& path);
+	std::string extension(const std::string& path) const;
 
 	bool isDirectory(const std::string& path) const;
 	void makeDirectory(const std::string& path) const;

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -327,7 +327,7 @@ std::string Filesystem::workingPath(const std::string& filename) const
  * \return	Returns a string containing the file extension, including the dot (".").
  *			An empty string will be returned if the file has no extension.
  */
-std::string Filesystem::extension(const std::string& path)
+std::string Filesystem::extension(const std::string& path) const
 {
 	// This is a naive approach but works for most cases.
 	size_t pos = path.find_last_of(".");

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -324,8 +324,8 @@ std::string Filesystem::workingPath(const std::string& filename) const
  *
  * \param	path	Path to check for an extension.
  *
- * \return	Returns a string containing the file extension. An empty string will be
- *			returned if the file has no extension or if it's a directory.
+ * \return	Returns a string containing the file extension, including the dot (".").
+ *			An empty string will be returned if the file has no extension.
  */
 std::string Filesystem::extension(const std::string& path)
 {
@@ -334,7 +334,7 @@ std::string Filesystem::extension(const std::string& path)
 
 	if (pos != std::string::npos)
 	{
-		return path.substr(pos + 1);
+		return path.substr(pos);
 	}
 	return std::string();
 }

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -22,12 +22,12 @@ TEST_F(FilesystemTest, dataPath) {
 }
 
 TEST_F(FilesystemTest, extension) {
-	EXPECT_EQ("txt", fs.extension("subdir/file.txt"));
-	EXPECT_EQ("txt", fs.extension("file.txt"));
-	EXPECT_EQ("reallyLongExtensionName", fs.extension("file.reallyLongExtensionName"));
-	EXPECT_EQ("a", fs.extension("file.a"));
-	EXPECT_EQ("file", fs.extension(".file"));
-	EXPECT_EQ("", fs.extension("file."));
+	EXPECT_EQ(".txt", fs.extension("subdir/file.txt"));
+	EXPECT_EQ(".txt", fs.extension("file.txt"));
+	EXPECT_EQ(".reallyLongExtensionName", fs.extension("file.reallyLongExtensionName"));
+	EXPECT_EQ(".a", fs.extension("file.a"));
+	EXPECT_EQ(".file", fs.extension(".file"));
+	EXPECT_EQ(".", fs.extension("file."));
 	EXPECT_EQ("", fs.extension("file"));
 }
 


### PR DESCRIPTION
Closes #179

This change is intentionally simple. I'm not giving special consideration to directories, and removed the comment about directories from the documentation. How it behaves with directories is unspecified. This is to give us more room to "fix" the behaviour with directories in the future. In particular, using `<filesystem>` methods should allow us to find the extension of a directory.

No internal methods, nor any downstream projects are currently using this method, so there should be no downstream effects from the change.
