### PR TITLE
Remove `Image::_center` member variable

### DIFF
--- a/include/NAS2D/Resources/Image.h
+++ b/include/NAS2D/Resources/Image.h
@@ -65,7 +65,6 @@ private:
 
 private:
 	std::pair<int, int> _size; /**< Width/Height information about the Image. */
-	std::pair<uint32_t, uint32_t> _center; /**<  */
 };
 
 

--- a/src/Resources/Image.cpp
+++ b/src/Resources/Image.cpp
@@ -71,7 +71,6 @@ Image::Image(int width, int height) : Resource(ARBITRARY_IMAGE_NAME)
 {
 	name(string_format("%s%i", ARBITRARY_IMAGE_NAME.c_str(), ++IMAGE_ARBITRARY));
 	_size = std::make_pair(width, height);
-	_center = std::make_pair(width / 2, height / 2);
 
 	// Update resource management.
 	IMAGE_ID_MAP[name()].texture_id = 0;
@@ -106,7 +105,6 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) : Resource(
 	SDL_Surface* pixels = SDL_CreateRGBSurfaceFrom(buffer, width, height, bytesPerPixel * 4, 0, 0, 0, 0, SDL_BYTEORDER == SDL_BIG_ENDIAN ? 0x000000FF : 0xFF000000);
 
 	_size = std::make_pair(width, height);
-	_center = std::make_pair(pixels->w / 2, pixels->h / 2);
 
 	unsigned int texture_id = generateTexture(buffer, bytesPerPixel, width, height);
 
@@ -158,7 +156,6 @@ Image& Image::operator=(const Image& rhs)
 
 	name(rhs.name());
 	_size = rhs._size;
-	_center = rhs._center;
 
 	auto it = IMAGE_ID_MAP.find(name());
 	if (it == IMAGE_ID_MAP.end())
@@ -206,7 +203,6 @@ void Image::load()
 	}
 
 	_size = std::make_pair(pixels->w, pixels->h);
-	_center = std::make_pair(pixels->w / 2, pixels->h / 2);
 
 	unsigned int texture_id = generateTexture(pixels->pixels, pixels->format->BytesPerPixel, pixels->w, pixels->h);
 
@@ -251,13 +247,13 @@ int Image::height() const
 
 int Image::center_x() const
 {
-	return _center.first;
+	return _size.first / 2;
 }
 
 
 int Image::center_y() const
 {
-	return _center.second;
+	return _size.second / 2;
 }
 
 

--- a/test/Resources/Image.test.cpp
+++ b/test/Resources/Image.test.cpp
@@ -6,3 +6,11 @@ TEST(Image, size) {
 	EXPECT_EQ((NAS2D::Vector<int>{1, 1}), NAS2D::Image(1, 1).size());
 	EXPECT_EQ((NAS2D::Vector<int>{4, 2}), NAS2D::Image(4, 2).size());
 }
+
+TEST(Image, center) {
+	EXPECT_EQ(0, NAS2D::Image(1, 1).center_x());
+	EXPECT_EQ(0, NAS2D::Image(1, 1).center_y());
+
+	EXPECT_EQ(2, NAS2D::Image(4, 2).center_x());
+	EXPECT_EQ(1, NAS2D::Image(4, 2).center_y());
+}


### PR DESCRIPTION
Closes #402

Removes the `_center` member variable, and just computes the center values on the fly. An optimizing compiler will convert division by 2 to a quick shift instruction. No need to add extra storage for a pre-computed value. Also no need to pre-compute in cases where it is never used.

This also eliminates the fixed size aspect of that value, which may not play well with 32-bit versus 64-bit builds.
