### PR TITLE
Add `override` keyword for Resources

### DIFF
--- a/include/NAS2D/Resources/Font.h
+++ b/include/NAS2D/Resources/Font.h
@@ -50,7 +50,7 @@ public:
 	const int glyphCellHeight() const;
 
 private:
-	void load() {}
+	void load() override {}
 };
 
 } // namespace

--- a/include/NAS2D/Resources/Image.h
+++ b/include/NAS2D/Resources/Image.h
@@ -61,7 +61,7 @@ public:
 	Color pixelColor(int x, int y) const;
 
 private:
-	void load();
+	void load() override;
 
 private:
 	std::pair<int, int> _size; /**< Width/Height information about the Image. */

--- a/include/NAS2D/Resources/Music.h
+++ b/include/NAS2D/Resources/Music.h
@@ -32,7 +32,7 @@ public:
 	virtual ~Music();
 
 private:
-	void load();
+	void load() override;
 };
 
 } // namespace

--- a/include/NAS2D/Resources/Sound.h
+++ b/include/NAS2D/Resources/Sound.h
@@ -38,7 +38,7 @@ protected:
 	void* sound() const;
 
 private:
-	void load();
+	void load() override;
 
 	void* _chunk{nullptr};
 };


### PR DESCRIPTION
Bulk update for issue #400.

This adds the `override` keyword where possible to the `Resource` derived classes.

This PR does not address similar changes affecting the XML code.

This was done with help from the `-Wsuggest-override` flag for GCC.
