### PR TITLE
Remove compiler flag to generate debug info

### DIFF
--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS.EXTRA) -Iinclude/
-CXXFLAGS := $(CXXFLAGS.EXTRA) -std=c++17 -g -Wall -Wpedantic -Werror $(shell sdl2-config --cflags)
+CXXFLAGS := $(CXXFLAGS.EXTRA) -std=c++17 -Wall -Wpedantic -Werror $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS.EXTRA)
 LDLIBS := $(LDLIBS.EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
 


### PR DESCRIPTION
Debug information makes the library much larger than it needs to be (~18MB versus 4MB), and isn't being used. In particular, it has no use as part of the CI builds, and isn't being used by local Linux developers.

Additionally, it is easy enough to generate debug information by passing the `-g` flag in the new `CXXFLAGS.EXTRA` variable. Hence, local developers always have that option if needed.

----

Makefile only change.
