### PR TITLE
Make Configuration use explicit types for private member function parameters

### DIFF
--- a/include/NAS2D/Configuration.h
+++ b/include/NAS2D/Configuration.h
@@ -9,8 +9,6 @@
 // ==================================================================================
 #pragma once
 
-#include "Exception.h"
-
 #include <string>
 #include <map>
 

--- a/include/NAS2D/Configuration.h
+++ b/include/NAS2D/Configuration.h
@@ -11,6 +11,7 @@
 
 #include "Exception.h"
 
+#include <string>
 #include <map>
 
 namespace NAS2D {

--- a/include/NAS2D/Configuration.h
+++ b/include/NAS2D/Configuration.h
@@ -89,9 +89,9 @@ private:
 
 	bool readConfig(const std::string& filePath);
 
-	void parseGraphics(NAS2D::Xml::XmlElement *node);
-	void parseAudio(NAS2D::Xml::XmlElement *node);
-	void parseOptions(NAS2D::Xml::XmlElement *node);
+	void parseGraphics(NAS2D::Xml::XmlElement* node);
+	void parseAudio(NAS2D::Xml::XmlElement* node);
+	void parseOptions(NAS2D::Xml::XmlElement* node);
 
 	Options mOptions{};
 

--- a/include/NAS2D/Configuration.h
+++ b/include/NAS2D/Configuration.h
@@ -16,6 +16,11 @@
 namespace NAS2D {
 
 
+namespace Xml {
+	class XmlElement;
+}
+
+
 /**
  * \class Configuration
  * \brief Configuration Parser.
@@ -85,9 +90,9 @@ private:
 
 	bool readConfig(const std::string& filePath);
 
-	void parseGraphics(void *node);
-	void parseAudio(void *node);
-	void parseOptions(void *node);
+	void parseGraphics(NAS2D::Xml::XmlElement *node);
+	void parseAudio(NAS2D::Xml::XmlElement *node);
+	void parseOptions(NAS2D::Xml::XmlElement *node);
 
 	Options mOptions{};
 

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -219,12 +219,8 @@ bool Configuration::readConfig(const std::string& filePath)
  *
  * \todo	Check for sane configurations, particularly screen resolution.
  */
-void Configuration::parseGraphics(void* _n)
+void Configuration::parseGraphics(XmlElement* element)
 {
-	// NOTE: Void pointer used to avoid implementation details in the class declaration.
-
-	XmlElement* element = static_cast<XmlNode*>(_n)->toElement();
-
 	const XmlAttribute* attribute = element->firstAttribute();
 	while (attribute)
 	{
@@ -246,12 +242,8 @@ void Configuration::parseGraphics(void* _n)
  * \note	If any values are invalid or non-existant, this
  *			function will set default values.
  */
-void Configuration::parseAudio(void* _n)
+void Configuration::parseAudio(XmlElement* element)
 {
-	// NOTE: Void pointer used to avoid implementation details in the class declaration.
-
-	XmlElement* element = static_cast<XmlNode*>(_n)->toElement();
-
 	const XmlAttribute* attribute = element->firstAttribute();
 	while (attribute)
 	{
@@ -319,11 +311,8 @@ void Configuration::parseAudio(void* _n)
  *
  * \note	Use of void pointer in declaration to avoid implementation details in header.
  */
-void Configuration::parseOptions(void* _n)
+void Configuration::parseOptions(XmlElement* element)
 {
-	// NOTE: Void pointer used to avoid implementation details in the class declaration.
-	XmlElement* element = static_cast<XmlNode*>(_n)->toElement();
-
 	for (auto setting = element->firstChildElement();
 		 setting != nullptr;
 		 setting = setting->nextSiblingElement())

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -195,9 +195,9 @@ bool Configuration::readConfig(const std::string& filePath)
 
 
 		// Start parsing through the Config.xml file.
-		for (auto xmlNode = root->firstChild();
+		for (auto xmlNode = root->firstChildElement();
 			 xmlNode != nullptr;
-			 xmlNode = xmlNode->nextSibling())
+			 xmlNode = xmlNode->nextSiblingElement())
 		{
 			if (xmlNode->value() == "graphics") { parseGraphics(xmlNode); }
 			else if (xmlNode->value() == "audio") { parseAudio(xmlNode); }
@@ -345,9 +345,9 @@ void Configuration::parseOptions(void* _n)
 		return;
 	}
 
-	for (auto xmlNode = element->firstChild();
+	for (auto xmlNode = element->firstChildElement();
 		 xmlNode != nullptr;
-		 xmlNode = xmlNode->nextSibling())
+		 xmlNode = xmlNode->nextSiblingElement())
 	{
 		if (xmlNode->value() == "option")
 		{

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -319,7 +319,7 @@ void Configuration::parseOptions(XmlElement* element)
 	{
 		if (setting->value() == "option")
 		{
-			const XmlAttribute* attribute = setting->toElement()->firstAttribute();
+			const XmlAttribute* attribute = setting->firstAttribute();
 
 			std::string name, value;
 			while (attribute)

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -195,17 +195,17 @@ bool Configuration::readConfig(const std::string& filePath)
 
 
 		// Start parsing through the Config.xml file.
-		for (auto xmlNode = root->firstChildElement();
-			 xmlNode != nullptr;
-			 xmlNode = xmlNode->nextSiblingElement())
+		for (auto section = root->firstChildElement();
+			 section != nullptr;
+			 section = section->nextSiblingElement())
 		{
-			if (xmlNode->value() == "graphics") { parseGraphics(xmlNode); }
-			else if (xmlNode->value() == "audio") { parseAudio(xmlNode); }
-			else if (xmlNode->value() == "options") { parseOptions(xmlNode); }
-			else if (xmlNode->type() == XmlNode::NodeType::XML_COMMENT) {} // Ignore comments
+			if (section->value() == "graphics") { parseGraphics(section); }
+			else if (section->value() == "audio") { parseAudio(section); }
+			else if (section->value() == "options") { parseOptions(section); }
+			else if (section->type() == XmlNode::NodeType::XML_COMMENT) {} // Ignore comments
 			else
 			{
-				std::cout << "Unexpected tag '<" << xmlNode->value() << ">' found in '" << filePath << "' on row " << xmlNode->row() << "." << std::endl;
+				std::cout << "Unexpected tag '<" << section->value() << ">' found in '" << filePath << "' on row " << section->row() << "." << std::endl;
 			}
 		}
 	}
@@ -345,13 +345,13 @@ void Configuration::parseOptions(void* _n)
 		return;
 	}
 
-	for (auto xmlNode = element->firstChildElement();
-		 xmlNode != nullptr;
-		 xmlNode = xmlNode->nextSiblingElement())
+	for (auto setting = element->firstChildElement();
+		 setting != nullptr;
+		 setting = setting->nextSiblingElement())
 	{
-		if (xmlNode->value() == "option")
+		if (setting->value() == "option")
 		{
-			const XmlAttribute* attribute = xmlNode->toElement()->firstAttribute();
+			const XmlAttribute* attribute = setting->toElement()->firstAttribute();
 
 			std::string name, value;
 			while (attribute)
@@ -374,7 +374,7 @@ void Configuration::parseOptions(void* _n)
 
 			if (name.empty() || value.empty())
 			{
-				std::cout << "Invalid name/value pair in <option> tag in configuration file on row " << xmlNode->row() << ". This option will be ignored." << std::endl;
+				std::cout << "Invalid name/value pair in <option> tag in configuration file on row " << setting->row() << ". This option will be ignored." << std::endl;
 			}
 			else
 			{
@@ -383,7 +383,7 @@ void Configuration::parseOptions(void* _n)
 		}
 		else
 		{
-			std::cout << "Unexpected tag '<" << xmlNode->value() << ">' found in configuration on row " << xmlNode->row() << "." << std::endl;
+			std::cout << "Unexpected tag '<" << setting->value() << ">' found in configuration on row " << setting->row() << "." << std::endl;
 		}
 	}
 }

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -225,13 +225,6 @@ void Configuration::parseGraphics(void* _n)
 
 	XmlElement* element = static_cast<XmlNode*>(_n)->toElement();
 
-	// Probably not a necessary check but here for robustness.
-	if (!element)
-	{
-		std::cout << "Unexpected XML tag '" << static_cast<XmlNode*>(_n)->value() << "' found in configuration file while processing the '<graphics>' element." << std::endl;
-		return;
-	}
-
 	const XmlAttribute* attribute = element->firstAttribute();
 	while (attribute)
 	{
@@ -258,13 +251,6 @@ void Configuration::parseAudio(void* _n)
 	// NOTE: Void pointer used to avoid implementation details in the class declaration.
 
 	XmlElement* element = static_cast<XmlNode*>(_n)->toElement();
-
-	// Probably not a necessary check but here for robustness.
-	if (!element)
-	{
-		std::cout << "Unexpected XML tag '" << static_cast<XmlNode*>(_n)->value() << "' found in configuration file while processing the '<audio>' element." << std::endl;
-		return;
-	}
 
 	const XmlAttribute* attribute = element->firstAttribute();
 	while (attribute)
@@ -337,13 +323,6 @@ void Configuration::parseOptions(void* _n)
 {
 	// NOTE: Void pointer used to avoid implementation details in the class declaration.
 	XmlElement* element = static_cast<XmlNode*>(_n)->toElement();
-
-	// Probably not a necessary check but here for robustness.
-	if (!element)
-	{
-		std::cout << "Unexpected XML tag '" << static_cast<XmlNode*>(_n)->value() << "' found in configuration file while processing the '<graphics>' element." << std::endl;
-		return;
-	}
 
 	for (auto setting = element->firstChildElement();
 		 setting != nullptr;

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -195,9 +195,9 @@ bool Configuration::readConfig(const std::string& filePath)
 
 
 		// Start parsing through the Config.xml file.
-		for (auto xmlNode = root->iterateChildren(nullptr);
+		for (auto xmlNode = root->firstChild();
 			 xmlNode != nullptr;
-			 xmlNode = root->iterateChildren(xmlNode))
+			 xmlNode = xmlNode->nextSibling())
 		{
 			if (xmlNode->value() == "graphics") { parseGraphics(xmlNode); }
 			else if (xmlNode->value() == "audio") { parseAudio(xmlNode); }
@@ -345,9 +345,9 @@ void Configuration::parseOptions(void* _n)
 		return;
 	}
 
-	for (auto xmlNode = element->iterateChildren(nullptr);
+	for (auto xmlNode = element->firstChild();
 		 xmlNode != nullptr;
-		 xmlNode = element->iterateChildren(xmlNode))
+		 xmlNode = xmlNode->nextSibling())
 	{
 		if (xmlNode->value() == "option")
 		{


### PR DESCRIPTION
Using explicit types eliminates the need for type casts, and being more specific about them means error checks can be removed. A forward declaration is enough to use an explicit type, without needing to `#include` implementation details from the header.

In hindsight, I probably should have swapped the order of the commit that removes the checks and the commit that changes the declared parameter types. Small point though, since all calls to the private method only ever pass objects of the correct type.
