### PR TITLE
Add `override` to XML code

### DIFF
--- a/include/NAS2D/Xml/XmlAttribute.h
+++ b/include/NAS2D/Xml/XmlAttribute.h
@@ -68,9 +68,9 @@ public:
 	 * Attribute parsing starts: first letter of the name
 	 * returns: the next char after the value end quote
 	 */
-	virtual const char* parse(const char* p, void* data);
+	const char* parse(const char* p, void* data) override;
 
-	virtual void write(std::string& buf, int depth) const;
+	void write(std::string& buf, int depth) const override;
 
 protected:
 	friend class XmlElement;

--- a/include/NAS2D/Xml/XmlComment.h
+++ b/include/NAS2D/Xml/XmlComment.h
@@ -30,20 +30,20 @@ public:
 
 	virtual ~XmlComment() {}
 
-	virtual XmlNode* clone() const;
+	XmlNode* clone() const override;
 
-	virtual void write(std::string& buf, int depth) const;
+	void write(std::string& buf, int depth) const override;
 
-	virtual const char* parse(const char* p, void* data);
+	const char* parse(const char* p, void* data) override;
 
-	virtual const XmlComment* toComment() const { return this; }
-	virtual XmlComment* toComment() { return this; }
+	const XmlComment* toComment() const override { return this; }
+	XmlComment* toComment() override { return this; }
 
-	virtual bool accept(void* visitor) const;
+	bool accept(void* visitor) const override;
 
 protected:
 	void copyTo(XmlComment* target) const;
-	virtual void streamIn(std::istream& in, std::string& tag);
+	void streamIn(std::istream& in, std::string& tag) override;
 
 private:
 

--- a/include/NAS2D/Xml/XmlDocument.h
+++ b/include/NAS2D/Xml/XmlDocument.h
@@ -19,7 +19,7 @@ public:
 
 	virtual ~XmlDocument() {}
 
-	virtual const char* parse(const char* p, void* data = nullptr);
+	const char* parse(const char* p, void* data = nullptr) override;
 
 	const XmlElement* rootElement() const;
 	XmlElement* rootElement();
@@ -32,18 +32,18 @@ public:
 
 	void clearError();
 
-	virtual const XmlDocument* toDocument() const { return this; }
-	virtual XmlDocument* toDocument() { return this; }
+	const XmlDocument* toDocument() const override { return this; }
+	XmlDocument* toDocument() override { return this; }
 
-	virtual bool accept(void* content) const;
-	virtual void write(std::string& buf, int depth = 0) const;
+	bool accept(void* content) const override;
+	void write(std::string& buf, int depth = 0) const override;
 
 public:
 	void error(XmlErrorCode err, const char* errorLocation, void* prevData);
 
 protected:
-	virtual XmlNode* clone() const;
-	virtual void streamIn(std::istream& in, std::string& tag);
+	XmlNode* clone() const override;
+	void streamIn(std::istream& in, std::string& tag) override;
 
 private:
 	void copyTo(XmlDocument* target) const;

--- a/include/NAS2D/Xml/XmlElement.h
+++ b/include/NAS2D/Xml/XmlElement.h
@@ -45,21 +45,21 @@ public:
 	const XmlAttribute* lastAttribute() const;
 	XmlAttribute* lastAttribute();
 
-	virtual XmlNode* clone() const;
+	XmlNode* clone() const override;
 
-	virtual void write(std::string& buf, int depth) const;
+	void write(std::string& buf, int depth) const override;
 
-	virtual const char* parse(const char* p, void* data);
+	const char* parse(const char* p, void* data) override;
 
-	virtual const XmlElement* toElement() const { return this; }
-	virtual XmlElement* toElement() { return this; }
+	const XmlElement* toElement() const override { return this; }
+	XmlElement* toElement() override { return this; }
 
-	virtual bool accept(void* visitor) const;
+	bool accept(void* visitor) const override;
 
 protected:
 	void copyTo(XmlElement* target) const;
 	void clearThis();	// like clear, but initializes 'this' object as well
-	virtual void streamIn(std::istream& in, std::string& tag);
+	void streamIn(std::istream& in, std::string& tag) override;
 	const char* readValue(const char* in, void* prevData);
 
 private:

--- a/include/NAS2D/Xml/XmlMemoryBuffer.h
+++ b/include/NAS2D/Xml/XmlMemoryBuffer.h
@@ -37,15 +37,15 @@ class XmlMemoryBuffer : public XmlVisitor
 public:
 	XmlMemoryBuffer();
 
-	virtual bool visitEnter(const XmlDocument&) { return true; }
-	virtual bool visitExit(const XmlDocument&) { return true; }
+	bool visitEnter(const XmlDocument&) override { return true; }
+	bool visitExit(const XmlDocument&) override { return true; }
 
-	virtual bool visitEnter(const XmlElement& element, const XmlAttribute* firstAttribute);
-	virtual bool visitExit(const XmlElement& element);
+	bool visitEnter(const XmlElement& element, const XmlAttribute* firstAttribute) override;
+	bool visitExit(const XmlElement& element) override;
 
-	virtual bool visit(const XmlText& text);
-	virtual bool visit(const XmlComment& comment);
-	virtual bool visit(const XmlUnknown& unknown);
+	bool visit(const XmlText& text) override;
+	bool visit(const XmlComment& comment) override;
+	bool visit(const XmlUnknown& unknown) override;
 
 	size_t size();
 

--- a/include/NAS2D/Xml/XmlText.h
+++ b/include/NAS2D/Xml/XmlText.h
@@ -35,7 +35,7 @@ public:
 	XmlText(const XmlText& copy);
 	XmlText& operator=(const XmlText& base);
 
-	virtual void write(std::string& buf, int depth) const;
+	void write(std::string& buf, int depth) const override;
 
 	/**
 	 * Queries whether this represents text using a CDATA section.
@@ -47,20 +47,20 @@ public:
 	 */
 	void CDATA(bool _cdata) { cdata = _cdata; }
 
-	virtual const char* parse(const char* p, void* data);
+	const char* parse(const char* p, void* data) override;
 
-	virtual const XmlText* toText() const { return this; }
-	virtual XmlText* toText() { return this; }
+	const XmlText* toText() const override { return this; }
+	XmlText* toText() override { return this; }
 
-	virtual bool accept(void* visitor) const;
+	bool accept(void* visitor) const override;
 
 protected:
 	///  [internal use] Creates a new Element and returns it.
-	virtual XmlNode* clone() const;
+	XmlNode* clone() const override;
 	void copyTo(XmlText* target) const;
 
 	bool blank() const;	// returns true if all white space and new lines
-	virtual void streamIn(std::istream& in, std::string& tag);
+	void streamIn(std::istream& in, std::string& tag) override;
 
 private:
 	bool cdata;			// true if this should be input and output as a CDATA style text element

--- a/include/NAS2D/Xml/XmlUnknown.h
+++ b/include/NAS2D/Xml/XmlUnknown.h
@@ -32,26 +32,26 @@ public:
 	XmlUnknown(const XmlUnknown& copy);
 	XmlUnknown& operator=(const XmlUnknown& copy);
 
-	virtual XmlNode* clone() const;
+	XmlNode* clone() const override;
 
 	/**
 	 * Print the Unknown to a buffer.
 	 */
-	virtual void write(std::string& buf, int depth) const;
+	void write(std::string& buf, int depth) const override;
 
-	virtual const char* parse(const char* p, void* data);
+	const char* parse(const char* p, void* data) override;
 
-	virtual const XmlUnknown* toUnknown() const { return this; }
-	virtual XmlUnknown* toUnknown() { return this; }
+	const XmlUnknown* toUnknown() const override { return this; }
+	XmlUnknown* toUnknown() override { return this; }
 
 	/**
 	 * Walk the XML tree visiting this node and all of its children.
 	 */
-	virtual bool accept(void* visitor) const;
+	bool accept(void* visitor) const override;
 
 protected:
 	void copyTo(XmlUnknown* target) const;
-	virtual void streamIn(std::istream& in, std::string& tag);
+	void streamIn(std::istream& in, std::string& tag) override;
 };
 
 } // namespace Xml


### PR DESCRIPTION
Closes #400

Add `override` keyword to XML class members. This was done for all places suggested by GCC when using the `-Wsuggest-override` flag.
