### PR TITLE
Add Filesystem special folders

### DIFF
--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -34,6 +34,7 @@ public:
 	~Filesystem();
 
 
+	std::string basePath() const;
 	std::string dataPath() const;
 	std::string workingPath(const std::string& filename) const;
 	StringList searchPath() const;

--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -35,6 +35,8 @@ public:
 
 
 	std::string basePath() const;
+	std::string prefPath() const;
+
 	std::string dataPath() const;
 	std::string workingPath(const std::string& filename) const;
 	StringList searchPath() const;
@@ -54,6 +56,9 @@ public:
 	void makeDirectory(const std::string& path) const;
 
 private:
+	std::string mAppName;
+	std::string mOrganizationName;
+
 	std::string			mDataPath;			/**< Data path string. This will typically be 'data/'. */
 };
 

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -41,7 +41,9 @@ enum MountPosition
 };
 
 
-NAS2D::Filesystem::Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName, const std::string& dataPath)
+NAS2D::Filesystem::Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName, const std::string& dataPath) :
+	mAppName(appName),
+	mOrganizationName(organizationName)
 {
 	if (PHYSFS_isInit()) { throw filesystem_already_initialized(); }
 
@@ -80,6 +82,21 @@ Filesystem::~Filesystem()
 std::string Filesystem::basePath() const
 {
 	return PHYSFS_getBaseDir();
+}
+
+
+/**
+ * Determines the path to the folder where user preferences are stored
+ *
+ * The user should have write access to the preferences folder, which is generally under their user folder.
+ *
+ * \note This path is dependent on the Operating System (OS).
+ * \note Path may be empty if the folder could not be created.
+ */
+std::string Filesystem::prefPath() const
+{
+	auto prefDir = PHYSFS_getPrefDir(mOrganizationName.c_str(), mAppName.c_str());
+	return (prefDir != nullptr) ? prefDir : "";
 }
 
 

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -73,6 +73,17 @@ Filesystem::~Filesystem()
 
 
 /**
+ * Determines the path to the folder where the executable is located
+ *
+ * The base path may or may not be the current working directory.
+ */
+std::string Filesystem::basePath() const
+{
+	return PHYSFS_getBaseDir();
+}
+
+
+/**
  * Adds a directory or supported archive to the Search Path.
  *
  * \param path	File path to add.


### PR DESCRIPTION
Closes #317

Add `Filesystem` special folders `basePath` and `prefPath`.

This allows for delayed mounting of special filesystem folders, or unmounting of default mounted folders.

This intentionally uses PhysFS functions. Doing this without the use of PhysFS is to be handled by later issues, such as #212. This is intended to create the structure for later changes to follow.

This should help unblock work on: #212, #320
