### PR TITLE
Add `Filesystem::dirSeparator()` method

### DIFF
--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -52,6 +52,8 @@ public:
 
 	std::string extension(const std::string& path) const;
 
+	std::string dirSeparator() const;
+
 	bool isDirectory(const std::string& path) const;
 	void makeDirectory(const std::string& path) const;
 

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -366,3 +366,15 @@ std::string Filesystem::extension(const std::string& path) const
 	}
 	return std::string();
 }
+
+/**
+ * Gets the dir separator for the current platform
+ *
+ * The dir separator separates the directories within a path. This is typically either "\\" for Windows, or "/" for Linux.
+ *
+ * \note The path separator may be more than one character
+ */
+std::string Filesystem::dirSeparator() const
+{
+	return PHYSFS_getDirSeparator();
+}

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -111,3 +111,10 @@ TEST_F(FilesystemTest, mountUnmount) {
 
 	EXPECT_THROW(fs.mount("nonExistentPath/"), std::runtime_error);
 }
+
+TEST_F(FilesystemTest, dirSeparator) {
+	// Varies by platform, so we can't know the exact value ("/", "\", ":")
+	// New platforms may choose a new unique value
+	// Some platforms may not even have a hierarchal filesystem ("")
+	EXPECT_NO_THROW(fs.dirSeparator());
+}

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -18,12 +18,12 @@ class FilesystemTest : public ::testing::Test {
 
 
 TEST_F(FilesystemTest, basePath) {
-	// Result is a path, so should end with a directory separator
+	// Result is a directory, and should end with a directory separator
 	EXPECT_THAT(fs.basePath(), testing::EndsWith(fs.dirSeparator()));
 }
 
 TEST_F(FilesystemTest, prefPath) {
-	// Result is a path, so should end with a directory separator
+	// Result is a directory, and should end with a directory separator
 	EXPECT_THAT(fs.prefPath(), testing::EndsWith(fs.dirSeparator()));
 }
 

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -17,6 +17,16 @@ class FilesystemTest : public ::testing::Test {
 };
 
 
+TEST_F(FilesystemTest, basePath) {
+	// Result is a path, so should end with a directory separator
+	EXPECT_THAT(fs.basePath(), testing::EndsWith(fs.dirSeparator()));
+}
+
+TEST_F(FilesystemTest, prefPath) {
+	// Result is a path, so should end with a directory separator
+	EXPECT_THAT(fs.prefPath(), testing::EndsWith(fs.dirSeparator()));
+}
+
 TEST_F(FilesystemTest, dataPath) {
 	EXPECT_EQ("data/", fs.dataPath());
 }


### PR DESCRIPTION
Add `Filesystem::dirSeparator()` method
- Windows: `\\`
- Linux: `/`
- Mac: `:`

Reference:
[`PHYSFS_getDirSeparator()`](https://icculus.org/physfs/docs/html/physfs_8h.html#ad1dc17d387c45e9155d1f0c348a7cbcc)

This may not find much direct use, though is perhaps useful internally for path manipulations, and for unit test code. In particular, unit tests which rely on platform specific folders can potentially use this to abstract away platform differences in unit test values.
