### PR TITLE
Remove `mDataPath` prefix for `Filesystem::mount`

### DIFF
--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -107,9 +107,7 @@ std::string Filesystem::prefPath() const
  */
 void Filesystem::mount(const std::string& path) const
 {
-	std::string searchPath(mDataPath + "/" + path);
-
-	if (PHYSFS_mount(searchPath.c_str(), "/", MountPosition::MOUNT_APPEND) == 0)
+	if (PHYSFS_mount(path.c_str(), "/", MountPosition::MOUNT_APPEND) == 0)
 	{
 		throw std::runtime_error(std::string("Couldn't add '") + path + "' to search path: " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}
@@ -123,9 +121,7 @@ void Filesystem::mount(const std::string& path) const
  */
 void Filesystem::unmount(const std::string& path) const
 {
-	std::string searchPath(mDataPath + "/" + path);
-
-	if (PHYSFS_unmount(searchPath.c_str()) == 0)
+	if (PHYSFS_unmount(path.c_str()) == 0)
 	{
 		throw std::runtime_error(std::string("Couldn't remove '") + path + "' from search path : " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -98,7 +98,7 @@ TEST_F(FilesystemTest, isDirectoryMakeDirectory) {
 }
 
 TEST_F(FilesystemTest, mountUnmount) {
-	const std::string extraMount = "extraData/";
+	const std::string extraMount = "data/extraData/";
 	const std::string extraFile = "extraFile.txt";
 
 	EXPECT_FALSE(fs.exists(extraFile));


### PR DESCRIPTION
This resolves the comment: https://github.com/lairworks/nas2d-core/issues/315#issuecomment-574686874

Remove `mDataPath` prefix when mounting folders. Instead, just use the raw `path` argument. This allows any folder on the filesystem to be mounted.

This helps combat the duplicate view of certain files since the typical `mDataPath` folder is already mounted by default.

----

Currently the downstream projects OPHD and op2-landlord do not call `mount` or `unmount` directly. Instead, they rely on the default mounting done by the `Filesystem` constructor. As the `Filesystem` class also doesn't call `mount` or `unmount` internally, the only current use is from the unit tests. That makes this update a pretty safe change, despite the change in previous buggy behaviour.
