### PR TITLE
Remove Filesystem's dataPath

### DIFF
--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -26,7 +26,7 @@ class Filesystem
 {
 public:
 	Filesystem() = delete;
-	Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName, const std::string& dataPath);
+	Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName);
 	Filesystem(const Filesystem&) = delete;
 	Filesystem& operator=(const Filesystem&) = delete;
 	Filesystem(Filesystem&&) = delete;
@@ -37,7 +37,6 @@ public:
 	std::string basePath() const;
 	std::string prefPath() const;
 
-	std::string dataPath() const;
 	std::string workingPath(const std::string& filename) const;
 	StringList searchPath() const;
 	void mount(const std::string& path) const;
@@ -60,8 +59,6 @@ public:
 private:
 	std::string mAppName;
 	std::string mOrganizationName;
-
-	std::string			mDataPath;			/**< Data path string. This will typically be 'data/'. */
 };
 
 }

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -41,7 +41,7 @@ enum MountPosition
 };
 
 
-NAS2D::Filesystem::Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName, const std::string& dataPath) :
+NAS2D::Filesystem::Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName) :
 	mAppName(appName),
 	mOrganizationName(organizationName)
 {
@@ -55,12 +55,6 @@ NAS2D::Filesystem::Filesystem(const std::string& argv_0, const std::string& appN
 	if (PHYSFS_setSaneConfig(organizationName.c_str(), appName.c_str(), nullptr, false, false) == 0)
 	{
 		throw filesystem_backend_init_failure(std::string("Unable to set a sane configuration: ") + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
-	}
-
-	mDataPath = dataPath;
-	if (PHYSFS_mount(mDataPath.c_str(), "/", MountPosition::MOUNT_PREPEND) == 0)
-	{
-		throw filesystem_backend_init_failure(std::string("Couldn't find data path: ") + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}
 }
 
@@ -308,15 +302,6 @@ void Filesystem::write(const File& file, bool overwrite) const
 	}
 
 	closeFile(myFile);
-}
-
-
-/**
- * Gets the base data path.
- */
-std::string Filesystem::dataPath() const
-{
-	return mDataPath;
 }
 
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -46,7 +46,7 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 
 	std::cout << "Initializing subsystems..." << std::endl << std::endl;
 
-	Utility<Filesystem>::init<Filesystem>(argv_0, appName, organizationName, dataPath);
+	Utility<Filesystem>::init<Filesystem>(argv_0, appName, organizationName).mount(dataPath);
 
 	Configuration& cf = Utility<Configuration>::get();
 	cf.load(configPath);

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -4,14 +4,16 @@
 
 
 TEST(Filesystem, ConstructDestruct) {
-	EXPECT_NO_THROW(NAS2D::Filesystem fs("", "NAS2DUnitTests", "LairWorks", "./"));
+	EXPECT_NO_THROW(NAS2D::Filesystem fs("", "NAS2DUnitTests", "LairWorks"));
 }
 
 class FilesystemTest : public ::testing::Test {
   protected:
 	FilesystemTest() :
-		fs("", "NAS2DUnitTests", "LairWorks", "data/")
-	{}
+		fs("", "NAS2DUnitTests", "LairWorks")
+	{
+		fs.mount("data/");
+	}
 
 	NAS2D::Filesystem fs;
 };
@@ -25,10 +27,6 @@ TEST_F(FilesystemTest, basePath) {
 TEST_F(FilesystemTest, prefPath) {
 	// Result is a directory, and should end with a directory separator
 	EXPECT_THAT(fs.prefPath(), testing::EndsWith(fs.dirSeparator()));
-}
-
-TEST_F(FilesystemTest, dataPath) {
-	EXPECT_EQ("data/", fs.dataPath());
 }
 
 TEST_F(FilesystemTest, extension) {


### PR DESCRIPTION
Closes #315

Remove `dataPath` setting from `Filesystem`. This solves the (built-in) double mount issue.

To mount additional data folders, explicitly call `mount` after object construction.

Note: This is a breaking change to the API, which affects source code compatibility. Downstream projects will need corresponding updates to avoid compile errors.
