### PR TITLE
Add `Filesystem::mountWrite` method

### DIFF
--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -40,7 +40,7 @@ public:
 	std::string workingPath(const std::string& filename) const;
 	StringList searchPath() const;
 	void mount(const std::string& path) const;
-	void mountWrite(const std::string& path) const;
+	void mountReadWrite(const std::string& path) const;
 	void unmount(const std::string& path) const;
 
 	StringList directoryList(const std::string& dir, const std::string& filter = std::string {}) const;

--- a/include/NAS2D/Filesystem.h
+++ b/include/NAS2D/Filesystem.h
@@ -40,6 +40,7 @@ public:
 	std::string workingPath(const std::string& filename) const;
 	StringList searchPath() const;
 	void mount(const std::string& path) const;
+	void mountWrite(const std::string& path) const;
 	void unmount(const std::string& path) const;
 
 	StringList directoryList(const std::string& dir, const std::string& filter = std::string {}) const;

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -109,6 +109,24 @@ void Filesystem::mount(const std::string& path) const
 
 
 /**
+ * Mount a folder with write access (includes read access)
+ *
+ * \param path	File path to add.
+ */
+void Filesystem::mountWrite(const std::string& path) const
+{
+	// Mount for read access
+	mount(path);
+
+	// Mount for write access
+	if (PHYSFS_setWriteDir(path.c_str()) == 0)
+	{
+		throw std::runtime_error(std::string("Couldn't add write folder '") + path + "': " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+	}
+}
+
+
+/**
  * Removes a directory or supported archive from the Search Path.
  *
  * \param path	File path to remove.

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -95,7 +95,7 @@ std::string Filesystem::prefPath() const
 
 
 /**
- * Adds a directory or supported archive to the Search Path.
+ * Mount a folder with read access
  *
  * \param path	File path to add.
  */
@@ -109,11 +109,11 @@ void Filesystem::mount(const std::string& path) const
 
 
 /**
- * Mount a folder with write access (includes read access)
+ * Mount a folder with read and write access
  *
  * \param path	File path to add.
  */
-void Filesystem::mountWrite(const std::string& path) const
+void Filesystem::mountReadWrite(const std::string& path) const
 {
 	// Mount for read access
 	mount(path);


### PR DESCRIPTION
This addresses: https://github.com/lairworks/nas2d-core/issues/320#issuecomment-583734421

Add ability to set a write folder, other than the initial default.

----

Would appreciate some feedback on the naming, and if read/write access should be tied together.
