### PR TITLE
Remove `Filesystem` auto mount

### DIFF
--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -51,11 +51,6 @@ NAS2D::Filesystem::Filesystem(const std::string& argv_0, const std::string& appN
 	{
 		throw filesystem_backend_init_failure(PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}
-
-	if (PHYSFS_setSaneConfig(organizationName.c_str(), appName.c_str(), nullptr, false, false) == 0)
-	{
-		throw filesystem_backend_init_failure(std::string("Unable to set a sane configuration: ") + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
-	}
 }
 
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -46,7 +46,9 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 
 	std::cout << "Initializing subsystems..." << std::endl << std::endl;
 
-	Utility<Filesystem>::init<Filesystem>(argv_0, appName, organizationName).mount(dataPath);
+	auto& fs = Utility<Filesystem>::init<Filesystem>(argv_0, appName, organizationName);
+	fs.mount(dataPath);
+	fs.mountReadWrite(fs.prefPath());
 
 	Configuration& cf = Utility<Configuration>::get();
 	cf.load(configPath);

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -16,7 +16,9 @@ class FilesystemTest : public ::testing::Test {
 	FilesystemTest() :
 		fs("", AppName, OrganizationName)
 	{
+		fs.mount(fs.basePath());
 		fs.mount("data/");
+		fs.mountReadWrite(fs.prefPath());
 	}
 
 	NAS2D::Filesystem fs;


### PR DESCRIPTION
Closes #320

Remove `Filesystem` auto mounting. Instead, any desired mounts should be setup after object construction.

----

Noticed #444 while working on this. Decided to defer to a new issue since handling that change well could involve extensive changes to the unit tests. For now, I'll stick with the long establish library behaviour for `dataPath`.
