### PR TITLE
Replace include of `NAS2D` with components used

### DIFF
--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -10,7 +10,14 @@
 
 #pragma once
 
-#include "../NAS2D.h"
+#include "Image.h"
+#include "../Signal.h"
+#include "../Timer.h"
+#include "../Utility.h"
+#include "../Filesystem.h"
+#include "../Renderer/Color.h"
+#include "../Renderer/Rectangle.h"
+#include "../Renderer/Renderer.h"
 
 #include <map>
 #include <string>


### PR DESCRIPTION
Reduce the transitive dependencies of `Sprite.h`, which results in fewer recompiles during an incremental build.

This was noticed while looking at downstream issue: https://github.com/OutpostUniverse/OPHD/issues/134

The change has a fairly significant impact on the dependency graph for the downstream project. It has also uncovered numerous places where downstream files were not including all the headers they were actually using.
