### PR TITLE
Add Rectangle::to<NewBaseType>()

### DIFF
--- a/include/NAS2D/Renderer/Rectangle.h
+++ b/include/NAS2D/Renderer/Rectangle.h
@@ -84,6 +84,11 @@ struct Rectangle
 		};
 	}
 
+	template <typename NewBaseType>
+	Rectangle<NewBaseType> to() const {
+		return static_cast<Rectangle<NewBaseType>>(*this);
+	}
+
 	// Start point inclusive (x, y), endpoint exclusive (x + width, y + height)
 	// Area in interval notation: [x .. x + width), [y .. y + height)
 	bool contains(const Point<BaseType>& point) const {

--- a/test/Renderer/Rectangle.test.cpp
+++ b/test/Renderer/Rectangle.test.cpp
@@ -30,6 +30,14 @@ TEST(Rectangle, endPoint) {
 	EXPECT_EQ((NAS2D::Point<int>{4, 6}), (NAS2D::Rectangle{1, 2, 3, 4}.endPoint()));
 }
 
+TEST(Rectangle, operatorType) {
+	EXPECT_EQ((NAS2D::Rectangle<int>{0, 0, 1, 1}), static_cast<NAS2D::Rectangle<int>>(NAS2D::Rectangle<float>{0.0, 0.0, 1.0, 1.0}));
+	EXPECT_EQ((NAS2D::Rectangle<int>{1, 2, 3, 4}), static_cast<NAS2D::Rectangle<int>>(NAS2D::Rectangle<float>{1.0, 2.0, 3.0, 4.0}));
+
+	EXPECT_EQ((NAS2D::Rectangle<float>{0.0, 0.0, 1.0, 1.0}), static_cast<NAS2D::Rectangle<float>>(NAS2D::Rectangle<int>{0, 0, 1, 1}));
+	EXPECT_EQ((NAS2D::Rectangle<float>{1.0, 2.0, 3.0, 4.0}), static_cast<NAS2D::Rectangle<float>>(NAS2D::Rectangle<int>{1, 2, 3, 4}));
+}
+
 TEST(Rectangle, contains) {
 	NAS2D::Rectangle rect = {1, 1, 2, 2};
 

--- a/test/Renderer/Rectangle.test.cpp
+++ b/test/Renderer/Rectangle.test.cpp
@@ -38,6 +38,14 @@ TEST(Rectangle, operatorType) {
 	EXPECT_EQ((NAS2D::Rectangle<float>{1.0, 2.0, 3.0, 4.0}), static_cast<NAS2D::Rectangle<float>>(NAS2D::Rectangle<int>{1, 2, 3, 4}));
 }
 
+TEST(Rectangle, to) {
+	EXPECT_EQ((NAS2D::Rectangle<int>{0, 0, 1, 1}), (NAS2D::Rectangle<float>{0.0, 0.0, 1.0, 1.0}.to<int>()));
+	EXPECT_EQ((NAS2D::Rectangle<int>{1, 2, 3, 4}), (NAS2D::Rectangle<float>{1.0, 2.0, 3.0, 4.0}.to<int>()));
+
+	EXPECT_EQ((NAS2D::Rectangle<float>{0.0, 0.0, 1.0, 1.0}), (NAS2D::Rectangle<int>{0, 0, 1, 1}.to<float>()));
+	EXPECT_EQ((NAS2D::Rectangle<float>{1.0, 2.0, 3.0, 4.0}), (NAS2D::Rectangle<int>{1, 2, 3, 4}.to<float>()));
+}
+
 TEST(Rectangle, contains) {
 	NAS2D::Rectangle rect = {1, 1, 2, 2};
 


### PR DESCRIPTION
Add `Rectangle::to<NewBaseType>()` method, as a new shorter easier to use way of converting a Rectangle to a new underlying base type.

- No need for `static_cast` in client code
- No need to specify the full struct type (in addition to the underlying `NewBaseType`)
- No need to specify the namespace
