### PR TITLE
Add Point::to<NewBaseType>()

### DIFF
--- a/include/NAS2D/Renderer/Point.h
+++ b/include/NAS2D/Renderer/Point.h
@@ -56,6 +56,11 @@ struct Point {
 		};
 	}
 
+	template <typename NewBaseType>
+	Point<NewBaseType> to() const {
+		return static_cast<Point<NewBaseType>>(*this);
+	}
+
 	void x(BaseType x) {
 		mX = x;
 	}

--- a/test/Renderer/Point.test.cpp
+++ b/test/Renderer/Point.test.cpp
@@ -28,7 +28,7 @@ TEST(Vector, SubtractPointToVector) {
 	EXPECT_EQ((NAS2D::Vector<int>{1, 1}), (NAS2D::Point<int>{2, 3}) - (NAS2D::Point<int>{1, 2}));
 }
 
-TEST(Point, Conversion) {
+TEST(Point, OperatorType) {
 	// Allow explicit conversion
 	EXPECT_EQ((NAS2D::Point<int>{1, 2}), static_cast<NAS2D::Point<int>>(NAS2D::Point<float>{1.0, 2.0}));
 	EXPECT_EQ((NAS2D::Point<float>{1.0, 2.0}), static_cast<NAS2D::Point<float>>(NAS2D::Point<int>{1, 2}));

--- a/test/Renderer/Point.test.cpp
+++ b/test/Renderer/Point.test.cpp
@@ -37,3 +37,8 @@ TEST(Point, OperatorType) {
 	EXPECT_EQ((NAS2D::Point<int>{1, 2}), (NAS2D::Point<float>{1.0, 2.0}));
 	EXPECT_EQ((NAS2D::Point<float>{1.0, 2.0}), (NAS2D::Point<int>{1, 2}));
 }
+
+TEST(Point, to) {
+	EXPECT_EQ((NAS2D::Point<int>{1, 2}), (NAS2D::Point<float>{1.0, 2.0}.to<int>()));
+	EXPECT_EQ((NAS2D::Point<float>{1.0, 2.0}), (NAS2D::Point<int>{1, 2}.to<float>()));
+}

--- a/test/Renderer/Point.test.cpp
+++ b/test/Renderer/Point.test.cpp
@@ -30,10 +30,10 @@ TEST(Vector, SubtractPointToVector) {
 
 TEST(Point, Conversion) {
 	// Allow explicit conversion
-	EXPECT_EQ((NAS2D::Point<int>{1, 1}), static_cast<NAS2D::Point<int>>(NAS2D::Point<float>{1.0, 1.0}));
-	EXPECT_EQ((NAS2D::Point<float>{1.0, 1.0}), static_cast<NAS2D::Point<float>>(NAS2D::Point<int>{1, 1}));
+	EXPECT_EQ((NAS2D::Point<int>{1, 2}), static_cast<NAS2D::Point<int>>(NAS2D::Point<float>{1.0, 2.0}));
+	EXPECT_EQ((NAS2D::Point<float>{1.0, 2.0}), static_cast<NAS2D::Point<float>>(NAS2D::Point<int>{1, 2}));
 
 	// Allow implicit conversion (may be deprecated in the future)
-	EXPECT_EQ((NAS2D::Point<int>{1, 1}), (NAS2D::Point<float>{1.0, 1.0}));
-	EXPECT_EQ((NAS2D::Point<float>{1.0, 1.0}), (NAS2D::Point<int>{1, 1}));
+	EXPECT_EQ((NAS2D::Point<int>{1, 2}), (NAS2D::Point<float>{1.0, 2.0}));
+	EXPECT_EQ((NAS2D::Point<float>{1.0, 2.0}), (NAS2D::Point<int>{1, 2}));
 }


### PR DESCRIPTION
Reference: #448 for corresponding `Rectangle` update

Add `Point::to<NewBaseType>()` method, as a new shorter easier to use way of converting a `Point` to a new underlying base type.

- No need for static_cast in client code
- No need to specify the full struct type (in addition to the underlying NewBaseType)
- No need to specify the namespace
