### PR TITLE
Add Vector::to<NewBaseType>()

### DIFF
--- a/include/NAS2D/Renderer/Vector.h
+++ b/include/NAS2D/Renderer/Vector.h
@@ -74,6 +74,11 @@ struct Vector {
 		};
 	}
 
+	template <typename NewBaseType>
+	Vector<NewBaseType> to() const {
+		return static_cast<Vector<NewBaseType>>(*this);
+	}
+
 };
 
 }

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -72,3 +72,8 @@ TEST(Vector, OperatorType) {
 	EXPECT_EQ((NAS2D::Vector<int>{1, 2}), static_cast<NAS2D::Vector<int>>(NAS2D::Vector<float>{1.0, 2.0}));
 	EXPECT_EQ((NAS2D::Vector<float>{1.0, 2.0}), static_cast<NAS2D::Vector<float>>(NAS2D::Vector<int>{1, 2}));
 }
+
+TEST(Vector, to) {
+	EXPECT_EQ((NAS2D::Vector<int>{1, 2}), (NAS2D::Vector<float>{1.0, 2.0}.to<int>()));
+	EXPECT_EQ((NAS2D::Vector<float>{1.0, 2.0}), (NAS2D::Vector<int>{1, 2}.to<float>()));
+}

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -67,3 +67,8 @@ TEST(Vector, DivideScalar) {
 
 	EXPECT_THROW((NAS2D::Vector<int>{2, 4} /= 0), std::domain_error);
 }
+
+TEST(Vector, OperatorType) {
+	EXPECT_EQ((NAS2D::Vector<int>{1, 2}), static_cast<NAS2D::Vector<int>>(NAS2D::Vector<float>{1.0, 2.0}));
+	EXPECT_EQ((NAS2D::Vector<float>{1.0, 2.0}), static_cast<NAS2D::Vector<float>>(NAS2D::Vector<int>{1, 2}));
+}


### PR DESCRIPTION
Reference: #448 for corresponding `Rectangle` update
Reference: #449 for corresponding `Point` update

Add `Vector::to<NewBaseType>()` method, as a new shorter easier to use way of converting a `Vector` to a new underlying base type.

- No need for static_cast in client code
- No need to specify the full struct type (in addition to the underlying NewBaseType)
- No need to specify the namespace
