### PR TITLE
Update `RendererOpenGL::drawImageToImage` method

### DIFF
--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -253,16 +253,18 @@ void RendererOpenGL::drawSubImageRepeated(Image& image, float rasterX, float ras
 
 void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const Point_2df& dstPoint)
 {
+	const auto dstPointInt = dstPoint.to<int>();
+
 	// Ignore the call if the detination point is outside the bounds of destination image.
-	if (!isRectInRect(static_cast<int>(dstPoint.x()), static_cast<int>(dstPoint.y()), source.width(), source.height(), 0, 0, destination.width(), destination.height()))
+	if (!isRectInRect(dstPointInt.x(), dstPointInt.y(), source.width(), source.height(), 0, 0, destination.width(), destination.height()))
 	{
 		return;
 	}
 
 	Rectangle_2d clipRect;
 
-	(static_cast<int>(dstPoint.x()) + source.width()) > destination.width() ? clipRect.width(source.width() - ((static_cast<int>(dstPoint.x()) + source.width()) - destination.width())) : clipRect.width(source.width());
-	(static_cast<int>(dstPoint.y()) + source.height()) > destination.height() ? clipRect.height(source.height() - ((static_cast<int>(dstPoint.y()) + source.height()) - destination.height())) : clipRect.height(source.height());
+	(dstPointInt.x() + source.width()) > destination.width() ? clipRect.width(source.width() - ((dstPointInt.x() + source.width()) - destination.width())) : clipRect.width(source.width());
+	(dstPointInt.y() + source.height()) > destination.height() ? clipRect.height(source.height() - ((dstPointInt.y() + source.height()) - destination.height())) : clipRect.height(source.height());
 
 	// Ignore this call if the clipping rect is smaller than 1 pixel in any dimension.
 	if (clipRect.width() < 1 || clipRect.height() < 1)

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -254,6 +254,7 @@ void RendererOpenGL::drawSubImageRepeated(Image& image, float rasterX, float ras
 void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const Point_2df& dstPoint)
 {
 	const auto dstPointInt = dstPoint.to<int>();
+	const auto dstEndPointInt = dstPointInt + source.size();
 
 	// Ignore the call if the detination point is outside the bounds of destination image.
 	if (!isRectInRect(dstPointInt.x(), dstPointInt.y(), source.width(), source.height(), 0, 0, destination.width(), destination.height()))
@@ -263,8 +264,8 @@ void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const P
 
 	Rectangle_2d clipRect;
 
-	(dstPointInt.x() + source.width()) > destination.width() ? clipRect.width(source.width() - ((dstPointInt.x() + source.width()) - destination.width())) : clipRect.width(source.width());
-	(dstPointInt.y() + source.height()) > destination.height() ? clipRect.height(source.height() - ((dstPointInt.y() + source.height()) - destination.height())) : clipRect.height(source.height());
+	dstEndPointInt.x() > destination.width() ? clipRect.width(source.width() - (dstEndPointInt.x() - destination.width())) : clipRect.width(source.width());
+	dstEndPointInt.y() > destination.height() ? clipRect.height(source.height() - (dstEndPointInt.y() - destination.height())) : clipRect.height(source.height());
 
 	// Ignore this call if the clipping rect is smaller than 1 pixel in any dimension.
 	if (clipRect.width() < 1 || clipRect.height() < 1)

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -256,8 +256,13 @@ void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const P
 	const auto dstPointInt = dstPoint.to<int>();
 	const auto dstEndPointInt = dstPointInt + source.size();
 
+	const auto origin = NAS2D::Point<int>{0, 0};
+
+	const auto sourceBoundsInDestination = NAS2D::Rectangle<int>::Create(dstPointInt, source.size());
+	const auto destinationBounds = NAS2D::Rectangle<int>::Create(origin, destination.size());
+
 	// Ignore the call if the detination point is outside the bounds of destination image.
-	if (!isRectInRect(dstPointInt.x(), dstPointInt.y(), source.width(), source.height(), 0, 0, destination.width(), destination.height()))
+	if (!sourceBoundsInDestination.overlaps(destinationBounds))
 	{
 		return;
 	}

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -264,8 +264,8 @@ void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const P
 
 	Rectangle_2d clipRect;
 
-	dstEndPointInt.x() > destination.width() ? clipRect.width(source.width() - (dstEndPointInt.x() - destination.width())) : clipRect.width(source.width());
-	dstEndPointInt.y() > destination.height() ? clipRect.height(source.height() - (dstEndPointInt.y() - destination.height())) : clipRect.height(source.height());
+	dstEndPointInt.x() > destination.width() ? clipRect.width(destination.width() - dstPointInt.x()) : clipRect.width(source.width());
+	dstEndPointInt.y() > destination.height() ? clipRect.height(destination.height() - dstPointInt.y()) : clipRect.height(source.height());
 
 	// Ignore this call if the clipping rect is smaller than 1 pixel in any dimension.
 	if (clipRect.width() < 1 || clipRect.height() < 1)

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -273,12 +273,6 @@ void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const P
 		availableSize.y < sourceSize.y ? availableSize.y : sourceSize.y
 	};
 
-	// Ignore call if the clipped rect is empty
-	if (clipSize.x <= 0 || clipSize.y <= 0)
-	{
-		return;
-	}
-
 	glColor4ub(255, 255, 255, 255);
 
 	//glPixelStorei(GL_UNPACK_ALIGNMENT, 1);

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -267,8 +267,8 @@ void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const P
 	dstEndPointInt.x() > destination.width() ? clipRect.width(destination.width() - dstPointInt.x()) : clipRect.width(source.width());
 	dstEndPointInt.y() > destination.height() ? clipRect.height(destination.height() - dstPointInt.y()) : clipRect.height(source.height());
 
-	// Ignore this call if the clipping rect is smaller than 1 pixel in any dimension.
-	if (clipRect.width() < 1 || clipRect.height() < 1)
+	// Ignore call if the clipped rect is empty
+	if (clipRect.width() <= 0 || clipRect.height() <= 0)
 	{
 		return;
 	}

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -253,8 +253,6 @@ void RendererOpenGL::drawSubImageRepeated(Image& image, float rasterX, float ras
 
 void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const Point_2df& dstPoint)
 {
-	glColor4ub(255, 255, 255, 255);
-
 	// Ignore the call if the detination point is outside the bounds of destination image.
 	if (!isRectInRect(static_cast<int>(dstPoint.x()), static_cast<int>(dstPoint.y()), source.width(), source.height(), 0, 0, destination.width(), destination.height()))
 	{
@@ -271,6 +269,8 @@ void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const P
 	{
 		return;
 	}
+
+	glColor4ub(255, 255, 255, 255);
 
 	//glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 	glBindTexture(GL_TEXTURE_2D, IMAGE_ID_MAP[destination.name()].texture_id);


### PR DESCRIPTION
Reference: #235, #382

This refactors the `RendererOpenGL::drawImageToImage` method. As part of the refactor, this removes the only call to the `isRectInRect` method. Functionality is replaced by the `Rectangle::overlaps` method. That allows the `isRectInRect` method to simply be removed, rather than renamed.

There are probably more updates that can be made to this particular method, though the focus of this PR was mainly the remove the only use of `isRectInRect`.
