### PR TITLE
Re-adds now-supported clang-format options

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -68,7 +68,7 @@ SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
-SpaceBeforeRangeBasedForLoopColon: false
+SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
 SpacesInAngles: false
 SpacesInCStyleCastParentheses: false

--- a/.clang-format
+++ b/.clang-format
@@ -4,9 +4,7 @@ AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: true
 
-#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
-#AllowShortLambdasOnASingleLine: All
-
+AllowShortLambdasOnASingleLine: All
 AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: false
@@ -56,8 +54,7 @@ IncludeCategories:
     - Priority: 1
 
 IndentCaseLabels: false
-#Unsupported in VS-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
-#IndentPPDirectives: BeforeHash
+IndentPPDirectives: BeforeHash
 IndentWidth: 4
 IndentWrappedFunctionNames: false
 NamespaceIndentation: All
@@ -67,21 +64,11 @@ SortIncludes : true
 SortUsingDeclarations: true
 SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
-
-#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
-#SpaceBeforeCpp11BracedList: false
-
-#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
-#SpaceBeforeCtorInitializerColon: true
-
-#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
-#SpaceBeforeInheritanceColon: true
-
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
-
-#Unsupported in VS2017-included ClangFormat 6.0 we'll see about VS2019's ClangFormat 7.0
-#SpaceBeforeRangeBasedForLoopColon: false
-
+SpaceBeforeRangeBasedForLoopColon: false
 SpaceInEmptyParentheses: false
 SpacesInAngles: false
 SpacesInCStyleCastParentheses: false


### PR DESCRIPTION
There is an option in Visual Studio to only apply clang-format changes on Keyboard combo `Ctrl+K, Ctrl+D` to the whole document or `Ctrl+K,Ctrl+F` for the current selection only.

`Tools > Options > Text Editor > C/C++ > Formatting > General > Clang Format execution > check "Run ClangFormat only for manually invoked formatting commands"`

This would have been good to know earlier... Oh well.

Here's a [reference guide](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) to the commands.

There are no anchor links, sorry. :(

You'll have to Ctrl+F search for the command....or just read through the entire document like I did. :/