### PR TITLE
Fix Image bounds check bug

### DIFF
--- a/src/Resources/Image.cpp
+++ b/src/Resources/Image.cpp
@@ -265,7 +265,7 @@ int Image::center_y() const
  */
 Color Image::pixelColor(int x, int y) const
 {
-	if (x < 0 || x > width() || y < 0 || y > height())
+	if (x < 0 || x >= width() || y < 0 || y >= height())
 	{
 		return Color(0, 0, 0, 255);
 	}


### PR DESCRIPTION
For 0-based indexes, a value at the `width` or `height` is out of bounds.
