### PR TITLE
minimum_size function does not recalculate the viewport

### DIFF
--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -579,6 +579,7 @@ void RendererOpenGL::size(int w, int h)
 void RendererOpenGL::minimum_size(int w, int h)
 {
 	SDL_SetWindowMinimumSize(underlyingWindow, w, h);
+	_resize(w, h);
 }
 
 


### PR DESCRIPTION
Found this using the `graphics-test` project.

Calling minimum_size will not recalculate the drawable area (the viewport) or move the window to the center relative to the new size.