### PR TITLE
Refactor Sprite to add Point and Vector methods

### DIFF
--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -90,6 +90,9 @@ public:
 	 */
 	const Color& color() const { return mColor; }
 
+	Vector<int> size() const;
+	Point<int> origin(Point<int> point) const;
+
 	int width() const;
 	int height() const;
 	int originX(int x) const;

--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -76,16 +76,6 @@ public:
 	void color(const Color& color) { mColor = color; }
 
 	/**
-	 * Sets the color of the Sprite.
-	 *
-	 * \param	red		Red value to set between 0 - 255.
-	 * \param	green	Green value to set between 0 - 255.
-	 * \param	blue	Blue value to set between 0 - 255.
-	 * \param	alpha	Alpha value to set between 0 - 255.
-	 */
-	void color(uint8_t red, uint8_t green, uint8_t blue, uint8_t alpha) { color(Color(red, green, blue, alpha)); }
-
-	/**
 	 * Gets the color of the Sprite.
 	 */
 	const Color& color() const { return mColor; }

--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -124,6 +124,9 @@ private:
 
 		const std::string& sheetId() const { return mSheetId; }
 
+		Rectangle<int> bounds() const { return mRect; };
+		Vector<int> anchor() const { return mAnchor; };
+
 		int anchorX() const { return mAnchor.x; }
 		int anchorY() const { return mAnchor.y; }
 

--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -124,8 +124,8 @@ private:
 
 		const std::string& sheetId() const { return mSheetId; }
 
-		int anchorX() const { return mAnchorX; }
-		int anchorY() const { return mAnchorY; }
+		int anchorX() const { return mAnchor.x; }
+		int anchorY() const { return mAnchor.y; }
 
 		int width() const { return mRect.width(); }
 		int height() const { return mRect.height(); }
@@ -137,9 +137,8 @@ private:
 	private:
 		std::string mSheetId;
 		int mFrameDelay;
-		int mAnchorX;
-		int mAnchorY;
-		Rectangle_2d mRect;
+		Vector<int> mAnchor;
+		Rectangle<int> mRect;
 	};
 
 private:

--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -117,6 +117,7 @@ private:
 	class SpriteFrame
 	{
 	public:
+		SpriteFrame(const std::string& sheetId, Point<int> startPoint, Vector<int> size, Vector<int> anchorOffset, int displayTimeMs);
 		SpriteFrame(const std::string& sheetId, int x, int y, int w, int h, int aX, int aY, int d);
 		SpriteFrame(const SpriteFrame &spriteframe) = default;
 		SpriteFrame& operator=(const SpriteFrame& rhs) = default;

--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -125,14 +125,6 @@ private:
 		Rectangle<int> bounds() const { return mRect; };
 		Vector<int> anchor() const { return mAnchor; };
 
-		int anchorX() const { return mAnchor.x; }
-		int anchorY() const { return mAnchor.y; }
-
-		int width() const { return mRect.width(); }
-		int height() const { return mRect.height(); }
-		int x() const { return mRect.x(); }
-		int y() const { return mRect.y(); }
-
 		int frameDelay() const { return mFrameDelay; }
 
 	private:

--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -106,7 +106,7 @@ private:
 	{
 		std::string sheetId;
 		Rectangle<int> bounds;
-		Vector<int> anchor;
+		Vector<int> anchorOffset;
 		int frameDelay;
 	};
 

--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -115,14 +115,14 @@ private:
 	class SpriteFrame
 	{
 	public:
-		SpriteFrame(const std::string& sheetId, Point<int> startPoint, Vector<int> size, Vector<int> anchorOffset, int displayTimeMs);
+		SpriteFrame(const std::string& sheetId, Rectangle<int> bounds, Vector<int> anchorOffset, int displayTimeMs);
 		SpriteFrame(const SpriteFrame &spriteframe) = default;
 		SpriteFrame& operator=(const SpriteFrame& rhs) = default;
 		~SpriteFrame() = default;
 
 		const std::string& sheetId() const { return mSheetId; }
 
-		Rectangle<int> bounds() const { return mRect; };
+		Rectangle<int> bounds() const { return mBounds; };
 		Vector<int> anchor() const { return mAnchor; };
 
 		int frameDelay() const { return mFrameDelay; }
@@ -131,7 +131,7 @@ private:
 		std::string mSheetId;
 		int mFrameDelay;
 		Vector<int> mAnchor;
-		Rectangle<int> mRect;
+		Rectangle<int> mBounds;
 	};
 
 private:

--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -93,11 +93,6 @@ public:
 	Vector<int> size() const;
 	Point<int> origin(Point<int> point) const;
 
-	int width() const;
-	int height() const;
-	int originX(int x) const;
-	int originY(int y) const;
-
 	/**
 	 * Returns a reference to the frame listener signal slot.
 	 */

--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -109,29 +109,15 @@ protected:
 
 private:
 	/**
-	 * \class	spriteFrame
+	 * \struct	SpriteFrame
 	 * \brief	Contains
 	 */
-	class SpriteFrame
+	struct SpriteFrame
 	{
-	public:
-		SpriteFrame(const std::string& sheetId, Rectangle<int> bounds, Vector<int> anchorOffset, int displayTimeMs);
-		SpriteFrame(const SpriteFrame &spriteframe) = default;
-		SpriteFrame& operator=(const SpriteFrame& rhs) = default;
-		~SpriteFrame() = default;
-
-		const std::string& sheetId() const { return mSheetId; }
-
-		Rectangle<int> bounds() const { return mBounds; };
-		Vector<int> anchor() const { return mAnchor; };
-
-		int frameDelay() const { return mFrameDelay; }
-
-	private:
-		std::string mSheetId;
-		int mFrameDelay;
-		Vector<int> mAnchor;
-		Rectangle<int> mBounds;
+		std::string sheetId;
+		Rectangle<int> bounds;
+		Vector<int> anchor;
+		int frameDelay;
 	};
 
 private:

--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -118,7 +118,6 @@ private:
 	{
 	public:
 		SpriteFrame(const std::string& sheetId, Point<int> startPoint, Vector<int> size, Vector<int> anchorOffset, int displayTimeMs);
-		SpriteFrame(const std::string& sheetId, int x, int y, int w, int h, int aX, int aY, int d);
 		SpriteFrame(const SpriteFrame &spriteframe) = default;
 		SpriteFrame& operator=(const SpriteFrame& rhs) = default;
 		~SpriteFrame() = default;

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -517,7 +517,10 @@ void Sprite::processFrames(const std::string& action, void* _node)
 				continue;
 			}
 
-			frameList.push_back(SpriteFrame(sheetId, x, y, width, height, anchorx, anchory, delay));
+			const auto startPoint = NAS2D::Point<int>{x, y};
+			const auto size = NAS2D::Vector<int>{width, height};
+			const auto anchorOffset = NAS2D::Vector<int>{anchorx, anchory};
+			frameList.push_back(SpriteFrame(sheetId, startPoint, size, anchorOffset, delay));
 		}
 		else
 		{

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -158,7 +158,7 @@ void Sprite::update(float x, float y)
 		mFrameCallback();
 	}
 
-	const auto drawPosition = Point{x, y} - frame.anchor;
+	const auto drawPosition = Point{x, y} - frame.anchorOffset;
 	const auto frameBounds = frame.bounds.to<float>();
 	Utility<Renderer>::get().drawSubImageRotated(mImageSheets[frame.sheetId], drawPosition.x(), drawPosition.y(), frameBounds.x(), frameBounds.y(), frameBounds.width(), frameBounds.height(), mRotationAngle, mColor);
 }
@@ -593,5 +593,5 @@ Vector<int> Sprite::size() const
 
 Point<int> Sprite::origin(Point<int> point) const
 {
-	return point - mActions.at(mCurrentAction)[mCurrentFrame].anchor;
+	return point - mActions.at(mCurrentAction)[mCurrentFrame].anchorOffset;
 }

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -136,7 +136,7 @@ void Sprite::skip(int frames)
  */
 void Sprite::update(float x, float y)
 {
-	const SpriteFrame frame = mActions[mCurrentAction][mCurrentFrame];
+	const auto& frame = mActions[mCurrentAction][mCurrentFrame];
 
 	if (!mPaused && (frame.frameDelay != FRAME_PAUSE))
 	{

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -571,10 +571,11 @@ void Sprite::addDefaultAction()
 	{
 		auto& imageSheet = mImageSheets["default"]; // Adds a default sheet. //-V607
 
-		int width = imageSheet.width();
-		int height = imageSheet.height();
+		const auto startPoint = NAS2D::Point{0, 0};
+		const auto size = imageSheet.size();
+		const auto anchorOffset = size / 2;
 
-		FrameList frameList{SpriteFrame("default", 0, 0, width, height, width / 2, height / 2, -1)};
+		FrameList frameList{SpriteFrame("default", startPoint, size, anchorOffset, -1)};
 		mActions["default"] = frameList;
 	}
 }

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -644,7 +644,6 @@ int Sprite::originY(int y) const
 Sprite::SpriteFrame::SpriteFrame(const std::string& sheetId, Point<int> startPoint, Vector<int> size, Vector<int> anchorOffset, int displayTimeMs) :
 	mSheetId(sheetId),
 	mFrameDelay(displayTimeMs),
-	mAnchorX(anchorOffset.x),
-	mAnchorY(anchorOffset.y),
+	mAnchor(anchorOffset),
 	mRect(NAS2D::Rectangle<int>::Create(startPoint, size))
 {}

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -519,10 +519,9 @@ void Sprite::processFrames(const std::string& action, void* _node)
 				continue;
 			}
 
-			const auto startPoint = NAS2D::Point<int>{x, y};
-			const auto size = NAS2D::Vector<int>{width, height};
+			const auto bounds = NAS2D::Rectangle<int>::Create(NAS2D::Point<int>{x, y}, NAS2D::Vector<int>{width, height});
 			const auto anchorOffset = NAS2D::Vector<int>{anchorx, anchory};
-			frameList.push_back(SpriteFrame(sheetId, startPoint, size, anchorOffset, delay));
+			frameList.push_back(SpriteFrame{sheetId, bounds, anchorOffset, delay});
 		}
 		else
 		{
@@ -576,11 +575,11 @@ void Sprite::addDefaultAction()
 	{
 		auto& imageSheet = mImageSheets["default"]; // Adds a default sheet. //-V607
 
-		const auto startPoint = NAS2D::Point{0, 0};
 		const auto size = imageSheet.size();
+		const auto bounds = NAS2D::Rectangle<int>::Create(NAS2D::Point{0, 0}, size);
 		const auto anchorOffset = size / 2;
 
-		FrameList frameList{SpriteFrame("default", startPoint, size, anchorOffset, -1)};
+		FrameList frameList{SpriteFrame{"default", bounds, anchorOffset, -1}};
 		mActions["default"] = frameList;
 	}
 }
@@ -603,9 +602,9 @@ Point<int> Sprite::origin(Point<int> point) const
 // = spriteFrame member function definitions.
 // ==================================================================================
 
-Sprite::SpriteFrame::SpriteFrame(const std::string& sheetId, Point<int> startPoint, Vector<int> size, Vector<int> anchorOffset, int displayTimeMs) :
+Sprite::SpriteFrame::SpriteFrame(const std::string& sheetId, Rectangle<int> bounds, Vector<int> anchorOffset, int displayTimeMs) :
 	mSheetId(sheetId),
 	mFrameDelay(displayTimeMs),
 	mAnchor(anchorOffset),
-	mRect(NAS2D::Rectangle<int>::Create(startPoint, size))
+	mBounds(bounds)
 {}

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -598,58 +598,6 @@ Point<int> Sprite::origin(Point<int> point) const
 }
 
 
-/**
- * Gets the width of the Sprite.
- *
- * \note	This gets the width of the current frame. For most
- *			most sprites this will be the same for all frames
- *			but can be surprising if frame sizes vary.
- */
-int Sprite::width() const
-{
-	return mActions.at(mCurrentAction)[mCurrentFrame].width();
-}
-
-
-/**
- * Gets the height of the Sprite.
- *
- * \note	This gets the height of the current frame. For most
- *			most sprites this will be the same for all frames
- *			but can be surprising if frame sizes vary.
- */
-int Sprite::height() const
-{
-	return mActions.at(mCurrentAction)[mCurrentFrame].height();
-}
-
-
-/**
- * Gets the origin X-Coordinate of the Sprite.
- *
- * \note	This gets the origin of the current frame. For most
- *			most sprites this will be the same for all frames
- *			but can be surprising if frame sizes vary.
- */
-int Sprite::originX(int x) const
-{
-	return x - mActions.at(mCurrentAction)[mCurrentFrame].anchorX();
-}
-
-
-/**
- * Gets the origin Y-Coordinate of the Sprite.
- *
- * \note	This gets the origin of the current frame. For most
- *			most sprites this will be the same for all frames
- *			but can be surprising if frame sizes vary.
- */
-int Sprite::originY(int y) const
-{
-	return y - mActions.at(mCurrentAction)[mCurrentFrame].anchorY();
-}
-
-
 
 // ==================================================================================
 // = spriteFrame member function definitions.

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -158,7 +158,9 @@ void Sprite::update(float x, float y)
 		mFrameCallback();
 	}
 
-	Utility<Renderer>::get().drawSubImageRotated(mImageSheets[frame.sheetId()], x - frame.anchorX(), y - frame.anchorY(), static_cast<float>(frame.x()), static_cast<float>(frame.y()), static_cast<float>(frame.width()), static_cast<float>(frame.height()), mRotationAngle, mColor);
+	const auto drawPosition = Point{x, y} - frame.anchor();
+	const auto frameBounds = frame.bounds().to<float>();
+	Utility<Renderer>::get().drawSubImageRotated(mImageSheets[frame.sheetId()], drawPosition.x(), drawPosition.y(), frameBounds.x(), frameBounds.y(), frameBounds.width(), frameBounds.height(), mRotationAngle, mColor);
 }
 
 

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -584,6 +584,18 @@ void Sprite::addDefaultAction()
 }
 
 
+Vector<int> Sprite::size() const
+{
+	return mActions.at(mCurrentAction)[mCurrentFrame].bounds().size();
+}
+
+
+Point<int> Sprite::origin(Point<int> point) const
+{
+	return point - mActions.at(mCurrentAction)[mCurrentFrame].anchor();
+}
+
+
 /**
  * Gets the width of the Sprite.
  *

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -637,6 +637,14 @@ int Sprite::originY(int y) const
 // = spriteFrame member function definitions.
 // ==================================================================================
 
+Sprite::SpriteFrame::SpriteFrame(const std::string& sheetId, Point<int> startPoint, Vector<int> size, Vector<int> anchorOffset, int displayTimeMs) :
+	mSheetId(sheetId),
+	mFrameDelay(displayTimeMs),
+	mAnchorX(anchorOffset.x),
+	mAnchorY(anchorOffset.y),
+	mRect(NAS2D::Rectangle<int>::Create(startPoint, size))
+{}
+
 /**
  * Constructor
  *

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -136,13 +136,13 @@ void Sprite::skip(int frames)
  */
 void Sprite::update(float x, float y)
 {
-	SpriteFrame frame = mActions[mCurrentAction][mCurrentFrame];
+	const SpriteFrame frame = mActions[mCurrentAction][mCurrentFrame];
 
-	if (!mPaused && (frame.frameDelay() != FRAME_PAUSE))
+	if (!mPaused && (frame.frameDelay != FRAME_PAUSE))
 	{
-		while (frame.frameDelay() > 0 && static_cast<int>(mTimer.accumulator()) >= frame.frameDelay())
+		while (frame.frameDelay > 0 && static_cast<int>(mTimer.accumulator()) >= frame.frameDelay)
 		{
-			mTimer.adjust_accumulator(frame.frameDelay());
+			mTimer.adjust_accumulator(frame.frameDelay);
 			mCurrentFrame++;
 		}
 
@@ -153,14 +153,14 @@ void Sprite::update(float x, float y)
 			mFrameCallback();		// Notifiy any frame listeners that the animation sequence has completed.
 		}
 	}
-	else if (frame.frameDelay() == FRAME_PAUSE)
+	else if (frame.frameDelay == FRAME_PAUSE)
 	{
 		mFrameCallback();
 	}
 
-	const auto drawPosition = Point{x, y} - frame.anchor();
-	const auto frameBounds = frame.bounds().to<float>();
-	Utility<Renderer>::get().drawSubImageRotated(mImageSheets[frame.sheetId()], drawPosition.x(), drawPosition.y(), frameBounds.x(), frameBounds.y(), frameBounds.width(), frameBounds.height(), mRotationAngle, mColor);
+	const auto drawPosition = Point{x, y} - frame.anchor;
+	const auto frameBounds = frame.bounds.to<float>();
+	Utility<Renderer>::get().drawSubImageRotated(mImageSheets[frame.sheetId], drawPosition.x(), drawPosition.y(), frameBounds.x(), frameBounds.y(), frameBounds.width(), frameBounds.height(), mRotationAngle, mColor);
 }
 
 
@@ -587,24 +587,11 @@ void Sprite::addDefaultAction()
 
 Vector<int> Sprite::size() const
 {
-	return mActions.at(mCurrentAction)[mCurrentFrame].bounds().size();
+	return mActions.at(mCurrentAction)[mCurrentFrame].bounds.size();
 }
 
 
 Point<int> Sprite::origin(Point<int> point) const
 {
-	return point - mActions.at(mCurrentAction)[mCurrentFrame].anchor();
+	return point - mActions.at(mCurrentAction)[mCurrentFrame].anchor;
 }
-
-
-
-// ==================================================================================
-// = spriteFrame member function definitions.
-// ==================================================================================
-
-Sprite::SpriteFrame::SpriteFrame(const std::string& sheetId, Rectangle<int> bounds, Vector<int> anchorOffset, int displayTimeMs) :
-	mSheetId(sheetId),
-	mFrameDelay(displayTimeMs),
-	mAnchor(anchorOffset),
-	mBounds(bounds)
-{}

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -648,23 +648,3 @@ Sprite::SpriteFrame::SpriteFrame(const std::string& sheetId, Point<int> startPoi
 	mAnchorY(anchorOffset.y),
 	mRect(NAS2D::Rectangle<int>::Create(startPoint, size))
 {}
-
-/**
- * Constructor
- *
- * \param	sId	Sprite sheet ID.
- * \param	x	X-Coordinte of the area to copy from the source Image object.
- * \param	y	Y-Coordinte of the area to copy from the source Image object.
- * \param	w	Width of the area to copy from the source Image object.
- * \param	h	Height of the area to copy from the source Image object.
- * \param	aX	X-Axis of the Anchor Point for this spriteFrame.
- * \param	aY	Y-Axis of the Anchor Point for this spriteFrame.
- * \param	d	Length of time milliseconds to display this spriteFrame during animation playback.
- */
-Sprite::SpriteFrame::SpriteFrame(const std::string& sId, int x, int y, int w, int h, int aX, int aY, int d) :
-	mSheetId(sId),
-	mFrameDelay(d),
-	mAnchorX(aX),
-	mAnchorY(aY),
-	mRect(x, y, w, h)
-{}


### PR DESCRIPTION
Refactors the `Sprite` and `SpriteFrame` classes to use `Point` and `Vector` methods. Simplifies `SpriteFrame` by changing it from a `class` to a `struct`.
