### PR TITLE
Refactors underlying OpenGL windowing

### DIFF
--- a/include/NAS2D/Renderer/RendererOpenGL.h
+++ b/include/NAS2D/Renderer/RendererOpenGL.h
@@ -86,6 +86,7 @@ private:
 
 	void _resize(int w, int h);
 	void setViewport(int w, int h);
+	void setOrthoProjection(int w, int h);
 };
 
 } // namespace

--- a/include/NAS2D/Renderer/RendererOpenGL.h
+++ b/include/NAS2D/Renderer/RendererOpenGL.h
@@ -85,6 +85,7 @@ private:
 	void initVideo(unsigned int resX, unsigned int resY, bool fullscreen, bool vsync);
 
 	void _resize(int w, int h);
+	void setViewport(int w, int h);
 };
 
 } // namespace

--- a/include/NAS2D/Renderer/RendererOpenGL.h
+++ b/include/NAS2D/Renderer/RendererOpenGL.h
@@ -84,7 +84,7 @@ private:
 	void initGL();
 	void initVideo(unsigned int resX, unsigned int resY, bool fullscreen, bool vsync);
 
-	void _resize(int w, int h);
+	void resizeWindow(int w, int h);
 	void setViewport(int w, int h);
 	void setOrthoProjection(int w, int h);
 	void setResolution(int w, int h);

--- a/include/NAS2D/Renderer/RendererOpenGL.h
+++ b/include/NAS2D/Renderer/RendererOpenGL.h
@@ -87,6 +87,7 @@ private:
 	void _resize(int w, int h);
 	void setViewport(int w, int h);
 	void setOrthoProjection(int w, int h);
+	void setResolution(int w, int h);
 };
 
 } // namespace

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -573,6 +573,7 @@ void RendererOpenGL::size(int w, int h)
 	SDL_SetWindowSize(underlyingWindow, w, h);
 	setViewport(w, h);
 	setOrthoProjection(w, h);
+	setResolution(w, h);
 	SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 }
 
@@ -637,7 +638,9 @@ void NAS2D::RendererOpenGL::setOrthoProjection(int w, int h)
 	glMatrixMode(GL_MODELVIEW);
 }
 
-	if (!fullscreen())
+void NAS2D::RendererOpenGL::setResolution(int w, int h)
+{
+	if(!fullscreen())
 	{
 		mResolution = {static_cast<float>(w), static_cast<float>(h)};
 	}

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -94,7 +94,7 @@ RendererOpenGL::RendererOpenGL(const std::string& title) : Renderer(title)
  */
 RendererOpenGL::~RendererOpenGL()
 {
-	Utility<EventHandler>::get().windowResized().disconnect(this, &RendererOpenGL::_resize);
+	Utility<EventHandler>::get().windowResized().disconnect(this, &RendererOpenGL::resizeViewport);
 
 	SDL_GL_DeleteContext(CONTEXT);
 	SDL_DestroyWindow(underlyingWindow);
@@ -571,7 +571,7 @@ float RendererOpenGL::height()
 void RendererOpenGL::size(int w, int h)
 {
 	SDL_SetWindowSize(underlyingWindow, w, h);
-	_resize(w, h);
+	resizeViewport(w, h);
 	SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 }
 
@@ -623,7 +623,7 @@ bool RendererOpenGL::resizeable()
 }
 
 
-void RendererOpenGL::_resize(int w, int h)
+void RendererOpenGL::resizeViewport(int w, int h)
 {
 	glViewport(0, 0, w, h);
 	glMatrixMode(GL_PROJECTION);
@@ -661,7 +661,7 @@ void RendererOpenGL::initGL()
 	glClear(GL_COLOR_BUFFER_BIT);
 	glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
 
-	_resize(static_cast<int>(width()), static_cast<int>(height()));
+	resizeViewport(static_cast<int>(width()), static_cast<int>(height()));
 
 	glShadeModel(GL_SMOOTH);
 	glEnable(GL_COLOR_MATERIAL);
@@ -737,7 +737,7 @@ void RendererOpenGL::initVideo(unsigned int resX, unsigned int resY, bool fullsc
 	glewInit();
 	initGL();
 
-	Utility<EventHandler>::get().windowResized().connect(this, &RendererOpenGL::_resize);
+	Utility<EventHandler>::get().windowResized().connect(this, &RendererOpenGL::resizeViewport);
 
 	SDL_DisplayMode dm;
 	if (SDL_GetDesktopDisplayMode(0, &dm) != 0)

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -94,7 +94,7 @@ RendererOpenGL::RendererOpenGL(const std::string& title) : Renderer(title)
  */
 RendererOpenGL::~RendererOpenGL()
 {
-	Utility<EventHandler>::get().windowResized().disconnect(this, &RendererOpenGL::resizeViewport);
+	Utility<EventHandler>::get().windowResized().disconnect(this, &RendererOpenGL::resizeWindow);
 
 	SDL_GL_DeleteContext(CONTEXT);
 	SDL_DestroyWindow(underlyingWindow);
@@ -630,6 +630,13 @@ void RendererOpenGL::setViewport(int w, int h)
 	glViewport(0, 0, w, h);
 }
 
+void NAS2D::RendererOpenGL::resizeWindow(int w, int h)
+{
+	setViewport(w, h);
+	setOrthoProjection(w, h);
+	setResolution(w, h);
+}
+
 void NAS2D::RendererOpenGL::setOrthoProjection(int w, int h)
 {
 	glMatrixMode(GL_PROJECTION);
@@ -747,7 +754,7 @@ void RendererOpenGL::initVideo(unsigned int resX, unsigned int resY, bool fullsc
 	glewInit();
 	initGL();
 
-	Utility<EventHandler>::get().windowResized().connect(this, &RendererOpenGL::resizeViewport);
+	Utility<EventHandler>::get().windowResized().connect(this, &RendererOpenGL::resizeWindow);
 
 	SDL_DisplayMode dm;
 	if (SDL_GetDesktopDisplayMode(0, &dm) != 0)

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -571,7 +571,7 @@ float RendererOpenGL::height()
 void RendererOpenGL::size(int w, int h)
 {
 	SDL_SetWindowSize(underlyingWindow, w, h);
-	resizeViewport(w, h);
+	setViewport(w, h);
 	SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 }
 
@@ -623,9 +623,11 @@ bool RendererOpenGL::resizeable()
 }
 
 
-void RendererOpenGL::resizeViewport(int w, int h)
+void RendererOpenGL::setViewport(int w, int h)
 {
 	glViewport(0, 0, w, h);
+}
+
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
 	glOrtho(0.0, (GLdouble)w, (GLdouble)h, 0.0, -1.0, 1.0);
@@ -661,7 +663,7 @@ void RendererOpenGL::initGL()
 	glClear(GL_COLOR_BUFFER_BIT);
 	glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
 
-	resizeViewport(static_cast<int>(width()), static_cast<int>(height()));
+	setViewport(static_cast<int>(width()), static_cast<int>(height()));
 
 	glShadeModel(GL_SMOOTH);
 	glEnable(GL_COLOR_MATERIAL);

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -572,6 +572,7 @@ void RendererOpenGL::size(int w, int h)
 {
 	SDL_SetWindowSize(underlyingWindow, w, h);
 	setViewport(w, h);
+	setOrthoProjection(w, h);
 	SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 }
 
@@ -628,10 +629,13 @@ void RendererOpenGL::setViewport(int w, int h)
 	glViewport(0, 0, w, h);
 }
 
+void NAS2D::RendererOpenGL::setOrthoProjection(int w, int h)
+{
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
 	glOrtho(0.0, (GLdouble)w, (GLdouble)h, 0.0, -1.0, 1.0);
 	glMatrixMode(GL_MODELVIEW);
+}
 
 	if (!fullscreen())
 	{
@@ -664,6 +668,7 @@ void RendererOpenGL::initGL()
 	glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
 
 	setViewport(static_cast<int>(width()), static_cast<int>(height()));
+	setOrthoProjection(static_cast<int>(width()), static_cast<int>(height()));
 
 	glShadeModel(GL_SMOOTH);
 	glEnable(GL_COLOR_MATERIAL);


### PR DESCRIPTION
These are private functions to RendererOpenGL.

Splits out the terribly named `_resize` into the three functions the implementation is actually doing:
 - `setViewport`
- `setOrthoProjection`
- `setResolution`

and renames `_resize` to `resizeWindow`