### PR TITLE
Simplify signal declarations

### DIFF
--- a/include/NAS2D/EventHandler.h
+++ b/include/NAS2D/EventHandler.h
@@ -258,7 +258,7 @@ public:
 	 *
 	 * \arg \c gained	Bool value indicating whether or not the app lost focus.
 	 */
-	using ActivateEventCallback = NAS2D::Signals::Signal1<bool>;
+	using ActivateEventCallback = NAS2D::Signals::Signal<bool>;
 
 	/**
 	 * \typedef	WindowHiddenEventCallback
@@ -272,7 +272,7 @@ public:
 	 *
 	 * \arg \c gained	Bool value indicating whether or not the app lost focus.
 	 */
-	using WindowHiddenEventCallback = NAS2D::Signals::Signal1<bool>;
+	using WindowHiddenEventCallback = NAS2D::Signals::Signal<bool>;
 
 	/**
 	 * \typedef	WindowExposedEventCallback
@@ -345,7 +345,7 @@ public:
 	 * \arg \c width	Width of the resized window.
 	 * \arg \c height	Height of the resized window.
 	 */
-	using WindowResizedEventCallback = NAS2D::Signals::Signal2<int, int>;
+	using WindowResizedEventCallback = NAS2D::Signals::Signal<int, int>;
 
 	/**
 	 * \typedef	JoystickAxisMotionEventCallback
@@ -363,7 +363,7 @@ public:
 						use additional axis as buttons.
 	 * \arg \c pos		Current position of the axis.
 	 */
-	using JoystickAxisMotionEventCallback = NAS2D::Signals::Signal3<int, int, int>;
+	using JoystickAxisMotionEventCallback = NAS2D::Signals::Signal<int, int, int>;
 
 	/**
 	 * \typedef	JoystickBallMotionEventCallback
@@ -381,7 +381,7 @@ public:
 	 * \arg \c xChange	Change in relative position of the X position.
 	 * \arg \c yChange	Change in relative position of the Y position.
 	 */
-	using JoystickBallMotionEventCallback = NAS2D::Signals::Signal4<int, int, int, int>;
+	using JoystickBallMotionEventCallback = NAS2D::Signals::Signal<int, int, int, int>;
 
 	/**
 	 * \typedef	JoystickButtonEventCallback
@@ -398,7 +398,7 @@ public:
 	 * \arg \c deviceId	Joystick ID which this event was generated from.
 	 * \arg \c buttonId	Button ID which the event was generated from.
 	 */
-	using JoystickButtonEventCallback = NAS2D::Signals::Signal2<int, int>;
+	using JoystickButtonEventCallback = NAS2D::Signals::Signal<int, int>;
 
 	/**
 	 * \typedef	JoystickHatMotionEventCallback
@@ -415,7 +415,7 @@ public:
 	 * \arg \c hatId	Hat ID.
 	 * \arg \c pos		Current position of the hat.
 	 */
-	using JoystickHatMotionEventCallback = NAS2D::Signals::Signal3<int, int, int>;
+	using JoystickHatMotionEventCallback = NAS2D::Signals::Signal<int, int, int>;
 
 	/**
 	 * \typedef	KeyDownEventCallback
@@ -433,7 +433,7 @@ public:
 	 * \arg \c mod		Keyboard modifier.
 	 * \arg \c repeat	Indicates that this event is a repeat and not an initial key event.
 	 */
-	using KeyDownEventCallback = NAS2D::Signals::Signal3<KeyCode, KeyModifier, bool>;
+	using KeyDownEventCallback = NAS2D::Signals::Signal<KeyCode, KeyModifier, bool>;
 
 	/**
 	 * \typedef	KeyUpEventCallback
@@ -450,7 +450,7 @@ public:
 	 * \arg \c mod		Keyboard modifier.
 	 * \arg \c repeat	Indicates that this event is a repeat and not an initial key event.
 	 */
-	using KeyUpEventCallback = NAS2D::Signals::Signal2<KeyCode, KeyModifier>;
+	using KeyUpEventCallback = NAS2D::Signals::Signal<KeyCode, KeyModifier>;
 
 	/**
 	 * \typedef	MouseButtonEventCallback
@@ -467,7 +467,7 @@ public:
 	 * \arg	\c x:		X position of the mouse button event.
 	 * \arg	\c y:		Y position of the mouse button event.
 	 */
-	using MouseButtonEventCallback = NAS2D::Signals::Signal3<MouseButton, int, int>;
+	using MouseButtonEventCallback = NAS2D::Signals::Signal<MouseButton, int, int>;
 
 	/**
 	 * \typedef	MouseMotionEventCallback
@@ -485,7 +485,7 @@ public:
 	 * \arg	\c relX:	X position of the mouse relative to its last position.
 	 * \arg	\c relY;	Y position of the mouse relative to its last position.
 	 */
-	using MouseMotionEventCallback = NAS2D::Signals::Signal4<int, int, int, int>;
+	using MouseMotionEventCallback = NAS2D::Signals::Signal<int, int, int, int>;
 
 	/**
 	 * \typedef	MouseWheelEventCallback
@@ -506,7 +506,7 @@ public:
 	 * 			more than one (on Windows this value is typical 120,
 	 * 			not 1).
 	 */
-	using MouseWheelEventCallback = NAS2D::Signals::Signal2<int, int>;
+	using MouseWheelEventCallback = NAS2D::Signals::Signal<int, int>;
 
 	/**
 	* \typedef	TextInputEventCallback
@@ -516,7 +516,7 @@ public:
 	* void function(const std::string&);
 	* \endcode
 	*/
-	using TextInputEventCallback = NAS2D::Signals::Signal1<const std::string&>;
+	using TextInputEventCallback = NAS2D::Signals::Signal<const std::string&>;
 
 	/**
 	 * \typedef	QuitEventCallback
@@ -528,7 +528,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using QuitEventCallback = NAS2D::Signals::Signal0<>;
+	using QuitEventCallback = NAS2D::Signals::Signal<>;
 
 public:
 	EventHandler();

--- a/include/NAS2D/EventHandler.h
+++ b/include/NAS2D/EventHandler.h
@@ -282,7 +282,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using WindowExposedEventCallback = NAS2D::Signals::Signal0<void>;
+	using WindowExposedEventCallback = NAS2D::Signals::Signal<>;
 
 	/**
 	 * \typedef	WindowMinimizedEventCallback
@@ -292,7 +292,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using WindowMinimizedEventCallback = NAS2D::Signals::Signal0<void>;
+	using WindowMinimizedEventCallback = NAS2D::Signals::Signal<>;
 
 	/**
 	 * \typedef	WindowMaximizedEventCallback
@@ -302,7 +302,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using WindowMaximizedEventCallback = NAS2D::Signals::Signal0<void>;
+	using WindowMaximizedEventCallback = NAS2D::Signals::Signal<>;
 
 	/**
 	 * \typedef	WindowRestoredEventCallback
@@ -312,7 +312,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using WindowRestoredEventCallback = NAS2D::Signals::Signal0<void>;
+	using WindowRestoredEventCallback = NAS2D::Signals::Signal<>;
 
 	/**
 	 * \typedef	WindowMouseEnterEventCallback
@@ -322,7 +322,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using WindowMouseEnterEventCallback = NAS2D::Signals::Signal0<void>;
+	using WindowMouseEnterEventCallback = NAS2D::Signals::Signal<>;
 
 	/**
 	 * \typedef	WindowMouseLeaveEventCallback
@@ -332,7 +332,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using WindowMouseLeaveEventCallback = NAS2D::Signals::Signal0<void>;
+	using WindowMouseLeaveEventCallback = NAS2D::Signals::Signal<>;
 
 	/**
 	 * \typedef	WindowResizedEventCallback

--- a/include/NAS2D/Mixer/Mixer.h
+++ b/include/NAS2D/Mixer/Mixer.h
@@ -151,13 +151,13 @@ public:
 	 * when a Music track has finished playing.
 	 */
 	 [[deprecated("Deprecated: Please use addMusicCompleteHandler and removeMusicCompleteHandler")]]
-	NAS2D::Signals::Signal0<>& musicComplete();
+	NAS2D::Signals::Signal<>& musicComplete();
 
-	void addMusicCompleteHandler(NAS2D::Signals::Signal0<>::DelegateType handler);
-	void removeMusicCompleteHandler(NAS2D::Signals::Signal0<>::DelegateType handler);
+	void addMusicCompleteHandler(NAS2D::Signals::Signal<>::DelegateType handler);
+	void removeMusicCompleteHandler(NAS2D::Signals::Signal<>::DelegateType handler);
 
 protected:
-	NAS2D::Signals::Signal0<> mMusicComplete; /**< Callback used when music finished playing. */
+	NAS2D::Signals::Signal<> mMusicComplete; /**< Callback used when music finished playing. */
 };
 
 } // namespace

--- a/include/NAS2D/Mixer/Mixer.h
+++ b/include/NAS2D/Mixer/Mixer.h
@@ -147,7 +147,7 @@ public:
 	virtual void musicVolume(int level) = 0;
 
 	/**
-	 * Gets a reference to a NAS2D::Signals::Signal0<void>, a signal raised
+	 * Gets a reference to a NAS2D::Signals::Signal<>, a signal raised
 	 * when a Music track has finished playing.
 	 */
 	 [[deprecated("Deprecated: Please use addMusicCompleteHandler and removeMusicCompleteHandler")]]

--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -101,7 +101,7 @@ public:
 	void fadeOut(float delayTime);
 	bool isFading() const;
 	bool isFaded() const;
-	NAS2D::Signals::Signal0<void>& fadeComplete() const;
+	NAS2D::Signals::Signal<>& fadeComplete() const;
 
 	virtual void showSystemPointer(bool) = 0;
 	virtual void addCursor(const std::string& filePath, int cursorId, int offx, int offy) = 0;

--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -37,7 +37,7 @@ extern const std::string SPRITE_VERSION;
 class Sprite
 {
 public:
-	using Callback = NAS2D::Signals::Signal0<>;	/**< Signal used when action animations complete. */
+	using Callback = NAS2D::Signals::Signal<>;	/**< Signal used when action animations complete. */
 
 	Sprite();
 	explicit Sprite(const std::string& filePath);

--- a/src/Mixer/Mixer.cpp
+++ b/src/Mixer/Mixer.cpp
@@ -30,19 +30,19 @@ void Mixer::resumeAllAudio()
 }
 
 
-Signals::Signal0<>& Mixer::musicComplete()
+Signals::Signal<>& Mixer::musicComplete()
 {
 	return mMusicComplete;
 }
 
 
-void Mixer::addMusicCompleteHandler(NAS2D::Signals::Signal0<>::DelegateType handler)
+void Mixer::addMusicCompleteHandler(NAS2D::Signals::Signal<>::DelegateType handler)
 {
 	return mMusicComplete.connect(handler);
 }
 
 
-void Mixer::removeMusicCompleteHandler(NAS2D::Signals::Signal0<>::DelegateType handler)
+void Mixer::removeMusicCompleteHandler(NAS2D::Signals::Signal<>::DelegateType handler)
 {
 	return mMusicComplete.disconnect(handler);
 }

--- a/src/Mixer/MixerSDL.cpp
+++ b/src/Mixer/MixerSDL.cpp
@@ -30,7 +30,7 @@ extern std::map<std::string, MusicInfo>	MUSIC_REF_MAP;
 // ==================================================================================
 // INTEROP WITH SDL2_MIXER
 // ==================================================================================
-NAS2D::Signals::Signal0<void> MIXER_HOOK_CALLBACK_SIGNAL;
+NAS2D::Signals::Signal<> MIXER_HOOK_CALLBACK_SIGNAL;
 void MIXER_HOOK() { MIXER_HOOK_CALLBACK_SIGNAL(); }
 // ==================================================================================
 

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -19,7 +19,7 @@ using namespace NAS2D;
 
 NAS2D::Timer		fadeTimer;
 
-NAS2D::Signals::Signal0<void>	fadeCompleteSignal;
+NAS2D::Signals::Signal<>	fadeCompleteSignal;
 
 /**
  * Internal constructor used by derived types to set the name of the Renderer.
@@ -263,7 +263,7 @@ bool Renderer::isFaded() const
 /**
  * Gets a refernece to the callback signal for fade transitions.
  */
-NAS2D::Signals::Signal0<void>& Renderer::fadeComplete() const
+NAS2D::Signals::Signal<>& Renderer::fadeComplete() const
 {
 	return fadeCompleteSignal;
 }

--- a/test/Signal.test.cpp
+++ b/test/Signal.test.cpp
@@ -14,7 +14,7 @@ namespace {
 TEST(Signal, ConnectEmitDisconnect) {
 	MockHandler handler;
 	auto delegate = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
-	NAS2D::Signals::Signal0<> signal;
+	NAS2D::Signals::Signal<> signal;
 
 	EXPECT_TRUE(signal.empty());
 


### PR DESCRIPTION
Simplify `Signal` declarations by removing explicit `void` for no parameter signals, and removing the explicit count of the number of signal parameters.
