### PR TITLE
Remove const from return type in Font

### DIFF
--- a/include/NAS2D/Resources/Font.h
+++ b/include/NAS2D/Resources/Font.h
@@ -46,8 +46,8 @@ public:
 
 	int ptSize() const;
 
-	const int glyphCellWidth() const;
-	const int glyphCellHeight() const;
+	int glyphCellWidth() const;
+	int glyphCellHeight() const;
 
 private:
 	void load() override {}

--- a/src/Resources/Font.cpp
+++ b/src/Resources/Font.cpp
@@ -154,7 +154,7 @@ NAS2D::Font& NAS2D::Font::operator=(const Font& rhs)
 /**
  * Gets the glyph cell width.
  */
-const int NAS2D::Font::glyphCellWidth() const
+int NAS2D::Font::glyphCellWidth() const
 {
 	return FONTMAP[name()].glyph_size.x();
 }
@@ -163,7 +163,7 @@ const int NAS2D::Font::glyphCellWidth() const
 /**
  * Gets the glyph cell height.
  */
-const int NAS2D::Font::glyphCellHeight() const
+int NAS2D::Font::glyphCellHeight() const
 {
 	return FONTMAP[name()].glyph_size.y();
 }


### PR DESCRIPTION
Use of `const` on a return type is meaningless. Clang warns about this if the function is ever called.
