### PR TITLE
Refactors _resize

### DIFF
--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -136,6 +136,8 @@ public:
 
 	virtual void setViewport(const Rectangle<int>& viewport) = 0;
 	virtual void setOrthoProjection(const Rectangle<float>& orthoBounds) = 0;
+	void setResolution(const Point<float> newResolution);
+
 protected:
 	Renderer(const std::string& appTitle);
 

--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -134,6 +134,8 @@ public:
 
 	virtual void update();
 
+	virtual void setViewport(const Rectangle<int>& viewport) = 0;
+
 protected:
 	Renderer(const std::string& appTitle);
 

--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -136,7 +136,7 @@ public:
 
 	virtual void setViewport(const Rectangle<int>& viewport) = 0;
 	virtual void setOrthoProjection(const Rectangle<float>& orthoBounds) = 0;
-	void setResolution(const Point<float> newResolution);
+	void setResolution(const Vector<float>& newResolution);
 
 protected:
 	Renderer(const std::string& appTitle);

--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -135,7 +135,7 @@ public:
 	virtual void update();
 
 	virtual void setViewport(const Rectangle<int>& viewport) = 0;
-
+	virtual void setOrthoProjection(const Rectangle<float>& orthoBounds) = 0;
 protected:
 	Renderer(const std::string& appTitle);
 

--- a/include/NAS2D/Renderer/RendererNull.h
+++ b/include/NAS2D/Renderer/RendererNull.h
@@ -71,6 +71,7 @@ public:
 	void update() override {}
 
 	void setViewport(const Rectangle<int>&) override {}
+	void setOrthoProjection(const Rectangle<float>&) override {};
 };
 
 } // namespace

--- a/include/NAS2D/Renderer/RendererNull.h
+++ b/include/NAS2D/Renderer/RendererNull.h
@@ -69,6 +69,8 @@ public:
 	void window_icon(const std::string&) override {}
 
 	void update() override {}
+
+	void setViewport(const Rectangle<int>&) override {}
 };
 
 } // namespace

--- a/include/NAS2D/Renderer/RendererOpenGL.h
+++ b/include/NAS2D/Renderer/RendererOpenGL.h
@@ -11,6 +11,9 @@
 
 #include "Renderer.h"
 
+#include "Point.h"
+#include "Vector.h"
+
 namespace NAS2D {
 
 /**
@@ -80,12 +83,15 @@ public:
 
 	void update() override;
 
+	void setViewport(const Rectangle<int>& viewport) override;
+
 private:
 
 	void initGL();
 	void initVideo(unsigned int resX, unsigned int resY, bool fullscreen, bool vsync);
 
 	void _resize(int w, int h);
+
 };
 
 } // namespace

--- a/include/NAS2D/Renderer/RendererOpenGL.h
+++ b/include/NAS2D/Renderer/RendererOpenGL.h
@@ -84,6 +84,7 @@ public:
 	void update() override;
 
 	void setViewport(const Rectangle<int>& viewport) override;
+	void setOrthoProjection(const Rectangle<float>& orthoBounds) override;
 
 private:
 

--- a/include/NAS2D/Renderer/RendererOpenGL.h
+++ b/include/NAS2D/Renderer/RendererOpenGL.h
@@ -11,9 +11,6 @@
 
 #include "Renderer.h"
 
-#include "Point.h"
-#include "Vector.h"
-
 namespace NAS2D {
 
 /**

--- a/include/NAS2D/Renderer/RendererOpenGL.h
+++ b/include/NAS2D/Renderer/RendererOpenGL.h
@@ -91,7 +91,7 @@ private:
 	void initGL();
 	void initVideo(unsigned int resX, unsigned int resY, bool fullscreen, bool vsync);
 
-	void _resize(int w, int h);
+	void onResize(int w, int h);
 
 };
 

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -534,10 +534,10 @@ void Renderer::update()
 	}
 }
 
-void NAS2D::Renderer::setResolution(const Point<float> newResolution)
+void NAS2D::Renderer::setResolution(const Vector<float>& newResolution)
 {
 	if (!fullscreen())
 	{
-		mResolution = newResolution;
+        mResolution = {newResolution.x, newResolution.y};
 	}
 }

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -538,6 +538,6 @@ void NAS2D::Renderer::setResolution(const Vector<float>& newResolution)
 {
 	if (!fullscreen())
 	{
-        mResolution = {newResolution.x, newResolution.y};
+		mResolution = {newResolution.x, newResolution.y};
 	}
 }

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -533,3 +533,11 @@ void Renderer::update()
 		drawBoxFilled(0, 0, width(), height(), mFadeColor.red(), mFadeColor.green(), mFadeColor.blue(), static_cast<uint8_t>(mCurrentFade));
 	}
 }
+
+void NAS2D::Renderer::setResolution(const Point<float> newResolution)
+{
+	if (!fullscreen())
+	{
+		mResolution = newResolution;
+	}
+}

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -642,6 +642,15 @@ void RendererOpenGL::setViewport(const Rectangle<int>& viewport)
 	glViewport(viewport.startPoint().x(), viewport.startPoint().y(), viewport.width(), viewport.height());
 }
 
+
+void NAS2D::RendererOpenGL::setOrthoProjection(const Rectangle<float>& orthoBounds)
+{
+	glMatrixMode(GL_PROJECTION);
+	glLoadIdentity();
+	glOrtho(orthoBounds.startPoint().x(), orthoBounds.endPoint().x(), orthoBounds.endPoint().y(), orthoBounds.startPoint().x(), -1.0, 1.0f);
+	glMatrixMode(GL_MODELVIEW);
+}
+
 void RendererOpenGL::window_icon(const std::string& path)
 {
 	if (!Utility<Filesystem>::get().exists(path)) { return; }
@@ -785,6 +794,7 @@ NAS2D::DisplayDesc NAS2D::RendererOpenGL::getClosestMatchingDisplayMode(const Di
 	auto err_str = "No matching display mode for " + display_str;
 	throw std::runtime_error(err_str);
 }
+
 // ==================================================================================
 // = NON PUBLIC IMPLEMENTATION
 // ==================================================================================

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -625,16 +625,12 @@ bool RendererOpenGL::resizeable()
 
 void RendererOpenGL::_resize(int w, int h)
 {
-	glViewport(0, 0, w, h);
-	glMatrixMode(GL_PROJECTION);
-	glLoadIdentity();
-	glOrtho(0.0, (GLdouble)w, (GLdouble)h, 0.0, -1.0, 1.0);
-	glMatrixMode(GL_MODELVIEW);
+	const auto wAsf = static_cast<float>(w);
+	const auto hAsf = static_cast<float>(h);
+	setViewport(Rectangle{0, 0, w, h});
+	setOrthoProjection(Rectangle<float>::Create(Point{0.0f, 0.0f}, Vector<float>{wAsf, hAsf}));
+	setResolution(Point{wAsf, hAsf});
 
-	if (!fullscreen())
-	{
-		mResolution = {static_cast<float>(w), static_cast<float>(h)};
-	}
 }
 
 void RendererOpenGL::setViewport(const Rectangle<int>& viewport)

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -579,7 +579,7 @@ void RendererOpenGL::size(int w, int h)
 void RendererOpenGL::minimum_size(int w, int h)
 {
 	SDL_SetWindowMinimumSize(underlyingWindow, w, h);
-	_resize(w, h);
+	onResize(w, h);
 }
 
 

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -625,11 +625,10 @@ bool RendererOpenGL::resizeable()
 
 void RendererOpenGL::onResize(int w, int h)
 {
-	const auto wAsf = static_cast<float>(w);
-	const auto hAsf = static_cast<float>(h);
+	const auto dimensions = Vector<int>{w, h}.to<float>();
 	setViewport(Rectangle{0, 0, w, h});
-	setOrthoProjection(Rectangle<float>::Create(Point{0.0f, 0.0f}, Vector<float>{wAsf, hAsf}));
-	setResolution(Point{wAsf, hAsf});
+	setOrthoProjection(Rectangle<float>::Create(Point{0.0f, 0.0f}, dimensions));
+	setResolution(dimensions);
 
 }
 

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -94,7 +94,7 @@ RendererOpenGL::RendererOpenGL(const std::string& title) : Renderer(title)
  */
 RendererOpenGL::~RendererOpenGL()
 {
-	Utility<EventHandler>::get().windowResized().disconnect(this, &RendererOpenGL::_resize);
+	Utility<EventHandler>::get().windowResized().disconnect(this, &RendererOpenGL::onResize);
 
 	SDL_GL_DeleteContext(CONTEXT);
 	SDL_DestroyWindow(underlyingWindow);
@@ -571,7 +571,7 @@ float RendererOpenGL::height()
 void RendererOpenGL::size(int w, int h)
 {
 	SDL_SetWindowSize(underlyingWindow, w, h);
-	_resize(w, h);
+	onResize(w, h);
 	SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 }
 
@@ -623,7 +623,7 @@ bool RendererOpenGL::resizeable()
 }
 
 
-void RendererOpenGL::_resize(int w, int h)
+void RendererOpenGL::onResize(int w, int h)
 {
 	const auto wAsf = static_cast<float>(w);
 	const auto hAsf = static_cast<float>(h);
@@ -670,7 +670,7 @@ void RendererOpenGL::initGL()
 	glClear(GL_COLOR_BUFFER_BIT);
 	glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
 
-	_resize(static_cast<int>(width()), static_cast<int>(height()));
+	onResize(static_cast<int>(width()), static_cast<int>(height()));
 
 	glShadeModel(GL_SMOOTH);
 	glEnable(GL_COLOR_MATERIAL);
@@ -746,7 +746,7 @@ void RendererOpenGL::initVideo(unsigned int resX, unsigned int resY, bool fullsc
 	glewInit();
 	initGL();
 
-	Utility<EventHandler>::get().windowResized().connect(this, &RendererOpenGL::_resize);
+	Utility<EventHandler>::get().windowResized().connect(this, &RendererOpenGL::onResize);
 
 	SDL_DisplayMode dm;
 	if (SDL_GetDesktopDisplayMode(0, &dm) != 0)

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -637,6 +637,10 @@ void RendererOpenGL::_resize(int w, int h)
 	}
 }
 
+void RendererOpenGL::setViewport(const Rectangle<int>& viewport)
+{
+	glViewport(viewport.startPoint().x(), viewport.startPoint().y(), viewport.width(), viewport.height());
+}
 
 void RendererOpenGL::window_icon(const std::string& path)
 {


### PR DESCRIPTION
Refactors `_resize`'s implementation by splitting it into three component functions that are also useful individually:

- `setViewport`
- `setOrthoProjection`
- `setResolution`

 and renames it to a more meaningful function name `onResize`.

Two of the component functions are implementation-defined between `DirectX` and `OpenGL` so their declarations were declared as pure virtual in the base `Renderer` class.

`setResolution` just sets the private member variable on `Renderer` so it made more sense to just declare it there.