### PR TITLE
Update Mingw-w64 dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - build-and-test
   build-linux-mingw:
     docker:
-      - image: outpostuniverse/nas2d-mingw:1.2
+      - image: outpostuniverse/nas2d-mingw:1.3
     steps:
       - checkout
       - build-and-test

--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -2,12 +2,23 @@
 
 FROM ubuntu:18.04
 
-# Install Mingw-w64
+# Install base development tools
+# Includes tools to build download, unpack, and build source packages
+# Includes tools needed for primary CircleCI containers
 RUN apt-get update && apt-get install -y --no-install-recommends \
     mingw-w64=5.0.3-1 \
     cmake=3.10.2-* \
     make=4.1-* \
     binutils=2.30-* \
+    git=1:2.17.1-* \
+    ssh=1:7.6p1-* \
+    curl=7.58.0-* \
+    tar=1.29b-* \
+    gzip=1.6-* \
+    bzip2=1.0.6-* \
+    gnupg=2.2.4-* \
+    software-properties-common=0.96.24.32.12 \
+    ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
 
 # Set custom variables for build script convenience
@@ -27,17 +38,6 @@ ENV  LD32=${ARCH32}-ld
 # Set 64-bit Mingw-w64 as default compiler
 ENV CXX=${CXX64}
 ENV  CC=${CC64}
-
-# Install utilities to fetch and install tools and dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates=* \
-    curl=7.58.0-* \
-    tar=1.29b-* \
-    gzip=1.6-* \
-    bzip2=1.0.6-* \
-    gnupg=2.2.4-* \
-    software-properties-common=0.96.24.32.12 \
-  && rm -rf /var/lib/apt/lists/*
 
 # Install wine so resulting unit test binaries can be run
 RUN curl -L https://dl.winehq.org/wine-builds/winehq.key | apt-key add - && \

--- a/makefile
+++ b/makefile
@@ -168,7 +168,7 @@ ImageName_clang := nas2d-clang
 ImageVersion_clang := 1.0
 
 ImageName_mingw := nas2d-mingw
-ImageVersion_mingw := 1.2
+ImageVersion_mingw := 1.3
 
 .PHONY: build-image
 build-image:


### PR DESCRIPTION
Update the Mingw-w64 Dockerfile to include CircleCI build tools needed by a primary container. This allows the image to be reused easier, such as to build downstream projects that depend on NAS2D.

Collects base packages together into one install command. This makes the image more similar to other toolchain Docker images, which have had a similar change.

----

Linux only change.
