### PR TITLE
Increase CircleCi build parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ commands:
           command: cp -r << parameters.buildPrefix >> << parameters.installPrefix >>
   build-and-test:
     steps:
-      - run: make --keep-going --jobs=4
-      - run: make --keep-going --jobs=4 test
-      - run: make --keep-going --jobs=4 check
+      - run: make --keep-going --jobs=5
+      - run: make --keep-going --jobs=5 test
+      - run: make --keep-going --jobs=5 check
 
 jobs:
   build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ commands:
           command: cp -r << parameters.buildPrefix >> << parameters.installPrefix >>
   build-and-test:
     steps:
-      - run: make --keep-going --jobs=3
-      - run: make --keep-going --jobs=3 test
-      - run: make --keep-going --jobs=3 check
+      - run: make --keep-going --jobs=4
+      - run: make --keep-going --jobs=4 test
+      - run: make --keep-going --jobs=4 check
 
 jobs:
   build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ commands:
           command: cp -r << parameters.buildPrefix >> << parameters.installPrefix >>
   build-and-test:
     steps:
-      - run: make --keep-going --jobs=2
-      - run: make --keep-going --jobs=2 test
-      - run: make --keep-going --jobs=2 check
+      - run: make --keep-going --jobs=3
+      - run: make --keep-going --jobs=3 test
+      - run: make --keep-going --jobs=3 check
 
 jobs:
   build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ commands:
           command: cp -r << parameters.buildPrefix >> << parameters.installPrefix >>
   build-and-test:
     steps:
-      - run: make --keep-going --jobs=6
-      - run: make --keep-going --jobs=6 test
-      - run: make --keep-going --jobs=6 check
+      - run: make --keep-going --jobs=7
+      - run: make --keep-going --jobs=7 test
+      - run: make --keep-going --jobs=7 check
 
 jobs:
   build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ commands:
           command: cp -r << parameters.buildPrefix >> << parameters.installPrefix >>
   build-and-test:
     steps:
-      - run: make --keep-going --jobs=8
-      - run: make --keep-going --jobs=8 test
-      - run: make --keep-going --jobs=8 check
+      - run: make --keep-going --jobs
+      - run: make --keep-going --jobs test
+      - run: make --keep-going --jobs check
 
 jobs:
   build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ commands:
           command: cp -r << parameters.buildPrefix >> << parameters.installPrefix >>
   build-and-test:
     steps:
-      - run: make --keep-going
-      - run: make --keep-going test
-      - run: make --keep-going check
+      - run: make --keep-going --jobs=2
+      - run: make --keep-going --jobs=2 test
+      - run: make --keep-going --jobs=2 check
 
 jobs:
   build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ commands:
           command: cp -r << parameters.buildPrefix >> << parameters.installPrefix >>
   build-and-test:
     steps:
-      - run: make --keep-going --jobs=7
-      - run: make --keep-going --jobs=7 test
-      - run: make --keep-going --jobs=7 check
+      - run: make --keep-going --jobs=8
+      - run: make --keep-going --jobs=8 test
+      - run: make --keep-going --jobs=8 check
 
 jobs:
   build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ commands:
           command: cp -r << parameters.buildPrefix >> << parameters.installPrefix >>
   build-and-test:
     steps:
-      - run: make --keep-going --jobs=5
-      - run: make --keep-going --jobs=5 test
-      - run: make --keep-going --jobs=5 check
+      - run: make --keep-going --jobs=6
+      - run: make --keep-going --jobs=6 test
+      - run: make --keep-going --jobs=6 check
 
 jobs:
   build-macos:


### PR DESCRIPTION
I did a bit of testing to see if increasing the build parallelism will make CircleCI runs faster. It does.

I tested from 1 to 8 concurrent processes spawned by `make`, and then infinitely many, which will spawn as many processes as dependency analysis dictates is possible for a machine with infinite resources.

No errors were encountered at maximum parallelism, so it seems the build machines have enough resources to handle this. If we ever encounter resource exhaustion as the project grows, we can scale back on the parallelism. I doubt that will ever be an issue though.

For Linux builds, the total run time was often dominated by the time to download the Docker image before starting the build. The image is considerably larger for the Mingw-w64 build, as it needs Wine to run the unit tests, which adds a lot to the image size. Starting the unit tests through Wine also adds about 2 seconds of lag to the test run time, which impacts total run time. For MacOS, total build time is often dominated by the `brew` package restore. In all cases, there was considerable variation in environment startup and prep time, before the build actually got started.

For each run, I recorded the `staticLibBuildTime`/`unitTestBuildTime`/`totalRunTime`.

Summary:

Concurrency | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | infinity
----------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | --------
linux-gcc | 18/13/46 | 8/7/29 | 7/5/33 | 6/5/36 | 4/3/20 | 3/3/24 | 3/3/43 | 2/3/21 | 3/2/19
linux-gcc-8 | 16/11/44 | 8/5/54 | 5/4/28 | 4/3/35 | 4/3/26 | 3/2/20 | 3/3/19 | 3/2/17 | 3/2/18
linux-clang | 15/11/45 | 7/6/31 | 5/4/22 | 6/5/27 | 3/2/23 | 3/2/18 | 3/2/23 | 2/2/26 | 2/2/38
linux-mingw | 16/13/56 | 9/8/54 | 6/6/48 | 4/4/42 | 3/3/39 | 4/4/53 | 4/3/45 | 2/3/44 | 3/2/33
macos-clang | 32/18/100 | 17/9/69 | 13/7/81 | 10/5/61 | 11/6/69 | 11/5/64 | 12/5/63 | 12/5/154 | 17/5/64
&nbsp;|&nbsp;|&nbsp;|&nbsp;|&nbsp;|&nbsp;|&nbsp;|&nbsp;|&nbsp;|&nbsp;|&nbsp;

----

As there is lag time between starting a compiler instance, and reporting any found errors, increased build parallelism can separate error messages from the compiler invocation line that resulted in that error message. The Linux compilers are pretty good at identifying the source of the error though, so this shouldn't be a problem.
