### PR TITLE
Update `make gtest` rule

### DIFF
--- a/makefile
+++ b/makefile
@@ -79,6 +79,24 @@ gtest:
 	  cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DBUILD_SHARED_LIBS=ON googletest-release-1.10.0/ && \
 	  make
 
+.PHONY: gtest-install
+gtest-install:
+	cd $(GTESTDIR) && \
+	  cp -r lib/ /usr/local/ && \
+	  cp -r \
+	    googletest-release-1.10.0/googletest/include/ \
+	    googletest-release-1.10.0/googlemock/include/ \
+	    /usr/local/ && \
+	  cp --parents -r \
+	    googletest-release-1.10.0/CMakeLists.txt \
+	    googletest-release-1.10.0/googletest/CMakeLists.txt \
+	    googletest-release-1.10.0/googletest/cmake/ \
+	    googletest-release-1.10.0/googletest/src/ \
+	    googletest-release-1.10.0/googlemock/CMakeLists.txt \
+	    googletest-release-1.10.0/googlemock/cmake/ \
+	    googletest-release-1.10.0/googlemock/src/ \
+	    /usr/local/src/
+
 TESTDIR := test
 TESTINTDIR := $(BUILDDIR)/testIntermediate
 TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')

--- a/makefile
+++ b/makefile
@@ -72,8 +72,12 @@ GTESTDIR := $(BUILDDIR)/gtest
 .PHONY: gtest
 gtest:
 	mkdir -p $(GTESTDIR)
-	cd $(GTESTDIR) && cmake -DCMAKE_CXX="$(CXX)" -DCMAKE_CXX_FLAGS="-std=c++17" $(GTESTSRCDIR)
-	make -C $(GTESTDIR)
+	cd $(GTESTDIR) && \
+	  curl --location https://github.com/google/googletest/archive/release-1.10.0.tar.gz | tar -xz && \
+	  cmake -DCMAKE_CXX_FLAGS="-std=c++17" googletest-release-1.10.0/ && \
+	  make && \
+	  cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DBUILD_SHARED_LIBS=ON googletest-release-1.10.0/ && \
+	  make
 
 TESTDIR := test
 TESTINTDIR := $(BUILDDIR)/testIntermediate

--- a/makefile
+++ b/makefile
@@ -65,12 +65,11 @@ clean-all: | clean
 
 ## Unit Test project ##
 
-.PHONY: gtest test check
-
 # Either of these should be a complete combined package. Only build one.
 GTESTSRCDIR := /usr/src/googletest/
 GTESTDIR := $(BUILDDIR)/gtest
 
+.PHONY: gtest
 gtest:
 	mkdir -p $(GTESTDIR)
 	cd $(GTESTDIR) && cmake -DCMAKE_CXX="$(CXX)" -DCMAKE_CXX_FLAGS="-std=c++17" $(GTESTSRCDIR)
@@ -90,7 +89,10 @@ TESTDEPFLAGS = -MT $@ -MMD -MP -MF $(TESTINTDIR)/$*.Td
 TESTCOMPILE.cpp = $(CXX) $(TESTCPPFLAGS) $(TESTDEPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
 TESTPOSTCOMPILE = @mv -f $(TESTINTDIR)/$*.Td $(TESTINTDIR)/$*.d && touch $@
 
+.PHONY: test
 test: $(TESTOUTPUT)
+
+.PHONY: check
 check: | test
 	cd test && $(RUN_PREFIX) ../$(TESTOUTPUT)
 

--- a/makefile
+++ b/makefile
@@ -65,23 +65,16 @@ clean-all: | clean
 
 ## Unit Test project ##
 
-.PHONY: gtest gmock test check
+.PHONY: gtest test check
 
 # Either of these should be a complete combined package. Only build one.
-GTESTSRCDIR := /usr/src/gtest/
-GMOCKSRCDIR := /usr/src/gmock/
+GTESTSRCDIR := /usr/src/googletest/
 GTESTDIR := $(BUILDDIR)/gtest
-GMOCKDIR := $(BUILDDIR)/gmock
 
 gtest:
 	mkdir -p $(GTESTDIR)
 	cd $(GTESTDIR) && cmake -DCMAKE_CXX="$(CXX)" -DCMAKE_CXX_FLAGS="-std=c++17" $(GTESTSRCDIR)
 	make -C $(GTESTDIR)
-
-gmock:
-	mkdir -p $(GMOCKDIR)
-	cd $(GMOCKDIR) && cmake -DCMAKE_CXX="$(CXX)" -DCMAKE_CXX_FLAGS="-std=c++17" $(GMOCKSRCDIR)
-	make -C $(GMOCKDIR)
 
 TESTDIR := test
 TESTINTDIR := $(BUILDDIR)/testIntermediate


### PR DESCRIPTION
This ports some of the updated Dockerfile setup rules to the local `makefile` to ease setting up a local Linux environment.

The older `gtest` rule was antiquated and no longer worked with current Ubuntu packages, and the current packages were no longer new enough to provide all GMock features that are now being used. A source install with a current package is necessary.

Linux only change.
