### PR TITLE
Add make lint rules

### DIFF
--- a/makefile
+++ b/makefile
@@ -137,6 +137,10 @@ include $(wildcard $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.d,$(TESTSRCS)))
 cppcheck:
 	cppcheck --quiet "$(SRCDIR)"
 
+.PHONY: cppclean
+cppclean:
+	cppclean --include-path "$(INCDIR)" "$(SRCDIR)"
+
 ### Linux development package dependencies ###
 # This section contains install rules to aid setup and compiling on Linux.
 # Only a few common Linux distributions are covered. Other distributions

--- a/makefile
+++ b/makefile
@@ -133,6 +133,9 @@ $(TESTINTDIR)/%.d: ;
 include $(wildcard $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.d,$(TESTSRCS)))
 
 
+.PHONY: lint
+lint: cppcheck cppclean
+
 .PHONY: cppcheck
 cppcheck:
 	cppcheck --quiet "$(SRCDIR)"

--- a/makefile
+++ b/makefile
@@ -133,6 +133,10 @@ $(TESTINTDIR)/%.d: ;
 include $(wildcard $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.d,$(TESTSRCS)))
 
 
+.PHONY: cppcheck
+cppcheck:
+	cppcheck --quiet "$(SRCDIR)"
+
 ### Linux development package dependencies ###
 # This section contains install rules to aid setup and compiling on Linux.
 # Only a few common Linux distributions are covered. Other distributions


### PR DESCRIPTION
Add `makefile` rules to run linter checks using `cppcheck` and `cppclean`.

Linux only change.
