### PR TITLE
Add `dataPath` mount relative to `basePath()`

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -48,6 +48,7 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 
 	auto& fs = Utility<Filesystem>::init<Filesystem>(argv_0, appName, organizationName);
 	fs.mount(dataPath);
+	fs.mount(fs.basePath() + dataPath);
 	fs.mountReadWrite(fs.prefPath());
 
 	Configuration& cf = Utility<Configuration>::get();


### PR DESCRIPTION
Closes #444

The `dataPath` is now mounted both relative to the current working directory, and relative to the `basePath()`. This allows for flexibility in packaging and modding. Static assets may be found relative to the executable for distribution and install purposes, or found relative to the current working directory for development and modding purposes.

The mount relative to the current working direction takes priority over the mount relative to the `basePath()`. This allows for easier modding, as a shared executable can be used with a new `dataPath` folder for static assets.