### PR TITLE
Makefile environment variable flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,10 @@ commands:
   build-and-test:
     steps:
       - run: export CXXFLAGS_EXTRA="-Werror"
-      - run: make --keep-going --jobs
-      - run: make --keep-going --jobs test
-      - run: make --keep-going --jobs check
+      - run: export MAKEFLAGS="--keep-going --jobs"
+      - run: make
+      - run: make test
+      - run: make check
 
 jobs:
   build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - build-and-test
   build-linux-mingw:
     docker:
-      - image: outpostuniverse/nas2d-mingw:1.3
+      - image: outpostuniverse/nas2d-mingw:1.4
     steps:
       - checkout
       - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ commands:
           command: cp -r << parameters.buildPrefix >> << parameters.installPrefix >>
   build-and-test:
     steps:
+      - run: export CXXFLAGS_EXTRA="-Werror"
       - run: make --keep-going --jobs
       - run: make --keep-going --jobs test
       - run: make --keep-going --jobs check

--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -147,7 +147,7 @@ RUN wineboot
 
 # Set default extra C pre-processor flags
 # This makes proper rebuilding easier in a debug session
-ENV CPPFLAGS.EXTRA=-D"GLEW_STATIC"
+ENV CPPFLAGS_EXTRA=-D"GLEW_STATIC"
 
 # Be explicit about the extra flags with the default command
-CMD ["make", "--keep-going", "check", "CPPFLAGS.EXTRA=-DGLEW_STATIC"]
+CMD ["make", "--keep-going", "check", "CPPFLAGS_EXTRA=-DGLEW_STATIC"]

--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -35,10 +35,6 @@ ENV CXX32=${ARCH32}-g++
 ENV  CC32=${ARCH32}-gcc
 ENV  LD32=${ARCH32}-ld
 
-# Set 64-bit Mingw-w64 as default compiler
-ENV CXX=${CXX64}
-ENV  CC=${CC64}
-
 # Install wine so resulting unit test binaries can be run
 RUN curl -L https://dl.winehq.org/wine-builds/winehq.key | apt-key add - && \
   apt-add-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ bionic main' && \
@@ -129,11 +125,16 @@ ENV PATH64="${PATH}:${BIN64}"
 ENV PATH32="${PATH}:${BIN32}"
 ENV WINEPATH64=${BIN64};/usr/lib/gcc/${ARCH64}/7.3-win32/
 ENV WINEPATH32=${BIN32};/usr/lib/gcc/${ARCH32}/7.3-win32/
+
 # Setup compiler and tooling default folders
 ENV CPLUS_INCLUDE_PATH="${INCLUDE64}"
 ENV LIBRARY_PATH="${LIB64}"
 ENV PATH="${PATH64}"
 ENV WINEPATH="${WINEPATH64}"
+
+# Set default compiler
+ENV CXX=${CXX64}
+ENV  CC=${CC64}
 
 RUN useradd -m -s /bin/bash user
 USER user

--- a/makefile
+++ b/makefile
@@ -21,10 +21,10 @@ Darwin_OpenGL_LIBS := -lGLEW -framework OpenGL
 Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
-CPPFLAGS := $(CPPFLAGS.EXTRA) -Iinclude/
-CXXFLAGS := $(CXXFLAGS.EXTRA) -std=c++17 -Wall -Wpedantic -Werror $(shell sdl2-config --cflags)
-LDFLAGS := $(LDFLAGS.EXTRA)
-LDLIBS := $(LDLIBS.EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
+CPPFLAGS := $(CPPFLAGS_EXTRA) -Iinclude/
+CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 -Wall -Wpedantic -Werror $(shell sdl2-config --cflags)
+LDFLAGS := $(LDFLAGS_EXTRA)
+LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
 
 Windows_RUN_PREFIX := wine
 RUN_PREFIX := $($(TARGET_OS)_RUN_PREFIX)
@@ -196,7 +196,7 @@ ImageName_clang := nas2d-clang
 ImageVersion_clang := 1.0
 
 ImageName_mingw := nas2d-mingw
-ImageVersion_mingw := 1.3
+ImageVersion_mingw := 1.4
 
 .PHONY: build-image
 build-image:

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS_EXTRA) -Iinclude/
-CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 -Wall -Wpedantic -Werror $(shell sdl2-config --cflags)
+CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 -Wall -Wpedantic $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA)
 LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
 


### PR DESCRIPTION
Move common `makefile` flags to environment variables.

This reduces repetition, and allows for a more customized environment.

Linux/MacOS only change.
