### PR TITLE
CI fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,9 @@ commands:
           command: cp -r << parameters.buildPrefix >> << parameters.installPrefix >>
   build-and-test:
     steps:
-      - run: export CXXFLAGS_EXTRA="-Werror"
-      - run: make --keep-going --jobs
-      - run: make --keep-going --jobs test
-      - run: make --keep-going --jobs check
+      - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror"
+      - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror" test
+      - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror" check
 
 jobs:
   build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,10 +58,9 @@ commands:
   build-and-test:
     steps:
       - run: export CXXFLAGS_EXTRA="-Werror"
-      - run: export MAKEFLAGS="--keep-going --jobs"
-      - run: make
-      - run: make test
-      - run: make check
+      - run: make --keep-going --jobs
+      - run: make --keep-going --jobs test
+      - run: make --keep-going --jobs check
 
 jobs:
   build-macos:


### PR DESCRIPTION
Environment variables are not persisted across `run` steps. Each `run` steps invokes a new shell.

Linux/MacOS only change.
