### PR TITLE
DisplayDesc partial order comparison

### DIFF
--- a/include/NAS2D/Renderer/DisplayDesc.h
+++ b/include/NAS2D/Renderer/DisplayDesc.h
@@ -17,4 +17,9 @@ namespace NAS2D
 	bool operator==(const DisplayDesc& a, const DisplayDesc& b);
 	bool operator!=(const DisplayDesc& a, const DisplayDesc& b);
 
+	bool operator<=(const DisplayDesc& a, const DisplayDesc& b);
+	bool operator>=(const DisplayDesc& a, const DisplayDesc& b);
+	bool operator<(const DisplayDesc& a, const DisplayDesc& b);
+	bool operator>(const DisplayDesc& a, const DisplayDesc& b);
+
 } // namespace NAS2D

--- a/src/Renderer/DisplayDesc.cpp
+++ b/src/Renderer/DisplayDesc.cpp
@@ -22,7 +22,7 @@ namespace NAS2D
 
 	bool operator>=(const DisplayDesc& a, const DisplayDesc& b)
 	{
-		return (a.width >= b.width) && (a.height >= b.height) && (a.refreshHz >= b.refreshHz);
+		return (b <= a);
 	}
 
 	bool operator<(const DisplayDesc& a, const DisplayDesc& b)
@@ -32,7 +32,7 @@ namespace NAS2D
 
 	bool operator>(const DisplayDesc& a, const DisplayDesc& b)
 	{
-		return (a >= b) && (a != b);
+		return (b < a);
 	}
 
 } // namespace NAS2D

--- a/src/Renderer/DisplayDesc.cpp
+++ b/src/Renderer/DisplayDesc.cpp
@@ -1,5 +1,6 @@
 #include "NAS2D/Renderer/DisplayDesc.h"
 
+
 namespace NAS2D
 {
 
@@ -11,6 +12,27 @@ namespace NAS2D
 	bool operator!=(const DisplayDesc& a, const DisplayDesc& b)
 	{
 		return !(a == b);
+	}
+
+
+	bool operator<=(const DisplayDesc& a, const DisplayDesc& b)
+	{
+		return (a.width <= b.width) && (a.height <= b.height) && (a.refreshHz <= b.refreshHz);
+	}
+
+	bool operator>=(const DisplayDesc& a, const DisplayDesc& b)
+	{
+		return (a.width >= b.width) && (a.height >= b.height) && (a.refreshHz >= b.refreshHz);
+	}
+
+	bool operator<(const DisplayDesc& a, const DisplayDesc& b)
+	{
+		return (a <= b) && (a != b);
+	}
+
+	bool operator>(const DisplayDesc& a, const DisplayDesc& b)
+	{
+		return (a >= b) && (a != b);
 	}
 
 } // namespace NAS2D

--- a/test/Renderer/DisplayDesc.test.cpp
+++ b/test/Renderer/DisplayDesc.test.cpp
@@ -1,0 +1,93 @@
+#include "NAS2D/Renderer/DisplayDesc.h"
+#include <gtest/gtest.h>
+
+
+TEST(DisplayDesc, OperatorEqual) {
+	// Check full equality
+	EXPECT_EQ((NAS2D::DisplayDesc{0, 0, 0}), (NAS2D::DisplayDesc{0, 0, 0}));
+	EXPECT_EQ((NAS2D::DisplayDesc{640, 480, 30}), (NAS2D::DisplayDesc{640, 480, 30}));
+
+	// Check inequality for each individual component
+	EXPECT_NE((NAS2D::DisplayDesc{640, 0, 0}), (NAS2D::DisplayDesc{0, 0, 0}));
+	EXPECT_NE((NAS2D::DisplayDesc{0, 480, 0}), (NAS2D::DisplayDesc{0, 0, 0}));
+	EXPECT_NE((NAS2D::DisplayDesc{0, 0, 30}), (NAS2D::DisplayDesc{0, 0, 0}));
+
+	// Check inequality of all components
+	EXPECT_NE((NAS2D::DisplayDesc{640, 480, 30}), (NAS2D::DisplayDesc{1024, 768, 60}));
+}
+
+TEST(DisplayDesc, OperatorLessEqual) {
+	// Check full equlity
+	EXPECT_LE((NAS2D::DisplayDesc{0, 0, 0}), (NAS2D::DisplayDesc{0, 0, 0}));
+	EXPECT_LE((NAS2D::DisplayDesc{640, 480, 30}), (NAS2D::DisplayDesc{640, 480, 30}));
+
+	// Check single component difference comparison
+	EXPECT_LE((NAS2D::DisplayDesc{1, 480, 30}), (NAS2D::DisplayDesc{640, 480, 30}));
+	EXPECT_LE((NAS2D::DisplayDesc{640, 1, 30}), (NAS2D::DisplayDesc{640, 480, 30}));
+	EXPECT_LE((NAS2D::DisplayDesc{640, 480, 1}), (NAS2D::DisplayDesc{640, 480, 30}));
+
+	// Check all component difference comparison
+	EXPECT_LE((NAS2D::DisplayDesc{640, 480, 30}), (NAS2D::DisplayDesc{1024, 768, 60}));
+
+	// Check incomparable
+	EXPECT_FALSE((NAS2D::DisplayDesc{1, 480, 30}) <= (NAS2D::DisplayDesc{640, 1, 30}));
+	EXPECT_FALSE((NAS2D::DisplayDesc{1, 480, 30}) <= (NAS2D::DisplayDesc{640, 480, 1}));
+	EXPECT_FALSE((NAS2D::DisplayDesc{640, 1, 30}) <= (NAS2D::DisplayDesc{640, 480, 1}));
+}
+
+TEST(DisplayDesc, OperatorGreaterEqual) {
+	// Check full equlity
+	EXPECT_GE((NAS2D::DisplayDesc{0, 0, 0}), (NAS2D::DisplayDesc{0, 0, 0}));
+	EXPECT_GE((NAS2D::DisplayDesc{640, 480, 30}), (NAS2D::DisplayDesc{640, 480, 30}));
+
+	// Check single component difference comparison
+	EXPECT_GE((NAS2D::DisplayDesc{640, 480, 30}), (NAS2D::DisplayDesc{1, 480, 30}));
+	EXPECT_GE((NAS2D::DisplayDesc{640, 480, 30}), (NAS2D::DisplayDesc{640, 1, 30}));
+	EXPECT_GE((NAS2D::DisplayDesc{640, 480, 30}), (NAS2D::DisplayDesc{640, 480, 1}));
+
+	// Check all component difference comparison
+	EXPECT_GE((NAS2D::DisplayDesc{1024, 768, 60}), (NAS2D::DisplayDesc{640, 480, 30}));
+
+	// Check incomparable
+	EXPECT_FALSE((NAS2D::DisplayDesc{1, 480, 30}) >= (NAS2D::DisplayDesc{640, 1, 30}));
+	EXPECT_FALSE((NAS2D::DisplayDesc{1, 480, 30}) >= (NAS2D::DisplayDesc{640, 480, 1}));
+	EXPECT_FALSE((NAS2D::DisplayDesc{640, 1, 30}) >= (NAS2D::DisplayDesc{640, 480, 1}));
+}
+
+TEST(DisplayDesc, OperatorLess) {
+	// Check full equlity
+	EXPECT_FALSE((NAS2D::DisplayDesc{0, 0, 0}) < (NAS2D::DisplayDesc{0, 0, 0}));
+	EXPECT_FALSE((NAS2D::DisplayDesc{640, 480, 30}) < (NAS2D::DisplayDesc{640, 480, 30}));
+
+	// Check single component difference comparison
+	EXPECT_LT((NAS2D::DisplayDesc{1, 480, 30}), (NAS2D::DisplayDesc{640, 480, 30}));
+	EXPECT_LT((NAS2D::DisplayDesc{640, 1, 30}), (NAS2D::DisplayDesc{640, 480, 30}));
+	EXPECT_LT((NAS2D::DisplayDesc{640, 480, 1}), (NAS2D::DisplayDesc{640, 480, 30}));
+
+	// Check all component difference comparison
+	EXPECT_LT((NAS2D::DisplayDesc{640, 480, 30}), (NAS2D::DisplayDesc{1024, 768, 60}));
+
+	// Check incomparable
+	EXPECT_FALSE((NAS2D::DisplayDesc{1, 480, 30}) < (NAS2D::DisplayDesc{640, 1, 30}));
+	EXPECT_FALSE((NAS2D::DisplayDesc{1, 480, 30}) < (NAS2D::DisplayDesc{640, 480, 1}));
+	EXPECT_FALSE((NAS2D::DisplayDesc{640, 1, 30}) < (NAS2D::DisplayDesc{640, 480, 1}));
+}
+
+TEST(DisplayDesc, OperatorGreater) {
+	// Check full equlity
+	EXPECT_FALSE((NAS2D::DisplayDesc{0, 0, 0}) > (NAS2D::DisplayDesc{0, 0, 0}));
+	EXPECT_FALSE((NAS2D::DisplayDesc{640, 480, 30}) > (NAS2D::DisplayDesc{640, 480, 30}));
+
+	// Check single component difference comparison
+	EXPECT_GT((NAS2D::DisplayDesc{640, 480, 30}), (NAS2D::DisplayDesc{1, 480, 30}));
+	EXPECT_GT((NAS2D::DisplayDesc{640, 480, 30}), (NAS2D::DisplayDesc{640, 1, 30}));
+	EXPECT_GT((NAS2D::DisplayDesc{640, 480, 30}), (NAS2D::DisplayDesc{640, 480, 1}));
+
+	// Check all component difference comparison
+	EXPECT_GT((NAS2D::DisplayDesc{1024, 768, 60}), (NAS2D::DisplayDesc{640, 480, 30}));
+
+	// Check incomparable
+	EXPECT_FALSE((NAS2D::DisplayDesc{1, 480, 30}) > (NAS2D::DisplayDesc{640, 1, 30}));
+	EXPECT_FALSE((NAS2D::DisplayDesc{1, 480, 30}) > (NAS2D::DisplayDesc{640, 480, 1}));
+	EXPECT_FALSE((NAS2D::DisplayDesc{640, 1, 30}) > (NAS2D::DisplayDesc{640, 480, 1}));
+}


### PR DESCRIPTION
Add partial order comparison for `DisplayDesc`.

The partial order comparison encapsulates how people might view comparisons between different screen modes. This can be used for filtering out screen modes that don't meet some minimum set of requirements.
