### PR TITLE
Add makefile rule for graphics test

### DIFF
--- a/makefile
+++ b/makefile
@@ -134,7 +134,8 @@ include $(wildcard $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.d,$(TESTSRCS)))
 
 
 .PHONY: test-graphics
-test-graphics: $(OUTPUT)
+test-graphics: $(BUILDDIR)/testGraphics
+$(BUILDDIR)/testGraphics: $(OUTPUT)
 	@mkdir -p $(BUILDDIR)
 	$(CXX) -o $(BUILDDIR)/testGraphics test-graphics/*.cpp $(CPPFLAGS) $(CXXFLAGS) $(TESTLDFLAGS) -lnas2d $(LDLIBS)
 

--- a/makefile
+++ b/makefile
@@ -138,6 +138,10 @@ test-graphics: $(OUTPUT)
 	@mkdir -p $(BUILDDIR)
 	$(CXX) -o $(BUILDDIR)/testGraphics test-graphics/*.cpp $(CPPFLAGS) $(CXXFLAGS) $(TESTLDFLAGS) -lnas2d $(LDLIBS)
 
+.PHONY: run-test-graphics
+run-test-graphics: | test-graphics
+	cd test-graphics/ && ../.build/testGraphics ; cd ..
+
 
 .PHONY: lint
 lint: cppcheck cppclean

--- a/makefile
+++ b/makefile
@@ -133,6 +133,12 @@ $(TESTINTDIR)/%.d: ;
 include $(wildcard $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.d,$(TESTSRCS)))
 
 
+.PHONY: test-graphics
+test-graphics: $(OUTPUT)
+	@mkdir -p $(BUILDDIR)
+	$(CXX) -o $(BUILDDIR)/testGraphics test-graphics/*.cpp $(CPPFLAGS) $(CXXFLAGS) $(TESTLDFLAGS) -lnas2d $(LDLIBS)
+
+
 .PHONY: lint
 lint: cppcheck cppclean
 


### PR DESCRIPTION
This adds Linux `makefile` rules for the test-graphics project introduced in #465.

Linux only change.
