### PR TITLE
Use Vector for size() in Renderer

### DIFF
--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -132,7 +132,7 @@ public:
 	virtual float height() = 0;
 
 	virtual void size(int w, int h) = 0;
-	const Point_2df& size();
+	Vector<float> size();
 
 	virtual void minimum_size(int w, int h) = 0;
 
@@ -160,7 +160,7 @@ protected:
 
 	void driverName(const std::string& name);
 
-	Point_2df mResolution{1600,900}; /**< Screen resolution. Reasonable default in 2019*/
+	Vector<float> mResolution{1600,900}; /**< Screen resolution. Reasonable default in 2019*/
 
 private:
 	enum class FadeType

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -477,7 +477,7 @@ void NAS2D::Renderer::drawTextShadow(Font& font, const std::string& text, Point<
 /**
  * Gets the current screen resolution as a Point_2df.
  */
-const Point_2df& Renderer::size()
+Vector<float> Renderer::size()
 {
 	return mResolution;
 }

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -553,7 +553,7 @@ float RendererOpenGL::width()
 		return DESKTOP_RESOLUTION.x();
 	}
 
-	return mResolution.x();
+	return mResolution.x;
 }
 
 
@@ -564,7 +564,7 @@ float RendererOpenGL::height()
 		return DESKTOP_RESOLUTION.y();
 	}
 
-	return mResolution.y();
+	return mResolution.y;
 }
 
 


### PR DESCRIPTION
A `size()` is more accurately represented by a `Vector` than by a `Point`.
