### PR TITLE
Fix warnings from `-Wextra`

### DIFF
--- a/src/Resources/Font.cpp
+++ b/src/Resources/Font.cpp
@@ -387,7 +387,7 @@ Point_2d generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int fo
 
 	SDL_Surface* glyphMap = SDL_CreateRGBSurface(SDL_SWSURFACE, textureSize, textureSize, BITS_32, rmask, gmask, bmask, amask);
 
-	SDL_Color white = { 255, 255, 255 };
+	SDL_Color white = { 255, 255, 255, 255 };
 	for (int row = 0; row < 16; row++)
 	{
 		for (int col = 0; col < GLYPH_MATRIX_SIZE; col++)

--- a/src/Xml/XmlComment.cpp
+++ b/src/Xml/XmlComment.cpp
@@ -36,7 +36,7 @@ XmlComment::XmlComment(const std::string& _value) : XmlNode(XmlNode::NodeType::X
 /**
  * Copy c'tor.
  */
-XmlComment::XmlComment(const XmlComment& copy)
+XmlComment::XmlComment(const XmlComment& copy) : XmlNode(XmlNode::NodeType::XML_COMMENT)
 {
 	copy.copyTo(this);
 }


### PR DESCRIPTION
Fixes a couple of warnings caught by `-Wextra`.

These fixes are enough to satisfy Clang and stock GCC with Ubuntu 18.04 when enabling this flag. It is not however sufficient to satisfy GCC-8, which warns about a bunch of casts in the `Delegate` code. As it doesn't look like the cast warnings will be fixed anytime soon, I'm submitting the easy fixes without enabling the `-Wextra` flag.
