### PR TITLE
Fix zero-as-null-pointer-constant warnings

### DIFF
--- a/include/NAS2D/Delegate.h
+++ b/include/NAS2D/Delegate.h
@@ -108,7 +108,7 @@ struct SimplifyMemFunc
 	inline static GenericClass* Convert(X* /*pthis*/, XFuncType /*function_to_bind*/, GenericMemFuncType& /*bound_func*/)
 	{
 		static_assert(N < 100, "Unsupported member function pointer on this compiler");
-		return 0;
+		return nullptr;
 	}
 };
 
@@ -236,11 +236,11 @@ protected:
 
 public:
 #if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-	DelegateMemento() : m_pthis(0), m_pFunction(0), m_pStaticFunction(0) {};
-	void clear() { m_pthis = 0; m_pFunction = 0; m_pStaticFunction = 0; }
+	DelegateMemento() : m_pthis(nullptr), m_pFunction(nullptr), m_pStaticFunction(nullptr) {};
+	void clear() { m_pthis = nullptr; m_pFunction = nullptr; m_pStaticFunction = nullptr; }
 #else
-	DelegateMemento() : m_pthis(0), m_pFunction(0) {};
-	void clear() { m_pthis = 0; m_pFunction = 0; }
+	DelegateMemento() : m_pthis(nullptr), m_pFunction(nullptr) {};
+	void clear() { m_pthis = nullptr; m_pFunction = nullptr; }
 #endif
 public:
 #if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
@@ -248,7 +248,7 @@ public:
 	{
 		if (m_pFunction != x.m_pFunction) return false;
 		if (m_pStaticFunction != x.m_pStaticFunction) return false;
-		if (m_pStaticFunction != 0) return m_pthis == x.m_pthis;
+		if (m_pStaticFunction != nullptr) return m_pthis == x.m_pthis;
 		else return true;
 	}
 #else
@@ -257,15 +257,15 @@ public:
 	inline bool IsLess(const DelegateMemento& right) const
 	{
 		#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-		if (m_pStaticFunction != 0 || right.m_pStaticFunction != 0) return m_pStaticFunction < right.m_pStaticFunction;
+		if (m_pStaticFunction != nullptr || right.m_pStaticFunction != nullptr) return m_pStaticFunction < right.m_pStaticFunction;
 		#endif
 		if (m_pthis != right.m_pthis) return m_pthis < right.m_pthis;
 
 		return memcmp(&m_pFunction, &right.m_pFunction, sizeof(m_pFunction)) < 0;
 	}
 
-	inline bool operator ! () const { return m_pthis == 0 && m_pFunction == 0; }
-	inline bool empty() const { return m_pthis == 0 && m_pFunction == 0; }
+	inline bool operator ! () const { return m_pthis == nullptr && m_pFunction == nullptr; }
+	inline bool empty() const { return m_pthis == nullptr && m_pFunction == nullptr; }
 
 public:
 	DelegateMemento& operator = (const DelegateMemento& right) { SetMementoFrom(right); return *this; }
@@ -300,7 +300,7 @@ public:
 	{
 		m_pthis = SimplifyMemFunc< sizeof(function_to_bind) > ::Convert(pthis, function_to_bind, m_pFunction);
 		#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-		m_pStaticFunction = 0;
+		m_pStaticFunction = nullptr;
 		#endif
 	}
 
@@ -309,7 +309,7 @@ public:
 	{
 		m_pthis = SimplifyMemFunc< sizeof(function_to_bind) > ::Convert(const_cast<X*>(pthis), function_to_bind, m_pFunction);
 		#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-		m_pStaticFunction = 0;
+		m_pStaticFunction = nullptr;
 		#endif
 	}
 
@@ -319,7 +319,7 @@ public:
 	{
 		bindconstmemfunc(pthis, function_to_bind);
 		#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-		m_pStaticFunction = 0;
+		m_pStaticFunction = nullptr;
 		#endif
 	}
 #endif
@@ -334,13 +334,13 @@ public:
 	inline void CopyFrom(DerivedClass* pParent, const DelegateMemento& x)
 	{
 		SetMementoFrom(x);
-		if (m_pStaticFunction != 0) m_pthis = reinterpret_cast<GenericClass*>(pParent);
+		if (m_pStaticFunction != nullptr) m_pthis = reinterpret_cast<GenericClass*>(pParent);
 	}
 
 	template <class DerivedClass, class ParentInvokerSig>
 	inline void bindstaticfunc(DerivedClass* pParent, ParentInvokerSig static_function_invoker, StaticFuncPtr function_to_bind)
 	{
-		if (function_to_bind == 0) m_pFunction = 0;
+		if (function_to_bind == nullptr) m_pFunction = nullptr;
 		else bindmemfunc(pParent, static_function_invoker);
 		m_pStaticFunction = reinterpret_cast<GenericFuncPtr>(function_to_bind);
 	}
@@ -353,7 +353,7 @@ public:
 	template <class DerivedClass, class ParentInvokerSig>
 	inline void bindstaticfunc(DerivedClass* pParent, ParentInvokerSig static_function_invoker, StaticFuncPtr function_to_bind)
 	{
-		if (function_to_bind == 0) m_pFunction = 0;
+		if (function_to_bind == nullptr) m_pFunction = nullptr;
 		else bindmemfunc(pParent, static_function_invoker);
 		static_assert(sizeof(GenericClass*) != sizeof(function_to_bind), "Can't use evil method");
 		m_pthis = horrible_cast<GenericClass*>(function_to_bind);
@@ -368,7 +368,7 @@ public:
 
 	inline bool IsEqualToStaticFuncPtr(StaticFuncPtr funcptr)
 	{
-		if (funcptr == 0) return empty();
+		if (funcptr == nullptr) return empty();
 		else return funcptr == reinterpret_cast<StaticFuncPtr>(GetStaticFunction());
 	}
 };

--- a/include/NAS2D/Delegate.h
+++ b/include/NAS2D/Delegate.h
@@ -248,7 +248,7 @@ public:
 	{
 		if (m_pFunction != x.m_pFunction) return false;
 		if (m_pStaticFunction != x.m_pStaticFunction) return false;
-		if (m_pStaticFunction != nullptr) return m_pthis == x.m_pthis;
+		if (m_pStaticFunction) return m_pthis == x.m_pthis;
 		else return true;
 	}
 #else
@@ -257,15 +257,15 @@ public:
 	inline bool IsLess(const DelegateMemento& right) const
 	{
 		#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-		if (m_pStaticFunction != nullptr || right.m_pStaticFunction != nullptr) return m_pStaticFunction < right.m_pStaticFunction;
+		if (m_pStaticFunction || right.m_pStaticFunction) return m_pStaticFunction < right.m_pStaticFunction;
 		#endif
 		if (m_pthis != right.m_pthis) return m_pthis < right.m_pthis;
 
 		return memcmp(&m_pFunction, &right.m_pFunction, sizeof(m_pFunction)) < 0;
 	}
 
-	inline bool operator ! () const { return m_pthis == nullptr && m_pFunction == nullptr; }
-	inline bool empty() const { return m_pthis == nullptr && m_pFunction == nullptr; }
+	inline bool operator ! () const { return !m_pthis && !m_pFunction; }
+	inline bool empty() const { return !m_pthis && !m_pFunction; }
 
 public:
 	DelegateMemento& operator = (const DelegateMemento& right) { SetMementoFrom(right); return *this; }
@@ -334,13 +334,13 @@ public:
 	inline void CopyFrom(DerivedClass* pParent, const DelegateMemento& x)
 	{
 		SetMementoFrom(x);
-		if (m_pStaticFunction != nullptr) m_pthis = reinterpret_cast<GenericClass*>(pParent);
+		if (m_pStaticFunction) m_pthis = reinterpret_cast<GenericClass*>(pParent);
 	}
 
 	template <class DerivedClass, class ParentInvokerSig>
 	inline void bindstaticfunc(DerivedClass* pParent, ParentInvokerSig static_function_invoker, StaticFuncPtr function_to_bind)
 	{
-		if (function_to_bind == nullptr) m_pFunction = nullptr;
+		if (!function_to_bind) m_pFunction = nullptr;
 		else bindmemfunc(pParent, static_function_invoker);
 		m_pStaticFunction = reinterpret_cast<GenericFuncPtr>(function_to_bind);
 	}
@@ -353,7 +353,7 @@ public:
 	template <class DerivedClass, class ParentInvokerSig>
 	inline void bindstaticfunc(DerivedClass* pParent, ParentInvokerSig static_function_invoker, StaticFuncPtr function_to_bind)
 	{
-		if (function_to_bind == nullptr) m_pFunction = nullptr;
+		if (!function_to_bind) m_pFunction = nullptr;
 		else bindmemfunc(pParent, static_function_invoker);
 		static_assert(sizeof(GenericClass*) != sizeof(function_to_bind), "Can't use evil method");
 		m_pthis = horrible_cast<GenericClass*>(function_to_bind);
@@ -368,7 +368,7 @@ public:
 
 	inline bool IsEqualToStaticFuncPtr(StaticFuncPtr funcptr)
 	{
-		if (funcptr == nullptr) return empty();
+		if (!funcptr) return empty();
 		else return funcptr == reinterpret_cast<StaticFuncPtr>(GetStaticFunction());
 	}
 };

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS_EXTRA) -Iinclude/
-CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 -Wall -Wpedantic $(shell sdl2-config --cflags)
+CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 -Wall -Wpedantic -Wzero-as-null-pointer-constant $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA)
 LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
 

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -820,7 +820,7 @@ GLuint generate_fbo(Image& image)
 		GLenum textureFormat = 0;
 		textureFormat = SDL_BYTEORDER == SDL_BIG_ENDIAN ? GL_BGRA : GL_RGBA;
 
-		glTexImage2D(GL_TEXTURE_2D, 0, textureFormat, image.width(), image.height(), 0, textureFormat, GL_UNSIGNED_BYTE, NULL);
+		glTexImage2D(GL_TEXTURE_2D, 0, textureFormat, image.width(), image.height(), 0, textureFormat, GL_UNSIGNED_BYTE, nullptr);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	}

--- a/src/Xml/XmlNode.cpp
+++ b/src/Xml/XmlNode.cpp
@@ -158,7 +158,7 @@ XmlNode* XmlNode::linkEndChild(XmlNode* node)
 	if (node->type() == XmlNode::NodeType::XML_DOCUMENT)
 	{
 		delete node;
-		if (document()) { document()->error(XmlErrorCode::XML_ERROR_DOCUMENT_TOP_ONLY, 0, 0); }
+		if (document()) { document()->error(XmlErrorCode::XML_ERROR_DOCUMENT_TOP_ONLY, nullptr, nullptr); }
 		return nullptr;
 	}
 
@@ -183,7 +183,7 @@ XmlNode* XmlNode::insertEndChild(const XmlNode& node)
 {
 	if (node.type() == XmlNode::NodeType::XML_DOCUMENT)
 	{
-		if (document()) { document()->error(XmlErrorCode::XML_ERROR_DOCUMENT_TOP_ONLY, 0, 0); }
+		if (document()) { document()->error(XmlErrorCode::XML_ERROR_DOCUMENT_TOP_ONLY, nullptr, nullptr); }
 
 		return nullptr;
 	}
@@ -212,7 +212,7 @@ XmlNode* XmlNode::insertBeforeChild(XmlNode* beforeThis, const XmlNode& addThis)
 
 	if (addThis.type() == XmlNode::NodeType::XML_DOCUMENT)
 	{
-		if (document()) { document()->error(XmlErrorCode::XML_ERROR_DOCUMENT_TOP_ONLY, 0, 0); }
+		if (document()) { document()->error(XmlErrorCode::XML_ERROR_DOCUMENT_TOP_ONLY, nullptr, nullptr); }
 		return nullptr;
 	}
 
@@ -248,7 +248,7 @@ XmlNode* XmlNode::insertAfterChild(XmlNode* afterThis, const XmlNode& addThis)
 	}
 	if (addThis.type() == XmlNode::NodeType::XML_DOCUMENT)
 	{
-		if (document()) { document()->error(XmlErrorCode::XML_ERROR_DOCUMENT_TOP_ONLY, 0, 0); }
+		if (document()) { document()->error(XmlErrorCode::XML_ERROR_DOCUMENT_TOP_ONLY, nullptr, nullptr); }
 		return nullptr;
 	}
 
@@ -288,7 +288,7 @@ XmlNode* XmlNode::replaceChild(XmlNode* replaceThis, const XmlNode& withThis)
 	{
 		// A document can never be a child.	Thanks to Noam.
 		XmlDocument* doc = document();
-		if (doc) { doc->error(XmlErrorCode::XML_ERROR_DOCUMENT_TOP_ONLY, 0, 0); }
+		if (doc) { doc->error(XmlErrorCode::XML_ERROR_DOCUMENT_TOP_ONLY, nullptr, nullptr); }
 		return nullptr;
 	}
 

--- a/src/Xml/XmlParser.cpp
+++ b/src/Xml/XmlParser.cpp
@@ -529,7 +529,7 @@ const char* XmlBase::readText(const char* p, std::string* text, bool trimWhiteSp
 		p += strlen(endTag);
 	}
 
-	return (p && *p) ? p : 0;
+	return (p && *p) ? p : nullptr;
 }
 
 
@@ -570,7 +570,7 @@ void XmlDocument::streamIn(std::istream& in, std::string& tag)
 			if (node)
 			{
 				node->streamIn(in, tag);
-				bool isElement = node->toElement() != 0;
+				bool isElement = node->toElement() != nullptr;
 				delete node;
 				node = nullptr;
 
@@ -681,7 +681,7 @@ void XmlDocument::error(XmlErrorCode err, const char* pError, void* data)
  */
 XmlNode* XmlNode::identify(const char* p)
 {
-	XmlNode* returnNode = 0;
+	XmlNode* returnNode = nullptr;
 
 	p = skipWhiteSpace(p);
 	if (!p || !*p || *p != '<')

--- a/src/Xml/XmlParser.cpp
+++ b/src/Xml/XmlParser.cpp
@@ -543,7 +543,7 @@ void XmlDocument::streamIn(std::istream& in, std::string& tag)
 	// sub-tag can orient itself.
 	if (!streamTo(in, '<', tag))
 	{
-		error(XmlErrorCode::XML_ERROR_PARSING_EMPTY, 0, 0);
+		error(XmlErrorCode::XML_ERROR_PARSING_EMPTY, nullptr, nullptr);
 		return;
 	}
 
@@ -555,7 +555,7 @@ void XmlDocument::streamIn(std::istream& in, std::string& tag)
 			int c = in.get();
 			if (c <= 0)
 			{
-				error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, 0, 0);
+				error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, nullptr, nullptr);
 				break;
 			}
 			tag += static_cast<char>(c);
@@ -580,14 +580,14 @@ void XmlDocument::streamIn(std::istream& in, std::string& tag)
 			}
 			else
 			{
-				error(XmlErrorCode::XML_ERROR, 0, 0);
+				error(XmlErrorCode::XML_ERROR, nullptr, nullptr);
 				return;
 			}
 		}
 	}
 
 	// We should have returned sooner.
-	error(XmlErrorCode::XML_ERROR, 0, 0);
+	error(XmlErrorCode::XML_ERROR, nullptr, nullptr);
 }
 
 
@@ -599,7 +599,7 @@ const char* XmlDocument::parse(const char* p, void* prevData)
 	// other tags, most of what happens here is skipping white space.
 	if (!p || !*p)
 	{
-		error(XmlErrorCode::XML_ERROR_DOCUMENT_EMPTY, 0, 0);
+		error(XmlErrorCode::XML_ERROR_DOCUMENT_EMPTY, nullptr, nullptr);
 		return nullptr;
 	}
 
@@ -617,7 +617,7 @@ const char* XmlDocument::parse(const char* p, void* prevData)
 	p = skipWhiteSpace(p);
 	if (!p)
 	{
-		error(XmlErrorCode::XML_ERROR_DOCUMENT_EMPTY, 0, 0);
+		error(XmlErrorCode::XML_ERROR_DOCUMENT_EMPTY, nullptr, nullptr);
 		return nullptr;
 	}
 
@@ -640,7 +640,7 @@ const char* XmlDocument::parse(const char* p, void* prevData)
 	// Was this empty?
 	if (!_firstChild)
 	{
-		error(XmlErrorCode::XML_ERROR_DOCUMENT_EMPTY, 0, 0);
+		error(XmlErrorCode::XML_ERROR_DOCUMENT_EMPTY, nullptr, nullptr);
 		return nullptr;
 	}
 
@@ -763,7 +763,7 @@ void XmlElement::streamIn(std::istream & in, std::string & tag)
 		if (c <= 0)
 		{
 			XmlDocument* doc = document();
-			if (doc) { doc->error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, 0, 0); }
+			if (doc) { doc->error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, nullptr, nullptr); }
 			return;
 		}
 
@@ -832,7 +832,7 @@ void XmlElement::streamIn(std::istream & in, std::string & tag)
 				if (c <= 0)
 				{
 					XmlDocument* doc = document();
-					if (doc) { doc->error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, 0, 0); }
+					if (doc) { doc->error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, nullptr, nullptr); }
 					return;
 				}
 
@@ -878,7 +878,7 @@ void XmlElement::streamIn(std::istream & in, std::string & tag)
 				if (c <= 0)
 				{
 					XmlDocument* doc = document();
-					if (doc) { doc->error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, 0, 0); }
+					if (doc) { doc->error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, nullptr, nullptr); }
 					return;
 				}
 				assert(c == '>');
@@ -916,7 +916,7 @@ const char* XmlElement::parse(const char* p, void* data)
 
 	if (!p || !*p)
 	{
-		if (doc) { doc->error(XmlErrorCode::XML_ERROR_PARSING_ELEMENT, 0, 0); }
+		if (doc) { doc->error(XmlErrorCode::XML_ERROR_PARSING_ELEMENT, nullptr, nullptr); }
 		return nullptr;
 	}
 
@@ -1113,7 +1113,7 @@ const char* XmlElement::readValue(const char* p, void* data)
 
 	if (!p)
 	{
-		if (doc) doc->error(XmlErrorCode::XML_ERROR_READING_ELEMENT_VALUE, 0, 0);
+		if (doc) doc->error(XmlErrorCode::XML_ERROR_READING_ELEMENT_VALUE, nullptr, nullptr);
 	}
 	return p;
 }
@@ -1127,7 +1127,7 @@ void XmlUnknown::streamIn(std::istream& in, std::string& tag)
 		if (c <= 0)
 		{
 			XmlDocument* doc = document();
-			if (doc) { doc->error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, 0, 0); }
+			if (doc) { doc->error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, nullptr, nullptr); }
 			return;
 		}
 		tag += static_cast<char>(c);
@@ -1168,7 +1168,7 @@ const char* XmlUnknown::parse(const char* p, void* data)
 
 	if (!p)
 	{
-		if (doc) { doc->error(XmlErrorCode::XML_ERROR_PARSING_UNKNOWN, 0, 0); }
+		if (doc) { doc->error(XmlErrorCode::XML_ERROR_PARSING_UNKNOWN, nullptr, nullptr); }
 	}
 
 	if (p && *p == '>')
@@ -1187,7 +1187,7 @@ void XmlComment::streamIn(std::istream& in, std::string& tag)
 		if (c <= 0)
 		{
 			XmlDocument* doc = document();
-			if (doc) { doc->error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, 0, 0); }
+			if (doc) { doc->error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, nullptr, nullptr); }
 			return;
 		}
 
@@ -1334,7 +1334,7 @@ void XmlText::streamIn(std::istream& in, std::string& tag)
 		if (c <= 0)
 		{
 			XmlDocument* doc = document();
-			if (doc) { doc->error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, 0, 0); }
+			if (doc) { doc->error(XmlErrorCode::XML_ERROR_EMBEDDED_NULL, nullptr, nullptr); }
 
 			return;
 		}


### PR DESCRIPTION
Fix zero-as-null-pointer-constant warnings, and enable warning flag:
`-Wzero-as-null-pointer-constant`