### PR TITLE
Fix extra semicolons

### DIFF
--- a/include/NAS2D/Delegate.h
+++ b/include/NAS2D/Delegate.h
@@ -239,7 +239,7 @@ public:
 	DelegateMemento() : m_pthis(nullptr), m_pFunction(nullptr), m_pStaticFunction(nullptr) {};
 	void clear() { m_pthis = nullptr; m_pFunction = nullptr; m_pStaticFunction = nullptr; }
 #else
-	DelegateMemento() : m_pthis(nullptr), m_pFunction(nullptr) {};
+	DelegateMemento() : m_pthis(nullptr), m_pFunction(nullptr) {}
 	void clear() { m_pthis = nullptr; m_pFunction = nullptr; }
 #endif
 public:

--- a/include/NAS2D/Renderer/DisplayDesc.h
+++ b/include/NAS2D/Renderer/DisplayDesc.h
@@ -11,7 +11,7 @@ namespace NAS2D
 		int height{0};
 		int refreshHz{0};
 
-		operator std::string() const { return std::to_string(width) + 'x' + std::to_string(height) + 'x' + std::to_string(refreshHz); };
+		operator std::string() const { return std::to_string(width) + 'x' + std::to_string(height) + 'x' + std::to_string(refreshHz); }
 	};
 
 	bool operator==(const DisplayDesc& a, const DisplayDesc& b);

--- a/include/NAS2D/Renderer/DisplayDesc.h
+++ b/include/NAS2D/Renderer/DisplayDesc.h
@@ -11,7 +11,7 @@ namespace NAS2D
 		int height{0};
 		int refreshHz{0};
 
-		operator std::string() const { return std::to_string(width) + 'x' + std::to_string(height) + 'x' + std::to_string(refreshHz); }
+		operator std::string() const;
 	};
 
 	bool operator==(const DisplayDesc& a, const DisplayDesc& b);

--- a/include/NAS2D/Renderer/RendererNull.h
+++ b/include/NAS2D/Renderer/RendererNull.h
@@ -21,8 +21,8 @@ public:
 	~RendererNull() override {}
 
 	std::vector<DisplayDesc> getDisplayModes() const override { return {}; }
-	DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc&) const override { return{}; };
-	Vector<int> getWindowClientArea() const noexcept override { return {}; };
+	DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc&) const override { return{}; }
+	Vector<int> getWindowClientArea() const noexcept override { return {}; }
 
 	void drawImage(Image&, float, float, float, uint8_t, uint8_t, uint8_t, uint8_t) override {}
 
@@ -72,7 +72,7 @@ public:
 	void update() override {}
 
 	void setViewport(const Rectangle<int>&) override {}
-	void setOrthoProjection(const Rectangle<float>&) override {};
+	void setOrthoProjection(const Rectangle<float>&) override {}
 };
 
 } // namespace

--- a/include/NAS2D/Utility.h
+++ b/include/NAS2D/Utility.h
@@ -179,8 +179,8 @@ public:
 	}
 
 private:
-	Utility<T>() {};							// Explicitly declared private.
-	~Utility() {};								// Explicitly declared private.
+	Utility<T>() {}							// Explicitly declared private.
+	~Utility() {}								// Explicitly declared private.
 	Utility<T>(const Utility& s);				// Explicitly declared private.
 	Utility<T>& operator=(const Utility& s);	// Explicitly declared private.
 

--- a/include/NAS2D/Utility.h
+++ b/include/NAS2D/Utility.h
@@ -55,6 +55,10 @@ template<typename T>
 class Utility
 {
 public:
+	Utility<T>() = delete;
+	~Utility() = delete;
+	Utility<T>(const Utility& s) = delete;
+	Utility<T>& operator=(const Utility& s) = delete;
 
 	/**
 	 * Gets a reference to a global instance of the specified type
@@ -179,11 +183,6 @@ public:
 	}
 
 private:
-	Utility<T>() {}							// Explicitly declared private.
-	~Utility() {}								// Explicitly declared private.
-	Utility<T>(const Utility& s);				// Explicitly declared private.
-	Utility<T>& operator=(const Utility& s);	// Explicitly declared private.
-
 	static T* mInstance;						/**< Internal instance of type \c T. */
 };
 

--- a/src/Renderer/DisplayDesc.cpp
+++ b/src/Renderer/DisplayDesc.cpp
@@ -4,6 +4,12 @@
 namespace NAS2D
 {
 
+	DisplayDesc::operator std::string() const
+	{
+		return std::to_string(width) + 'x' + std::to_string(height) + 'x' + std::to_string(refreshHz);
+	}
+
+
 	bool operator==(const DisplayDesc& a, const DisplayDesc& b)
 	{
 		return a.width == b.width && a.height == b.height && a.refreshHz == b.refreshHz;


### PR DESCRIPTION
Found using the flag `-Wextra-semi`.

The warning flag is supported by Clang and GCC-8. It is not supported by GCC-7.5 (which is stock with Ubuntu 18.04), nor by Mingw-w64. Enabling the flag globally would cause CI build failures for the linux (stock GCC) and Mingw builds. As such, it is not being added to the `makefile`.
