### PR TITLE
Refactor Image and ImageInfo

### DIFF
--- a/include/NAS2D/Resources/ImageInfo.h
+++ b/include/NAS2D/Resources/ImageInfo.h
@@ -19,7 +19,7 @@
  */
 struct ImageInfo
 {
-	SDL_Surface* pixels{nullptr};
+	SDL_Surface* surface{nullptr};
 	unsigned int texture_id{0u};
 	unsigned int fbo_id{0u};
 	int w{0};

--- a/include/NAS2D/Resources/ImageInfo.h
+++ b/include/NAS2D/Resources/ImageInfo.h
@@ -10,13 +10,16 @@
 #pragma once
 
 
+#include <SDL2/SDL_image.h>
+
+
 /**
  * Struct containing basic information related to Images. Not part of the public
  * interface.
  */
 struct ImageInfo
 {
-	void* pixels{nullptr};
+	SDL_Surface* pixels{nullptr};
 	unsigned int texture_id{0u};
 	unsigned int fbo_id{0u};
 	int w{0};

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -484,14 +484,14 @@ void RendererOpenGL::addCursor(const std::string& filePath, int cursorId, int of
 		return;
 	}
 
-	SDL_Surface* pixels = IMG_Load_RW(SDL_RWFromConstMem(imageFile.raw_bytes(), static_cast<int>(imageFile.size())), 0);
-	if (!pixels)
+	SDL_Surface* surface = IMG_Load_RW(SDL_RWFromConstMem(imageFile.raw_bytes(), static_cast<int>(imageFile.size())), 0);
+	if (!surface)
 	{
 		std::cout << "RendererOpenGL::addCursor(): " << SDL_GetError() << std::endl;
 		return;
 	}
 
-	SDL_Cursor* cur = SDL_CreateColorCursor(pixels, offx, offy);
+	SDL_Cursor* cur = SDL_CreateColorCursor(surface, offx, offy);
 	if (!cur)
 	{
 		std::cout << "RendererOpenGL::addCursor(): " << SDL_GetError() << std::endl;

--- a/src/Resources/Image.cpp
+++ b/src/Resources/Image.cpp
@@ -287,7 +287,7 @@ Color Image::pixelColor(int x, int y) const
 		return Color(0, 0, 0, 255);
 	}
 
-	SDL_Surface* surface = static_cast<SDL_Surface*>(IMAGE_ID_MAP[name()].pixels);
+	SDL_Surface* surface = IMAGE_ID_MAP[name()].pixels;
 
 	if (!surface) { throw image_null_data(); }
 
@@ -373,7 +373,7 @@ void updateImageReferenceCount(const std::string& name)
 
 		if (it->second.pixels != nullptr)
 		{
-			SDL_FreeSurface(static_cast<SDL_Surface*>(it->second.pixels));
+			SDL_FreeSurface(it->second.pixels);
 			it->second.pixels = nullptr;
 		}
 

--- a/src/Resources/Image.cpp
+++ b/src/Resources/Image.cpp
@@ -113,7 +113,7 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) : Resource(
 	IMAGE_ID_MAP[name()].w = width;
 	IMAGE_ID_MAP[name()].h = height;
 	IMAGE_ID_MAP[name()].ref_count++;
-	IMAGE_ID_MAP[name()].pixels = surface;
+	IMAGE_ID_MAP[name()].surface = surface;
 }
 
 
@@ -212,7 +212,7 @@ void Image::load()
 	IMAGE_ID_MAP[name()].h = height();
 	IMAGE_ID_MAP[name()].ref_count++;
 
-	IMAGE_ID_MAP[name()].pixels = surface;
+	IMAGE_ID_MAP[name()].surface = surface;
 
 	loaded(true);
 }
@@ -287,7 +287,7 @@ Color Image::pixelColor(int x, int y) const
 		return Color(0, 0, 0, 255);
 	}
 
-	SDL_Surface* surface = IMAGE_ID_MAP[name()].pixels;
+	SDL_Surface* surface = IMAGE_ID_MAP[name()].surface;
 
 	if (!surface) { throw image_null_data(); }
 
@@ -371,10 +371,10 @@ void updateImageReferenceCount(const std::string& name)
 			glDeleteFramebuffers(1, &it->second.fbo_id);
 		}
 
-		if (it->second.pixels != nullptr)
+		if (it->second.surface != nullptr)
 		{
-			SDL_FreeSurface(it->second.pixels);
-			it->second.pixels = nullptr;
+			SDL_FreeSurface(it->second.surface);
+			it->second.surface = nullptr;
 		}
 
 		IMAGE_ID_MAP.erase(it);


### PR DESCRIPTION
Reafactor `Image` and `ImageInfo` to make the code a little easier to understand.

I was originally going to update the old C-style casts in `Image::pixelColor`, but ended up leaving that out of this change set. That will come in a followup change. (The casting between types of different size is causing pointer alignment warnings when compiled with `-Wcast-align`).
