### PR TITLE
Replace uses of `string_format` with `std::to_string`

### DIFF
--- a/src/Resources/Font.cpp
+++ b/src/Resources/Font.cpp
@@ -71,7 +71,7 @@ unsigned nextPowerOf2(unsigned n)
 NAS2D::Font::Font(const std::string& filePath, int ptSize) :	Resource(filePath)
 {
 	loaded(::load(name(), ptSize));
-	name(name() + string_format("_%ipt", ptSize));
+	name(name() + "_" + std::to_string(ptSize) + "pt");
 }
 
 
@@ -232,7 +232,7 @@ int NAS2D::Font::ptSize() const
  */
 bool load(const std::string& path, unsigned int ptSize)
 {
-	std::string fontname = path + string_format("_%ipt", ptSize);
+	std::string fontname = path + "_" + std::to_string(ptSize) + "pt";
 	if (fontAlreadyLoaded(fontname))
 	{
 		++FONTMAP[fontname].ref_count;
@@ -301,12 +301,12 @@ bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int gl
 
 	if (glyphMap->w / GLYPH_MATRIX_SIZE != glyphWidth)
 	{
-		throw font_invalid_glyph_map(string_format("image width is %i, expected %i.", glyphMap->w, glyphWidth * GLYPH_MATRIX_SIZE));
+		throw font_invalid_glyph_map("image width is " + std::to_string(glyphMap->w) + ", expected " + std::to_string(glyphWidth * GLYPH_MATRIX_SIZE) + ".");
 	}
 
 	if (glyphMap->h / GLYPH_MATRIX_SIZE != glyphHeight)
 	{
-		throw font_invalid_glyph_map(string_format("image height is %i, expected %i.", glyphMap->h, glyphHeight * GLYPH_MATRIX_SIZE));
+		throw font_invalid_glyph_map("image height is " + std::to_string(glyphMap->h) + ", expected " + std::to_string(glyphHeight * GLYPH_MATRIX_SIZE) + ".");
 	}
 
 	GlyphMetricsList& glm = FONTMAP[path].metrics;

--- a/src/Resources/Image.cpp
+++ b/src/Resources/Image.cpp
@@ -69,7 +69,7 @@ Image::Image() : Resource(DEFAULT_IMAGE_NAME)
  */
 Image::Image(int width, int height) : Resource(ARBITRARY_IMAGE_NAME)
 {
-	name(string_format("%s%i", ARBITRARY_IMAGE_NAME.c_str(), ++IMAGE_ARBITRARY));
+	name(ARBITRARY_IMAGE_NAME + std::to_string(++IMAGE_ARBITRARY));
 	_size = Vector<int>{width, height};
 
 	// Update resource management.
@@ -100,7 +100,7 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) : Resource(
 		throw image_unsupported_bit_depth();
 	}
 
-	name(string_format("%s%i", ARBITRARY_IMAGE_NAME.c_str(), ++IMAGE_ARBITRARY));
+	name(ARBITRARY_IMAGE_NAME + std::to_string(++IMAGE_ARBITRARY));
 
 	SDL_Surface* surface = SDL_CreateRGBSurfaceFrom(buffer, width, height, bytesPerPixel * 4, 0, 0, 0, 0, SDL_BYTEORDER == SDL_BIG_ENDIAN ? 0x000000FF : 0xFF000000);
 


### PR DESCRIPTION
Using `std::to_string` is a type safe alternative that avoids the risk of a format string not matching the number or types of arguments passed.

Reference: #507

I've deferred on removing the `string_format` function and associated unit tests. Given the safety concerns for format strings, we should probably remove the function, though I'll wait until we've had that discussion first.

Edit: The `-Wformat-nonliteral` flag was not enabled here, as the current unit test code for the `string_format` function would trigger warnings.
