### PR TITLE
Fix cast alignment warning

### DIFF
--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS_EXTRA) -Iinclude/
-CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 -Wall -Wpedantic -Wzero-as-null-pointer-constant $(shell sdl2-config --cflags)
+CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 -Wall -Wpedantic -Wzero-as-null-pointer-constant -Wcast-align $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA)
 LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
 

--- a/src/Resources/Image.cpp
+++ b/src/Resources/Image.cpp
@@ -295,20 +295,20 @@ Color Image::pixelColor(int x, int y) const
 	uint8_t bytesPerPixel = surface->format->BytesPerPixel;
 	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + static_cast<std::size_t>(y) * surface->pitch + static_cast<std::size_t>(x) * bytesPerPixel;
 
-	unsigned int c = 0;
+	unsigned int pixelBytes = 0;
 
 	switch (bytesPerPixel)
 	{
 	case 1:
 	{
 		auto p = reinterpret_cast<uint8_t*>(pixelPtr);
-		c = *p;
+		pixelBytes = *p;
 		break;
 	}
 	case 2:
 	{
 		auto p = reinterpret_cast<uint16_t*>(pixelPtr);
-		c = *p;
+		pixelBytes = *p;
 		break;
 	}
 	case 3:
@@ -316,18 +316,18 @@ Color Image::pixelColor(int x, int y) const
 		auto p = reinterpret_cast<uint8_t*>(pixelPtr);
 		if constexpr (SDL_BYTEORDER == SDL_BIG_ENDIAN)
 		{
-			c = p[0] << 16 | p[1] << 8 | p[2];
+			pixelBytes = p[0] << 16 | p[1] << 8 | p[2];
 		}
 		else
 		{
-			c = p[0] | p[1] << 8 | p[2] << 16;
+			pixelBytes = p[0] | p[1] << 8 | p[2] << 16;
 		}
 		break;
 	}
 	case 4:
 	{
 		auto p = reinterpret_cast<uint32_t*>(pixelPtr);
-		c = *p;
+		pixelBytes = *p;
 		break;
 	}
 	default:	// Should never be possible.
@@ -336,7 +336,7 @@ Color Image::pixelColor(int x, int y) const
 	}
 
 	uint8_t r, g, b, a;
-	SDL_GetRGBA(c, surface->format, &r, &g, &b, &a);
+	SDL_GetRGBA(pixelBytes, surface->format, &r, &g, &b, &a);
 	SDL_UnlockSurface(surface);
 
 	return Color(r, g, b, a);

--- a/src/Resources/Image.cpp
+++ b/src/Resources/Image.cpp
@@ -293,21 +293,27 @@ Color Image::pixelColor(int x, int y) const
 
 	SDL_LockSurface(surface);
 	uint8_t bpp = surface->format->BytesPerPixel;
-	uint8_t* p = (uint8_t*)surface->pixels + static_cast<std::size_t>(y) * surface->pitch + static_cast<std::size_t>(x) * bpp;
+	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + static_cast<std::size_t>(y) * surface->pitch + static_cast<std::size_t>(x) * bpp;
 
 	unsigned int c = 0;
 
 	switch (bpp)
 	{
 	case 1:
+	{
+		auto p = reinterpret_cast<uint8_t*>(pixelPtr);
 		c = *p;
 		break;
-
+	}
 	case 2:
-		c = *(uint16_t*)p;
+	{
+		auto p = reinterpret_cast<uint16_t*>(pixelPtr);
+		c = *p;
 		break;
-
+	}
 	case 3:
+	{
+		auto p = reinterpret_cast<uint8_t*>(pixelPtr);
 		if constexpr (SDL_BYTEORDER == SDL_BIG_ENDIAN)
 		{
 			c = p[0] << 16 | p[1] << 8 | p[2];
@@ -317,11 +323,13 @@ Color Image::pixelColor(int x, int y) const
 			c = p[0] | p[1] << 8 | p[2] << 16;
 		}
 		break;
-
+	}
 	case 4:
-		c = *(uint32_t*)p;
+	{
+		auto p = reinterpret_cast<uint32_t*>(pixelPtr);
+		c = *p;
 		break;
-
+	}
 	default:	// Should never be possible.
 		throw image_bad_data();
 		break;

--- a/src/Resources/Image.cpp
+++ b/src/Resources/Image.cpp
@@ -292,12 +292,12 @@ Color Image::pixelColor(int x, int y) const
 	if (!surface) { throw image_null_data(); }
 
 	SDL_LockSurface(surface);
-	uint8_t bpp = surface->format->BytesPerPixel;
-	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + static_cast<std::size_t>(y) * surface->pitch + static_cast<std::size_t>(x) * bpp;
+	uint8_t bytesPerPixel = surface->format->BytesPerPixel;
+	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + static_cast<std::size_t>(y) * surface->pitch + static_cast<std::size_t>(x) * bytesPerPixel;
 
 	unsigned int c = 0;
 
-	switch (bpp)
+	switch (bytesPerPixel)
 	{
 	case 1:
 	{


### PR DESCRIPTION
Closes #509

Removes old C-style casts, fixes pointer cast alignment warning, and enables warning `-Wcast-align`.

Extra braces were added to allow for block scoped variable definitions.
