### PR TITLE
Integer roundUpPowerOf2

### DIFF
--- a/include/NAS2D/MathUtils.h
+++ b/include/NAS2D/MathUtils.h
@@ -24,6 +24,7 @@ namespace NAS2D
 
 	int divideUp(int to_divide, int divisor);
 
+	uint32_t roundUpPowerOf2(uint32_t number);
 
 /**
  * \fn OutputType scaleLinear(const InputType& a, const OutputType& b)

--- a/src/MathUtils.cpp
+++ b/src/MathUtils.cpp
@@ -28,3 +28,21 @@ int NAS2D::divideUp(int to_divide, int divisor)
 	}
 	return (to_divide + (divisor - 1)) / divisor;
 }
+
+/**
+ * Rounds a number up to a power of 2
+ *
+ * Domain: 1 .. 2^31
+ * Values outside the domain may map to 0 (which is not a power of 2)
+ * Note: 0 is outside the domain
+ */
+uint32_t NAS2D::roundUpPowerOf2(uint32_t number)
+{
+	--number;
+	number |= number >> 1;
+	number |= number >> 2;
+	number |= number >> 4;
+	number |= number >> 8;
+	number |= number >> 16;
+	return ++number;
+}

--- a/src/MathUtils.cpp
+++ b/src/MathUtils.cpp
@@ -11,6 +11,8 @@
 #include <stdexcept>
 
 
+namespace NAS2D {
+
 /**
  * \fn int divideUp(int a, int b)
  *
@@ -21,7 +23,7 @@
  *
  * \return	Returns the divided number rounded up to the nearest whole number.
  */
-int NAS2D::divideUp(int to_divide, int divisor)
+int divideUp(int to_divide, int divisor)
 {
 	if (divisor == 0) {
 		throw std::domain_error("Division by zero: divideUp(to_divide, 0)");
@@ -36,7 +38,7 @@ int NAS2D::divideUp(int to_divide, int divisor)
  * Values outside the domain may map to 0 (which is not a power of 2)
  * Note: 0 is outside the domain
  */
-uint32_t NAS2D::roundUpPowerOf2(uint32_t number)
+uint32_t roundUpPowerOf2(uint32_t number)
 {
 	--number;
 	number |= number >> 1;
@@ -46,3 +48,5 @@ uint32_t NAS2D::roundUpPowerOf2(uint32_t number)
 	number |= number >> 16;
 	return ++number;
 }
+
+} // namespace

--- a/src/Resources/Font.cpp
+++ b/src/Resources/Font.cpp
@@ -13,6 +13,7 @@
 #include "NAS2D/Exception.h"
 #include "NAS2D/Filesystem.h"
 #include "NAS2D/Utility.h"
+#include "NAS2D/MathUtils.h"
 
 #include <GL/glew.h>
 
@@ -379,7 +380,7 @@ Point_2d generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int fo
 		glm.push_back(metrics);
 	}
 
-	Point_2d size(nextPowerOf2(largest_width), nextPowerOf2(largest_width));
+	Point_2d size(roundUpPowerOf2(largest_width), roundUpPowerOf2(largest_width));
 	int textureSize = size.x() * GLYPH_MATRIX_SIZE;
 
 	unsigned int rmask = 0, gmask = 0, bmask = 0, amask = 0;

--- a/src/Resources/Font.cpp
+++ b/src/Resources/Font.cpp
@@ -56,12 +56,6 @@ void setupMasks(unsigned int& rmask, unsigned int& gmask, unsigned int& bmask, u
 void updateFontReferenceCount(const std::string& name);
 
 
-unsigned nextPowerOf2(unsigned n)
-{
-	return (unsigned)pow(2, ceil(log((float)n) / log(2.0f)));
-}
-
-
 /**
  * Instantiate a Font using a TrueType or OpenType font.
  *

--- a/test/MathUtils.test.cpp
+++ b/test/MathUtils.test.cpp
@@ -38,6 +38,45 @@ TEST(MathUtils, divideUp)
 	EXPECT_EQ(20, NAS2D::divideUp(256, 13));
 }
 
+TEST(MathUtils, roundUpPowerOf2)
+{
+	EXPECT_EQ(1, NAS2D::roundUpPowerOf2(1));
+	EXPECT_EQ(2, NAS2D::roundUpPowerOf2(2));
+	EXPECT_EQ(4, NAS2D::roundUpPowerOf2(3));
+	EXPECT_EQ(4, NAS2D::roundUpPowerOf2(4));
+	EXPECT_EQ(8, NAS2D::roundUpPowerOf2(5));
+	EXPECT_EQ(8, NAS2D::roundUpPowerOf2(8));
+	EXPECT_EQ(16, NAS2D::roundUpPowerOf2(9));
+	EXPECT_EQ(16, NAS2D::roundUpPowerOf2(16));
+	EXPECT_EQ(32, NAS2D::roundUpPowerOf2(17));
+	EXPECT_EQ(32, NAS2D::roundUpPowerOf2(32));
+	EXPECT_EQ(64, NAS2D::roundUpPowerOf2(33));
+	EXPECT_EQ(64, NAS2D::roundUpPowerOf2(64));
+	EXPECT_EQ(128, NAS2D::roundUpPowerOf2(65));
+	EXPECT_EQ(128, NAS2D::roundUpPowerOf2(128));
+	EXPECT_EQ(256, NAS2D::roundUpPowerOf2(129));
+	EXPECT_EQ(256, NAS2D::roundUpPowerOf2(256));
+	EXPECT_EQ(512, NAS2D::roundUpPowerOf2(257));
+	EXPECT_EQ(512, NAS2D::roundUpPowerOf2(512));
+	EXPECT_EQ(1024, NAS2D::roundUpPowerOf2(513));
+	EXPECT_EQ(1024, NAS2D::roundUpPowerOf2(1024));
+	EXPECT_EQ(2048, NAS2D::roundUpPowerOf2(1025));
+	EXPECT_EQ(2048, NAS2D::roundUpPowerOf2(2048));
+	EXPECT_EQ(4096, NAS2D::roundUpPowerOf2(2049));
+	EXPECT_EQ(4096, NAS2D::roundUpPowerOf2(4096));
+
+	EXPECT_EQ(32768, NAS2D::roundUpPowerOf2(32768));
+	EXPECT_EQ(65536, NAS2D::roundUpPowerOf2(32769));
+	EXPECT_EQ(65536, NAS2D::roundUpPowerOf2(65536));
+
+	EXPECT_EQ(8388608, NAS2D::roundUpPowerOf2(8388608));
+	EXPECT_EQ(16777216, NAS2D::roundUpPowerOf2(8388609));
+	EXPECT_EQ(16777216, NAS2D::roundUpPowerOf2(16777216));
+
+	// Largest value before 32-bit overflow of result
+	EXPECT_EQ(2147483648, NAS2D::roundUpPowerOf2(2147483648));
+}
+
 TEST(MathUtils, mapDomainToRange)
 {
 	// Fahrenheit to Celcius


### PR DESCRIPTION
Fixes one of the warnings from #510.

Provides an integer based method to round up to a power of 2 (next, or current if already a power of 2).

Using an integer based method avoids the cost of type conversions, and heavy floating point math operations. It also avoids the potential for rounding errors associated with floating point.

References:
[StackOverflow: Rounding up to next power of 2](https://stackoverflow.com/questions/466204/rounding-up-to-next-power-of-2)
[Bit Twiddling Hacks: Round up to the next highest power of 2](https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2)
