### PR TITLE
Xml declare data where used

### DIFF
--- a/src/Xml/XmlBase.cpp
+++ b/src/Xml/XmlBase.cpp
@@ -15,24 +15,6 @@ using namespace NAS2D::Xml;
 
 bool XmlBase::condenseWhiteSpace = true;
 
-const std::vector<std::string> XML_ERROR_TABLE = {
-	"No error",
-	"Unspecified Error",
-	"Error parsing Element.",
-	"Failed to read Element name.",
-	"Error reading Element value.",
-	"Error reading Attributes.",
-	"Error: Empty tag.",
-	"Error reading end tag.",
-	"Error parsing Unknown.",
-	"Error parsing Comment.",
-	"Error parsing Declaration.",
-	"Error: Document empty.",
-	"Error: Unexpected EOF found in input stream.",
-	"Error parsing CDATA.",
-	"Error adding XmlDocument to document: XmlDocument can only be at the root.",
-};
-
 
 /**
  * Get the row of the node in the document.

--- a/src/Xml/XmlBase.cpp
+++ b/src/Xml/XmlBase.cpp
@@ -15,28 +15,23 @@ using namespace NAS2D::Xml;
 
 bool XmlBase::condenseWhiteSpace = true;
 
-std::vector<std::string> XML_ERROR_TABLE;
-
-void fillErrorTable()
-{
-	if (!XML_ERROR_TABLE.empty()) { return; }
-
-	XML_ERROR_TABLE.push_back("No error");
-	XML_ERROR_TABLE.push_back("Unspecified Error");
-	XML_ERROR_TABLE.push_back("Error parsing Element.");
-	XML_ERROR_TABLE.push_back("Failed to read Element name.");
-	XML_ERROR_TABLE.push_back("Error reading Element value.");
-	XML_ERROR_TABLE.push_back("Error reading Attributes.");
-	XML_ERROR_TABLE.push_back("Error: Empty tag.");
-	XML_ERROR_TABLE.push_back("Error reading end tag.");
-	XML_ERROR_TABLE.push_back("Error parsing Unknown.");
-	XML_ERROR_TABLE.push_back("Error parsing Comment.");
-	XML_ERROR_TABLE.push_back("Error parsing Declaration.");
-	XML_ERROR_TABLE.push_back("Error: Document empty.");
-	XML_ERROR_TABLE.push_back("Error: Unexpected EOF found in input stream.");
-	XML_ERROR_TABLE.push_back("Error parsing CDATA.");
-	XML_ERROR_TABLE.push_back("Error adding XmlDocument to document: XmlDocument can only be at the root.");
-}
+const std::vector<std::string> XML_ERROR_TABLE = {
+	"No error",
+	"Unspecified Error",
+	"Error parsing Element.",
+	"Failed to read Element name.",
+	"Error reading Element value.",
+	"Error reading Attributes.",
+	"Error: Empty tag.",
+	"Error reading end tag.",
+	"Error parsing Unknown.",
+	"Error parsing Comment.",
+	"Error parsing Declaration.",
+	"Error: Document empty.",
+	"Error: Unexpected EOF found in input stream.",
+	"Error parsing CDATA.",
+	"Error adding XmlDocument to document: XmlDocument can only be at the root.",
+};
 
 
 /**

--- a/src/Xml/XmlParser.cpp
+++ b/src/Xml/XmlParser.cpp
@@ -50,7 +50,24 @@
 #	endif
 #endif
 
-extern std::vector<std::string> XML_ERROR_TABLE;
+const std::vector<std::string> XML_ERROR_TABLE = {
+	"No error",
+	"Unspecified Error",
+	"Error parsing Element.",
+	"Failed to read Element name.",
+	"Error reading Element value.",
+	"Error reading Attributes.",
+	"Error: Empty tag.",
+	"Error reading end tag.",
+	"Error parsing Unknown.",
+	"Error parsing Comment.",
+	"Error parsing Declaration.",
+	"Error: Document empty.",
+	"Error: Unexpected EOF found in input stream.",
+	"Error parsing CDATA.",
+	"Error adding XmlDocument to document: XmlDocument can only be at the root.",
+};
+
 
 namespace NAS2D {
 namespace Xml {

--- a/src/Xml/XmlParser.cpp
+++ b/src/Xml/XmlParser.cpp
@@ -51,7 +51,6 @@
 #endif
 
 extern std::vector<std::string> XML_ERROR_TABLE;
-extern void fillErrorTable();
 
 namespace NAS2D {
 namespace Xml {
@@ -654,11 +653,6 @@ void XmlDocument::error(XmlErrorCode err, const char* pError, void* data)
 	if (_error)
 	{
 		return;
-	}
-
-	if (XML_ERROR_TABLE.empty())
-	{
-		fillErrorTable();
 	}
 
 	assert(XmlErrorCode::XML_NO_ERROR < err && err < XmlErrorCode::XML_ERROR_STRING_COUNT);


### PR DESCRIPTION
Fixes one of the warnings from #510.

It seems the XML code was using a string data table from the parser, but for some odd reason the table was created in the `XmlBase` file, where it wasn't used.

Doing early initialization of the string table using the constructor seems more straightforward. One small downside is the table will always be initialized, whether it is used or not.

With C++20, it may be possible to do the initialization at compile time. Of course, by then, we may remove the XML code from direct inclusion in this library, so none of this will matter.
