### PR TITLE
Wrap private file level method in anonymous namespace

### DIFF
--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -23,10 +23,12 @@ const string NAS2D::SPRITE_VERSION("0.99");
 const int FRAME_PAUSE = -1;
 
 
-// Adds a row/name tag to the end of messages.
-string endTag(int row, const std::string& name)
-{
-	return " (Row: " + std::to_string(row) + ", " + name + ")";
+namespace {
+	// Adds a row/name tag to the end of messages.
+	string endTag(int row, const std::string& name)
+	{
+		return " (Row: " + std::to_string(row) + ", " + name + ")";
+	}
 }
 
 


### PR DESCRIPTION
Fix one of the warnings from #510.

The `endTag` method is a private file level helper function (non-class member). It is not meant to be shared with other translation units. As such, it can be wrapped in an anonymous namespace to protect it from being accessed from other translation units.

From the [GCC Warnings](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html) page under `-Wmissing-declarations`:

> Warn if a global function is defined without a previous declaration. Do so even if the definition itself provides a prototype. Use this option to detect global functions that are not declared in header files. In C, no warnings are issued for functions with previous non-prototype declarations; use -Wmissing-prototypes to detect missing prototypes. In C++, no warnings are issued for function templates, or for inline functions, or for functions in anonymous namespaces.