### PR TITLE
Add angleToDirection method

### DIFF
--- a/include/NAS2D/Trig.h
+++ b/include/NAS2D/Trig.h
@@ -24,8 +24,6 @@ float degToRad(float degree);
 float radToDeg(float rad);
 float angleFromPoints(float x, float y, float x2, float y2);
 Vector<float> angleToDirection(float angle);
-[[deprecated("Please use angleToDirection instead")]]
-Point_2df getDirectionVector(float angle);
 
 bool lineIntersectsCircle(const Point_2d& p, const Point_2d& q, const Point_2d& c, float r);
 

--- a/include/NAS2D/Trig.h
+++ b/include/NAS2D/Trig.h
@@ -24,6 +24,7 @@ float degToRad(float degree);
 float radToDeg(float rad);
 float angleFromPoints(float x, float y, float x2, float y2);
 Vector<float> angleToDirection(float angle);
+[[deprecated("Please use angleToDirection instead")]]
 Point_2df getDirectionVector(float angle);
 
 bool lineIntersectsCircle(const Point_2d& p, const Point_2d& q, const Point_2d& c, float r);

--- a/include/NAS2D/Trig.h
+++ b/include/NAS2D/Trig.h
@@ -23,6 +23,7 @@ extern const float RAD2DEG;
 float degToRad(float degree);
 float radToDeg(float rad);
 float angleFromPoints(float x, float y, float x2, float y2);
+Vector<float> angleToDirection(float angle);
 Point_2df getDirectionVector(float angle);
 
 bool lineIntersectsCircle(const Point_2d& p, const Point_2d& q, const Point_2d& c, float r);

--- a/src/Trig.cpp
+++ b/src/Trig.cpp
@@ -54,6 +54,17 @@ float NAS2D::angleFromPoints(float x, float y, float x2, float y2)
 /**
  * Gets a directional vector from an angle in degrees.
  */
+Vector<float> angleToDirection(float angle)
+{
+	// static_cast<float> used to suppress warning at possible loss of data. Intentionally
+	// surpressed as we don't need that level of precision.
+	return {static_cast<float>(std::sin(NAS2D::degToRad(angle))), static_cast<float>(-std::cos(NAS2D::degToRad(angle)))};
+}
+
+
+/**
+ * Gets a directional vector from an angle in degrees.
+ */
 Point_2df NAS2D::getDirectionVector(float angle)
 {
 	// static_cast<float> used to suppress warning at possible loss of data. Intentionally

--- a/src/Trig.cpp
+++ b/src/Trig.cpp
@@ -54,7 +54,7 @@ float NAS2D::angleFromPoints(float x, float y, float x2, float y2)
 /**
  * Gets a directional vector from an angle in degrees.
  */
-Vector<float> angleToDirection(float angle)
+Vector<float> NAS2D::angleToDirection(float angle)
 {
 	// static_cast<float> used to suppress warning at possible loss of data. Intentionally
 	// surpressed as we don't need that level of precision.

--- a/src/Trig.cpp
+++ b/src/Trig.cpp
@@ -59,15 +59,6 @@ Vector<float> NAS2D::angleToDirection(float angle)
 
 
 /**
- * Gets a directional vector from an angle in degrees.
- */
-Point_2df NAS2D::getDirectionVector(float angle)
-{
-	return Point_2df(std::sin(NAS2D::degToRad(angle)), -std::cos(NAS2D::degToRad(angle)));
-}
-
-
-/**
  * Determines if a given line intersects a given circle.
  *
  * \param	p	First point of a line segment.

--- a/src/Trig.cpp
+++ b/src/Trig.cpp
@@ -45,9 +45,7 @@ float NAS2D::radToDeg(float rad)
  */
 float NAS2D::angleFromPoints(float x, float y, float x2, float y2)
 {
-	// static_cast<float> used to suppress warning at possible loss of data. Intentionally
-	// surpressed as we don't need that level of precision.
-	return 90.0f - radToDeg(static_cast<float>(std::atan2(y2 - y, x2 - x)));
+	return 90.0f - radToDeg(std::atan2(y2 - y, x2 - x));
 }
 
 

--- a/src/Trig.cpp
+++ b/src/Trig.cpp
@@ -56,9 +56,7 @@ float NAS2D::angleFromPoints(float x, float y, float x2, float y2)
  */
 Vector<float> NAS2D::angleToDirection(float angle)
 {
-	// static_cast<float> used to suppress warning at possible loss of data. Intentionally
-	// surpressed as we don't need that level of precision.
-	return {static_cast<float>(std::sin(NAS2D::degToRad(angle))), static_cast<float>(-std::cos(NAS2D::degToRad(angle)))};
+	return {std::sin(NAS2D::degToRad(angle)), -std::cos(NAS2D::degToRad(angle))};
 }
 
 
@@ -67,9 +65,7 @@ Vector<float> NAS2D::angleToDirection(float angle)
  */
 Point_2df NAS2D::getDirectionVector(float angle)
 {
-	// static_cast<float> used to suppress warning at possible loss of data. Intentionally
-	// surpressed as we don't need that level of precision.
-	return Point_2df(static_cast<float>(std::sin(NAS2D::degToRad(angle))), static_cast<float>(-std::cos(NAS2D::degToRad(angle))));
+	return Point_2df(std::sin(NAS2D::degToRad(angle)), -std::cos(NAS2D::degToRad(angle)));
 }
 
 


### PR DESCRIPTION
Needed to adjust a method's return type from `Point` to `Vector`:
- Add `angleToDirection` method (returns a `Vector`).
- Deprecate `getDirectionVector` method (oddly returns `Point`, as it predates the introduction of `Vector`).

I chose to deprecate rather than remove the old method so old code wouldn't immediately break. The old method is used in nas2d-tests.

Edit: I also chose to rename the method so it would describe the concept rather than the type being used. Type names should normally be kept out of identifier names (except maybe for a generic type conversion method).
