### PR TITLE
Add Color default for opaque colors

### DIFF
--- a/include/NAS2D/Renderer/Color.h
+++ b/include/NAS2D/Renderer/Color.h
@@ -39,7 +39,7 @@ public:
 	static const Color NoAlpha;
 
 	Color() = default;
-	Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+	Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
 
 public:
 	void operator()(uint8_t r, uint8_t g, uint8_t b, uint8_t a);


### PR DESCRIPTION
This allows only 3 values to be specified when constructing `Color` objects, which will default to a fully opaque color.

This may be obsoleted by switch to a struct with public fields, since the `alpha` field already defaults to `255`. Until then, it is necessary for 3 component Color construction.

Noticed this while looking into wrapping previously unpacked color component parameters.
