### PR TITLE
Add Renderer::center()

### DIFF
--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -140,6 +140,7 @@ public:
 
 	virtual void minimum_size(int w, int h) = 0;
 
+	Point<float> center();
 	float center_x();
 	float center_y();
 

--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -135,8 +135,8 @@ public:
 	virtual float width() = 0;
 	virtual float height() = 0;
 
-	virtual void size(int w, int h) = 0;
 	Vector<float> size();
+	virtual void size(int w, int h) = 0;
 
 	virtual void minimum_size(int w, int h) = 0;
 

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -507,6 +507,15 @@ Vector<float> Renderer::size()
 
 
 /**
+ * Gets the center coordinates of the screen.
+ */
+Point<float> Renderer::center()
+{
+	return Point<float>{} + mResolution / 2;
+}
+
+
+/**
  * Gets the center X-Coordinate of the screen.
  */
 float Renderer::center_x()

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -498,7 +498,7 @@ void NAS2D::Renderer::drawTextShadow(Font& font, const std::string& text, Point<
 }
 
 /**
- * Gets the current screen resolution as a Point_2df.
+ * Gets the current screen resolution as a Vector.
  */
 Vector<float> Renderer::size()
 {


### PR DESCRIPTION
Add `Renderer::center()` method, returning packed coordinates.

The origin is added using `Point{}` to convert the result from `Vector` to `Point`.
