### PR TITLE
Refactor Sprite::skip

### DIFF
--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -49,7 +49,7 @@ public:
 	void pause();
 	void resume();
 
-	void skip(int frames);
+	void skip(int frameCount);
 
 	void update(Point<float> position);
 	void update(float x, float y);

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -112,12 +112,10 @@ void Sprite::resume()
  */
 void Sprite::skip(int frames)
 {
-	if (mActions.find(mCurrentAction) == mActions.end())
+	if (mActions.find(mCurrentAction) != mActions.end())
 	{
-		return;
+		mCurrentFrame = frames % mActions[mCurrentAction].size();
 	}
-
-	mCurrentFrame = frames % mActions[mCurrentAction].size();
 }
 
 

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -108,13 +108,13 @@ void Sprite::resume()
 /**
  * Skips animation playback frames.
  *
- * \param	frames	Number of frames to skip.
+ * \param	frameCount	Number of frames to skip.
  */
-void Sprite::skip(int frames)
+void Sprite::skip(int frameCount)
 {
 	if (mActions.find(mCurrentAction) != mActions.end())
 	{
-		mCurrentFrame = frames % mActions[mCurrentAction].size();
+		mCurrentFrame = frameCount % mActions[mCurrentAction].size();
 	}
 }
 

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -112,7 +112,7 @@ void Sprite::resume()
  */
 void Sprite::skip(int frames)
 {
-	if (mActions.find(toLowercase(mCurrentAction)) == mActions.end())
+	if (mActions.find(mCurrentAction) == mActions.end())
 	{
 		return;
 	}


### PR DESCRIPTION
Refactor `Sprite::skip`.

----

I noticed #523 while working on this. I wanted to keep refactoring separate from implementation change, hence the separate issue.

----

There's probably more that can be done with this method, such as avoiding the double lookup (both `find` and `operator[]`). The result is surprisingly ugly though, using currently available standard library methods. The `find` method returns an iterator, which dereferences to a `std::pair`. The result is just too ugly. I thought I would defer on changing that part for now.

More long term, I wonder if we should use a `std::vector` rather than a `std::map`, and move the name lookup outside of this code. Rather than specify actions by named string, we should perhaps be specifying them by numerical index. The string to index lookup can be done ahead of time during file loading, caching the results. Might need a separate issue to track this idea.
