### PR TITLE
Remove Trig static_cast

### DIFF
--- a/src/Trig.cpp
+++ b/src/Trig.cpp
@@ -45,9 +45,7 @@ float NAS2D::radToDeg(float rad)
  */
 float NAS2D::angleFromPoints(float x, float y, float x2, float y2)
 {
-	// static_cast<float> used to suppress warning at possible loss of data. Intentionally
-	// surpressed as we don't need that level of precision.
-	return 90.0f - radToDeg(static_cast<float>(std::atan2(y2 - y, x2 - x)));
+	return 90.0f - radToDeg(std::atan2(y2 - y, x2 - x));
 }
 
 

--- a/src/Trig.cpp
+++ b/src/Trig.cpp
@@ -56,9 +56,7 @@ float NAS2D::angleFromPoints(float x, float y, float x2, float y2)
  */
 Point_2df NAS2D::getDirectionVector(float angle)
 {
-	// static_cast<float> used to suppress warning at possible loss of data. Intentionally
-	// surpressed as we don't need that level of precision.
-	return Point_2df(static_cast<float>(std::sin(NAS2D::degToRad(angle))), static_cast<float>(-std::cos(NAS2D::degToRad(angle))));
+	return Point_2df(std::sin(NAS2D::degToRad(angle)), -std::cos(NAS2D::degToRad(angle)));
 }
 
 


### PR DESCRIPTION
Cherry-picked from #516.

At the very least, we should remove the `static_cast`s, which are no longer needed since C++11.
