### PR TITLE
Change `getDirectionVector` to return a `Vector`

### DIFF
--- a/include/NAS2D/Trig.h
+++ b/include/NAS2D/Trig.h
@@ -23,7 +23,7 @@ extern const float RAD2DEG;
 float degToRad(float degree);
 float radToDeg(float rad);
 float angleFromPoints(float x, float y, float x2, float y2);
-Point_2df getDirectionVector(float angle);
+Vector<float> getDirectionVector(float angle);
 
 bool lineIntersectsCircle(const Point_2d& p, const Point_2d& q, const Point_2d& c, float r);
 

--- a/src/Trig.cpp
+++ b/src/Trig.cpp
@@ -52,9 +52,9 @@ float NAS2D::angleFromPoints(float x, float y, float x2, float y2)
 /**
  * Gets a directional vector from an angle in degrees.
  */
-Point_2df NAS2D::getDirectionVector(float angle)
+Vector<float> NAS2D::getDirectionVector(float angle)
 {
-	return Point_2df(std::sin(NAS2D::degToRad(angle)), -std::cos(NAS2D::degToRad(angle)));
+	return {std::sin(NAS2D::degToRad(angle)), -std::cos(NAS2D::degToRad(angle))};
 }
 
 


### PR DESCRIPTION
Change `getDirectionVector` to return a `Vector`. This makes the name less confusing, and makes the results more useful, as a `Vector` can be scaled and added.

The original `getDirectionVector` function predates the addition of `Vector` as a separate type from Point.

----

This function only seems to be used in one place in nas2d-tests, so should be easy to update all calls to it when updating the NAS2D submodule.

----

Scavenged from #516.
