### PR TITLE
Specify C++ compiler for Physfs build step

### DIFF
--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -108,9 +108,9 @@ RUN curl --location https://github.com/nigels-com/glew/releases/download/glew-2.
   make -C glew-2.1.0/ SYSTEM=linux-mingw-w64 CC="${CC32}" LD="${LD32}" LDFLAGS.EXTRA=-L"/usr/${ARCH32}/lib/" GLEW_DEST="${INSTALL32}" install && \
   rm -rf glew-2.1.0/ glew.*
 RUN curl https://icculus.org/physfs/downloads/physfs-3.0.2.tar.bz2 | tar -xj && \
-  cmake -H"physfs-3.0.2/" -B"${ARCH64}" -DCMAKE_INSTALL_PREFIX="${INSTALL64}" -DCMAKE_C_COMPILER="${CC64}" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" && \
+  cmake -H"physfs-3.0.2/" -B"${ARCH64}" -DCMAKE_INSTALL_PREFIX="${INSTALL64}" -DCMAKE_CXX_COMPILER="${CXX64}" -DCMAKE_C_COMPILER="${CC64}" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" && \
   make -C "${ARCH64}" install && \
-  cmake -H"physfs-3.0.2/" -B"${ARCH32}" -DCMAKE_INSTALL_PREFIX="${INSTALL32}" -DCMAKE_C_COMPILER="${CC32}" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" && \
+  cmake -H"physfs-3.0.2/" -B"${ARCH32}" -DCMAKE_INSTALL_PREFIX="${INSTALL32}" -DCMAKE_CXX_COMPILER="${CXX32}" -DCMAKE_C_COMPILER="${CC32}" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" && \
   make -C "${ARCH32}" install && \
   rm -rf physfs-3.0.2/ "${ARCH64}" "${ARCH32}"
 


### PR DESCRIPTION
Physfs doesn't actually use a C++ compiler, however the build the can still fail if it tries to find a C++ compiler and can't find a working one. This hasn't been an issue for the build image, though if the steps are repeated in a non-docker environment, where CXX may be set to a different compiler, a failure can be observed. Although the change is not strictly required for the Docker image to work, it perhaps serves as useful documentation for anyone trying to replicate the Docker environment.

Linux only change.
