### PR TITLE
Replace C-style casts

### DIFF
--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -684,13 +684,13 @@ void RendererOpenGL::initGL()
 	// Spit out system graphics information.
 	std::cout << "\t- OpenGL System Info -" << std::endl;
 
-	driverName((char*)glGetString(GL_RENDERER));
+	driverName((const char*)glGetString(GL_RENDERER));
 
 	std::cout << "\tVendor: " << glGetString(GL_VENDOR) << std::endl;
 	std::cout << "\tRenderer: " << driverName() << std::endl;
 	std::cout << "\tDriver Version: " << glGetString(GL_VERSION) << std::endl;
 
-	std::string glsl_v = (char*)glGetString(GL_SHADING_LANGUAGE_VERSION);
+	std::string glsl_v = (const char*)glGetString(GL_SHADING_LANGUAGE_VERSION);
 	if (glsl_v.empty())
 	{
 		throw renderer_no_glsl();

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -315,7 +315,7 @@ void RendererOpenGL::drawLine(float x, float y, float x2, float y2, uint8_t r, u
 	glDisable(GL_TEXTURE_2D);
 	glEnableClientState(GL_COLOR_ARRAY);
 
-	line(x, y, x2, y2, (float)line_width, r / 255.0f, g / 255.0f, b / 255.0f, a / 255.0f);
+	line(x, y, x2, y2, static_cast<float>(line_width), r / 255.0f, g / 255.0f, b / 255.0f, a / 255.0f);
 
 	glDisableClientState(GL_COLOR_ARRAY);
 	glEnable(GL_TEXTURE_2D);
@@ -459,7 +459,7 @@ void RendererOpenGL::drawText(NAS2D::Font& font, const std::string& text, float 
 	{
 		GlyphMetrics& gm = gml[std::clamp<std::size_t>(text[i], 0, 255)];
 
-		fillVertexArray(x + offset, y, (float)font.glyphCellWidth(), (float)font.glyphCellHeight());
+		fillVertexArray(x + offset, y, static_cast<float>(font.glyphCellWidth()), static_cast<float>(font.glyphCellHeight()));
 		fillTextureArray(gm.uvX, gm.uvY, gm.uvW, gm.uvH);
 
 		drawVertexArray(FONTMAP[font.name()].texture_id, false);

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -684,13 +684,13 @@ void RendererOpenGL::initGL()
 	// Spit out system graphics information.
 	std::cout << "\t- OpenGL System Info -" << std::endl;
 
-	driverName((const char*)glGetString(GL_RENDERER));
+	driverName(reinterpret_cast<const char*>(glGetString(GL_RENDERER)));
 
 	std::cout << "\tVendor: " << glGetString(GL_VENDOR) << std::endl;
 	std::cout << "\tRenderer: " << driverName() << std::endl;
 	std::cout << "\tDriver Version: " << glGetString(GL_VERSION) << std::endl;
 
-	std::string glsl_v = (const char*)glGetString(GL_SHADING_LANGUAGE_VERSION);
+	std::string glsl_v = reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
 	if (glsl_v.empty())
 	{
 		throw renderer_no_glsl();

--- a/src/Resources/Font.cpp
+++ b/src/Resources/Font.cpp
@@ -317,10 +317,10 @@ bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int gl
 		{
 			const std::size_t glyph = (row * GLYPH_MATRIX_SIZE) + col;
 
-			glm[glyph].uvX = (float)(col * glyphWidth) / (float)glyphMap->w;
-			glm[glyph].uvY = (float)(row * glyphHeight) / (float)glyphMap->h;
-			glm[glyph].uvW = glm[glyph].uvX + (float)(glyphWidth) / (float)glyphMap->w;
-			glm[glyph].uvH = glm[glyph].uvY + (float)(glyphHeight) / (float)glyphMap->h;
+			glm[glyph].uvX = static_cast<float>(col * glyphWidth) / static_cast<float>(glyphMap->w);
+			glm[glyph].uvY = static_cast<float>(row * glyphHeight) / static_cast<float>(glyphMap->h);
+			glm[glyph].uvW = glm[glyph].uvX + static_cast<float>(glyphWidth) / static_cast<float>(glyphMap->w);
+			glm[glyph].uvH = glm[glyph].uvY + static_cast<float>(glyphHeight) / static_cast<float>(glyphMap->h);
 			glm[glyph].advance = glyphSpace;
 		}
 	}
@@ -389,10 +389,10 @@ Point_2d generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int fo
 		{
 			int glyph = (row * GLYPH_MATRIX_SIZE) + col;
 
-			glm[glyph].uvX = (float)(col * size.x()) / (float)textureSize;
-			glm[glyph].uvY = (float)(row * size.y()) / (float)textureSize;
-			glm[glyph].uvW = glm[glyph].uvX + (float)(size.x()) / (float)textureSize;
-			glm[glyph].uvH = glm[glyph].uvY + (float)(size.y()) / (float)textureSize;
+			glm[glyph].uvX = static_cast<float>(col * size.x()) / static_cast<float>(textureSize);
+			glm[glyph].uvY = static_cast<float>(row * size.y()) / static_cast<float>(textureSize);
+			glm[glyph].uvW = glm[glyph].uvX + static_cast<float>(size.x()) / static_cast<float>(textureSize);
+			glm[glyph].uvH = glm[glyph].uvY + static_cast<float>(size.y()) / static_cast<float>(textureSize);
 
 			// HACK HACK HACK!
 			// Apparently glyph zero has no size with some fonts and so SDL_TTF complains about it.

--- a/src/Xml/XmlParser.cpp
+++ b/src/Xml/XmlParser.cpp
@@ -275,10 +275,10 @@ const char* XmlBase::readName(const char* p, std::string& name)
 	// After that, they can be letters, underscores, numbers, hyphens,
 	// or colons. (Colons are valid ony for namespaces, but tinyxml can't
 	// tell namespaces from names.)
-	if (p && *p && (isAlpha((unsigned char)*p) || *p == '_'))
+	if (p && *p && (isAlpha(static_cast<unsigned char>(*p)) || *p == '_'))
 	{
 		const char* start = p;
-		while (p && *p && (isAlphaNum((unsigned char)*p)
+		while (p && *p && (isAlphaNum(static_cast<unsigned char>(*p))
 			|| *p == '_'
 			|| *p == '-'
 			|| *p == '.'
@@ -368,7 +368,7 @@ const char* XmlBase::getEntity(const char* p, char* value, int* length)
 			}
 		}
 
-		*value = (char)ucs;
+		*value = static_cast<char>(ucs);
 		*length = 1;
 
 		return p + delta + 1;
@@ -565,7 +565,7 @@ void XmlDocument::streamIn(std::istream& in, std::string& tag)
 
 	while (in.good())
 	{
-		int tagIndex = (int)tag.length();
+		int tagIndex = static_cast<int>(tag.length());
 		while (in.good() && in.peek() != '>')
 		{
 			int c = in.get();
@@ -827,7 +827,7 @@ void XmlElement::streamIn(std::istream & in, std::string & tag)
 
 			assert(in.peek() == '<');
 
-			int tagIndex = (int)tag.length();
+			int tagIndex = static_cast<int>(tag.length());
 
 			bool closingTag = false;
 			bool firstCharFound = false;

--- a/src/Xml/XmlParser.cpp
+++ b/src/Xml/XmlParser.cpp
@@ -145,7 +145,7 @@ void XmlParsingData::stamp(const char* now)
 	while (p < now)
 	{
 		// Treat p as unsigned, so we have a happy compiler.
-		const unsigned char* pU = (const unsigned char*)p;
+		const unsigned char* pU = reinterpret_cast<const unsigned char*>(p);
 
 		// Code contributed by Fletcher Dunn: (modified by lee)
 		switch (*pU)


### PR DESCRIPTION
Reference: #528 (`-Wold-style-cast`)

Replaces old C-style casts with `static_cast` or `reinterpret_cast`.
