### PR TITLE
Rename parameter to not shadow member variable

### DIFF
--- a/include/NAS2D/Xml/XmlComment.h
+++ b/include/NAS2D/Xml/XmlComment.h
@@ -24,7 +24,7 @@ class XmlComment : public XmlNode
 public:
 	XmlComment();
 
-	explicit XmlComment(const std::string& _value);
+	explicit XmlComment(const std::string& commentValue);
 	XmlComment(const XmlComment& copy);
 	XmlComment& operator=(const XmlComment& base);
 

--- a/src/Xml/XmlComment.cpp
+++ b/src/Xml/XmlComment.cpp
@@ -27,9 +27,9 @@ XmlComment::XmlComment() : XmlNode(XmlNode::NodeType::XML_COMMENT)
  *
  * \param	_value	Reference to a \c std::string with the value to use for the comment.
  */
-XmlComment::XmlComment(const std::string& _value) : XmlNode(XmlNode::NodeType::XML_COMMENT)
+XmlComment::XmlComment(const std::string& commentValue) : XmlNode(XmlNode::NodeType::XML_COMMENT)
 {
-	value(_value);
+	value(commentValue);
 }
 
 


### PR DESCRIPTION
Reference: #528.

Fixes warning flagged by `-Wshadow-field`.

The `XmlComment` class already has a `_value` member (inherited from `XmlNode`), and a `value` method (inherited from `XmlNode`). Neither name should be used for the parameter.
