### PR TITLE
Renderer member function const-correctness

### DIFF
--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -45,9 +45,9 @@ public:
 	virtual DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const = 0;
 	virtual Vector<int> getWindowClientArea() const noexcept = 0;
 
-	const std::string& driverName();
+	const std::string& driverName() const;
 
-	const std::string& title();
+	const std::string& title() const;
 	void title(const std::string& title);
 
 	virtual void window_icon(const std::string& path) = 0;
@@ -132,27 +132,27 @@ public:
 	void clearScreen(const Color& color);
 	virtual void clearScreen(uint8_t r, uint8_t g, uint8_t b) = 0;
 
-	virtual float width() = 0;
-	virtual float height() = 0;
+	virtual float width() const = 0;
+	virtual float height() const = 0;
 
-	Vector<float> size();
+	Vector<float> size() const;
 	virtual void size(int w, int h) = 0;
 
 	virtual void minimum_size(int w, int h) = 0;
 
-	Point<float> center();
-	float center_x();
-	float center_y();
+	Point<float> center() const;
+	float center_x() const;
+	float center_y() const;
 
 	void clipRect(const Rectangle_2df& rect);
 	void clipRectClear();
 	virtual void clipRect(float x, float y, float width, float height) = 0;
 
 	virtual void fullscreen(bool fs, bool maintain = false) = 0;
-	virtual bool fullscreen() = 0;
+	virtual bool fullscreen() const = 0;
 
 	virtual void resizeable(bool _r) = 0;
-	virtual bool resizeable() = 0;
+	virtual bool resizeable() const = 0;
 
 	virtual void update();
 

--- a/include/NAS2D/Renderer/RendererNull.h
+++ b/include/NAS2D/Renderer/RendererNull.h
@@ -53,17 +53,17 @@ public:
 
 	void clearScreen(uint8_t, uint8_t, uint8_t) override {}
 
-	float width() override { return 0.0f; }
-	float height() override { return 0.0f; }
+	float width() const override { return 0.0f; }
+	float height() const override { return 0.0f; }
 
 	void size(int, int) override {}
 	void minimum_size(int, int) override {}
 
 	void fullscreen(bool, bool = false) override {}
-	bool fullscreen() override { return false; }
+	bool fullscreen() const override { return false; }
 
 	void resizeable(bool) override {}
-	bool resizeable() override { return false; }
+	bool resizeable() const override { return false; }
 
 	void clipRect(float, float, float, float) final override {}
 

--- a/include/NAS2D/Renderer/RendererOpenGL.h
+++ b/include/NAS2D/Renderer/RendererOpenGL.h
@@ -63,17 +63,17 @@ public:
 
 	void clearScreen(uint8_t r, uint8_t g, uint8_t b) override;
 
-	float width() override;
-	float height() override;
+	float width() const override;
+	float height() const override;
 
 	void size(int w, int h) override;
 	void minimum_size(int w, int h) override;
 
 	void fullscreen(bool fs, bool maintain = false) override;
-	bool fullscreen() override;
+	bool fullscreen() const override;
 
 	void resizeable(bool resizable) override;
-	bool resizeable() override;
+	bool resizeable() const override;
 
 	void clipRect(float x, float y, float width, float height) final override;
 

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -500,7 +500,7 @@ void NAS2D::Renderer::drawTextShadow(Font& font, const std::string& text, Point<
 /**
  * Gets the current screen resolution as a Vector.
  */
-Vector<float> Renderer::size()
+Vector<float> Renderer::size() const
 {
 	return mResolution;
 }
@@ -509,7 +509,7 @@ Vector<float> Renderer::size()
 /**
  * Gets the center coordinates of the screen.
  */
-Point<float> Renderer::center()
+Point<float> Renderer::center() const
 {
 	return Point<float>{} + mResolution / 2;
 }
@@ -518,7 +518,7 @@ Point<float> Renderer::center()
 /**
  * Gets the center X-Coordinate of the screen.
  */
-float Renderer::center_x()
+float Renderer::center_x() const
 {
 	return width() / 2;
 }
@@ -527,7 +527,7 @@ float Renderer::center_x()
 /**
  * Gets the center Y-Coordinate of the screen.
  */
-float Renderer::center_y()
+float Renderer::center_y() const
 {
 	return height() / 2;
 }
@@ -536,7 +536,7 @@ float Renderer::center_y()
 /**
  * Returns the name of the driver as named by the operating system.
  */
-const std::string& Renderer::driverName()
+const std::string& Renderer::driverName() const
 {
 	return mDriverName;
 }
@@ -557,7 +557,7 @@ void Renderer::driverName(const std::string& name)
 /**
  * Returns the title of the application window.
  */
-const std::string& Renderer::title()
+const std::string& Renderer::title() const
 {
 	return mTitle;
 }

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -546,7 +546,7 @@ void RendererOpenGL::update()
 }
 
 
-float RendererOpenGL::width()
+float RendererOpenGL::width() const
 {
 	if ((SDL_GetWindowFlags(underlyingWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP)
 	{
@@ -557,7 +557,7 @@ float RendererOpenGL::width()
 }
 
 
-float RendererOpenGL::height()
+float RendererOpenGL::height() const
 {
 	if ((SDL_GetWindowFlags(underlyingWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP)
 	{
@@ -600,7 +600,7 @@ void RendererOpenGL::fullscreen(bool fs, bool maintain)
 }
 
 
-bool RendererOpenGL::fullscreen()
+bool RendererOpenGL::fullscreen() const
 {
 	return	((SDL_GetWindowFlags(underlyingWindow) & SDL_WINDOW_FULLSCREEN) == SDL_WINDOW_FULLSCREEN) ||
 			((SDL_GetWindowFlags(underlyingWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP);
@@ -618,7 +618,7 @@ void RendererOpenGL::resizeable(bool resizable)
 }
 
 
-bool RendererOpenGL::resizeable()
+bool RendererOpenGL::resizeable() const
 {
 	return (SDL_GetWindowFlags(underlyingWindow) & SDL_WINDOW_RESIZABLE) == SDL_WINDOW_RESIZABLE;
 }


### PR DESCRIPTION
Marks the member functions that contain nothing but `return [expression]` as `const`.