### PR TITLE
Enable extra warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,8 @@ jobs:
   build-linux-mingw:
     docker:
       - image: outpostuniverse/nas2d-mingw:1.4
+    environment:
+      - WARN_EXTRA: "-Wno-redundant-decls"
     steps:
       - checkout
       - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,8 @@ jobs:
   build-linux-gcc8:
     docker:
       - image: outpostuniverse/nas2d-gcc8:1.0
+    environment:
+      - WARN_EXTRA: "-Wno-cast-function-type"
     steps:
       - checkout
       - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,8 @@ jobs:
   build-linux-clang:
     docker:
       - image: outpostuniverse/nas2d-clang:1.0
+    environment:
+      - WARN_EXTRA: "-Wmissing-prototypes"
     steps:
       - checkout
       - build-and-test

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS_EXTRA) -Iinclude/
-CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wcast-align -Wmissing-declarations -Wmissing-include-dirs -Wswitch-enum -Wswitch-default -Winvalid-pch -Wmissing-format-attribute $(WARN_EXTRA)
+CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wcast-align -Wmissing-declarations -Wmissing-include-dirs -Wswitch-enum -Wswitch-default -Winvalid-pch -Wmissing-format-attribute -Wredundant-decls $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 $(CXXFLAGS_WARN) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA)
 LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)

--- a/makefile
+++ b/makefile
@@ -22,7 +22,8 @@ Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS_EXTRA) -Iinclude/
-CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 -Wall -Wpedantic -Wzero-as-null-pointer-constant -Wcast-align $(shell sdl2-config --cflags)
+CXXFLAGS_WARN := -Wall -Wpedantic -Wzero-as-null-pointer-constant -Wcast-align $(WARN_EXTRA)
+CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 $(CXXFLAGS_WARN) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA)
 LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
 

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS_EXTRA) -Iinclude/
-CXXFLAGS_WARN := -Wall -Wpedantic -Wzero-as-null-pointer-constant -Wcast-align $(WARN_EXTRA)
+CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wcast-align $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 $(CXXFLAGS_WARN) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA)
 LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS_EXTRA) -Iinclude/
-CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wcast-align $(WARN_EXTRA)
+CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wcast-align -Wmissing-declarations -Wmissing-include-dirs -Wswitch-enum -Wswitch-default -Winvalid-pch -Wmissing-format-attribute $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 $(CXXFLAGS_WARN) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA)
 LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)


### PR DESCRIPTION
Enables the bulk of the suggested warnings from issue #528.

The following 3 enabled flags have exlusions:
- `-Wmissing-prototypes` - Clang only (flag not supported by GCC)
- `-Wredundant-decls` - Excluded for Mingw-w64, due to conflicts with builtins
- `-Wcast-function-type` (enabled by `-Wextra`) - Excluded for GCC-8, due to warnings about casts used by `Delegate` code, which likely won't be fixed anytime soon.

Linux/MacOS only change.
