### PR TITLE
Wrap calls to glGetString

### DIFF
--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -697,7 +697,7 @@ void RendererOpenGL::initGL()
 	std::cout << "\tRenderer: " << driverName() << std::endl;
 	std::cout << "\tDriver Version: " << glString(GL_VERSION) << std::endl;
 
-	std::string glsl_v = glString(GL_SHADING_LANGUAGE_VERSION);
+	auto glsl_v = glString(GL_SHADING_LANGUAGE_VERSION);
 	if (glsl_v.empty())
 	{
 		throw renderer_no_glsl();

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -697,13 +697,13 @@ void RendererOpenGL::initGL()
 	std::cout << "\tRenderer: " << driverName() << std::endl;
 	std::cout << "\tDriver Version: " << glString(GL_VERSION) << std::endl;
 
-	auto glsl_v = glString(GL_SHADING_LANGUAGE_VERSION);
-	if (glsl_v.empty())
+	auto glShadingLanguageVersion = glString(GL_SHADING_LANGUAGE_VERSION);
+	if (glShadingLanguageVersion.empty())
 	{
 		throw renderer_no_glsl();
 	}
 
-	std::cout << "\tGLSL Version: " << glsl_v << std::endl;
+	std::cout << "\tGLSL Version: " << glShadingLanguageVersion << std::endl;
 
 	glEnable(GL_TEXTURE_2D);
 

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -696,14 +696,13 @@ void RendererOpenGL::initGL()
 	std::cout << "\tVendor: " << glString(GL_VENDOR) << std::endl;
 	std::cout << "\tRenderer: " << driverName() << std::endl;
 	std::cout << "\tDriver Version: " << glString(GL_VERSION) << std::endl;
-
 	auto glShadingLanguageVersion = glString(GL_SHADING_LANGUAGE_VERSION);
+	std::cout << "\tGLSL Version: " << glShadingLanguageVersion << std::endl;
+
 	if (glShadingLanguageVersion.empty())
 	{
 		throw renderer_no_glsl();
 	}
-
-	std::cout << "\tGLSL Version: " << glShadingLanguageVersion << std::endl;
 
 	glEnable(GL_TEXTURE_2D);
 

--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -58,6 +58,13 @@ namespace {
 
 	GLfloat vertexArray[12] = {}; /**< Vertex array for quad drawing functions (all blitter functions). */
 	GLfloat textureCoordArray[12] = {}; /**< Texture coordinate array for quad drawing functions (all blitter functions). */
+
+
+	std::string glString(GLenum name)
+	{
+		const auto apiResult = glGetString(name);
+		return apiResult ? reinterpret_cast<const char*>(apiResult) : "";
+	}
 }
 
 
@@ -684,13 +691,13 @@ void RendererOpenGL::initGL()
 	// Spit out system graphics information.
 	std::cout << "\t- OpenGL System Info -" << std::endl;
 
-	driverName(reinterpret_cast<const char*>(glGetString(GL_RENDERER)));
+	driverName(glString(GL_RENDERER));
 
-	std::cout << "\tVendor: " << glGetString(GL_VENDOR) << std::endl;
+	std::cout << "\tVendor: " << glString(GL_VENDOR) << std::endl;
 	std::cout << "\tRenderer: " << driverName() << std::endl;
-	std::cout << "\tDriver Version: " << glGetString(GL_VERSION) << std::endl;
+	std::cout << "\tDriver Version: " << glString(GL_VERSION) << std::endl;
 
-	std::string glsl_v = reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
+	std::string glsl_v = glString(GL_SHADING_LANGUAGE_VERSION);
 	if (glsl_v.empty())
 	{
 		throw renderer_no_glsl();


### PR DESCRIPTION
Closes #544

Wraps call to `glGetString`, allowing for translation of `nullptr` results to an empty `std::string`. Previously the code would crash in the `std::string` constructor if `nullptr` result was returned.
