### PR TITLE
Limit variable scope in Renderer

### DIFF
--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -123,7 +123,7 @@ public:
 	void fadeOut(float delayTime);
 	bool isFading() const;
 	bool isFaded() const;
-	NAS2D::Signals::Signal<>& fadeComplete() const;
+	NAS2D::Signals::Signal<>& fadeComplete();
 
 	virtual void showSystemPointer(bool) = 0;
 	virtual void addCursor(const std::string& filePath, int cursorId, int offx, int offy) = 0;

--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -15,6 +15,7 @@
 #include "Point.h"
 #include "Vector.h"
 #include "Rectangle.h"
+#include "../Timer.h"
 #include "../Signal.h"
 #include "../Resources/Image.h"
 #include "../Resources/Font.h"
@@ -183,6 +184,8 @@ private:
 	float mCurrentFade{0.0f}; /**< Current fade amount. */
 
 	FadeType mCurrentFadeType{FadeType::None};
+	Timer fadeTimer;
+	Signals::Signal<> fadeCompleteSignal;
 };
 
 } // namespace

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -19,8 +19,8 @@ using namespace NAS2D;
 
 
 namespace {
-	NAS2D::Timer fadeTimer;
-	NAS2D::Signals::Signal<> fadeCompleteSignal;
+	Timer fadeTimer;
+	Signals::Signal<> fadeCompleteSignal;
 }
 
 

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -324,7 +324,7 @@ bool Renderer::isFaded() const
 /**
  * Gets a refernece to the callback signal for fade transitions.
  */
-NAS2D::Signals::Signal<>& Renderer::fadeComplete() const
+NAS2D::Signals::Signal<>& Renderer::fadeComplete()
 {
 	return fadeCompleteSignal;
 }

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -10,18 +10,10 @@
 
 #include "NAS2D/Renderer/Renderer.h"
 
-#include "NAS2D/Timer.h"
-
 #include <iostream>
 #include <algorithm>
 
 using namespace NAS2D;
-
-
-namespace {
-	Timer fadeTimer;
-	Signals::Signal<> fadeCompleteSignal;
-}
 
 
 /**

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -17,9 +17,13 @@
 
 using namespace NAS2D;
 
-NAS2D::Timer		fadeTimer;
 
-NAS2D::Signals::Signal<>	fadeCompleteSignal;
+namespace {
+	NAS2D::Timer		fadeTimer;
+
+	NAS2D::Signals::Signal<>	fadeCompleteSignal;
+}
+
 
 /**
  * Internal constructor used by derived types to set the name of the Renderer.

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -19,9 +19,8 @@ using namespace NAS2D;
 
 
 namespace {
-	NAS2D::Timer		fadeTimer;
-
-	NAS2D::Signals::Signal<>	fadeCompleteSignal;
+	NAS2D::Timer fadeTimer;
+	NAS2D::Signals::Signal<> fadeCompleteSignal;
 }
 
 


### PR DESCRIPTION
Reference: #528 (`-Wmissing-variable-declarations`)

Move file level variables in to member variables of `Renderer` class.
