### PR TITLE
Refactor FpsCounter

### DIFF
--- a/include/NAS2D/FpsCounter.h
+++ b/include/NAS2D/FpsCounter.h
@@ -26,6 +26,13 @@ class FpsCounter
 {
 public:
 	unsigned int fps();
+
+private:
+	static constexpr unsigned int FpsCountsSize = 25;
+	unsigned int fpsCounts[FpsCountsSize] = { 0 };
+
+	unsigned int currentTick = 0;
+	unsigned int fpsCountIndex = 0;
 };
 
 } // namespace

--- a/include/NAS2D/FpsCounter.h
+++ b/include/NAS2D/FpsCounter.h
@@ -25,8 +25,6 @@ namespace NAS2D {
 class FpsCounter
 {
 public:
-	FpsCounter();
-
 	unsigned int fps();
 };
 

--- a/include/NAS2D/FpsCounter.h
+++ b/include/NAS2D/FpsCounter.h
@@ -17,10 +17,6 @@ namespace NAS2D {
  *
  * FPS values are only approximates. As the FPS count gets higher, the returned value
  * becomes a more average count.
- *
- * \note	Because of the nature of FPS counters and their limited context, the
- *			FpsCounter has been designed with shared state. This means that multiple
- *			instances of FpsCounter will share values.
  */
 class FpsCounter
 {

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -28,7 +28,7 @@ unsigned int FpsCounter::fps()
 	const auto lastTick = currentTick;
 	currentTick = SDL_GetTicks();
 
-	auto tickDelta = std::min(currentTick - lastTick, 1u);
+	const auto tickDelta = std::min(currentTick - lastTick, 1u);
 
 	fpsCounts[++fpsCountIndex] = 1000 / tickDelta;
 

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -14,14 +14,17 @@
 
 using namespace NAS2D;
 
-const unsigned int FPS_COUNTS_SIZE = 25;
-unsigned int FPS_COUNTS[FPS_COUNTS_SIZE] = { 0 };
 
-unsigned int	CURRENT_TICK		= 0;
-unsigned int	LAST_TICK			= 0;
-unsigned int	TICK_DELTA			= 0;
-unsigned int	INDEX				= 0;
-unsigned int	ACCUMULATOR			= 0;
+namespace {
+	const unsigned int FPS_COUNTS_SIZE = 25;
+	unsigned int FPS_COUNTS[FPS_COUNTS_SIZE] = { 0 };
+
+	unsigned int	CURRENT_TICK		= 0;
+	unsigned int	LAST_TICK			= 0;
+	unsigned int	TICK_DELTA			= 0;
+	unsigned int	INDEX				= 0;
+	unsigned int	ACCUMULATOR			= 0;
+}
 
 
 /**

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -24,7 +24,7 @@ using namespace NAS2D;
  */
 unsigned int FpsCounter::fps()
 {
-	auto lastTick = currentTick;
+	const auto lastTick = currentTick;
 	currentTick = SDL_GetTicks();
 
 	auto tickDelta = currentTick - lastTick;

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -16,14 +16,14 @@ using namespace NAS2D;
 
 
 namespace {
-	const unsigned int FPS_COUNTS_SIZE = 25;
-	unsigned int FPS_COUNTS[FPS_COUNTS_SIZE] = { 0 };
+	const unsigned int FpsCountsSize = 25;
+	unsigned int fpsCounts[FpsCountsSize] = { 0 };
 
-	unsigned int CURRENT_TICK = 0;
-	unsigned int LAST_TICK = 0;
-	unsigned int TICK_DELTA = 0;
-	unsigned int INDEX = 0;
-	unsigned int ACCUMULATOR = 0;
+	unsigned int currentTick = 0;
+	unsigned int lastTick = 0;
+	unsigned int tickDelta = 0;
+	unsigned int fpsCountIndex = 0;
+	unsigned int accumulator = 0;
 }
 
 
@@ -32,22 +32,22 @@ namespace {
  */
 unsigned int FpsCounter::fps()
 {
-	LAST_TICK = CURRENT_TICK;
-	CURRENT_TICK = SDL_GetTicks();
+	lastTick = currentTick;
+	currentTick = SDL_GetTicks();
 
-	TICK_DELTA = CURRENT_TICK - LAST_TICK;
+	tickDelta = currentTick - lastTick;
 
-	if (TICK_DELTA == 0) { TICK_DELTA = 1; }
+	if (tickDelta == 0) { tickDelta = 1; }
 
-	FPS_COUNTS[++INDEX] = 1000 / TICK_DELTA;
+	fpsCounts[++fpsCountIndex] = 1000 / tickDelta;
 
-	if (INDEX >= FPS_COUNTS_SIZE) { INDEX = 0; }
+	if (fpsCountIndex >= FpsCountsSize) { fpsCountIndex = 0; }
 
-	ACCUMULATOR = 0;
-	for (auto i : FPS_COUNTS)
+	accumulator = 0;
+	for (auto i : fpsCounts)
 	{
-		ACCUMULATOR += i;
+		accumulator += i;
 	}
 
-	return ACCUMULATOR / FPS_COUNTS_SIZE;
+	return accumulator / FpsCountsSize;
 }

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -20,10 +20,7 @@ namespace {
 	unsigned int fpsCounts[FpsCountsSize] = { 0 };
 
 	unsigned int currentTick = 0;
-	unsigned int lastTick = 0;
-	unsigned int tickDelta = 0;
 	unsigned int fpsCountIndex = 0;
-	unsigned int accumulator = 0;
 }
 
 
@@ -32,10 +29,10 @@ namespace {
  */
 unsigned int FpsCounter::fps()
 {
-	lastTick = currentTick;
+	auto lastTick = currentTick;
 	currentTick = SDL_GetTicks();
 
-	tickDelta = currentTick - lastTick;
+	auto tickDelta = currentTick - lastTick;
 
 	if (tickDelta == 0) { tickDelta = 1; }
 
@@ -43,7 +40,7 @@ unsigned int FpsCounter::fps()
 
 	if (fpsCountIndex >= FpsCountsSize) { fpsCountIndex = 0; }
 
-	accumulator = 0;
+	unsigned int accumulator = 0;
 	for (auto i : fpsCounts)
 	{
 		accumulator += i;

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -24,7 +24,6 @@ unsigned int FpsCounter::fps()
 	currentTick = SDL_GetTicks();
 
 	auto tickDelta = currentTick - lastTick;
-
 	if (tickDelta == 0) { tickDelta = 1; }
 
 	fpsCounts[++fpsCountIndex] = 1000 / tickDelta;

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -12,6 +12,10 @@
 
 #include <SDL2/SDL.h>
 
+#include <numeric>
+#include <iterator>
+
+
 using namespace NAS2D;
 
 
@@ -30,11 +34,6 @@ unsigned int FpsCounter::fps()
 
 	if (fpsCountIndex >= FpsCountsSize) { fpsCountIndex = 0; }
 
-	unsigned int accumulator = 0;
-	for (auto i : fpsCounts)
-	{
-		accumulator += i;
-	}
-
-	return accumulator / FpsCountsSize;
+	auto sum = std::accumulate(std::begin(fpsCounts), std::end(fpsCounts), 0);
+	return sum / FpsCountsSize;
 }

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -19,11 +19,11 @@ namespace {
 	const unsigned int FPS_COUNTS_SIZE = 25;
 	unsigned int FPS_COUNTS[FPS_COUNTS_SIZE] = { 0 };
 
-	unsigned int	CURRENT_TICK		= 0;
-	unsigned int	LAST_TICK			= 0;
-	unsigned int	TICK_DELTA			= 0;
-	unsigned int	INDEX				= 0;
-	unsigned int	ACCUMULATOR			= 0;
+	unsigned int CURRENT_TICK = 0;
+	unsigned int LAST_TICK = 0;
+	unsigned int TICK_DELTA = 0;
+	unsigned int INDEX = 0;
+	unsigned int ACCUMULATOR = 0;
 }
 
 

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -15,15 +15,6 @@
 using namespace NAS2D;
 
 
-namespace {
-	const unsigned int FpsCountsSize = 25;
-	unsigned int fpsCounts[FpsCountsSize] = { 0 };
-
-	unsigned int currentTick = 0;
-	unsigned int fpsCountIndex = 0;
-}
-
-
 /**
  * Gets an average count of Frames per Second.
  */

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -28,13 +28,6 @@ namespace {
 
 
 /**
- * FpsCounter c'tor
- */
-FpsCounter::FpsCounter()
-{}
-
-
-/**
  * Gets an average count of Frames per Second.
  */
 unsigned int FpsCounter::fps()

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -34,6 +34,6 @@ unsigned int FpsCounter::fps()
 
 	if (fpsCountIndex >= FpsCountsSize) { fpsCountIndex = 0; }
 
-	auto sum = std::accumulate(std::begin(fpsCounts), std::end(fpsCounts), 0);
+	const auto sum = std::accumulate(std::begin(fpsCounts), std::end(fpsCounts), 0);
 	return sum / FpsCountsSize;
 }

--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -14,6 +14,7 @@
 
 #include <numeric>
 #include <iterator>
+#include <algorithm>
 
 
 using namespace NAS2D;
@@ -27,8 +28,7 @@ unsigned int FpsCounter::fps()
 	const auto lastTick = currentTick;
 	currentTick = SDL_GetTicks();
 
-	auto tickDelta = currentTick - lastTick;
-	if (tickDelta == 0) { tickDelta = 1; }
+	auto tickDelta = std::min(currentTick - lastTick, 1u);
 
 	fpsCounts[++fpsCountIndex] = 1000 / tickDelta;
 


### PR DESCRIPTION
Reference: #528 (`-Wmissing-variable-declarations`)

Noticed a few bugs (#554) while working on this. As fixing them involves a behaviour change, I wanted to keep them separate from refactoring changes.

Refactors the `FpsCounter` class to remove global variables, and replace them with member variables and function local variables. Rename them from ALL_CAPS to camelCase.
