### PR TITLE
Fix XML documentation

### DIFF
--- a/src/Xml/XmlComment.cpp
+++ b/src/Xml/XmlComment.cpp
@@ -25,7 +25,7 @@ XmlComment::XmlComment() : XmlNode(XmlNode::NodeType::XML_COMMENT)
  *
  * Constructs an XML Comment with a value.
  *
- * \param	_value	Reference to a \c std::string with the value to use for the comment.
+ * \param	commentValue	Reference to a \c std::string with the value to use for the comment.
  */
 XmlComment::XmlComment(const std::string& commentValue) : XmlNode(XmlNode::NodeType::XML_COMMENT)
 {

--- a/src/Xml/XmlHandle.cpp
+++ b/src/Xml/XmlHandle.cpp
@@ -290,7 +290,7 @@ XmlHandle XmlHandle::childElement(int index) const
  * return a handle to the second node 'element_a'.
  *
  * \param value Value of the node to look for.
- * \param index	Index position of the child.
+ * \param count	Index position of the child.
  *
  * \return	Returns a handle to a child node or nullptr
  *			if there are no children or 'count' is past

--- a/src/Xml/XmlParser.cpp
+++ b/src/Xml/XmlParser.cpp
@@ -477,12 +477,11 @@ bool XmlBase::stringEqual(const char* p, const char* tag, bool ignoreCase)
  * Reads text. Returns a pointer past the given end tag. Wickedly complex options, but it
  * keeps the (sensitive) code in one place.
  *
- * \param in				Where to start
+ * \param p				Where to start
  * \param text				The string read
- * \param ignoreWhiteSpace	Wheather to keep the white space
+ * \param trimWhiteSpace	Wheather to keep the white space
  * \param endTag			What ends this text
- * \param ignoreCase		Whether to ignore case in the end tag
- * \param encoding			The current encoding.
+ * \param caseInsensitive		Whether to ignore case in the end tag
  */
 const char* XmlBase::readText(const char* p, std::string* text, bool trimWhiteSpace, const char* endTag, bool caseInsensitive)
 {


### PR DESCRIPTION
Reference: #528 (`-Wdocumentation`)

Fix Doxygen documentation bugs in XML code. (See #556 for the non-XML code).
