### PR TITLE
Remove bad documentation command `\fixme`

### DIFF
--- a/src/Renderer/RendererOpenGL.cpp
+++ b/src/Renderer/RendererOpenGL.cpp
@@ -482,7 +482,6 @@ void RendererOpenGL::showSystemPointer(bool _b)
 
 void RendererOpenGL::addCursor(const std::string& filePath, int cursorId, int offx, int offy)
 {
-	/// \fixme proper cleanup
 	File imageFile = Utility<Filesystem>::get().open(filePath);
 	if (imageFile.size() == 0)
 	{


### PR DESCRIPTION
Reference: #528 (`-Wdocumentation-unknown-command`)

There is a [`\todo`](http://www.doxygen.nl/manual/commands.html#cmdtodo) that can be used instead.

The comment probably isn't of sufficient value to be worth keeping.
