### PR TITLE
Explicit override

### DIFF
--- a/include/NAS2D/Mixer/MixerNull.h
+++ b/include/NAS2D/Mixer/MixerNull.h
@@ -8,12 +8,6 @@ namespace NAS2D
 	class MixerNull : public Mixer
 	{
 	public:
-		MixerNull() = default;
-		MixerNull(const MixerNull& other) = default;
-		MixerNull(MixerNull&& other) = default;
-		MixerNull& operator=(const MixerNull& other) = default;
-		MixerNull& operator=(MixerNull&& other) = default;
-
 		virtual void playSound(Sound& sound) override;
 
 		virtual void stopSound() override;

--- a/include/NAS2D/Mixer/MixerNull.h
+++ b/include/NAS2D/Mixer/MixerNull.h
@@ -13,7 +13,6 @@ namespace NAS2D
 		MixerNull(MixerNull&& other) = default;
 		MixerNull& operator=(const MixerNull& other) = default;
 		MixerNull& operator=(MixerNull&& other) = default;
-		virtual ~MixerNull() = default;
 
 		virtual void playSound(Sound& sound) override;
 

--- a/include/NAS2D/Mixer/MixerSDL.h
+++ b/include/NAS2D/Mixer/MixerSDL.h
@@ -31,7 +31,7 @@ public:
 	MixerSDL& operator=(const MixerSDL&) = delete;
 	MixerSDL(MixerSDL&&) = default;
 	MixerSDL& operator=(MixerSDL&&) = default;
-	virtual ~MixerSDL();
+	~MixerSDL() override;
 
 	// Sound Functions
 	void playSound(Sound& sound) override;

--- a/include/NAS2D/Resources/Font.h
+++ b/include/NAS2D/Resources/Font.h
@@ -38,7 +38,7 @@ public:
 	Font(const std::string& filePath, int glyphWidth, int glyphHeight, int glyphSpace);
 	Font(const Font& font);
 	Font& operator=(const Font& font);
-	~Font();
+	~Font() override;
 
 	int width(const std::string& str) const;
 	int height() const;

--- a/include/NAS2D/Resources/Image.h
+++ b/include/NAS2D/Resources/Image.h
@@ -49,7 +49,7 @@ public:
 	Image(const Image &rhs);
 	Image& operator=(const Image& rhs);
 
-	~Image();
+	~Image() override;
 
 	Vector<int> size() const;
 	Vector<int> center() const;

--- a/include/NAS2D/Resources/Music.h
+++ b/include/NAS2D/Resources/Music.h
@@ -29,7 +29,7 @@ public:
 	Music(const Music& rhs);
 	Music& operator=(const Music& rhs);
 
-	virtual ~Music();
+	~Music() override;
 
 private:
 	void load() override;

--- a/include/NAS2D/Resources/Sound.h
+++ b/include/NAS2D/Resources/Sound.h
@@ -30,7 +30,7 @@ public:
 	Sound(Sound&& other) = default;
 	Sound& operator=(Sound&& other) = default;
 	explicit Sound(const std::string& filePath);
-	virtual ~Sound();
+	~Sound() override;
 
 protected:
 	friend class MixerSDL;

--- a/include/NAS2D/State.h
+++ b/include/NAS2D/State.h
@@ -79,7 +79,7 @@ class State
 public:
 	State() {}
 
-	virtual ~State() {}
+	virtual ~State() = default;
 
 protected:
 	friend class StateManager;

--- a/include/NAS2D/Xml/XmlBase.h
+++ b/include/NAS2D/Xml/XmlBase.h
@@ -55,7 +55,7 @@ public:
 	XmlBase() {}
 	XmlBase(const XmlBase&) = delete;
 	void operator=(const XmlBase& base) = delete;
-	virtual ~XmlBase() {}
+	virtual ~XmlBase() = default;
 
 	/**
 	 * Writes the XML entity to a string buffer.

--- a/include/NAS2D/Xml/XmlComment.h
+++ b/include/NAS2D/Xml/XmlComment.h
@@ -28,8 +28,6 @@ public:
 	XmlComment(const XmlComment& copy);
 	XmlComment& operator=(const XmlComment& base);
 
-	virtual ~XmlComment() {}
-
 	XmlNode* clone() const override;
 
 	void write(std::string& buf, int depth) const override;

--- a/include/NAS2D/Xml/XmlDocument.h
+++ b/include/NAS2D/Xml/XmlDocument.h
@@ -17,8 +17,6 @@ public:
 	XmlDocument(const XmlDocument& copy);
 	XmlDocument& operator=(const XmlDocument& copy);
 
-	virtual ~XmlDocument() {}
-
 	const char* parse(const char* p, void* data = nullptr) override;
 
 	const XmlElement* rootElement() const;

--- a/include/NAS2D/Xml/XmlElement.h
+++ b/include/NAS2D/Xml/XmlElement.h
@@ -28,7 +28,7 @@ class XmlElement : public XmlNode
 public:
 	explicit XmlElement(const std::string& _value);
 	XmlElement(const XmlElement& copy);
-	virtual ~XmlElement();
+	~XmlElement() override;
 
 	XmlElement& operator=(const XmlElement& base);
 

--- a/include/NAS2D/Xml/XmlNode.h
+++ b/include/NAS2D/Xml/XmlNode.h
@@ -44,7 +44,7 @@ public:
 	XmlNode();
 	XmlNode(const XmlNode&) = delete;
 	void operator=(const XmlNode& base) = delete;
-	virtual ~XmlNode();
+	~XmlNode() override;
 
 	const std::string& value() const;
 	void value(const std::string& value);

--- a/include/NAS2D/Xml/XmlText.h
+++ b/include/NAS2D/Xml/XmlText.h
@@ -30,7 +30,6 @@ public:
 	 * If you want it be output as a CDATA text	element, call \c CDATA(true).
 	 */
 	explicit XmlText(const std::string& initValue);
-	virtual ~XmlText() {}
 
 	XmlText(const XmlText& copy);
 	XmlText& operator=(const XmlText& base);

--- a/include/NAS2D/Xml/XmlUnknown.h
+++ b/include/NAS2D/Xml/XmlUnknown.h
@@ -27,7 +27,7 @@ class XmlUnknown : public XmlNode
 {
 public:
 	XmlUnknown();
-	virtual ~XmlUnknown();
+	~XmlUnknown() override;
 
 	XmlUnknown(const XmlUnknown& copy);
 	XmlUnknown& operator=(const XmlUnknown& copy);

--- a/include/NAS2D/Xml/XmlVisitor.h
+++ b/include/NAS2D/Xml/XmlVisitor.h
@@ -40,7 +40,7 @@ class XmlUnknown;
 class XmlVisitor
 {
 public:
-	virtual ~XmlVisitor() {}
+	virtual ~XmlVisitor() = default;
 
 	virtual bool visitEnter(const XmlDocument&) { return true; }
 	virtual bool visitExit(const XmlDocument&) { return true; }


### PR DESCRIPTION
Reference: #528 (`-Winconsistent-missing-destructor-override`)

Add `override` keyword for derived class destructors.

Remove explicit default destructors in derived classes.
