### PR TITLE
Reduce spacing in MixerNull

### DIFF
--- a/include/NAS2D/Mixer/MixerNull.h
+++ b/include/NAS2D/Mixer/MixerNull.h
@@ -9,31 +9,23 @@ namespace NAS2D
 	{
 	public:
 		virtual void playSound(Sound& sound) override;
-
 		virtual void stopSound() override;
-
 		virtual void pauseSound() override;
-
 		virtual void resumeSound() override;
 
 		virtual void stopMusic() override;
-
 		virtual void pauseMusic() override;
-
 		virtual void resumeMusic() override;
 
 		virtual void fadeInMusic(Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) override;
-
 		virtual void fadeOutMusic(int time = Mixer::DEFAULT_FADE_TIME) override;
 
 		virtual bool musicPlaying() const override;
 
 		virtual void mute() override;
-
 		virtual void unmute() override;
 
 		virtual void soundVolume(int level) override;
-
 		virtual void musicVolume(int level) override;
 
 	protected:


### PR DESCRIPTION
Removing blanks lines allows similar functions to be grouped together.
