### PR TITLE
Silence `-Wcast-function-type` for GCC >= 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,8 +82,6 @@ jobs:
   build-linux-gcc8:
     docker:
       - image: outpostuniverse/nas2d-gcc8:1.0
-    environment:
-      - WARN_EXTRA: "-Wno-cast-function-type"
     steps:
       - checkout
       - build-and-test

--- a/include/NAS2D/Delegate.h
+++ b/include/NAS2D/Delegate.h
@@ -87,6 +87,13 @@ struct VoidToDefaultVoid { using type = T; };
 template <>
 struct VoidToDefaultVoid<void> { using type = DefaultVoid; };
 
+
+template <class GenericMemFuncType, class XFuncType>
+GenericMemFuncType CastMemFuncPtr(XFuncType function_to_bind)
+{
+	return reinterpret_cast<GenericMemFuncType>(function_to_bind);
+}
+
 // GenericClass is a fake class, ONLY used to provide a type. It is vitally important
 // that it is never defined.
 #ifdef	FASTDLGT_MICROSOFT_MFP
@@ -121,7 +128,7 @@ struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE>
 		#if defined __DMC__
 		bound_func = horrible_cast<GenericMemFuncType>(function_to_bind);
 		#else
-		bound_func = reinterpret_cast<GenericMemFuncType>(function_to_bind);
+		bound_func = CastMemFuncPtr<GenericMemFuncType>(function_to_bind);
 		#endif
 		return reinterpret_cast<GenericClass*>(pthis);
 	}
@@ -172,7 +179,7 @@ struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE + 2 * sizeof(int)>
 	{
 		union { XFuncType func; GenericClass* (X::*ProbeFunc)(); MicrosoftVirtualMFP s; } u;
 		u.func = function_to_bind;
-		bound_func = reinterpret_cast<GenericMemFuncType>(u.s.codeptr);
+		bound_func = CastMemFuncPtr<GenericMemFuncType>(u.s.codeptr);
 		union { GenericVirtualClass::ProbePtrType virtfunc; MicrosoftVirtualMFP s; } u2;
 
 		static_assert(sizeof(function_to_bind) == sizeof(u.s) && sizeof(function_to_bind) == sizeof(u.ProbeFunc) && sizeof(u2.virtfunc) == sizeof(u2.s), "Can't use horrible cast");
@@ -325,7 +332,7 @@ public:
 #endif
 
 	inline GenericClass* GetClosureThis() const { return m_pthis; }
-	inline GenericMemFunc GetClosureMemPtr() const { return reinterpret_cast<GenericMemFunc>(m_pFunction); }
+	inline GenericMemFunc GetClosureMemPtr() const { return CastMemFuncPtr<GenericMemFunc>(m_pFunction); }
 
 #if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
 

--- a/include/NAS2D/Delegate.h
+++ b/include/NAS2D/Delegate.h
@@ -91,7 +91,14 @@ struct VoidToDefaultVoid<void> { using type = DefaultVoid; };
 template <class GenericMemFuncType, class XFuncType>
 GenericMemFuncType CastMemFuncPtr(XFuncType function_to_bind)
 {
+	#if __GNUC__ >= 8
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wcast-function-type"
+	#endif
 	return reinterpret_cast<GenericMemFuncType>(function_to_bind);
+	#if __GNUC__ >= 8
+	#pragma GCC diagnostic pop
+	#endif
 }
 
 // GenericClass is a fake class, ONLY used to provide a type. It is vitally important


### PR DESCRIPTION
Reference: #528
Reference: #539

Silence `-Wcast-function-type` for GCC >= 8 in `Delegate` code.

By making this built-in to the code, it's less likely a needed command line option will be forgotten when compiling manually. It's also fairly easy to search the code for disabled warnings using the `#pragma` preprocessor command.

Further, by only disabling the warning for a single line, we can still potentially benefit from the warning for the rest of the code base.
