### PR TITLE
DrawSubImage Rectangle

### DIFF
--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -58,9 +58,9 @@ public:
 	void drawImage(Image& image, Point<float> position, float scale, Color color);
 	virtual void drawImage(Image& image, float x, float y, float scale, uint8_t r, uint8_t g, uint8_t b, uint8_t a) = 0;
 
-	void drawSubImage(Image& image, Point<float> raster, Rectangle<float> subImageRect);
-	void drawSubImage(Image& image, Point<float> raster, Point<float> position, Vector<float> size);
-	void drawSubImage(Image& image, float rasterX, float rasterY, float x, float y, float width, float height);
+	void drawSubImage(Image& image, Point<float> raster, Rectangle<float> subImageRect, const Color& color = Color::Normal);
+	void drawSubImage(Image& image, Point<float> raster, Point<float> position, Vector<float> size, const Color& color = Color::Normal);
+	void drawSubImage(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, const Color& color = Color::Normal);
 	virtual void drawSubImage(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, uint8_t r, uint8_t g, uint8_t b, uint8_t a) = 0;
 
 	void drawSubImageRotated(Image& image, Point<float> raster, Rectangle<float> subImageRect, float degrees, const Color& color = Color::Normal);

--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -58,10 +58,12 @@ public:
 	void drawImage(Image& image, Point<float> position, float scale, Color color);
 	virtual void drawImage(Image& image, float x, float y, float scale, uint8_t r, uint8_t g, uint8_t b, uint8_t a) = 0;
 
+	void drawSubImage(Image& image, Point<float> raster, Rectangle<float> subImageRect);
 	void drawSubImage(Image& image, Point<float> raster, Point<float> position, Vector<float> size);
 	void drawSubImage(Image& image, float rasterX, float rasterY, float x, float y, float width, float height);
 	virtual void drawSubImage(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, uint8_t r, uint8_t g, uint8_t b, uint8_t a) = 0;
 
+	void drawSubImageRotated(Image& image, Point<float> raster, Rectangle<float> subImageRect, float degrees, const Color& color = Color::Normal);
 	void drawSubImageRotated(Image& image, Point<float> raster, Point<float> position, Vector<float> size, float degrees, const Color& color = Color::Normal);
 	void drawSubImageRotated(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, float degrees, const Color& color = Color::Normal);
 	virtual void drawSubImageRotated(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, float degrees, uint8_t r, uint8_t g, uint8_t b, uint8_t a) = 0;

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -60,6 +60,12 @@ void NAS2D::Renderer::drawImage(Image& image, Point<float> position, float scale
 }
 
 
+void NAS2D::Renderer::drawSubImage(Image& image, Point<float> raster, Rectangle<float> subImageRect)
+{
+	drawSubImage(image, raster, subImageRect.startPoint(), subImageRect.size());
+}
+
+
 void NAS2D::Renderer::drawSubImage(Image& image, Point<float> raster, Point<float> position, Vector<float> size)
 {
 	drawSubImage(image, raster.x(), raster.y(), position.x(), position.y(), size.x, size.y, 255, 255, 255, 255);
@@ -80,6 +86,12 @@ void NAS2D::Renderer::drawSubImage(Image& image, Point<float> raster, Point<floa
 void Renderer::drawSubImage(Image& image, float rasterX, float rasterY, float x, float y, float width, float height)
 {
 	drawSubImage(image, rasterX, rasterY, x, y, width, height, 255, 255, 255, 255);
+}
+
+
+void NAS2D::Renderer::drawSubImageRotated(Image& image, Point<float> raster, Rectangle<float> subImageRect, float degrees, const Color& color)
+{
+	drawSubImageRotated(image, raster, subImageRect.startPoint(), subImageRect.size(), degrees, color);
 }
 
 

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -60,15 +60,15 @@ void NAS2D::Renderer::drawImage(Image& image, Point<float> position, float scale
 }
 
 
-void NAS2D::Renderer::drawSubImage(Image& image, Point<float> raster, Rectangle<float> subImageRect)
+void NAS2D::Renderer::drawSubImage(Image& image, Point<float> raster, Rectangle<float> subImageRect, const Color& color)
 {
-	drawSubImage(image, raster, subImageRect.startPoint(), subImageRect.size());
+	drawSubImage(image, raster, subImageRect.startPoint(), subImageRect.size(), color);
 }
 
 
-void NAS2D::Renderer::drawSubImage(Image& image, Point<float> raster, Point<float> position, Vector<float> size)
+void NAS2D::Renderer::drawSubImage(Image& image, Point<float> raster, Point<float> position, Vector<float> size, const Color& color)
 {
-	drawSubImage(image, raster.x(), raster.y(), position.x(), position.y(), size.x, size.y, 255, 255, 255, 255);
+	drawSubImage(image, raster.x(), raster.y(), position.x(), position.y(), size.x, size.y, color);
 }
 
 
@@ -83,9 +83,9 @@ void NAS2D::Renderer::drawSubImage(Image& image, Point<float> raster, Point<floa
  * \param	width		Width of the area to start getting pixel data from.
  * \param	height		Height of the area to start getting pixel data from.
  */
-void Renderer::drawSubImage(Image& image, float rasterX, float rasterY, float x, float y, float width, float height)
+void Renderer::drawSubImage(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, const Color& color)
 {
-	drawSubImage(image, rasterX, rasterY, x, y, width, height, 255, 255, 255, 255);
+	drawSubImage(image, rasterX, rasterY, x, y, width, height, color.red(), color.green(), color.blue(), color.alpha());
 }
 
 


### PR DESCRIPTION
Add `DrawSubImage` and `DrawSubImageRotated` overloads that take a `Rectangle` describing the sub-region of the Image that will be displayed.

Add defaulted `Color` parameter missing from some overloads, so they are all consistent. The default ensures code that didn't pass the parameter continue to behave as before.
