### PR TITLE
Rename colors to be consistent

### DIFF
--- a/include/NAS2D/Renderer/Color.h
+++ b/include/NAS2D/Renderer/Color.h
@@ -23,9 +23,9 @@ class Color
 public:
 	static const Color Black;
 	static const Color Blue;
-	static const Color Bright_green;
-	static const Color Cyan;
 	static const Color Green;
+	static const Color Cyan;
+	static const Color DarkGreen;
 	static const Color Grey;
 	static const Color Magenta;
 	static const Color Navy;

--- a/src/Renderer/Color.cpp
+++ b/src/Renderer/Color.cpp
@@ -14,9 +14,9 @@ using namespace NAS2D;
 
 const Color Color::Black(0, 0, 0);
 const Color Color::Blue(0, 0, 255);
-const Color Color::Bright_green(0, 255, 0);
+const Color Color::Green(0, 255, 0);
 const Color Color::Cyan(0, 255, 255);
-const Color Color::Green(0, 128, 0);
+const Color Color::DarkGreen(0, 128, 0);
 const Color Color::Grey(128, 128, 128);
 const Color Color::Magenta(255, 0, 255);
 const Color Color::Navy(35, 60, 85);

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -53,7 +53,7 @@ NAS2D::State* TestGraphics::update()
 	r.drawBox(10, 50, 40, 40, 255, 255, 255);
 	r.drawBoxFilled(70, 50, 40, 40, 200, 0, 0);
 
-	r.drawGradient(10, 100, 100, 100, NAS2D::Color::Blue, NAS2D::Color::Bright_green, NAS2D::Color::Red, NAS2D::Color::Magenta);
+	r.drawGradient(10, 100, 100, 100, NAS2D::Color::Blue, NAS2D::Color::Green, NAS2D::Color::Red, NAS2D::Color::Magenta);
 
 	r.drawCircle(150, 70, 20, 0, 200, 0, 255, 16);
 	r.drawCircle(150, 120, 20, 0, 200, 0, 255, 16, 0.5f);


### PR DESCRIPTION
Naming (0, 255, 0) "Bright Green" is inconsistent with the other primary and secondary colors of Red, Blue, Yellow, Cyan, etc. in the sRGB color space.