### PR TITLE
Adds raw numeric constructor and helper functions

### DIFF
--- a/include/NAS2D/Renderer/Color.h
+++ b/include/NAS2D/Renderer/Color.h
@@ -40,9 +40,15 @@ public:
 
 	Color() = default;
 	Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
+	explicit Color(uint32_t value);
 
 public:
 	void operator()(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+
+	void setRgbaFromRawValue(uint32_t value);
+	void setRgbFromRawValue(uint32_t value);
+	uint32_t getRgbaAsRawValue() const;
+	uint32_t getRgbAsRawValue() const;
 
 	uint8_t red() const;
 	uint8_t green() const;

--- a/src/Renderer/Color.cpp
+++ b/src/Renderer/Color.cpp
@@ -48,6 +48,40 @@ const Color Color::NoAlpha(0, 0, 0, 0);
 Color::Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a) : mR(r), mG(g), mB(b), mA(a)
 {}
 
+Color::Color(uint32_t value)
+{
+	setRgbaFromRawValue(value);
+}
+
+void Color::setRgbaFromRawValue(uint32_t value)
+{
+	mR = static_cast<uint8_t>((value & 0xFF000000u) >> 24);
+	mG = static_cast<uint8_t>((value & 0x00FF0000u) >> 16);
+	mB = static_cast<uint8_t>((value & 0x0000FF00u) >> 8);
+	mA = static_cast<uint8_t>((value & 0x000000FFu) >> 0);
+}
+
+void Color::setRgbFromRawValue(uint32_t value)
+{
+	mR = static_cast<uint8_t>((value & 0xFF000000u) >> 24);
+	mG = static_cast<uint8_t>((value & 0x00FF0000u) >> 16);
+	mB = static_cast<uint8_t>((value & 0x0000FF00u) >> 8);
+}
+
+uint32_t Color::getRgbaAsRawValue() const
+{
+	return static_cast<uint32_t>(((static_cast<uint32_t>(mR) << 24) & 0xFF000000u)
+								| ((static_cast<uint32_t>(mG) << 16) & 0x00FF0000u)
+								| ((static_cast<uint32_t>(mB) << 8) & 0x0000FF00u)
+								| ((static_cast<uint32_t>(mA) << 0) & 0x000000FFu));
+}
+uint32_t Color::getRgbAsRawValue() const
+{
+	return static_cast<uint32_t>(((static_cast<uint32_t>(mR) << 24) & 0xFF0000u)
+								| ((static_cast<uint32_t>(mG) << 16) & 0x00FF00u)
+								| ((static_cast<uint32_t>(mB) << 8) & 0x0000FFu));
+}
+
 
 /**
  * Sets a Color with a given RGBA value set.


### PR DESCRIPTION
Adds a numeric constructor for Colors.

Intended for hex-value construction when dealing with somewhat complicated values: `Color morning_blue{0x8DA399FF};`.

As a side effect generating a random color is much easier:

```cpp
Color c = Color::RandomWithAlpha();
//...
Color Color::RandomWithAlpha()
{
    return Color{MathUtils::RandomIntLessThan(0x100000000u)};
}
```
and random full-alpha colors:
```cpp
Color c = Color::Random();
//...
Color::Random()
{
    return Color{(MathUtils::RandomIntLessThan(0x1000000) << 8) | 0xFF};
}
```