### PR TITLE
Vector deduction guide

### DIFF
--- a/include/NAS2D/Renderer/Vector.h
+++ b/include/NAS2D/Renderer/Vector.h
@@ -78,7 +78,10 @@ struct Vector {
 	Vector<NewBaseType> to() const {
 		return static_cast<Vector<NewBaseType>>(*this);
 	}
-
 };
+
+
+template <typename BaseType>
+Vector(BaseType, BaseType) -> Vector<BaseType>;
 
 }

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -1,6 +1,13 @@
 #include "NAS2D/Renderer/Vector.h"
 #include <gtest/gtest.h>
+#include <type_traits>
 
+
+TEST(Vector, DeductionGuidedConstruction) {
+	EXPECT_TRUE((std::is_same_v<NAS2D::Vector<int>, decltype(NAS2D::Vector{0, 0})>));
+	EXPECT_TRUE((std::is_same_v<NAS2D::Vector<double>, decltype(NAS2D::Vector{0.0, 0.0})>));
+	EXPECT_TRUE((std::is_same_v<NAS2D::Vector<float>, decltype(NAS2D::Vector{0.0f, 0.0f})>));
+}
 
 TEST(Vector, DefaultConstructible) {
 	EXPECT_EQ((NAS2D::Vector<int>{0, 0}), NAS2D::Vector<int>{});

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -3,6 +3,10 @@
 #include <type_traits>
 
 
+TEST(Vector, Aggregate) {
+	EXPECT_TRUE((std::is_aggregate_v<NAS2D::Vector<int>>));
+}
+
 TEST(Vector, DeductionGuidedConstruction) {
 	EXPECT_TRUE((std::is_same_v<NAS2D::Vector<int>, decltype(NAS2D::Vector{0, 0})>));
 	EXPECT_TRUE((std::is_same_v<NAS2D::Vector<double>, decltype(NAS2D::Vector{0.0, 0.0})>));


### PR DESCRIPTION
Add [Class Template Argument Deduction](https://en.cppreference.com/w/cpp/language/class_template_argument_deduction) (CTAD) guide for `Vector` struct.

This allows shorter terser syntax, where the template type argument can be omitted:
```cpp
Vector<int>{0, 0}; // Without using CTAD
Vector{0, 0}; // Using CTAD
```

----

Reference: [How to Use Class Template Argument Deduction](https://devblogs.microsoft.com/cppblog/how-to-use-class-template-argument-deduction/)
Reference: [`std::is_same`](https://en.cppreference.com/w/cpp/types/is_same)
