### PR TITLE
Reduce Renderer::drawImage overloads by using defaults

### DIFF
--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -53,9 +53,8 @@ public:
 
 	virtual void window_icon(const std::string& path) = 0;
 
-	void drawImage(Image& image, Point<float> position, float scale = 1.0f);
 	void drawImage(Image& image, float x, float y, float scale = 1.0f);
-	void drawImage(Image& image, Point<float> position, float scale, Color color);
+	void drawImage(Image& image, Point<float> position, float scale = 1.0, Color color = Color::White);
 	virtual void drawImage(Image& image, float x, float y, float scale, uint8_t r, uint8_t g, uint8_t b, uint8_t a) = 0;
 
 	void drawSubImage(Image& image, Point<float> raster, Rectangle<float> subImageRect, const Color& color = Color::Normal);

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -35,11 +35,6 @@ Renderer::~Renderer()
 }
 
 
-void Renderer::drawImage(Image& image, Point<float> position, float scale)
-{
-	drawImage(image, position.x(), position.y(), scale);
-}
-
 /**
  * Draws an Image to the screen.
  *


### PR DESCRIPTION
Rather than hardcode the defaults in the function implementation, we can instead move them to default parameters, and reduce the number of overloads.
