### PR TITLE
Add Renderer::drawImageRect overload taking Rectangle

### DIFF
--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -85,6 +85,7 @@ public:
 
 	void drawImageRect(Point<float> position, Vector<float> size, Image& topLeft, Image& top, NAS2D::Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);
 	void drawImageRect(float x, float y, float w, float h, Image& topLeft, Image& top, NAS2D::Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);
+	void drawImageRect(Rectangle<float> rect, ImageList& images);
 	void drawImageRect(Point<float> position, Vector<float> size, ImageList& images);
 	void drawImageRect(float x, float y, float w, float h, ImageList& images);
 

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -212,6 +212,12 @@ void Renderer::drawImageRect(float x, float y, float w, float h, Image& topLeft,
 }
 
 
+void NAS2D::Renderer::drawImageRect(Rectangle<float> rect, ImageList& images)
+{
+	drawImageRect(rect.startPoint(), rect.size(), images);
+}
+
+
 void NAS2D::Renderer::drawImageRect(Point<float> position, Vector<float> size, ImageList& images)
 {
 	drawImageRect(position.x(), position.y(), size.x, size.y, images);


### PR DESCRIPTION
Add `Renderer::drawImageRect` overload that takes a `Rectangle` parameter.

Yes, we were lacking that.
