### PR TITLE
Add Renderer::drawImageStretched overload taking Rectangle

### DIFF
--- a/include/NAS2D/Renderer/Renderer.h
+++ b/include/NAS2D/Renderer/Renderer.h
@@ -72,6 +72,7 @@ public:
 	void drawImageRotated(Image& image, float x, float y, float degrees, const Color& color = Color::Normal, float scale = 1.0f);
 	virtual void drawImageRotated(Image& image, float x, float y, float degrees, uint8_t r, uint8_t g, uint8_t b, uint8_t a, float scale = 1.0f) = 0;
 
+	void drawImageStretched(Image& image, Rectangle<float> rect, Color color = Color::Normal);
 	void drawImageStretched(Image& image, Point<float> position, Vector<float> size, Color color = Color::Normal);
 	void drawImageStretched(Image& image, float x, float y, float w, float h, Color color = Color::Normal);
 	virtual void drawImageStretched(Image& image, float x, float y, float w, float h, uint8_t r, uint8_t g, uint8_t b, uint8_t a) = 0;

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -142,6 +142,12 @@ void Renderer::drawImageRotated(Image& image, float x, float y, float degrees, c
 }
 
 
+void NAS2D::Renderer::drawImageStretched(Image& image, Rectangle<float> rect, Color color)
+{
+	drawImageStretched(image, rect.startPoint(), rect.size(), color);
+}
+
+
 void NAS2D::Renderer::drawImageStretched(Image& image, Point<float> position, Vector<float> size, Color color)
 {
 	drawImageStretched(image, position.x(), position.y(), size.x, size.y, color);


### PR DESCRIPTION
Related to #581, this is another method that was missing an obvious `Rectangle` overload.
