### PR TITLE
Fix FpsCounter bug

### DIFF
--- a/src/FpsCounter.cpp
+++ b/src/FpsCounter.cpp
@@ -28,7 +28,7 @@ unsigned int FpsCounter::fps()
 	const auto lastTick = currentTick;
 	currentTick = SDL_GetTicks();
 
-	const auto tickDelta = std::min(currentTick - lastTick, 1u);
+	const auto tickDelta = std::max(currentTick - lastTick, 1u);
 
 	fpsCounts[fpsCountIndex] = 1000 / tickDelta;
 


### PR DESCRIPTION
Should use `max` to clamp the low end and set a minimum value.

Noticed a bug I introduced which causes crashes in the test project. The clamping meant to guard against dividing by 0 was actually causing divide by 0.
