### PR TITLE
Remove `string_format` function

### DIFF
--- a/include/NAS2D/StringUtils.h
+++ b/include/NAS2D/StringUtils.h
@@ -34,17 +34,6 @@ namespace NAS2D
 	bool startsWith(std::string_view string, char start) noexcept;
 	bool endsWith(std::string_view string, char end) noexcept;
 
-	template<typename... Args>
-	std::string string_format(const std::string& format, Args... args)
-	{
-		std::string buffer;
-		std::size_t size = snprintf(buffer.data(), buffer.size(), format.c_str(), args...);
-		buffer.resize(size + 1); // Including null (avoid clipping/undefined behavior)
-		snprintf(buffer.data(), buffer.size(), format.c_str(), args...);
-		buffer.resize(size); // Strip null temrinator
-		return buffer;
-	}
-
 	/**
  * \typedef StringList
  * \brief	A list of std::string's.

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -36,26 +36,3 @@ TEST(String, splitSkipEmpty)
 	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitSkipEmpty("ab.c", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc.", '.'));
 }
-
-TEST(String, string_format)
-{
-	// Numbers
-	EXPECT_EQ("-1", NAS2D::string_format("%d", -1));
-	EXPECT_EQ("0", NAS2D::string_format("%d", 0));
-	EXPECT_EQ("1", NAS2D::string_format("%d", 1));
-
-	// Padded numbers
-	EXPECT_EQ(" 10", NAS2D::string_format("%3d", 10));
-	EXPECT_EQ("010", NAS2D::string_format("%03d", 10));
-	// Negative padded numbers
-	EXPECT_EQ("-10", NAS2D::string_format("%3d", -10));
-	EXPECT_EQ("-10", NAS2D::string_format("%03d", -10));
-	EXPECT_EQ(" -10", NAS2D::string_format("%4d", -10));
-	EXPECT_EQ("-010", NAS2D::string_format("%04d", -10));
-
-	// Strings
-	EXPECT_EQ("Hello World", NAS2D::string_format("Hello %s", "World"));
-
-	// Padded strings
-	EXPECT_EQ("  ABC", NAS2D::string_format("%5s", "ABC"));
-}


### PR DESCRIPTION
Closes #507 (`-Wformat-nonliteral`)

Remove `string_format` function. As an alternative, when converting numbers to strings, use `std::to_string`.

Long term, C++20 is introducing a std::format method:
https://en.cppreference.com/w/cpp/utility/format/format

The newer C++20 method should play better with localization, while remaining type safe. It should provide a much better basis for supporting language translations.
