### PR TITLE
Rename `skip` to `setFrame` in `Sprite` class

### DIFF
--- a/include/NAS2D/Resources/Sprite.h
+++ b/include/NAS2D/Resources/Sprite.h
@@ -49,7 +49,7 @@ public:
 	void pause();
 	void resume();
 
-	void skip(int frameCount);
+	void setFrame(int frameIndex);
 
 	void update(Point<float> position);
 	void update(float x, float y);

--- a/src/Resources/Sprite.cpp
+++ b/src/Resources/Sprite.cpp
@@ -106,15 +106,15 @@ void Sprite::resume()
 
 
 /**
- * Skips animation playback frames.
+ * Sets the animation playback frame.
  *
- * \param	frameCount	Number of frames to skip.
+ * \param	frameIndex	New frame index
  */
-void Sprite::skip(int frameCount)
+void Sprite::setFrame(int frameIndex)
 {
 	if (mActions.find(mCurrentAction) != mActions.end())
 	{
-		mCurrentFrame = frameCount % mActions[mCurrentAction].size();
+		mCurrentFrame = frameIndex % mActions[mCurrentAction].size();
 	}
 }
 


### PR DESCRIPTION
Closes #523

The name update makes the name consistent with the implementation. This should allow callers to have a better expectation of what actually happens when it is called.

Will need a corresponding adjustment in OPHD, where the method is used.
