### PR TITLE
Add deduction guide for Point and Rectangle

### DIFF
--- a/NAS2D/Renderer/Point.h
+++ b/NAS2D/Renderer/Point.h
@@ -104,4 +104,7 @@ using Point_2df = Point<float>;
 extern template struct Point<float>;
 
 
+template <typename BaseType>
+Point(BaseType, BaseType) -> Point<BaseType>;
+
 } // namespace

--- a/NAS2D/Renderer/Rectangle.h
+++ b/NAS2D/Renderer/Rectangle.h
@@ -168,4 +168,8 @@ extern template struct Rectangle<int>;
 using Rectangle_2df = Rectangle<float>;
 extern template struct Rectangle<float>;
 
+
+template <typename BaseType>
+Rectangle(BaseType, BaseType, BaseType, BaseType) -> Rectangle<BaseType>;
+
 } // namespace


### PR DESCRIPTION
Closes #587

Implements deduction guides for `Point` and `Rectangle`.

Silences warnings from `-Wctad-maybe-unsupported`.
