### PR TITLE
StateManager::setState explicitly takes ownership of resource

### DIFF
--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -132,14 +132,14 @@ void Game::mount(const std::string& path)
  * \warning	The State object becomes owned by the StateManager. Do not delete
  *			the State.
  */
-void Game::go(State *state)
+void Game::go(std::unique_ptr<State> state)
 {
 	std::cout << "** GAME STATE START **\n\n";
 	std::cout.flush();
 
 	StateManager stateManager;
 
-	stateManager.setState(state);
+	stateManager.setState(std::move(state));
 
 	// Game Loop
 	while (stateManager.update())

--- a/NAS2D/Game.h
+++ b/NAS2D/Game.h
@@ -12,6 +12,7 @@
 
 #include "StateManager.h"
 
+#include <memory>
 #include <string>
 
 namespace NAS2D {
@@ -61,7 +62,7 @@ public:
 
 	void mount(const std::string& path);
 
-	void go(State *state);
+	void go(std::unique_ptr<State> state);
 };
 
 } // namespace

--- a/NAS2D/StateManager.cpp
+++ b/NAS2D/StateManager.cpp
@@ -50,11 +50,8 @@ StateManager::~StateManager()
  *
  * \note	Passing a nullptr to this function will terminate the
  * 			application.
- *
- * \warning	The pointer given to the StateManager becomes owned by
- *			the StateManager.
  */
-void StateManager::setState(State* state)
+void StateManager::setState(std::unique_ptr<State> state)
 {
 	if (!state)
 	{
@@ -66,7 +63,7 @@ void StateManager::setState(State* state)
 	delete mActiveState;
 
 	// Initialize the new one
-	mActiveState = state;
+	mActiveState = state.release();
 	mActiveState->initialize();
 
 	mActive = true;

--- a/NAS2D/StateManager.cpp
+++ b/NAS2D/StateManager.cpp
@@ -19,9 +19,7 @@ using namespace NAS2D;
 /**
  * C'tor
  */
-StateManager::StateManager() :
-	mActiveState(nullptr),
-	mActive(true)
+StateManager::StateManager()
 {
 	// Ensure that all quit messages are handled in some way even if a State object doesn't.
 	Utility<EventHandler>::get().quit().connect(this, &StateManager::handleQuit);

--- a/NAS2D/StateManager.cpp
+++ b/NAS2D/StateManager.cpp
@@ -86,7 +86,7 @@ bool StateManager::update()
 		}
 		else if (nextState != mActiveState)
 		{
-			setState(nextState);
+			setState(std::unique_ptr<State>(nextState));
 		}
 
 		Utility<EventHandler>::get().pump();

--- a/NAS2D/StateManager.cpp
+++ b/NAS2D/StateManager.cpp
@@ -35,11 +35,7 @@ StateManager::StateManager() :
  */
 StateManager::~StateManager()
 {
-	if (mActiveState)
-	{
-		Utility<EventHandler>::get().disconnectAll();
-		delete mActiveState;
-	}
+	Utility<EventHandler>::get().disconnectAll();
 }
 
 
@@ -60,10 +56,8 @@ void StateManager::setState(std::unique_ptr<State> state)
 
 	if (mForceStopAudio) { Utility<Mixer>::get().stopAllAudio(); }
 
-	delete mActiveState;
-
 	// Initialize the new one
-	mActiveState = state.release();
+	mActiveState = std::move(state);
 	mActiveState->initialize();
 
 	mActive = true;
@@ -84,7 +78,7 @@ bool StateManager::update()
 		{
 			mActive = false;
 		}
-		else if (nextState != mActiveState)
+		else if (nextState != mActiveState.get())
 		{
 			setState(std::unique_ptr<State>(nextState));
 		}

--- a/NAS2D/StateManager.h
+++ b/NAS2D/StateManager.h
@@ -42,7 +42,7 @@ public:
 private:
 	void handleQuit();
 
-	State			*mActiveState;
+	std::unique_ptr<State> mActiveState{};
 	bool			mActive;
 	bool			mForceStopAudio = true;
 };

--- a/NAS2D/StateManager.h
+++ b/NAS2D/StateManager.h
@@ -43,8 +43,8 @@ private:
 	void handleQuit();
 
 	std::unique_ptr<State> mActiveState{};
-	bool			mActive;
-	bool			mForceStopAudio = true;
+	bool			mActive{true};
+	bool			mForceStopAudio{true};
 };
 
 } // namespace

--- a/NAS2D/StateManager.h
+++ b/NAS2D/StateManager.h
@@ -13,6 +13,8 @@
 #include "State.h"
 #include "Utility.h"
 
+#include <memory>
+
 namespace NAS2D {
 
 /**
@@ -30,7 +32,7 @@ public:
 	StateManager();
 	~StateManager();
 
-	void setState(State* state);
+	void setState(std::unique_ptr<State> state);
 	bool update();
 
 	bool active() const;

--- a/test-graphics/main.cpp
+++ b/test-graphics/main.cpp
@@ -11,6 +11,7 @@
 #include "TestGraphics.h"
 
 #include <iostream>
+#include <memory>
 #include <string>
 
 int main(int /*argc*/, char *argv[])
@@ -19,7 +20,7 @@ int main(int /*argc*/, char *argv[])
 	try
 	{
 		NAS2D::Game game("NAS2D Graphics Test", "NAS2D_GraphicsTest", "LairWorks", argv[0]);
-		game.go(new TestGraphics());
+		game.go(std::make_unique<TestGraphics>());
 	}
 	catch(std::exception& e)
 	{


### PR DESCRIPTION
The documentation for `StateManager::setState` says it takes ownership of the `State* state` argument and that it should not be deleted by the caller.

Making the argument a `std::unique_ptr` enforces this in a safe manner.