### PR TITLE
Color compare

### DIFF
--- a/NAS2D/Renderer/Color.cpp
+++ b/NAS2D/Renderer/Color.cpp
@@ -57,6 +57,18 @@ Color::Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a) : mR(r), mG(g), mB(b), 
 {}
 
 
+bool Color::operator==(Color other) const
+{
+	return (mR == other.mR) && (mG == other.mG) && (mB == other.mB) && (mA == other.mA);
+}
+
+
+bool Color::operator!=(Color other) const
+{
+	return !(*this == other);
+}
+
+
 /**
  * Sets a Color with a given RGBA value set.
  *

--- a/NAS2D/Renderer/Color.h
+++ b/NAS2D/Renderer/Color.h
@@ -49,6 +49,9 @@ public:
 	Color() = default;
 	Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
 
+	bool operator==(Color other) const;
+	bool operator!=(Color other) const;
+
 	void operator()(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
 	uint8_t red() const;

--- a/NAS2D/Renderer/Color.h
+++ b/NAS2D/Renderer/Color.h
@@ -49,7 +49,6 @@ public:
 	Color() = default;
 	Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
 
-public:
 	void operator()(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
 	uint8_t red() const;

--- a/test/Renderer/Color.test.cpp
+++ b/test/Renderer/Color.test.cpp
@@ -1,0 +1,15 @@
+#include "NAS2D/Renderer/Color.h"
+#include <gtest/gtest.h>
+
+
+TEST(Color, OperatorCompare) {
+	EXPECT_EQ((NAS2D::Color{255, 255, 255, 255}), (NAS2D::Color{255, 255, 255, 255}));
+	EXPECT_EQ((NAS2D::Color{0, 0, 0, 0}), (NAS2D::Color{0, 0, 0, 0}));
+	EXPECT_EQ((NAS2D::Color{0, 1, 2, 3}), (NAS2D::Color{0, 1, 2, 3}));
+	EXPECT_EQ((NAS2D::Color{3, 2, 1, 0}), (NAS2D::Color{3, 2, 1, 0}));
+
+	EXPECT_NE((NAS2D::Color{1, 0, 0, 0}), (NAS2D::Color{0, 0, 0, 0}));
+	EXPECT_NE((NAS2D::Color{0, 1, 0, 0}), (NAS2D::Color{0, 0, 0, 0}));
+	EXPECT_NE((NAS2D::Color{0, 0, 1, 0}), (NAS2D::Color{0, 0, 0, 0}));
+	EXPECT_NE((NAS2D::Color{0, 0, 0, 1}), (NAS2D::Color{0, 0, 0, 0}));
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -45,6 +45,7 @@
     <IntDir>$(SolutionDir)Temporary\$(ProjectName)_$(PlatformShortName)_$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemGroup>
+    <ClCompile Include="Renderer/Color.test.cpp" />
     <ClCompile Include="Renderer/Point.test.cpp" />
     <ClCompile Include="Renderer/Rectangle.test.cpp" />
     <ClCompile Include="Renderer/Vector.test.cpp" />


### PR DESCRIPTION
Add `Color` comparison operators.

If we make the fields public, we probably get the comparison for free. Until then, these can be used to do full color comparisons. At any rate, the added unit tests will ensure `Color` comparisons are still possible afterwards.
