### PR TITLE
Remove Color::operator()

### DIFF
--- a/NAS2D/Renderer/Color.cpp
+++ b/NAS2D/Renderer/Color.cpp
@@ -70,23 +70,6 @@ bool Color::operator!=(Color other) const
 
 
 /**
- * Sets a Color with a given RGBA value set.
- *
- * \param r	Red compontent. Valid values are 0 - 255.
- * \param g	Green compontent. Valid values are 0 - 255.
- * \param b	Blue compontent. Valid values are 0 - 255.
- * \param a	Alpha compontent. Valid values are 0 - 255.
- */
-void Color::operator()(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	red(r);
-	green(g);
-	blue(b);
-	alpha(a);
-}
-
-
-/**
  * Gets the red component value of the color.
  */
 uint8_t Color::red() const

--- a/NAS2D/Renderer/Color.h
+++ b/NAS2D/Renderer/Color.h
@@ -52,8 +52,6 @@ public:
 	bool operator==(Color other) const;
 	bool operator!=(Color other) const;
 
-	void operator()(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-
 	uint8_t red() const;
 	uint8_t green() const;
 	uint8_t blue() const;


### PR DESCRIPTION
This method is not currently used.

For an alternative in new code, construct a new `Color` object. This can be done by overwriting an object in place:

```
color(r, g, b, a); // Old syntax
color = {r, g, b, a}; // Overwrite with newly constructed object
```

I would claim the intent of the later is perhaps more clear anyway.
