### PR TITLE
Add `std::` prefix to `std::size_t`

### DIFF
--- a/NAS2D/File.h
+++ b/NAS2D/File.h
@@ -106,13 +106,13 @@ public:
 	/**
 	 * Gets the size, in bytes, of the File.
 	 */
-	size_t size() const { return mByteStream.size(); }
+	std::size_t size() const { return mByteStream.size(); }
 
 
 	/**
 	 * Gets the size, in bytes, of the File.
 	 */
-	size_t length() const { return size(); }
+	std::size_t length() const { return size(); }
 
 	/**
 	 * Resizes the File.
@@ -168,7 +168,7 @@ public:
 	 *
 	 * \param pos	Position of the iterator to get.
 	 */
-	iterator seek(size_t pos) { iterator it = mByteStream.begin() + pos; return it; }
+	iterator seek(std::size_t pos) { iterator it = mByteStream.begin() + pos; return it; }
 
 	/**
 	 * Gets a reverse iterator to the byte at a specified position.
@@ -177,7 +177,7 @@ public:
 	 *
 	 * \see seek
 	 */
-	reverse_iterator rseek(size_t pos) { reverse_iterator it = mByteStream.rbegin() + pos; return it; }
+	reverse_iterator rseek(std::size_t pos) { reverse_iterator it = mByteStream.rbegin() + pos; return it; }
 
 	/**
 	 * Gets a byte from the byte stream at a specified position.
@@ -187,7 +187,7 @@ public:
 	 * \warning	Out of range positions yield undefined behavior. Some compilers will
 	 *			throw an \c out_of_range exception.
 	 */
-	byte& operator[](size_t pos) { return mByteStream[pos]; }
+	byte& operator[](std::size_t pos) { return mByteStream[pos]; }
 
 	/**
 	 * Gets a const byte from the byte stream at a specified position.
@@ -197,7 +197,7 @@ public:
 	 * \warning	Out of range positions yield undefined behavior. Some compilers will
 	 *			throw an \c out_of_range exception.
 	 */
-	const_byte& operator[](size_t pos) const { return mByteStream[pos]; }
+	const_byte& operator[](std::size_t pos) const { return mByteStream[pos]; }
 
 	/**
 	 * Clears the File and leaves it completely empty.

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -175,7 +175,7 @@ StringList Filesystem::directoryList(const std::string& dir, const std::string& 
 	}
 	else
 	{
-		size_t filterLen = filter.size();
+		std::size_t filterLen = filter.size();
 		for (char **i = rc; *i != nullptr; i++)
 		{
 			std::string tmpStr = *i;
@@ -330,7 +330,7 @@ std::string Filesystem::workingPath(const std::string& filename) const
 	if (!filename.empty())
 	{
 		std::string tmpStr(filename);
-		size_t pos = tmpStr.rfind("/");
+		std::size_t pos = tmpStr.rfind("/");
 		tmpStr = tmpStr.substr(0, pos + 1);
 		return tmpStr;
 	}
@@ -352,7 +352,7 @@ std::string Filesystem::workingPath(const std::string& filename) const
 std::string Filesystem::extension(const std::string& path) const
 {
 	// This is a naive approach but works for most cases.
-	size_t pos = path.find_last_of(".");
+	std::size_t pos = path.find_last_of(".");
 
 	if (pos != std::string::npos)
 	{

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -246,9 +246,9 @@ void RendererOpenGL::drawSubImageRepeated(Image& image, float rasterX, float ras
 	glScissor(static_cast<int>(rasterX), static_cast<int>(RendererOpenGL::height() - rasterY - h), static_cast<int>(w), static_cast<int>(h));
 
 
-	for (size_t row = 0; row <= heightReach; ++row)
+	for (std::size_t row = 0; row <= heightReach; ++row)
 	{
-		for (size_t col = 0; col <= widthReach; ++col)
+		for (std::size_t col = 0; col <= widthReach; ++col)
 		{
 			drawSubImage(image, rasterX + (col * (subW - subX)), rasterY + (row * (subH - subY)), subX, subY, subW, subH, 255, 255, 255, 255);
 		}
@@ -462,7 +462,7 @@ void RendererOpenGL::drawText(NAS2D::Font& font, const std::string& text, float 
 	GlyphMetricsList& gml = fontMap[font.name()].metrics;
 	if (gml.empty()) { return; }
 
-	for (size_t i = 0; i < text.size(); i++)
+	for (std::size_t i = 0; i < text.size(); i++)
 	{
 		GlyphMetrics& gm = gml[std::clamp<std::size_t>(text[i], 0, 255)];
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -177,7 +177,7 @@ int NAS2D::Font::width(const std::string& str) const
 	GlyphMetricsList& gml = fontMap[name()].metrics;
 	if (gml.empty()) { return 0; }
 
-	for (size_t i = 0; i < str.size(); i++)
+	for (std::size_t i = 0; i < str.size(); i++)
 	{
 		auto glyph = std::clamp<std::size_t>(str[i], 0, 255);
 		width += gml[glyph].advance + gml[glyph].minX;
@@ -306,7 +306,7 @@ bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int gl
 
 	GlyphMetricsList& glm = fontMap[path].metrics;
 	glm.resize(ASCII_TABLE_COUNT);
-	for (size_t i = 0; i < glm.size(); ++i)
+	for (std::size_t i = 0; i < glm.size(); ++i)
 	{
 		glm[i].minX = glyphWidth;
 	}

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -138,7 +138,7 @@ private:
 	std::string mSpriteName{"Default Constructed"}; /**< Name of this Sprite. */
 	std::string mCurrentAction{DEFAULT_ACTION}; /**< The current Action being performed. */
 
-	size_t mCurrentFrame{0}; /**< The current frame index in the current Action's frame list. */
+	std::size_t mCurrentFrame{0}; /**< The current frame index in the current Action's frame list. */
 
 	Callback mFrameCallback; /**< Callback to signal a listener whenever an animation sequence completes. */
 

--- a/NAS2D/Xml/XmlMemoryBuffer.cpp
+++ b/NAS2D/Xml/XmlMemoryBuffer.cpp
@@ -126,7 +126,7 @@ bool XmlMemoryBuffer::visit(const XmlUnknown& unknown)
 }
 
 
-size_t XmlMemoryBuffer::size()
+std::size_t XmlMemoryBuffer::size()
 {
 	return _buffer.size();
 }

--- a/NAS2D/Xml/XmlMemoryBuffer.h
+++ b/NAS2D/Xml/XmlMemoryBuffer.h
@@ -47,7 +47,7 @@ public:
 	bool visit(const XmlComment& comment) override;
 	bool visit(const XmlUnknown& unknown) override;
 
-	size_t size();
+	std::size_t size();
 
 	const std::string& buffer();
 

--- a/NAS2D/Xml/XmlParser.cpp
+++ b/NAS2D/Xml/XmlParser.cpp
@@ -857,7 +857,7 @@ void XmlElement::streamIn(std::istream & in, std::string & tag)
 				// Early out if we find the CDATA id.
 				if (c == '[' && tag.size() >= 9)
 				{
-					size_t len = tag.size();
+					std::size_t len = tag.size();
 					const char* start = tag.c_str() + len - 9;
 					if (strcmp(start, "<![CDATA[") == 0)
 					{
@@ -1354,7 +1354,7 @@ void XmlText::streamIn(std::istream& in, std::string& tag)
 
 		if (cdata && c == '>' && tag.size() >= 3)
 		{
-			size_t len = tag.size();
+			std::size_t len = tag.size();
 			if (tag[len - 2] == ']' && tag[len - 3] == ']')
 			{
 				// terminator of cdata.


### PR DESCRIPTION
Global Search/Replace:
- `size_t` => `std::size_t` (will double the prefix on already prefixed names)
- `std::std::size_t` => `std::size_t` (remove doubled prefixes)
