### PR TITLE
Linux release package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,8 @@ commands:
       - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror" test
       - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror" check
       - run: make package
+      - store_artifacts:
+          path: .build/package/
 
 jobs:
   build-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ commands:
       - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror"
       - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror" test
       - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror" check
+      - run: make package
 
 jobs:
   build-macos:


### PR DESCRIPTION
Add `makefile` rule to build a release `package`:
```
make package
```

Package includes an "include/" folder with all header files, plus the compiled library file.

Archive is tagged with the most recent git tag, plus modifiers to indicate additional commits or dirty (uncommitted) changes. The archive is also tagged with the build configuration, such as target OS and architecture.

Examples:
```
nas2d-1.5.0-Linux.x64.tar.gz
nas2d-1.5.0-1010-ge2e57bc-Linux.x64.tar.gz
nas2d-1.5.0-1010-ge2e57bc-dirty-Linux.x64.tar.gz
```
- `nas2d` - base package name
- `1.5.0` - package version (most recent git tag)
- `-1010-ge2e57bc` - (optional) marks recent commits since tag
  - 1010 additional commits since tag, ending at `g`it tag `e2e57bc`
- `-dirty` - (optional) marks local uncommitted modifictions
- `Linux.x64` - build config (target OS, and architecture)

----

Have CI build a release package, and store it as a build artifact.

----

Linux and MacOS build config change.
