### PR TITLE
Auto releases

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,9 @@ install:
   - set APPVEYOR_SAVE_CACHE_ON_ERROR=true
 build:
   project: NAS2D.sln
+artifacts:
+  - path: "Temporary/*.zip"
+    name: BuildArtifacts
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%\test
   - '%APPVEYOR_BUILD_FOLDER%\test\%PLATFORM%\%CONFIGURATION%\test.exe'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,3 +18,13 @@ artifacts:
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%\test
   - '%APPVEYOR_BUILD_FOLDER%\test\%PLATFORM%\%CONFIGURATION%\test.exe'
+deploy:
+  on:
+    branch: master
+    APPVEYOR_REPO_TAG: true
+    CONFIGURATION: Release
+  artifact: BuildArtifacts
+  description: ''
+  provider: GitHub
+  auth_token:
+    secure: TmV7XiO84JvSaLJnbrRrtoOugcFLSogA4I55yBZ1Y+QAmv28EOgO1M8lX+NSJWA/

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -81,6 +81,9 @@
     <PreBuildEvent>
       <Message>Installing vcpkg dependencies</Message>
     </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>..\Package.bat $(TargetPath) $(Platform) $(Configuration)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -104,6 +107,9 @@
     <PreBuildEvent>
       <Message>Installing vcpkg dependencies</Message>
     </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>..\Package.bat $(TargetPath) $(Platform) $(Configuration)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -134,6 +140,9 @@
     <PreBuildEvent>
       <Message>Installing vcpkg dependencies</Message>
     </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>..\Package.bat $(TargetPath) $(Platform) $(Configuration)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -164,6 +173,9 @@
     <PreBuildEvent>
       <Message>Installing vcpkg dependencies</Message>
     </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>..\Package.bat $(TargetPath) $(Platform) $(Configuration)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Configuration.cpp" />

--- a/Package.bat
+++ b/Package.bat
@@ -1,0 +1,23 @@
+@echo off
+
+set ProjectName=NAS2D
+set OutputFolder=Temporary\
+set PackageFolder=%OutputFolder%Package\
+
+set TargetPath=%1
+set Platform=%2
+set Configuration=%3
+
+
+for /f %%i in ('git describe --tags --dirty') do set Version=%%i
+
+set Config=Windows.%Platform%.%Configuration%
+set PackageName=nas2d-%Version%-%Config%.zip
+
+cd /D "%~dp0"
+xcopy /y /q "%TargetPath%" "%PackageFolder%"
+xcopy /s /y /q NAS2D\*.h "%PackageFolder%include\"
+cd "%PackageFolder%"
+
+powershell -Command "Compress-Archive -Path 'NAS2D.lib', 'include/' -DestinationPath '%PackageName%' -Force"
+move /Y *.zip ..


### PR DESCRIPTION
Add support for automatic GitHub releases on tag.

Add a release packaging script, triggered by `PostBuildEvent`. Release package includes the compiled static library, and an `include/` folder containing all the header files. The release package is marked with the most recent tag, and optionally, with the number of commits since the last tag, and whether or not there have been any uncommitted dirty changes. The package is also tagged with the target OS and architecture.

After a build is complete on AppVeyor, the release package is uploaded as a build artifact.

If the build was triggered by a new tag on `master` being pushed to GitHub, then the CI build will automatically upload the release artifact as a new GitHub release.
