### PR TITLE
Update SDL2-Mixer's dependency options

### DIFF
--- a/InstallVcpkgDeps.bat
+++ b/InstallVcpkgDeps.bat
@@ -16,4 +16,4 @@ if not defined PLATFORM (
 )
 
 :Install
-vcpkg install --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer gtest
+vcpkg install --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[dynamic-load,libflac,libmodplug,libvorbis,opusfile] gtest


### PR DESCRIPTION
Reference: https://github.com/OutpostUniverse/OPHD/issues/219

Add support for more optional audio formats. In particular, for OGG Vorbis. To get the install to work, we need to use the dynamic load option. This requires loading the "vorbisfile.dll" file at runtime to process OGG files.

The "vorbisfile.dll" might not be copied by Vcpkg dependency management during build, so that may need to be a manual step. The DLL has dependencies of it's own, so the following files need to be copied for an executable that wishes to use OGG Vorbis files:
- `vorbisfile.dll`
- `vorbis.dll`
- `ogg.dll`

----

If you've already installed SDL2-Mixer with the previous settings, you may wish to uninstall it using:
```
vcpkg remove sdl2-mixer:x64-windows sdl2-mixer:x86-windows
```
