### PR TITLE
Sign conversion warnings

### DIFF
--- a/NAS2D/File.h
+++ b/NAS2D/File.h
@@ -123,7 +123,7 @@ public:
 	 *				will truncate the existing data. There is no way to
 	 *				recover the data once the File is resized.
 	 */
-	void resize(int size) { mByteStream.resize(size); }
+	void resize(std::size_t size) { mByteStream.resize(size); }
 
 
 	/**
@@ -136,7 +136,7 @@ public:
 	 *				will truncate the existing data. There is no way to
 	 *				recover the data once the File is resized.
 	 */
-	void resize(int size, byte b) { mByteStream.resize(size, b); }
+	void resize(std::size_t size, byte b) { mByteStream.resize(size, b); }
 
 	/**
 	 * Indicates that the File is empty.

--- a/NAS2D/File.h
+++ b/NAS2D/File.h
@@ -168,7 +168,7 @@ public:
 	 *
 	 * \param pos	Position of the iterator to get.
 	 */
-	iterator seek(std::size_t pos) { iterator it = mByteStream.begin() + pos; return it; }
+	iterator seek(std::ptrdiff_t pos) { iterator it = mByteStream.begin() + pos; return it; }
 
 	/**
 	 * Gets a reverse iterator to the byte at a specified position.
@@ -177,7 +177,7 @@ public:
 	 *
 	 * \see seek
 	 */
-	reverse_iterator rseek(std::size_t pos) { reverse_iterator it = mByteStream.rbegin() + pos; return it; }
+	reverse_iterator rseek(std::ptrdiff_t pos) { reverse_iterator it = mByteStream.rbegin() + pos; return it; }
 
 	/**
 	 * Gets a byte from the byte stream at a specified position.

--- a/NAS2D/FpsCounter.cpp
+++ b/NAS2D/FpsCounter.cpp
@@ -35,6 +35,6 @@ unsigned int FpsCounter::fps()
 	++fpsCountIndex;
 	if (fpsCountIndex >= FpsCountsSize) { fpsCountIndex = 0; }
 
-	const auto sum = std::accumulate(std::begin(fpsCounts), std::end(fpsCounts), 0);
+	const auto sum = std::accumulate(std::begin(fpsCounts), std::end(fpsCounts), 0u);
 	return sum / FpsCountsSize;
 }

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -249,7 +249,7 @@ bool load(const std::string& path, unsigned int ptSize)
 		return false;
 	}
 
-	TTF_Font *font = TTF_OpenFontRW(SDL_RWFromConstMem(fontBuffer.raw_bytes(), static_cast<int>(fontBuffer.size())), 0, ptSize);
+	TTF_Font *font = TTF_OpenFontRW(SDL_RWFromConstMem(fontBuffer.raw_bytes(), static_cast<int>(fontBuffer.size())), 0, static_cast<int>(ptSize));
 	if (!font)
 	{
 		std::cout << "Font::load(): " << TTF_GetError() << std::endl;

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -177,9 +177,9 @@ int NAS2D::Font::width(const std::string& str) const
 	GlyphMetricsList& gml = fontMap[name()].metrics;
 	if (gml.empty()) { return 0; }
 
-	for (std::size_t i = 0; i < str.size(); i++)
+	for (auto character : str)
 	{
-		auto glyph = std::clamp<std::size_t>(str[i], 0, 255);
+		auto glyph = std::clamp<std::size_t>(character, 0, 255);
 		width += gml[glyph].advance + gml[glyph].minX;
 	}
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -179,7 +179,7 @@ int NAS2D::Font::width(const std::string& str) const
 
 	for (auto character : str)
 	{
-		auto glyph = std::clamp<std::size_t>(character, 0, 255);
+		auto glyph = std::clamp<std::size_t>(static_cast<uint8_t>(character), 0, 255);
 		width += gml[glyph].advance + gml[glyph].minX;
 	}
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -208,7 +208,7 @@ int NAS2D::Font::ascent() const
 /**
  * Returns the point size of the Font.
  */
-int NAS2D::Font::ptSize() const
+unsigned int NAS2D::Font::ptSize() const
 {
 	return fontMap[name()].pt_size;
 }

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -63,7 +63,7 @@ void updateFontReferenceCount(const std::string& name);
  * \param	ptSize		Point size of the font. Defaults to 12pt.
  *
  */
-NAS2D::Font::Font(const std::string& filePath, int ptSize) :	Resource(filePath)
+NAS2D::Font::Font(const std::string& filePath, unsigned int ptSize) :	Resource(filePath)
 {
 	loaded(::load(name(), ptSize));
 	name(name() + "_" + std::to_string(ptSize) + "pt");

--- a/NAS2D/Resources/Font.h
+++ b/NAS2D/Resources/Font.h
@@ -34,7 +34,7 @@ class Font : public Resource
 {
 public:
 	Font();
-	explicit Font(const std::string& filePath, int ptSize = 12);
+	explicit Font(const std::string& filePath, unsigned int ptSize = 12);
 	Font(const std::string& filePath, int glyphWidth, int glyphHeight, int glyphSpace);
 	Font(const Font& font);
 	Font& operator=(const Font& font);

--- a/NAS2D/Resources/Font.h
+++ b/NAS2D/Resources/Font.h
@@ -44,7 +44,7 @@ public:
 	int height() const;
 	int ascent() const;
 
-	int ptSize() const;
+	unsigned int ptSize() const;
 
 	int glyphCellWidth() const;
 	int glyphCellHeight() const;

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -293,7 +293,7 @@ Color Image::pixelColor(int x, int y) const
 
 	SDL_LockSurface(surface);
 	uint8_t bytesPerPixel = surface->format->BytesPerPixel;
-	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + static_cast<std::size_t>(y) * surface->pitch + static_cast<std::size_t>(x) * bytesPerPixel;
+	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + static_cast<std::size_t>(y) * static_cast<std::size_t>(surface->pitch) + static_cast<std::size_t>(x) * bytesPerPixel;
 
 	unsigned int pixelBytes = 0;
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -110,7 +110,7 @@ void Sprite::resume()
  *
  * \param	frameIndex	New frame index
  */
-void Sprite::setFrame(int frameIndex)
+void Sprite::setFrame(std::size_t frameIndex)
 {
 	if (mActions.find(mCurrentAction) != mActions.end())
 	{

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -576,7 +576,7 @@ void Sprite::addDefaultAction()
 		const auto bounds = NAS2D::Rectangle<int>::Create(NAS2D::Point{0, 0}, size);
 		const auto anchorOffset = size / 2;
 
-		FrameList frameList{SpriteFrame{"default", bounds, anchorOffset, -1}};
+		FrameList frameList{SpriteFrame{"default", bounds, anchorOffset, FRAME_PAUSE}};
 		mActions["default"] = frameList;
 	}
 }

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -20,7 +20,7 @@ using namespace NAS2D::Xml;
 
 const string NAS2D::SPRITE_VERSION("0.99");
 
-const int FRAME_PAUSE = -1;
+const auto FRAME_PAUSE = unsigned(-1);
 
 
 namespace {
@@ -125,7 +125,7 @@ void Sprite::update(Point<float> position)
 
 	if (!mPaused && (frame.frameDelay != FRAME_PAUSE))
 	{
-		while (frame.frameDelay > 0 && static_cast<int>(mTimer.accumulator()) >= frame.frameDelay)
+		while (frame.frameDelay > 0 && mTimer.accumulator() >= frame.frameDelay)
 		{
 			mTimer.adjust_accumulator(frame.frameDelay);
 			mCurrentFrame++;
@@ -518,7 +518,7 @@ void Sprite::processFrames(const std::string& action, void* _node)
 
 			const auto bounds = NAS2D::Rectangle<int>::Create(NAS2D::Point<int>{x, y}, NAS2D::Vector{width, height});
 			const auto anchorOffset = NAS2D::Vector{anchorx, anchory};
-			frameList.push_back(SpriteFrame{sheetId, bounds, anchorOffset, delay});
+			frameList.push_back(SpriteFrame{sheetId, bounds, anchorOffset, static_cast<unsigned int>(delay)});
 		}
 		else
 		{

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -108,7 +108,7 @@ private:
 		std::string sheetId;
 		Rectangle<int> bounds;
 		Vector<int> anchorOffset;
-		int frameDelay;
+		unsigned int frameDelay;
 	};
 
 private:

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -49,7 +49,7 @@ public:
 	void pause();
 	void resume();
 
-	void setFrame(int frameIndex);
+	void setFrame(std::size_t frameIndex);
 
 	void update(Point<float> position);
 	void update(float x, float y);


### PR DESCRIPTION
Reference: #528 (`-Wsign-conversion`)

Fixes a number of miscellaneous sign conversion warnings.

There are more warnings to fix, these are just some of the easier ones.
