### PR TITLE
Use Vector for FontInfo::glyph_size

### DIFF
--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -374,7 +374,7 @@ Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int
 		glm.push_back(metrics);
 	}
 
-	Point<int> size(roundUpPowerOf2(largest_width), roundUpPowerOf2(largest_width));
+	auto size = Point<int>(roundUpPowerOf2(largest_width), roundUpPowerOf2(largest_width));
 	int textureSize = size.x() * GLYPH_MATRIX_SIZE;
 
 	unsigned int rmask = 0, gmask = 0, bmask = 0, amask = 0;

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -374,7 +374,7 @@ Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int
 		glm.push_back(metrics);
 	}
 
-	auto size = Point<int>(roundUpPowerOf2(largest_width), roundUpPowerOf2(largest_width));
+	const auto size = Point<int>(roundUpPowerOf2(largest_width), roundUpPowerOf2(largest_width));
 	int textureSize = size.x() * GLYPH_MATRIX_SIZE;
 
 	unsigned int rmask = 0, gmask = 0, bmask = 0, amask = 0;

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -374,7 +374,7 @@ Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int
 		glm.push_back(metrics);
 	}
 
-	const auto size = Point(roundUpPowerOf2(largest_width), roundUpPowerOf2(largest_width)).to<int>();
+	const auto size = Point{roundUpPowerOf2(largest_width), roundUpPowerOf2(largest_width)}.to<int>();
 	int textureSize = size.x() * GLYPH_MATRIX_SIZE;
 
 	unsigned int rmask = 0, gmask = 0, bmask = 0, amask = 0;

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -374,8 +374,8 @@ Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int
 		glm.push_back(metrics);
 	}
 
-	const auto size = Point{roundUpPowerOf2(largest_width), roundUpPowerOf2(largest_width)}.to<int>();
-	int textureSize = size.x() * GLYPH_MATRIX_SIZE;
+	const auto size = Vector{roundUpPowerOf2(largest_width), roundUpPowerOf2(largest_width)}.to<int>();
+	int textureSize = size.x * GLYPH_MATRIX_SIZE;
 
 	unsigned int rmask = 0, gmask = 0, bmask = 0, amask = 0;
 	setupMasks(rmask, gmask, bmask, amask);
@@ -389,10 +389,10 @@ Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int
 		{
 			int glyph = (row * GLYPH_MATRIX_SIZE) + col;
 
-			glm[glyph].uvX = static_cast<float>(col * size.x()) / static_cast<float>(textureSize);
-			glm[glyph].uvY = static_cast<float>(row * size.y()) / static_cast<float>(textureSize);
-			glm[glyph].uvW = glm[glyph].uvX + static_cast<float>(size.x()) / static_cast<float>(textureSize);
-			glm[glyph].uvH = glm[glyph].uvY + static_cast<float>(size.y()) / static_cast<float>(textureSize);
+			glm[glyph].uvX = static_cast<float>(col * size.x) / static_cast<float>(textureSize);
+			glm[glyph].uvY = static_cast<float>(row * size.y) / static_cast<float>(textureSize);
+			glm[glyph].uvW = glm[glyph].uvX + static_cast<float>(size.x) / static_cast<float>(textureSize);
+			glm[glyph].uvH = glm[glyph].uvY + static_cast<float>(size.y) / static_cast<float>(textureSize);
 
 			// HACK HACK HACK!
 			// Apparently glyph zero has no size with some fonts and so SDL_TTF complains about it.
@@ -408,7 +408,7 @@ Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int
 			else
 			{
 				SDL_SetSurfaceBlendMode(srf, SDL_BLENDMODE_NONE);
-				SDL_Rect rect = { col * size.x(), row * size.y(), 0, 0 };
+				SDL_Rect rect = { col * size.x, row * size.y, 0, 0 };
 				SDL_BlitSurface(srf, nullptr, glyphMap, &rect);
 				SDL_FreeSurface(srf);
 			}
@@ -423,7 +423,7 @@ Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int
 	fontMap[name].ref_count++;
 	SDL_FreeSurface(glyphMap);
 
-	return {size.x(), size.y()};
+	return size;
 }
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -374,7 +374,7 @@ Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int
 		glm.push_back(metrics);
 	}
 
-	const auto size = Point<int>(roundUpPowerOf2(largest_width), roundUpPowerOf2(largest_width));
+	const auto size = Point(roundUpPowerOf2(largest_width), roundUpPowerOf2(largest_width)).to<int>();
 	int textureSize = size.x() * GLYPH_MATRIX_SIZE;
 
 	unsigned int rmask = 0, gmask = 0, bmask = 0, amask = 0;

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -50,7 +50,7 @@ extern unsigned int generateTexture(void *buffer, int bytesPerPixel, int width, 
 // ==================================================================================
 bool load(const std::string& path, unsigned int ptSize);
 bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace);
-Point<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int font_size);
+Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int font_size);
 bool fontAlreadyLoaded(const std::string& name);
 void setupMasks(unsigned int& rmask, unsigned int& gmask, unsigned int& bmask, unsigned int& amask);
 void updateFontReferenceCount(const std::string& name);
@@ -258,7 +258,7 @@ bool load(const std::string& path, unsigned int ptSize)
 
 	fontMap[fontname].height = TTF_FontHeight(font);
 	fontMap[fontname].ascent = TTF_FontAscent(font);
-	fontMap[fontname].glyph_size = generateGlyphMap(font, fontname, ptSize) - Point{0, 0};
+	fontMap[fontname].glyph_size = generateGlyphMap(font, fontname, ptSize);
 	TTF_CloseFont(font);
 
 	return true;
@@ -344,7 +344,7 @@ bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int gl
  *
  * Internal function used to generate a glyph texture map from an TTF_Font struct.
  */
-Point<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int font_size)
+Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int font_size)
 {
 	int largest_width = 0;
 
@@ -423,7 +423,7 @@ Point<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int 
 	fontMap[name].ref_count++;
 	SDL_FreeSurface(glyphMap);
 
-	return size;
+	return {size.x(), size.y()};
 }
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -151,7 +151,7 @@ NAS2D::Font& NAS2D::Font::operator=(const Font& rhs)
  */
 int NAS2D::Font::glyphCellWidth() const
 {
-	return fontMap[name()].glyph_size.x();
+	return fontMap[name()].glyph_size.x;
 }
 
 
@@ -160,7 +160,7 @@ int NAS2D::Font::glyphCellWidth() const
  */
 int NAS2D::Font::glyphCellHeight() const
 {
-	return fontMap[name()].glyph_size.y();
+	return fontMap[name()].glyph_size.y;
 }
 
 
@@ -258,7 +258,7 @@ bool load(const std::string& path, unsigned int ptSize)
 
 	fontMap[fontname].height = TTF_FontHeight(font);
 	fontMap[fontname].ascent = TTF_FontAscent(font);
-	fontMap[fontname].glyph_size = generateGlyphMap(font, fontname, ptSize);
+	fontMap[fontname].glyph_size = generateGlyphMap(font, fontname, ptSize) - Point{0, 0};
 	TTF_CloseFont(font);
 
 	return true;

--- a/NAS2D/Resources/FontInfo.h
+++ b/NAS2D/Resources/FontInfo.h
@@ -42,7 +42,7 @@ struct FontInfo
 	int height{0};
 	int ascent{0};
 	int ref_count{0};
-	NAS2D::Point<int> glyph_size;
+	Point<int> glyph_size;
 	GlyphMetricsList metrics;
 };
 

--- a/NAS2D/Resources/FontInfo.h
+++ b/NAS2D/Resources/FontInfo.h
@@ -13,6 +13,9 @@
 
 #include <iostream>
 
+
+namespace NAS2D {
+
 struct GlyphMetrics
 {
 	float uvX{0.0f};
@@ -42,3 +45,5 @@ struct FontInfo
 	NAS2D::Point<int> glyph_size;
 	GlyphMetricsList metrics;
 };
+
+}

--- a/NAS2D/Resources/FontInfo.h
+++ b/NAS2D/Resources/FontInfo.h
@@ -42,7 +42,7 @@ struct FontInfo
 	int height{0};
 	int ascent{0};
 	int ref_count{0};
-	Point<int> glyph_size;
+	Vector<int> glyph_size;
 	GlyphMetricsList metrics;
 };
 


### PR DESCRIPTION
A size value is now more appropriately handled by the Vector type than the older Point type.
