### PR TITLE
Update FontInfo header include for Vector

### DIFF
--- a/NAS2D/Resources/FontInfo.h
+++ b/NAS2D/Resources/FontInfo.h
@@ -9,7 +9,7 @@
 // ==================================================================================
 #pragma once
 
-#include "../Renderer/Point.h"
+#include "../Renderer/Vector.h"
 
 #include <iostream>
 


### PR DESCRIPTION
Reference: #606

Internally used type was recently changed from `Point` to `Vector`. It so happens that `Point.h` includes `Vector.h`, so this change was missed earlier in #606.
