### PR TITLE
Fix sign conversion warnings in StringUtils

### DIFF
--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -45,7 +45,7 @@ std::string toUppercase(std::string str)
 
 std::vector<std::string> split(std::string str, char delim /*= ','*/)
 {
-	const auto potential_count = 1 + std::count(std::begin(str), std::end(str), delim);
+	const auto potential_count = static_cast<std::size_t>(1 + std::count(std::begin(str), std::end(str), delim));
 	StringList result{};
 	result.reserve(potential_count);
 
@@ -65,7 +65,7 @@ std::vector<std::string> split(std::string str, char delim /*= ','*/)
 }
 std::vector<std::string> splitSkipEmpty(std::string str, char delim /*= ','*/)
 {
-	const auto potential_count = 1 + std::count(std::begin(str), std::end(str), delim);
+	const auto potential_count = static_cast<std::size_t>(1 + std::count(std::begin(str), std::end(str), delim));
 	StringList result{};
 	result.reserve(potential_count);
 

--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -45,9 +45,9 @@ std::string toUppercase(std::string str)
 
 std::vector<std::string> split(std::string str, char delim /*= ','*/)
 {
-	const auto potential_count = static_cast<std::size_t>(1 + std::count(std::begin(str), std::end(str), delim));
+	const auto potentialCount = static_cast<std::size_t>(1 + std::count(std::begin(str), std::end(str), delim));
 	StringList result{};
-	result.reserve(potential_count);
+	result.reserve(potentialCount);
 
 	std::istringstream ss(str);
 
@@ -65,9 +65,9 @@ std::vector<std::string> split(std::string str, char delim /*= ','*/)
 }
 std::vector<std::string> splitSkipEmpty(std::string str, char delim /*= ','*/)
 {
-	const auto potential_count = static_cast<std::size_t>(1 + std::count(std::begin(str), std::end(str), delim));
+	const auto potentialCount = static_cast<std::size_t>(1 + std::count(std::begin(str), std::end(str), delim));
 	StringList result{};
-	result.reserve(potential_count);
+	result.reserve(potentialCount);
 
 	std::istringstream ss(str);
 


### PR DESCRIPTION
Reference: #528 (`-Wsign-conversion`)

For some odd reason [`std::count`](https://en.cppreference.com/w/cpp/algorithm/count) returns a signed type. Formally it returns `typename iterator_traits<InputIt>::difference_type`, which for most standard containers is [`std::ptrdiff_t`](https://en.cppreference.com/w/cpp/types/ptrdiff_t).
