### PR TITLE
Use unnamed namespace in Image

### DIFF
--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -24,19 +24,19 @@
 using namespace NAS2D;
 using namespace NAS2D::Exception;
 
-const std::string DEFAULT_IMAGE_NAME	= "Default Image";
-const std::string ARBITRARY_IMAGE_NAME	= "arbitrary_image_";
-
 
 using TextureIdMap = std::map<std::string, ImageInfo>;
-
 TextureIdMap imageIdMap; /**< Lookup table for OpenGL Texture ID's. */
-int IMAGE_ARBITRARY = 0; /**< Counter for arbitrary image ID's. */
+
 
 // ==================================================================================
 // = UNEXPOSED FUNCTION PROTOTYPES
 // ==================================================================================
 namespace {
+const std::string DEFAULT_IMAGE_NAME	= "Default Image";
+const std::string ARBITRARY_IMAGE_NAME	= "arbitrary_image_";
+int IMAGE_ARBITRARY = 0; /**< Counter for arbitrary image ID's. */
+
 bool checkTextureId(const std::string& name);
 unsigned int generateTexture(void *buffer, int bytesPerPixel, int width, int height);
 void updateImageReferenceCount(const std::string& name);

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -36,9 +36,11 @@ int IMAGE_ARBITRARY = 0; /**< Counter for arbitrary image ID's. */
 // ==================================================================================
 // = UNEXPOSED FUNCTION PROTOTYPES
 // ==================================================================================
+namespace {
 bool checkTextureId(const std::string& name);
 unsigned int generateTexture(void *buffer, int bytesPerPixel, int width, int height);
 void updateImageReferenceCount(const std::string& name);
+}
 
 
 /**
@@ -346,7 +348,7 @@ Color Image::pixelColor(int x, int y) const
 // = Unexposed module-level functions defined here that don't need to be part of the
 // = API interface.
 // ==================================================================================
-
+namespace {
 /**
 * Internal function used to clean up references to fonts when the Image
 * destructor or copy assignment operators are called.
@@ -442,4 +444,6 @@ unsigned int generateTexture(void *buffer, int bytesPerPixel, int width, int hei
 	glTexImage2D(GL_TEXTURE_2D, 0, textureFormat, width, height, 0, textureFormat, GL_UNSIGNED_BYTE, buffer);
 
 	return texture_id;
+}
+
 }

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -29,9 +29,6 @@ using TextureIdMap = std::map<std::string, ImageInfo>;
 TextureIdMap imageIdMap; /**< Lookup table for OpenGL Texture ID's. */
 
 
-// ==================================================================================
-// = UNEXPOSED FUNCTION PROTOTYPES
-// ==================================================================================
 namespace {
 	const std::string DEFAULT_IMAGE_NAME	= "Default Image";
 	const std::string ARBITRARY_IMAGE_NAME	= "arbitrary_image_";
@@ -344,10 +341,6 @@ Color Image::pixelColor(int x, int y) const
 }
 
 
-// ==================================================================================
-// = Unexposed module-level functions defined here that don't need to be part of the
-// = API interface.
-// ==================================================================================
 namespace {
 	/**
 	* Internal function used to clean up references to fonts when the Image

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -407,37 +407,37 @@ namespace {
 }
 
 
-	/**
-	 * Generates a new OpenGL texture from an SDL_Surface.
-	 */
-	unsigned int generateTexture(void *buffer, int bytesPerPixel, int width, int height)
+/**
+ * Generates a new OpenGL texture from an SDL_Surface.
+ */
+unsigned int generateTexture(void *buffer, int bytesPerPixel, int width, int height)
+{
+	GLenum textureFormat = 0;
+	switch (bytesPerPixel)
 	{
-		GLenum textureFormat = 0;
-		switch (bytesPerPixel)
-		{
-		case 4:
-			textureFormat = SDL_BYTEORDER == SDL_BIG_ENDIAN ? GL_BGRA : GL_RGBA;
-			break;
-		case 3:
-			textureFormat = SDL_BYTEORDER == SDL_BIG_ENDIAN ? GL_BGR : GL_RGB;
-			break;
+	case 4:
+		textureFormat = SDL_BYTEORDER == SDL_BIG_ENDIAN ? GL_BGRA : GL_RGBA;
+		break;
+	case 3:
+		textureFormat = SDL_BYTEORDER == SDL_BIG_ENDIAN ? GL_BGR : GL_RGB;
+		break;
 
-		default:
-			throw image_unsupported_bit_depth();
-		}
-
-		GLuint texture_id;
-		glGenTextures(1, &texture_id);
-		glBindTexture(GL_TEXTURE_2D, texture_id);
-
-		// Set texture and pixel handling states.
-		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-		glTexImage2D(GL_TEXTURE_2D, 0, textureFormat, width, height, 0, textureFormat, GL_UNSIGNED_BYTE, buffer);
-
-		return texture_id;
+	default:
+		throw image_unsupported_bit_depth();
 	}
+
+	GLuint texture_id;
+	glGenTextures(1, &texture_id);
+	glBindTexture(GL_TEXTURE_2D, texture_id);
+
+	// Set texture and pixel handling states.
+	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+	glTexImage2D(GL_TEXTURE_2D, 0, textureFormat, width, height, 0, textureFormat, GL_UNSIGNED_BYTE, buffer);
+
+	return texture_id;
+}

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -29,13 +29,15 @@ using TextureIdMap = std::map<std::string, ImageInfo>;
 TextureIdMap imageIdMap; /**< Lookup table for OpenGL Texture ID's. */
 
 
+unsigned int generateTexture(void *buffer, int bytesPerPixel, int width, int height);
+
+
 namespace {
 	const std::string DEFAULT_IMAGE_NAME	= "Default Image";
 	const std::string ARBITRARY_IMAGE_NAME	= "arbitrary_image_";
 	int IMAGE_ARBITRARY = 0; /**< Counter for arbitrary image ID's. */
 
 	bool checkTextureId(const std::string& name);
-	unsigned int generateTexture(void *buffer, int bytesPerPixel, int width, int height);
 	void updateImageReferenceCount(const std::string& name);
 }
 
@@ -402,6 +404,7 @@ namespace {
 
 		return false;
 	}
+}
 
 
 	/**
@@ -438,4 +441,3 @@ namespace {
 
 		return texture_id;
 	}
-}


### PR DESCRIPTION
Wrap private details in unnamed namespace. This prevents name collision errors during the link step. It also guards against someone gaining access to the methods by providing an `extern` declaration from a different translation unit.
