### PR TITLE
Add Vector::lengthSquared() method

### DIFF
--- a/NAS2D/Renderer/Vector.h
+++ b/NAS2D/Renderer/Vector.h
@@ -66,6 +66,10 @@ struct Vector {
 		return {x / scalar, y / scalar};
 	}
 
+	BaseType lengthSquared() const {
+		return (x * x) + (y * y);
+	}
+
 	template <typename NewBaseType>
 	operator Vector<NewBaseType>() const {
 		return {

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -79,6 +79,23 @@ TEST(Vector, DivideScalar) {
 	EXPECT_THROW((NAS2D::Vector{2, 4} /= 0), std::domain_error);
 }
 
+TEST(Vector, lengthSquared) {
+	// Test a few simple vectors
+	for (int i = 0; i < 10; ++i) {
+		// Single coordinate is simple squaring
+		// Test symmetry in both coordinates
+		EXPECT_EQ(i*i, (NAS2D::Vector{i, 0}).lengthSquared());
+		EXPECT_EQ(i*i, (NAS2D::Vector{0, i}).lengthSquared());
+		// Double equal coordinates doubles result
+		EXPECT_EQ(2 * i*i, (NAS2D::Vector{i, i}).lengthSquared());
+	}
+
+	// Test a few mixed values
+	EXPECT_EQ(5, (NAS2D::Vector{1, 2}).lengthSquared());
+	EXPECT_EQ(13, (NAS2D::Vector{2, 3}).lengthSquared());
+	EXPECT_EQ(25, (NAS2D::Vector{3, 4}).lengthSquared());
+}
+
 TEST(Vector, OperatorType) {
 	EXPECT_EQ((NAS2D::Vector<int>{1, 2}), static_cast<NAS2D::Vector<int>>(NAS2D::Vector<float>{1.0, 2.0}));
 	EXPECT_EQ((NAS2D::Vector<float>{1.0, 2.0}), static_cast<NAS2D::Vector<float>>(NAS2D::Vector<int>{1, 2}));


### PR DESCRIPTION
Add `Vector::lengthSquared()` method to help with distance boundary checking and distance calculations.

Using the square is more efficient for distance boundary checking, since it avoids an expensive square root operation.

Providing only the square avoids issues of what type to return for a generic `Vector` struct with `BaseType` fields. The standard library square root algorithm always returns floating point. This might not always be appropriate if `BaseType` is an integer type. We could cast, which adds more overhead, or we could implement a custom integer based square root algorithm. All decisions that can be decided another day, if and when we choose to address the issue.
