### PR TITLE
Mark Vector::dotProduct as const

### DIFF
--- a/NAS2D/Renderer/Vector.h
+++ b/NAS2D/Renderer/Vector.h
@@ -70,7 +70,7 @@ struct Vector {
 		return (x * x) + (y * y);
 	}
 
-	BaseType dotProduct(const Vector& other) {
+	BaseType dotProduct(const Vector& other) const {
 		return (x * other.x) + (y * other.y);
 	}
 

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -84,10 +84,13 @@ TEST(Vector, lengthSquared) {
 	for (int i = 0; i < 10; ++i) {
 		// Single coordinate is simple squaring
 		// Test symmetry in both coordinates
-		EXPECT_EQ(i*i, (NAS2D::Vector{i, 0}).lengthSquared());
-		EXPECT_EQ(i*i, (NAS2D::Vector{0, i}).lengthSquared());
+		const auto vectorX = NAS2D::Vector{i, 0};
+		const auto vectorY = NAS2D::Vector{0, i};
+		EXPECT_EQ(i*i, vectorX.lengthSquared());
+		EXPECT_EQ(i*i, vectorY.lengthSquared());
 		// Double equal coordinates doubles result
-		EXPECT_EQ(2 * i*i, (NAS2D::Vector{i, i}).lengthSquared());
+		const auto vectorXY = NAS2D::Vector{i, i};
+		EXPECT_EQ(2 * i*i, vectorXY.lengthSquared());
 	}
 
 	// Test a few mixed values

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -99,13 +99,16 @@ TEST(Vector, lengthSquared) {
 TEST(Vector, dotProduct) {
 	// Test a few simple vectors
 	for (int i = 0; i < 10; ++i) {
+		const auto vectorX = NAS2D::Vector{i, 0};
+		const auto vectorY = NAS2D::Vector{0, i};
 		// Pairwise disjoint coordinates
-		EXPECT_EQ(0, (NAS2D::Vector{i, 0}.dotProduct(NAS2D::Vector{0, i})));
+		EXPECT_EQ(0, vectorX.dotProduct(vectorY));
 		// Equal single coordinates
-		EXPECT_EQ(i*i, (NAS2D::Vector{i, 0}.dotProduct(NAS2D::Vector{i, 0})));
-		EXPECT_EQ(i*i, (NAS2D::Vector{0, i}.dotProduct(NAS2D::Vector{0, i})));
+		EXPECT_EQ(i*i, vectorX.dotProduct(vectorX));
+		EXPECT_EQ(i*i, vectorY.dotProduct(vectorY));
 		// Equal pair coordinates
-		EXPECT_EQ(2 * i*i, (NAS2D::Vector{i, i}.dotProduct(NAS2D::Vector{i, i})));
+		const auto vectorXY = NAS2D::Vector{i, i};
+		EXPECT_EQ(2 * i*i, vectorXY.dotProduct(vectorXY));
 	}
 
 	// Test a few mixed values


### PR DESCRIPTION
Mark `Vector::dotProduct` as `const`. This was missed in PR #617.
