### PR TITLE
Move lineIntersectsCircle

### DIFF
--- a/NAS2D/MathUtils.cpp
+++ b/NAS2D/MathUtils.cpp
@@ -8,10 +8,41 @@
 // = Acknowledgment of your use of NAS2D is appreciated but is not required.
 // ==================================================================================
 #include "MathUtils.h"
+#include <algorithm>
 #include <stdexcept>
 
 
 namespace NAS2D {
+
+/**
+ * Determines if a given line intersects a given circle.
+ *
+ * \param	p	First point of a line segment.
+ * \param	q	Second point of a line segment.
+ * \param	c	Center point of a circle.
+ * \param	r	Radius of a circle.
+ */
+bool lineIntersectsCircle(const Point<int>& p, const Point<int>& q, const Point<int>& c, float r)
+{
+	float dx = static_cast<float>(q.x() - p.x());
+	float dy = static_cast<float>(q.y() - p.y());
+
+	float t = -(((p.x() - c.x()) * dx) + ((p.y() - c.y()) * dy)) / ((dx * dx) + (dy * dy));
+
+	t = std::clamp(t, 0.0f, 1.0f);
+
+	dx = (p.x() + (t * (q.x() - p.x()))) - c.x();
+	dy = (p.y() + (t * (q.y() - p.y()))) - c.y();
+	float rt = (dx * dx) + (dy * dy);
+
+	if (rt < (r * r))
+	{
+		return true;
+	}
+
+	return false;
+}
+
 
 /**
  * Basic integer division that rounds up to the nearest whole number.

--- a/NAS2D/MathUtils.h
+++ b/NAS2D/MathUtils.h
@@ -21,6 +21,7 @@
 
 namespace NAS2D
 {
+	bool lineIntersectsCircle(const Point<int>& p, const Point<int>& q, const Point<int>& c, float r);
 
 	int divideUp(int to_divide, int divisor);
 

--- a/NAS2D/Trig.cpp
+++ b/NAS2D/Trig.cpp
@@ -13,38 +13,38 @@
 #include <cmath>
 #include <algorithm>
 
-using namespace NAS2D;
+namespace NAS2D {
 
 // Common Trig Defines
-const float NAS2D::PI = 3.14159265f;
-const float NAS2D::PI_2 = NAS2D::PI * 2;
+const float PI = 3.14159265f;
+const float PI_2 = PI * 2;
 
-const float NAS2D::DEG2RAD = NAS2D::PI / 180.0f;
-const float NAS2D::RAD2DEG = 180 / NAS2D::PI;
+const float DEG2RAD = PI / 180.0f;
+const float RAD2DEG = 180 / PI;
 
 
 /**
  * Gets an angle in radians from degrees.
  */
-float NAS2D::degToRad(float degree)
+float degToRad(float degree)
 {
-	return degree * NAS2D::DEG2RAD;
+	return degree * DEG2RAD;
 }
 
 
 /**
  * Gets an angle in degrees from radians.
  */
-float NAS2D::radToDeg(float rad)
+float radToDeg(float rad)
 {
-	return rad * -NAS2D::RAD2DEG;
+	return rad * -RAD2DEG;
 }
 
 
 /**
  * Gets the angle of a line in degrees given two points.
  */
-float NAS2D::angleFromPoints(float x, float y, float x2, float y2)
+float angleFromPoints(float x, float y, float x2, float y2)
 {
 	return 90.0f - radToDeg(std::atan2(y2 - y, x2 - x));
 }
@@ -56,9 +56,9 @@ float NAS2D::angleFromPoints(float x, float y, float x2, float y2)
  * Assumes screen coordinates (origin is top left).
  * Angle of 0 corresponds to up, and increases clockwise.
  */
-Vector<float> NAS2D::getDirectionVector(float angle)
+Vector<float> getDirectionVector(float angle)
 {
-	return {std::sin(NAS2D::degToRad(angle)), -std::cos(NAS2D::degToRad(angle))};
+	return {std::sin(degToRad(angle)), -std::cos(degToRad(angle))};
 }
 
 
@@ -70,7 +70,7 @@ Vector<float> NAS2D::getDirectionVector(float angle)
  * \param	c	Center point of a circle.
  * \param	r	Radius of a circle.
  */
-bool NAS2D::lineIntersectsCircle(const Point<int>& p, const Point<int>& q, const Point<int>& c, float r)
+bool lineIntersectsCircle(const Point<int>& p, const Point<int>& q, const Point<int>& c, float r)
 {
 	float dx = static_cast<float>(q.x() - p.x());
 	float dy = static_cast<float>(q.y() - p.y());
@@ -89,4 +89,6 @@ bool NAS2D::lineIntersectsCircle(const Point<int>& p, const Point<int>& q, const
 	}
 
 	return false;
+}
+
 }

--- a/NAS2D/Trig.cpp
+++ b/NAS2D/Trig.cpp
@@ -11,7 +11,6 @@
 #include "Trig.h"
 
 #include <cmath>
-#include <algorithm>
 
 namespace NAS2D {
 
@@ -59,36 +58,6 @@ float angleFromPoints(float x, float y, float x2, float y2)
 Vector<float> getDirectionVector(float angle)
 {
 	return {std::sin(degToRad(angle)), -std::cos(degToRad(angle))};
-}
-
-
-/**
- * Determines if a given line intersects a given circle.
- *
- * \param	p	First point of a line segment.
- * \param	q	Second point of a line segment.
- * \param	c	Center point of a circle.
- * \param	r	Radius of a circle.
- */
-bool lineIntersectsCircle(const Point<int>& p, const Point<int>& q, const Point<int>& c, float r)
-{
-	float dx = static_cast<float>(q.x() - p.x());
-	float dy = static_cast<float>(q.y() - p.y());
-
-	float t = -(((p.x() - c.x()) * dx) + ((p.y() - c.y()) * dy)) / ((dx * dx) + (dy * dy));
-
-	t = std::clamp(t, 0.0f, 1.0f);
-
-	dx = (p.x() + (t * (q.x() - p.x()))) - c.x();
-	dy = (p.y() + (t * (q.y() - p.y()))) - c.y();
-	float rt = (dx * dx) + (dy * dy);
-
-	if (rt < (r * r))
-	{
-		return true;
-	}
-
-	return false;
 }
 
 }

--- a/NAS2D/Trig.h
+++ b/NAS2D/Trig.h
@@ -25,6 +25,4 @@ float radToDeg(float rad);
 float angleFromPoints(float x, float y, float x2, float y2);
 Vector<float> getDirectionVector(float angle);
 
-bool lineIntersectsCircle(const Point<int>& p, const Point<int>& q, const Point<int>& c, float r);
-
 }

--- a/test/MathUtils.test.cpp
+++ b/test/MathUtils.test.cpp
@@ -3,16 +3,15 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-TEST(MathUtils, divideUpByZero)
-{
+
+TEST(MathUtils, divideUpByZero) {
 	EXPECT_THROW(NAS2D::divideUp(0, 0), std::domain_error);
 	EXPECT_THROW(NAS2D::divideUp(1, 0), std::domain_error);
 	EXPECT_THROW(NAS2D::divideUp(2, 0), std::domain_error);
 	EXPECT_THROW(NAS2D::divideUp(256, 0), std::domain_error);
 }
 
-TEST(MathUtils, divideUp)
-{
+TEST(MathUtils, divideUp) {
 	EXPECT_EQ(0, NAS2D::divideUp(0, 1));
 	EXPECT_EQ(0, NAS2D::divideUp(0, 2));
 	EXPECT_EQ(0, NAS2D::divideUp(0, 3));
@@ -38,8 +37,7 @@ TEST(MathUtils, divideUp)
 	EXPECT_EQ(20, NAS2D::divideUp(256, 13));
 }
 
-TEST(MathUtils, roundUpPowerOf2)
-{
+TEST(MathUtils, roundUpPowerOf2) {
 	EXPECT_EQ(1u, NAS2D::roundUpPowerOf2(1));
 	EXPECT_EQ(2u, NAS2D::roundUpPowerOf2(2));
 	EXPECT_EQ(4u, NAS2D::roundUpPowerOf2(3));
@@ -77,8 +75,7 @@ TEST(MathUtils, roundUpPowerOf2)
 	EXPECT_EQ(2147483648u, NAS2D::roundUpPowerOf2(2147483648));
 }
 
-TEST(MathUtils, mapDomainToRange)
-{
+TEST(MathUtils, mapDomainToRange) {
 	// Fahrenheit to Celcius
 	EXPECT_NEAR(-18.33333f, NAS2D::scaleLinear(-1.0f, 32.0f, 212.0f, 0.0f, 100.0f), 0.0001f);
 	EXPECT_NEAR(-18.33333f, NAS2D::scaleLinear(-1.0f, 212.0f, 32.0f, 100.0f, 0.0f), 0.0001f);

--- a/test/MathUtils.test.cpp
+++ b/test/MathUtils.test.cpp
@@ -4,6 +4,30 @@
 #include <gtest/gtest.h>
 
 
+TEST(MathUtils, lineIntersectsCircle) {
+	const auto circleCenter = NAS2D::Point{0, 0};
+
+	// Interior
+	EXPECT_TRUE((lineIntersectsCircle(NAS2D::Point{-1, 0}, NAS2D::Point{1, 0}, circleCenter, 1)));
+	EXPECT_TRUE((lineIntersectsCircle(NAS2D::Point{0, -1}, NAS2D::Point{0, 1}, circleCenter, 1)));
+	EXPECT_TRUE((lineIntersectsCircle(NAS2D::Point{-1, -1}, NAS2D::Point{1, 1}, circleCenter, 1)));
+	EXPECT_TRUE((lineIntersectsCircle(NAS2D::Point{-1, 1}, NAS2D::Point{1, -1}, circleCenter, 1)));
+	EXPECT_TRUE((lineIntersectsCircle(NAS2D::Point{-1, -1}, NAS2D::Point{1, 2}, circleCenter, 1)));
+	EXPECT_TRUE((lineIntersectsCircle(NAS2D::Point{-1, -1}, NAS2D::Point{2, 1}, circleCenter, 1)));
+
+	// Boundary
+	EXPECT_FALSE((lineIntersectsCircle(NAS2D::Point{-1, -1}, NAS2D::Point{1, -1}, circleCenter, 1)));
+	EXPECT_FALSE((lineIntersectsCircle(NAS2D::Point{-1, 1}, NAS2D::Point{1, 1}, circleCenter, 1)));
+	EXPECT_FALSE((lineIntersectsCircle(NAS2D::Point{-1, -1}, NAS2D::Point{-1, 1}, circleCenter, 1)));
+	EXPECT_FALSE((lineIntersectsCircle(NAS2D::Point{1, -1}, NAS2D::Point{1, 1}, circleCenter, 1)));
+
+	// Exterior
+	EXPECT_FALSE((lineIntersectsCircle(NAS2D::Point{-1, -2}, NAS2D::Point{1, -2}, circleCenter, 1)));
+	EXPECT_FALSE((lineIntersectsCircle(NAS2D::Point{-1, 2}, NAS2D::Point{1, 2}, circleCenter, 1)));
+	EXPECT_FALSE((lineIntersectsCircle(NAS2D::Point{-2, -1}, NAS2D::Point{-2, 1}, circleCenter, 1)));
+	EXPECT_FALSE((lineIntersectsCircle(NAS2D::Point{2, -1}, NAS2D::Point{2, 1}, circleCenter, 1)));
+}
+
 TEST(MathUtils, divideUpByZero) {
 	EXPECT_THROW(NAS2D::divideUp(0, 0), std::domain_error);
 	EXPECT_THROW(NAS2D::divideUp(1, 0), std::domain_error);

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -3,8 +3,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-TEST(String, split)
-{
+
+TEST(String, split) {
 	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::split("a,b,c"));
 	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split("abc"));
 	EXPECT_EQ((NAS2D::StringList{"", "abc"}), NAS2D::split(",abc"));
@@ -20,8 +20,7 @@ TEST(String, split)
 	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::split("abc.", '.'));
 }
 
-TEST(String, splitSkipEmpty)
-{
+TEST(String, splitSkipEmpty) {
 	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitSkipEmpty("a,b,c"));
 	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc"));
 	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty(",abc"));

--- a/test/Version.test.cpp
+++ b/test/Version.test.cpp
@@ -3,8 +3,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-TEST(Version, versionString)
-{
+
+TEST(Version, versionString) {
 #if GTEST_USES_POSIX_RE == 1
 	EXPECT_THAT(NAS2D::versionString(), testing::MatchesRegex(R"([0-9]+\.[0-9]+\.[0-9]+)"));
 #elif GTEST_USES_SIMPLE_RE == 1


### PR DESCRIPTION
Move `lineIntersectsCircle` from Trig to MathUtils. Add unit tests.

This method doesn't actually make use of any trigonometric functions, nor would it be used by them.
