### PR TITLE
Fix test graphics project

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -93,10 +93,23 @@ std::string Filesystem::prefPath() const
  * Mount a folder with read access
  *
  * \param path	File path to add.
+ *
+ * \return Nonzero on success, zero on error.
+ */
+int Filesystem::mountSoftFail(const std::string& path) const
+{
+	return PHYSFS_mount(path.c_str(), "/", MountPosition::MOUNT_APPEND);
+}
+
+
+/**
+ * Mount a folder with read access
+ *
+ * \param path	File path to add.
  */
 void Filesystem::mount(const std::string& path) const
 {
-	if (PHYSFS_mount(path.c_str(), "/", MountPosition::MOUNT_APPEND) == 0)
+	if (mountSoftFail(path) == 0)
 	{
 		throw std::runtime_error(std::string("Couldn't add '") + path + "' to search path: " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -39,6 +39,7 @@ public:
 
 	std::string workingPath(const std::string& filename) const;
 	StringList searchPath() const;
+	int mountSoftFail(const std::string& path) const;
 	void mount(const std::string& path) const;
 	void mountReadWrite(const std::string& path) const;
 	void unmount(const std::string& path) const;

--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -47,8 +47,8 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 	std::cout.flush();
 
 	auto& fs = Utility<Filesystem>::init<Filesystem>(argv_0, appName, organizationName);
-	fs.mount(dataPath);
-	fs.mount(fs.basePath() + dataPath);
+	fs.mountSoftFail(dataPath);
+	fs.mountSoftFail(fs.basePath() + dataPath);
 	fs.mountReadWrite(fs.prefPath());
 
 	Configuration& cf = Utility<Configuration>::get();

--- a/makefile
+++ b/makefile
@@ -155,7 +155,7 @@ include $(wildcard $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.d,$(TESTSRCS)))
 test-graphics: $(BUILDDIR)/testGraphics
 $(BUILDDIR)/testGraphics: $(OUTPUT)
 	@mkdir -p $(BUILDDIR)
-	$(CXX) -o $(BUILDDIR)/testGraphics test-graphics/*.cpp $(CPPFLAGS) $(CXXFLAGS) $(TESTLDFLAGS) -lnas2d $(LDLIBS)
+	$(CXX) -o $(BUILDDIR)/testGraphics test-graphics/*.cpp $(TESTCPPFLAGS) $(CXXFLAGS) $(TESTLDFLAGS) -lnas2d $(LDLIBS)
 
 .PHONY: run-test-graphics
 run-test-graphics: | test-graphics


### PR DESCRIPTION
Update `makefile` for repository reorganization, and allow for soft mount failures for default data folder locations.
