### PR TITLE
Remove Rectangle<int> overloads for drawBox and drawBoxFilled

### DIFF
--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -391,21 +391,6 @@ void Renderer::drawBox(const Rectangle<float>& rect, const Color& color)
 /**
  * Draws a hollow box on the primary surface.
  *
- * \param	rect	A reference to a Rectangle<int> defining the box dimensions.
- * \param	r		Red Color Value. Must be between 0 - 255.
- * \param	g		Green Color Value. Must be between 0 - 255.
- * \param	b		Blue Color Value. Must be between 0 - 255.
- * \param	a		Alpha Value. Must be between 0 - 255.
- */
-void Renderer::drawBox(const Rectangle<int>& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	drawBox(static_cast<float>(rect.x()), static_cast<float>(rect.y()), static_cast<float>(rect.width()), static_cast<float>(rect.height()), r, g, b, a);
-}
-
-
-/**
- * Draws a hollow box on the primary surface.
- *
  * \param	rect	A reference to a Rectangle<float> defining the box dimensions.
  * \param	r		Red Color Value. Must be between 0 - 255.
  * \param	g		Green Color Value. Must be between 0 - 255.
@@ -421,21 +406,6 @@ void Renderer::drawBox(const Rectangle<float>& rect, uint8_t r, uint8_t g, uint8
 void Renderer::drawBoxFilled(const Rectangle<float>& rect, const Color& color)
 {
 	drawBoxFilled(rect.x(), rect.y(), rect.width(), rect.height(), color.red, color.green, color.blue, color.alpha);
-}
-
-
-/**
- * Fills a given area with a solid color.
- *
- * \param	rect	A reference to a Rectangle<float> defining the box dimensions.
- * \param	r		Red Color Value. Must be between 0 - 255.
- * \param	g		Green Color Value. Must be between 0 - 255.
- * \param	b		Blue Color Value. Must be between 0 - 255.
- * \param	a		Alpha Value. Must be between 0 - 255.
- */
-void Renderer::drawBoxFilled(const Rectangle<int>& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	drawBoxFilled(static_cast<float>(rect.x()), static_cast<float>(rect.y()), static_cast<float>(rect.width()), static_cast<float>(rect.height()), r, g, b, a);
 }
 
 

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -100,12 +100,10 @@ public:
 	virtual void drawLine(float x, float y, float x2, float y2, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255, int line_width = 1) = 0;
 
 	void drawBox(const Rectangle<float>& rect, const Color& color = Color::White);
-	void drawBox(const Rectangle<int>& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
 	void drawBox(const Rectangle<float>& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
 	virtual void drawBox(float x, float y, float w, float h, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255) = 0;
 
 	void drawBoxFilled(const Rectangle<float>& rect, const Color& color = Color::White);
-	void drawBoxFilled(const Rectangle<int>& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
 	void drawBoxFilled(const Rectangle<float>& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
 	virtual void drawBoxFilled(float x, float y, float width, float height, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255) = 0;
 


### PR DESCRIPTION
The `Rectangle<int>` struct will already auto convert to `Rectangle<float>`, so there is no need to provide both overloads.
