### PR TITLE
Add Vector reflect methods

### DIFF
--- a/NAS2D/Renderer/Vector.h
+++ b/NAS2D/Renderer/Vector.h
@@ -74,6 +74,16 @@ struct Vector {
 		return (x * other.x) + (y * other.y);
 	}
 
+	// Reflect the x-coordinate (flip across Y-axis)
+	Vector reflectX() const {
+		return {-x, y};
+	}
+
+	// Reflect the y-coordinate (flip across X-axis)
+	Vector reflectY() const {
+		return {x, -y};
+	}
+
 	template <typename NewBaseType>
 	operator Vector<NewBaseType>() const {
 		return {

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -120,6 +120,30 @@ TEST(Vector, dotProduct) {
 	EXPECT_EQ(18, (NAS2D::Vector{3, 4}).dotProduct(NAS2D::Vector{2, 3}));
 }
 
+TEST(Vector, reflectX) {
+	EXPECT_EQ((NAS2D::Vector{-1, 1}), (NAS2D::Vector{1, 1}).reflectX());
+	EXPECT_EQ((NAS2D::Vector{-1, 2}), (NAS2D::Vector{1, 2}).reflectX());
+	EXPECT_EQ((NAS2D::Vector{-2, 1}), (NAS2D::Vector{2, 1}).reflectX());
+	EXPECT_EQ((NAS2D::Vector{-2, 2}), (NAS2D::Vector{2, 2}).reflectX());
+
+	EXPECT_EQ((NAS2D::Vector{1, 1}), (NAS2D::Vector{-1, 1}).reflectX());
+	EXPECT_EQ((NAS2D::Vector{1, 2}), (NAS2D::Vector{-1, 2}).reflectX());
+	EXPECT_EQ((NAS2D::Vector{2, 1}), (NAS2D::Vector{-2, 1}).reflectX());
+	EXPECT_EQ((NAS2D::Vector{2, 2}), (NAS2D::Vector{-2, 2}).reflectX());
+}
+
+TEST(Vector, reflectY) {
+	EXPECT_EQ((NAS2D::Vector{1, -1}), (NAS2D::Vector{1, 1}).reflectY());
+	EXPECT_EQ((NAS2D::Vector{1, -2}), (NAS2D::Vector{1, 2}).reflectY());
+	EXPECT_EQ((NAS2D::Vector{2, -1}), (NAS2D::Vector{2, 1}).reflectY());
+	EXPECT_EQ((NAS2D::Vector{2, -2}), (NAS2D::Vector{2, 2}).reflectY());
+
+	EXPECT_EQ((NAS2D::Vector{1, 1}), (NAS2D::Vector{1, -1}).reflectY());
+	EXPECT_EQ((NAS2D::Vector{1, 2}), (NAS2D::Vector{1, -2}).reflectY());
+	EXPECT_EQ((NAS2D::Vector{2, 1}), (NAS2D::Vector{2, -1}).reflectY());
+	EXPECT_EQ((NAS2D::Vector{2, 2}), (NAS2D::Vector{2, -2}).reflectY());
+}
+
 TEST(Vector, OperatorType) {
 	EXPECT_EQ((NAS2D::Vector<int>{1, 2}), static_cast<NAS2D::Vector<int>>(NAS2D::Vector<float>{1.0, 2.0}));
 	EXPECT_EQ((NAS2D::Vector<float>{1.0, 2.0}), static_cast<NAS2D::Vector<float>>(NAS2D::Vector<int>{1, 2}));


### PR DESCRIPTION
Add `Vector::reflectX()` and `Vector::reflectY()` methods.

The `reflectX()` methods reflects the X-coordinate (flips the vector about the Y-axis).
The `reflectY()` methods reflects the Y-coordinate (flips the vector about the X-axis).

Hopefully the meaning of the names isn't too confusing, and won't cause people to swap them by accident.
