### PR TITLE
Fix Codacy warning in Filesystem code

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -192,7 +192,7 @@ StringList Filesystem::directoryList(const std::string& dir, const std::string& 
 		for (char **i = rc; *i != nullptr; i++)
 		{
 			std::string tmpStr = *i;
-			if (tmpStr.rfind(filter, strlen(*i) - filterLen) != std::string::npos)
+			if (tmpStr.rfind(filter, tmpStr.length() - filterLen) != std::string::npos)
 			{
 				fileList.push_back(*i);
 			}


### PR DESCRIPTION
Fix Codacy warning in `Filesystem` code.

As a bonus, it should be more efficient to ask a `std::string` for the `length`, rather than call `strlen`.

I think in the past, the Codacy warning was mistakenly assumed to be about the `rfind` call, rather than the `strlen` call embedded withing the parameters.
