### PR TITLE
Remove `NAS2D::` prefix

### DIFF
--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -89,9 +89,9 @@ private:
 
 	bool readConfig(const std::string& filePath);
 
-	void parseGraphics(NAS2D::Xml::XmlElement* node);
-	void parseAudio(NAS2D::Xml::XmlElement* node);
-	void parseOptions(NAS2D::Xml::XmlElement* node);
+	void parseGraphics(Xml::XmlElement* node);
+	void parseAudio(Xml::XmlElement* node);
+	void parseOptions(Xml::XmlElement* node);
 
 	Options mOptions{};
 

--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -746,12 +746,14 @@ void EventHandler::disconnectAll()
 }
 
 
-/**
- * Posts a quit event to the event system.
- */
-void NAS2D::postQuitEvent()
-{
-	SDL_Event event;
-	event.type = SDL_QUIT;
-	SDL_PushEvent(&event);
+namespace NAS2D {
+	/**
+	 * Posts a quit event to the event system.
+	 */
+	void postQuitEvent()
+	{
+		SDL_Event event;
+		event.type = SDL_QUIT;
+		SDL_PushEvent(&event);
+	}
 }

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -258,7 +258,7 @@ public:
 	 *
 	 * \arg \c gained	Bool value indicating whether or not the app lost focus.
 	 */
-	using ActivateEventCallback = NAS2D::Signals::Signal<bool>;
+	using ActivateEventCallback = Signals::Signal<bool>;
 
 	/**
 	 * \typedef	WindowHiddenEventCallback
@@ -272,7 +272,7 @@ public:
 	 *
 	 * \arg \c gained	Bool value indicating whether or not the app lost focus.
 	 */
-	using WindowHiddenEventCallback = NAS2D::Signals::Signal<bool>;
+	using WindowHiddenEventCallback = Signals::Signal<bool>;
 
 	/**
 	 * \typedef	WindowExposedEventCallback
@@ -282,7 +282,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using WindowExposedEventCallback = NAS2D::Signals::Signal<>;
+	using WindowExposedEventCallback = Signals::Signal<>;
 
 	/**
 	 * \typedef	WindowMinimizedEventCallback
@@ -292,7 +292,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using WindowMinimizedEventCallback = NAS2D::Signals::Signal<>;
+	using WindowMinimizedEventCallback = Signals::Signal<>;
 
 	/**
 	 * \typedef	WindowMaximizedEventCallback
@@ -302,7 +302,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using WindowMaximizedEventCallback = NAS2D::Signals::Signal<>;
+	using WindowMaximizedEventCallback = Signals::Signal<>;
 
 	/**
 	 * \typedef	WindowRestoredEventCallback
@@ -312,7 +312,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using WindowRestoredEventCallback = NAS2D::Signals::Signal<>;
+	using WindowRestoredEventCallback = Signals::Signal<>;
 
 	/**
 	 * \typedef	WindowMouseEnterEventCallback
@@ -322,7 +322,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using WindowMouseEnterEventCallback = NAS2D::Signals::Signal<>;
+	using WindowMouseEnterEventCallback = Signals::Signal<>;
 
 	/**
 	 * \typedef	WindowMouseLeaveEventCallback
@@ -332,7 +332,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using WindowMouseLeaveEventCallback = NAS2D::Signals::Signal<>;
+	using WindowMouseLeaveEventCallback = Signals::Signal<>;
 
 	/**
 	 * \typedef	WindowResizedEventCallback
@@ -345,7 +345,7 @@ public:
 	 * \arg \c width	Width of the resized window.
 	 * \arg \c height	Height of the resized window.
 	 */
-	using WindowResizedEventCallback = NAS2D::Signals::Signal<int, int>;
+	using WindowResizedEventCallback = Signals::Signal<int, int>;
 
 	/**
 	 * \typedef	JoystickAxisMotionEventCallback
@@ -363,7 +363,7 @@ public:
 						use additional axis as buttons.
 	 * \arg \c pos		Current position of the axis.
 	 */
-	using JoystickAxisMotionEventCallback = NAS2D::Signals::Signal<int, int, int>;
+	using JoystickAxisMotionEventCallback = Signals::Signal<int, int, int>;
 
 	/**
 	 * \typedef	JoystickBallMotionEventCallback
@@ -381,7 +381,7 @@ public:
 	 * \arg \c xChange	Change in relative position of the X position.
 	 * \arg \c yChange	Change in relative position of the Y position.
 	 */
-	using JoystickBallMotionEventCallback = NAS2D::Signals::Signal<int, int, int, int>;
+	using JoystickBallMotionEventCallback = Signals::Signal<int, int, int, int>;
 
 	/**
 	 * \typedef	JoystickButtonEventCallback
@@ -398,7 +398,7 @@ public:
 	 * \arg \c deviceId	Joystick ID which this event was generated from.
 	 * \arg \c buttonId	Button ID which the event was generated from.
 	 */
-	using JoystickButtonEventCallback = NAS2D::Signals::Signal<int, int>;
+	using JoystickButtonEventCallback = Signals::Signal<int, int>;
 
 	/**
 	 * \typedef	JoystickHatMotionEventCallback
@@ -415,7 +415,7 @@ public:
 	 * \arg \c hatId	Hat ID.
 	 * \arg \c pos		Current position of the hat.
 	 */
-	using JoystickHatMotionEventCallback = NAS2D::Signals::Signal<int, int, int>;
+	using JoystickHatMotionEventCallback = Signals::Signal<int, int, int>;
 
 	/**
 	 * \typedef	KeyDownEventCallback
@@ -433,7 +433,7 @@ public:
 	 * \arg \c mod		Keyboard modifier.
 	 * \arg \c repeat	Indicates that this event is a repeat and not an initial key event.
 	 */
-	using KeyDownEventCallback = NAS2D::Signals::Signal<KeyCode, KeyModifier, bool>;
+	using KeyDownEventCallback = Signals::Signal<KeyCode, KeyModifier, bool>;
 
 	/**
 	 * \typedef	KeyUpEventCallback
@@ -450,7 +450,7 @@ public:
 	 * \arg \c mod		Keyboard modifier.
 	 * \arg \c repeat	Indicates that this event is a repeat and not an initial key event.
 	 */
-	using KeyUpEventCallback = NAS2D::Signals::Signal<KeyCode, KeyModifier>;
+	using KeyUpEventCallback = Signals::Signal<KeyCode, KeyModifier>;
 
 	/**
 	 * \typedef	MouseButtonEventCallback
@@ -467,7 +467,7 @@ public:
 	 * \arg	\c x:		X position of the mouse button event.
 	 * \arg	\c y:		Y position of the mouse button event.
 	 */
-	using MouseButtonEventCallback = NAS2D::Signals::Signal<MouseButton, int, int>;
+	using MouseButtonEventCallback = Signals::Signal<MouseButton, int, int>;
 
 	/**
 	 * \typedef	MouseMotionEventCallback
@@ -485,7 +485,7 @@ public:
 	 * \arg	\c relX:	X position of the mouse relative to its last position.
 	 * \arg	\c relY;	Y position of the mouse relative to its last position.
 	 */
-	using MouseMotionEventCallback = NAS2D::Signals::Signal<int, int, int, int>;
+	using MouseMotionEventCallback = Signals::Signal<int, int, int, int>;
 
 	/**
 	 * \typedef	MouseWheelEventCallback
@@ -506,7 +506,7 @@ public:
 	 * 			more than one (on Windows this value is typical 120,
 	 * 			not 1).
 	 */
-	using MouseWheelEventCallback = NAS2D::Signals::Signal<int, int>;
+	using MouseWheelEventCallback = Signals::Signal<int, int>;
 
 	/**
 	 * \typedef	TextInputEventCallback
@@ -516,7 +516,7 @@ public:
 	 * void function(const std::string&);
 	 * \endcode
 	 */
-	using TextInputEventCallback = NAS2D::Signals::Signal<const std::string&>;
+	using TextInputEventCallback = Signals::Signal<const std::string&>;
 
 	/**
 	 * \typedef	QuitEventCallback
@@ -528,7 +528,7 @@ public:
 	 * void function(void);
 	 * \endcode
 	 */
-	using QuitEventCallback = NAS2D::Signals::Signal<>;
+	using QuitEventCallback = Signals::Signal<>;
 
 public:
 	EventHandler();

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -41,7 +41,7 @@ enum MountPosition
 };
 
 
-NAS2D::Filesystem::Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName) :
+Filesystem::Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName) :
 	mAppName(appName),
 	mOrganizationName(organizationName)
 {

--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -42,7 +42,7 @@ using namespace NAS2D;
 Game::Game(const std::string& title, const std::string& appName, const std::string& organizationName, const std::string& argv_0, const std::string& configPath, const std::string& dataPath)
 {
 	std::cout << "NAS2D BUILD: " << __DATE__ << " | " << __TIME__ << '\n';
-	std::cout << "NAS2D VERSION: " << NAS2D::versionString() << "\n\n";
+	std::cout << "NAS2D VERSION: " << versionString() << "\n\n";
 	std::cout << "Initializing subsystems...\n\n";
 	std::cout.flush();
 

--- a/NAS2D/Mixer/Mixer.cpp
+++ b/NAS2D/Mixer/Mixer.cpp
@@ -36,13 +36,13 @@ Signals::Signal<>& Mixer::musicComplete()
 }
 
 
-void Mixer::addMusicCompleteHandler(NAS2D::Signals::Signal<>::DelegateType handler)
+void Mixer::addMusicCompleteHandler(Signals::Signal<>::DelegateType handler)
 {
 	return mMusicComplete.connect(handler);
 }
 
 
-void Mixer::removeMusicCompleteHandler(NAS2D::Signals::Signal<>::DelegateType handler)
+void Mixer::removeMusicCompleteHandler(Signals::Signal<>::DelegateType handler)
 {
 	return mMusicComplete.disconnect(handler);
 }

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -147,17 +147,17 @@ public:
 	virtual void musicVolume(int level) = 0;
 
 	/**
-	 * Gets a reference to a NAS2D::Signals::Signal<>, a signal raised
+	 * Gets a reference to a Signals::Signal<>, a signal raised
 	 * when a Music track has finished playing.
 	 */
 	 [[deprecated("Deprecated: Please use addMusicCompleteHandler and removeMusicCompleteHandler")]]
-	NAS2D::Signals::Signal<>& musicComplete();
+	Signals::Signal<>& musicComplete();
 
-	void addMusicCompleteHandler(NAS2D::Signals::Signal<>::DelegateType handler);
-	void removeMusicCompleteHandler(NAS2D::Signals::Signal<>::DelegateType handler);
+	void addMusicCompleteHandler(Signals::Signal<>::DelegateType handler);
+	void removeMusicCompleteHandler(Signals::Signal<>::DelegateType handler);
 
 protected:
-	NAS2D::Signals::Signal<> mMusicComplete; /**< Callback used when music finished playing. */
+	Signals::Signal<> mMusicComplete; /**< Callback used when music finished playing. */
 };
 
 } // namespace

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -32,7 +32,7 @@ namespace {
 	// INTEROP WITH SDL2_MIXER
 	// ==================================================================================
 	// Global so it can be accessed without capturing `this`
-	NAS2D::Signals::Signal<> musicFinished;
+	Signals::Signal<> musicFinished;
 	// ==================================================================================
 }
 

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -35,7 +35,7 @@ Renderer::~Renderer()
 }
 
 
-void NAS2D::Renderer::drawImage(Image& image, Point<float> position, float scale, Color color)
+void Renderer::drawImage(Image& image, Point<float> position, float scale, Color color)
 {
 	drawImage(image, position.x(), position.y(), scale, color.red, color.green, color.blue, color.alpha);
 }
@@ -55,13 +55,13 @@ void Renderer::drawImage(Image& image, float x, float y, float scale)
 }
 
 
-void NAS2D::Renderer::drawSubImage(Image& image, Point<float> raster, Rectangle<float> subImageRect, const Color& color)
+void Renderer::drawSubImage(Image& image, Point<float> raster, Rectangle<float> subImageRect, const Color& color)
 {
 	drawSubImage(image, raster, subImageRect.startPoint(), subImageRect.size(), color);
 }
 
 
-void NAS2D::Renderer::drawSubImage(Image& image, Point<float> raster, Point<float> position, Vector<float> size, const Color& color)
+void Renderer::drawSubImage(Image& image, Point<float> raster, Point<float> position, Vector<float> size, const Color& color)
 {
 	drawSubImage(image, raster.x(), raster.y(), position.x(), position.y(), size.x, size.y, color);
 }
@@ -84,13 +84,13 @@ void Renderer::drawSubImage(Image& image, float rasterX, float rasterY, float x,
 }
 
 
-void NAS2D::Renderer::drawSubImageRotated(Image& image, Point<float> raster, Rectangle<float> subImageRect, float degrees, const Color& color)
+void Renderer::drawSubImageRotated(Image& image, Point<float> raster, Rectangle<float> subImageRect, float degrees, const Color& color)
 {
 	drawSubImageRotated(image, raster, subImageRect.startPoint(), subImageRect.size(), degrees, color);
 }
 
 
-void NAS2D::Renderer::drawSubImageRotated(Image& image, Point<float> raster, Point<float> position, Vector<float> size, float degrees, const Color& color)
+void Renderer::drawSubImageRotated(Image& image, Point<float> raster, Point<float> position, Vector<float> size, float degrees, const Color& color)
 {
 	drawSubImageRotated(image, raster.x(), raster.y(), position.x(), position.y(), size.x, size.y, degrees, color);
 }
@@ -115,7 +115,7 @@ void Renderer::drawSubImageRotated(Image& image, float rasterX, float rasterY, f
 }
 
 
-void NAS2D::Renderer::drawImageRotated(Image& image, Point<float> position, float degrees, const Color& color, float scale)
+void Renderer::drawImageRotated(Image& image, Point<float> position, float degrees, const Color& color, float scale)
 {
 	drawImageRotated(image, position.x(), position.y(), degrees, color, scale);
 }
@@ -137,13 +137,13 @@ void Renderer::drawImageRotated(Image& image, float x, float y, float degrees, c
 }
 
 
-void NAS2D::Renderer::drawImageStretched(Image& image, Rectangle<float> rect, Color color)
+void Renderer::drawImageStretched(Image& image, Rectangle<float> rect, Color color)
 {
 	drawImageStretched(image, rect.startPoint(), rect.size(), color);
 }
 
 
-void NAS2D::Renderer::drawImageStretched(Image& image, Point<float> position, Vector<float> size, Color color)
+void Renderer::drawImageStretched(Image& image, Point<float> position, Vector<float> size, Color color)
 {
 	drawImageStretched(image, position.x(), position.y(), size.x, size.y, color);
 }
@@ -171,7 +171,7 @@ void Renderer::drawImageRepeated(Image& image, Rectangle<float> rect)
 }
 
 
-void NAS2D::Renderer::drawImageRepeated(Image& image, Point<float> position, Vector<float> size)
+void Renderer::drawImageRepeated(Image& image, Point<float> position, Vector<float> size)
 {
 	drawImageRepeated(image, position.x(), position.y(), size.x, size.y);
 }
@@ -186,7 +186,7 @@ void Renderer::drawSubImageRepeated(Image& image, const Rectangle<float>& source
 }
 
 
-void NAS2D::Renderer::drawImageRect(Point<float> position, Vector<float> size, Image& topLeft, Image& top, NAS2D::Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight)
+void Renderer::drawImageRect(Point<float> position, Vector<float> size, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight)
 {
 	drawImageRect(position.x(), position.y(), size.x, size.y, topLeft, top, topRight, left, center, right, bottomLeft, bottom, bottomRight);
 }
@@ -213,13 +213,13 @@ void Renderer::drawImageRect(float x, float y, float w, float h, Image& topLeft,
 }
 
 
-void NAS2D::Renderer::drawImageRect(Rectangle<float> rect, ImageList& images)
+void Renderer::drawImageRect(Rectangle<float> rect, ImageList& images)
 {
 	drawImageRect(rect.startPoint(), rect.size(), images);
 }
 
 
-void NAS2D::Renderer::drawImageRect(Point<float> position, Vector<float> size, ImageList& images)
+void Renderer::drawImageRect(Point<float> position, Vector<float> size, ImageList& images)
 {
 	drawImageRect(position.x(), position.y(), size.x, size.y, images);
 }
@@ -335,13 +335,13 @@ bool Renderer::isFaded() const
 /**
  * Gets a refernece to the callback signal for fade transitions.
  */
-NAS2D::Signals::Signal<>& Renderer::fadeComplete()
+Signals::Signal<>& Renderer::fadeComplete()
 {
 	return fadeCompleteSignal;
 }
 
 
-void NAS2D::Renderer::drawPoint(Point<float> position, const Color& color)
+void Renderer::drawPoint(Point<float> position, const Color& color)
 {
 	drawPoint(position.x(), position.y(), color);
 }
@@ -360,7 +360,7 @@ void Renderer::drawPoint(float x, float y, const Color& color)
 }
 
 
-void NAS2D::Renderer::drawLine(Point<float> startPosition, Point<float> endPosition, const Color& color, int line_width)
+void Renderer::drawLine(Point<float> startPosition, Point<float> endPosition, const Color& color, int line_width)
 {
 	drawLine(startPosition.x(), startPosition.y(), endPosition.x(), endPosition.y(), color, line_width);
 }
@@ -468,13 +468,13 @@ void Renderer::drawGradient(float x, float y, float w, float h, const Color& c1,
 }
 
 
-void NAS2D::Renderer::drawText(Font& font, const std::string& text, Point<float> position, Color color)
+void Renderer::drawText(Font& font, const std::string& text, Point<float> position, Color color)
 {
 	drawText(font, text, position.x(), position.y(), color.red, color.green, color.blue, color.alpha);
 }
 
 
-void NAS2D::Renderer::drawTextShadow(Font& font, const std::string& text, Point<float> position, Vector<float> shadowOffset, Color textColor, Color shadowColor)
+void Renderer::drawTextShadow(Font& font, const std::string& text, Point<float> position, Vector<float> shadowOffset, Color textColor, Color shadowColor)
 {
 	const auto shadowPosition = position + shadowOffset;
 	drawText(font, text, shadowPosition.x(), shadowPosition.y(), shadowColor.red, shadowColor.green, shadowColor.blue, shadowColor.alpha);
@@ -640,7 +640,7 @@ void Renderer::update()
 	}
 }
 
-void NAS2D::Renderer::setResolution(const Vector<float>& newResolution)
+void Renderer::setResolution(const Vector<float>& newResolution)
 {
 	if (!fullscreen())
 	{

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -83,8 +83,8 @@ public:
 	void drawSubImageRepeated(Image& image, const Rectangle<float>& source, const Rectangle<float>& destination);
 	virtual void drawSubImageRepeated(Image& image, float rasterX, float rasterY, float w, float h, float subX, float subY, float subW, float subH) = 0;
 
-	void drawImageRect(Point<float> position, Vector<float> size, Image& topLeft, Image& top, NAS2D::Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);
-	void drawImageRect(float x, float y, float w, float h, Image& topLeft, Image& top, NAS2D::Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);
+	void drawImageRect(Point<float> position, Vector<float> size, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);
+	void drawImageRect(float x, float y, float w, float h, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);
 	void drawImageRect(Rectangle<float> rect, ImageList& images);
 	void drawImageRect(Point<float> position, Vector<float> size, ImageList& images);
 	void drawImageRect(float x, float y, float w, float h, ImageList& images);
@@ -125,7 +125,7 @@ public:
 	void fadeOut(float delayTime);
 	bool isFading() const;
 	bool isFaded() const;
-	NAS2D::Signals::Signal<>& fadeComplete();
+	Signals::Signal<>& fadeComplete();
 
 	virtual void showSystemPointer(bool) = 0;
 	virtual void addCursor(const std::string& filePath, int cursorId, int offx, int offy) = 0;

--- a/NAS2D/Renderer/RendererNull.h
+++ b/NAS2D/Renderer/RendererNull.h
@@ -45,7 +45,7 @@ public:
 
 	void drawGradient(float, float, float, float, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t) override {}
 
-	void drawText(NAS2D::Font&, const std::string&, float, float, uint8_t, uint8_t, uint8_t, uint8_t) override {}
+	void drawText(Font&, const std::string&, float, float, uint8_t, uint8_t, uint8_t, uint8_t) override {}
 
 	void showSystemPointer(bool) override {}
 	void addCursor(const std::string&, int, int, int) override {}

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -264,10 +264,10 @@ void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const P
 	const auto dstPointInt = dstPoint.to<int>();
 	const auto sourceSize = source.size();
 
-	const auto origin = NAS2D::Point<int>{0, 0};
+	const auto origin = Point<int>{0, 0};
 
-	const auto sourceBoundsInDestination = NAS2D::Rectangle<int>::Create(dstPointInt, sourceSize);
-	const auto destinationBounds = NAS2D::Rectangle<int>::Create(origin, destination.size());
+	const auto sourceBoundsInDestination = Rectangle<int>::Create(dstPointInt, sourceSize);
+	const auto destinationBounds = Rectangle<int>::Create(origin, destination.size());
 
 	// Ignore the call if the detination point is outside the bounds of destination image.
 	if (!sourceBoundsInDestination.overlaps(destinationBounds))
@@ -276,7 +276,7 @@ void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const P
 	}
 
 	const auto availableSize = destinationBounds.endPoint() - dstPointInt;
-	const auto clipSize = NAS2D::Vector{
+	const auto clipSize = Vector{
 		availableSize.x < sourceSize.x ? availableSize.x : sourceSize.x,
 		availableSize.y < sourceSize.y ? availableSize.y : sourceSize.y
 	};
@@ -452,7 +452,7 @@ void RendererOpenGL::drawBoxFilled(float x, float y, float width, float height, 
 }
 
 
-void RendererOpenGL::drawText(NAS2D::Font& font, const std::string& text, float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+void RendererOpenGL::drawText(Font& font, const std::string& text, float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
 	if (!font.loaded() || text.empty()) { return; }
 
@@ -649,7 +649,7 @@ void RendererOpenGL::setViewport(const Rectangle<int>& viewport)
 }
 
 
-void NAS2D::RendererOpenGL::setOrthoProjection(const Rectangle<float>& orthoBounds)
+void RendererOpenGL::setOrthoProjection(const Rectangle<float>& orthoBounds)
 {
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
@@ -768,7 +768,7 @@ void RendererOpenGL::initVideo(Vector<int> resolution, bool fullscreen, bool vsy
 	desktopResolution = {static_cast<float>(dm.w), static_cast<float>(dm.h)};
 }
 
-std::vector<NAS2D::DisplayDesc> NAS2D::RendererOpenGL::getDisplayModes() const
+std::vector<DisplayDesc> RendererOpenGL::getDisplayModes() const
 {
 	const auto displayIndex = SDL_GetWindowDisplayIndex(underlyingWindow);
 	const auto numResolutions = SDL_GetNumDisplayModes(displayIndex);
@@ -777,7 +777,7 @@ std::vector<NAS2D::DisplayDesc> NAS2D::RendererOpenGL::getDisplayModes() const
 		throw std::runtime_error("Error getting number of display modes for display index: " + std::to_string(displayIndex) + " : " + std::string{SDL_GetError()});
 	}
 
-	std::vector<NAS2D::DisplayDesc> result{};
+	std::vector<DisplayDesc> result{};
 	result.reserve(static_cast<std::size_t>(numResolutions));
 	for (int i = 0; i < numResolutions; ++i)
 	{
@@ -788,7 +788,7 @@ std::vector<NAS2D::DisplayDesc> NAS2D::RendererOpenGL::getDisplayModes() const
 	return result;
 }
 
-NAS2D::DisplayDesc NAS2D::RendererOpenGL::getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const
+DisplayDesc RendererOpenGL::getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const
 {
 	const auto displayIndex = SDL_GetWindowDisplayIndex(underlyingWindow);
 	SDL_DisplayMode preferredMode{};
@@ -804,7 +804,7 @@ NAS2D::DisplayDesc NAS2D::RendererOpenGL::getClosestMatchingDisplayMode(const Di
 	throw std::runtime_error("No matching display mode for " + std::string{preferredDisplayDesc});
 }
 
-NAS2D::Vector<int> NAS2D::RendererOpenGL::getWindowClientArea() const noexcept
+Vector<int> RendererOpenGL::getWindowClientArea() const noexcept
 {
 	Vector<int> size;
 	SDL_GetWindowSize(underlyingWindow, &size.x, &size.y);

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -59,7 +59,7 @@ public:
 
 	void drawGradient(float x, float y, float w, float h, uint8_t r1, uint8_t g1, uint8_t b1, uint8_t a1, uint8_t r2, uint8_t g2, uint8_t b2, uint8_t a2, uint8_t r3, uint8_t g3, uint8_t b3, uint8_t a3, uint8_t r4, uint8_t g4, uint8_t b4, uint8_t a4) override;
 
-	void drawText(NAS2D::Font& font, const std::string& text, float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a) override;
+	void drawText(Font& font, const std::string& text, float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a) override;
 
 	void showSystemPointer(bool) override;
 	void addCursor(const std::string& filePath, int cursorId, int offx, int offy) override;

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -59,7 +59,7 @@ namespace {
  * \param	ptSize		Point size of the font. Defaults to 12pt.
  *
  */
-NAS2D::Font::Font(const std::string& filePath, unsigned int ptSize) : Resource(filePath)
+Font::Font(const std::string& filePath, unsigned int ptSize) : Resource(filePath)
 {
 	loaded(::load(name(), ptSize));
 	name(name() + "_" + std::to_string(ptSize) + "pt");
@@ -75,7 +75,7 @@ NAS2D::Font::Font(const std::string& filePath, unsigned int ptSize) : Resource(f
  * \param	glyphSpace	Space between glyphs when rendering a bitmap font. This value can be negative.
  *
  */
-NAS2D::Font::Font(const std::string& filePath, int glyphWidth, int glyphHeight, int glyphSpace) : Resource(filePath)
+Font::Font(const std::string& filePath, int glyphWidth, int glyphHeight, int glyphSpace) : Resource(filePath)
 {
 	loaded(loadBitmap(filePath, glyphWidth, glyphHeight, glyphSpace));
 }
@@ -86,7 +86,7 @@ NAS2D::Font::Font(const std::string& filePath, int glyphWidth, int glyphHeight, 
  *
  * Fonts instantiated with this constructor are not valid for use.
  */
-NAS2D::Font::Font() : Resource("Default Font")
+Font::Font() : Resource("Default Font")
 {}
 
 
@@ -95,7 +95,7 @@ NAS2D::Font::Font() : Resource("Default Font")
  *
  * \param	rhs	Font to copy.
  */
-NAS2D::Font::Font(const Font& rhs) : Resource(rhs.name())
+Font::Font(const Font& rhs) : Resource(rhs.name())
 {
 	auto it = fontMap.find(name());
 	if (it != fontMap.end())
@@ -113,7 +113,7 @@ NAS2D::Font::Font(const Font& rhs) : Resource(rhs.name())
 /**
 * D'tor
 */
-NAS2D::Font::~Font()
+Font::~Font()
 {
 	updateFontReferenceCount(name());
 }
@@ -124,7 +124,7 @@ NAS2D::Font::~Font()
  *
  * \param rhs Font to copy.
  */
-NAS2D::Font& NAS2D::Font::operator=(const Font& rhs)
+Font& Font::operator=(const Font& rhs)
 {
 	if (this == &rhs) { return *this; }
 
@@ -145,7 +145,7 @@ NAS2D::Font& NAS2D::Font::operator=(const Font& rhs)
 /**
  * Gets the glyph cell width.
  */
-int NAS2D::Font::glyphCellWidth() const
+int Font::glyphCellWidth() const
 {
 	return fontMap[name()].glyph_size.x;
 }
@@ -154,7 +154,7 @@ int NAS2D::Font::glyphCellWidth() const
 /**
  * Gets the glyph cell height.
  */
-int NAS2D::Font::glyphCellHeight() const
+int Font::glyphCellHeight() const
 {
 	return fontMap[name()].glyph_size.y;
 }
@@ -165,7 +165,7 @@ int NAS2D::Font::glyphCellHeight() const
  *
  * \param	str		Reference to a std::string to get the width of.
  */
-int NAS2D::Font::width(const std::string& str) const
+int Font::width(const std::string& str) const
 {
 	if (str.empty()) { return 0; }
 
@@ -186,7 +186,7 @@ int NAS2D::Font::width(const std::string& str) const
 /**
  * Gets the height in pixels of the Font.
  */
-int NAS2D::Font::height() const
+int Font::height() const
 {
 	return fontMap[name()].height;
 }
@@ -195,7 +195,7 @@ int NAS2D::Font::height() const
 /**
  * The maximum pixel ascent of all glyphs in the Font.
  */
-int NAS2D::Font::ascent() const
+int Font::ascent() const
 {
 	return fontMap[name()].ascent;
 }
@@ -204,7 +204,7 @@ int NAS2D::Font::ascent() const
 /**
  * Returns the point size of the Font.
  */
-unsigned int NAS2D::Font::ptSize() const
+unsigned int Font::ptSize() const
 {
 	return fontMap[name()].pt_size;
 }

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -18,7 +18,11 @@ using namespace std;
 using namespace NAS2D;
 using namespace NAS2D::Xml;
 
-const string NAS2D::SPRITE_VERSION("0.99");
+
+namespace NAS2D {
+	const string SPRITE_VERSION("0.99");
+}
+
 
 const auto FRAME_PAUSE = unsigned(-1);
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -516,8 +516,8 @@ void Sprite::processFrames(const std::string& action, void* _node)
 				continue;
 			}
 
-			const auto bounds = NAS2D::Rectangle<int>::Create(NAS2D::Point<int>{x, y}, NAS2D::Vector{width, height});
-			const auto anchorOffset = NAS2D::Vector{anchorx, anchory};
+			const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
+			const auto anchorOffset = Vector{anchorx, anchory};
 			frameList.push_back(SpriteFrame{sheetId, bounds, anchorOffset, static_cast<unsigned int>(delay)});
 		}
 		else
@@ -573,7 +573,7 @@ void Sprite::addDefaultAction()
 		auto& imageSheet = mImageSheets["default"]; // Adds a default sheet. //-V607
 
 		const auto size = imageSheet.size();
-		const auto bounds = NAS2D::Rectangle<int>::Create(NAS2D::Point{0, 0}, size);
+		const auto bounds = Rectangle<int>::Create(Point{0, 0}, size);
 		const auto anchorOffset = size / 2;
 
 		FrameList frameList{SpriteFrame{"default", bounds, anchorOffset, FRAME_PAUSE}};

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -24,10 +24,9 @@ namespace NAS2D {
 }
 
 
-const auto FRAME_PAUSE = unsigned(-1);
-
-
 namespace {
+	const auto FRAME_PAUSE = unsigned(-1);
+
 	// Adds a row/name tag to the end of messages.
 	string endTag(int row, const std::string& name)
 	{

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -37,7 +37,7 @@ extern const std::string SPRITE_VERSION;
 class Sprite
 {
 public:
-	using Callback = NAS2D::Signals::Signal<>; /**< Signal used when action animations complete. */
+	using Callback = Signals::Signal<>; /**< Signal used when action animations complete. */
 
 	Sprite();
 	explicit Sprite(const std::string& filePath);


### PR DESCRIPTION
The `NAS2D::` prefix is kind of understood when it's a reference within the library. Indeed, we should be making references from the `NAS2D` namespace.

Having the `NAS2D::` prefix there is more likely a sign that something was declared in the global namespace by accident, rather than within the NAS2D namespace. Indeed, a couple of such fixed references were noted while working on this.
