### PR TITLE
Mark Font reference as const in drawText calls

### DIFF
--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -468,13 +468,13 @@ void Renderer::drawGradient(float x, float y, float w, float h, const Color& c1,
 }
 
 
-void Renderer::drawText(Font& font, const std::string& text, Point<float> position, Color color)
+void Renderer::drawText(const Font& font, const std::string& text, Point<float> position, Color color)
 {
 	drawText(font, text, position.x(), position.y(), color.red, color.green, color.blue, color.alpha);
 }
 
 
-void Renderer::drawTextShadow(Font& font, const std::string& text, Point<float> position, Vector<float> shadowOffset, Color textColor, Color shadowColor)
+void Renderer::drawTextShadow(const Font& font, const std::string& text, Point<float> position, Vector<float> shadowOffset, Color textColor, Color shadowColor)
 {
 	const auto shadowPosition = position + shadowOffset;
 	drawText(font, text, shadowPosition.x(), shadowPosition.y(), shadowColor.red, shadowColor.green, shadowColor.blue, shadowColor.alpha);
@@ -572,7 +572,7 @@ void Renderer::title(const std::string& title)
  * \param sb		Blue color value between 0 - 255.
  * \param a			Alpha color value between 0 - 255.
  */
-void Renderer::drawTextShadow(Font& font, const std::string& text, float x, float y, int distance, uint8_t r, uint8_t g, uint8_t b, uint8_t sr, uint8_t sg, uint8_t sb, uint8_t a )
+void Renderer::drawTextShadow(const Font& font, const std::string& text, float x, float y, int distance, uint8_t r, uint8_t g, uint8_t b, uint8_t sr, uint8_t sg, uint8_t sb, uint8_t a )
 {
 	drawText(font, text, x + distance, y + distance, sr, sg, sb, a);
 	drawText(font, text, x, y, r, g, b, a);

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -115,10 +115,10 @@ public:
 	void drawGradient(float x, float y, float w, float h, const Color& c1, const Color& c2, const Color& c3, const Color& c4);
 	virtual void drawGradient(float x, float y, float w, float h, uint8_t r1, uint8_t g1, uint8_t b1, uint8_t a1, uint8_t r2, uint8_t g2, uint8_t b2, uint8_t a2, uint8_t r3, uint8_t g3, uint8_t b3, uint8_t a3, uint8_t r4, uint8_t g4, uint8_t b4, uint8_t a4) = 0;
 
-	void drawText(Font& font, const std::string& text, Point<float> position, Color color);
-	virtual void drawText(Font& font, const std::string& text, float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255) = 0;
-	void drawTextShadow(Font& font, const std::string& text, Point<float> position, Vector<float> shadowOffset, Color textColor, Color shadowColor);
-	void drawTextShadow(Font& font, const std::string& text, float x, float y, int sDistance, uint8_t r, uint8_t g, uint8_t b, uint8_t sr, uint8_t sg, uint8_t sb, uint8_t a = 255);
+	void drawText(const Font& font, const std::string& text, Point<float> position, Color color);
+	virtual void drawText(const Font& font, const std::string& text, float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255) = 0;
+	void drawTextShadow(const Font& font, const std::string& text, Point<float> position, Vector<float> shadowOffset, Color textColor, Color shadowColor);
+	void drawTextShadow(const Font& font, const std::string& text, float x, float y, int sDistance, uint8_t r, uint8_t g, uint8_t b, uint8_t sr, uint8_t sg, uint8_t sb, uint8_t a = 255);
 
 	void fadeColor(const Color& color);
 	void fadeIn(float delayTime);

--- a/NAS2D/Renderer/RendererNull.h
+++ b/NAS2D/Renderer/RendererNull.h
@@ -45,7 +45,7 @@ public:
 
 	void drawGradient(float, float, float, float, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t) override {}
 
-	void drawText(Font&, const std::string&, float, float, uint8_t, uint8_t, uint8_t, uint8_t) override {}
+	void drawText(const Font&, const std::string&, float, float, uint8_t, uint8_t, uint8_t, uint8_t) override {}
 
 	void showSystemPointer(bool) override {}
 	void addCursor(const std::string&, int, int, int) override {}

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -452,7 +452,7 @@ void RendererOpenGL::drawBoxFilled(float x, float y, float width, float height, 
 }
 
 
-void RendererOpenGL::drawText(Font& font, const std::string& text, float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+void RendererOpenGL::drawText(const Font& font, const std::string& text, float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
 	if (!font.loaded() || text.empty()) { return; }
 

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -59,7 +59,7 @@ public:
 
 	void drawGradient(float x, float y, float w, float h, uint8_t r1, uint8_t g1, uint8_t b1, uint8_t a1, uint8_t r2, uint8_t g2, uint8_t b2, uint8_t a2, uint8_t r3, uint8_t g3, uint8_t b3, uint8_t a3, uint8_t r4, uint8_t g4, uint8_t b4, uint8_t a4) override;
 
-	void drawText(Font& font, const std::string& text, float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a) override;
+	void drawText(const Font& font, const std::string& text, float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a) override;
 
 	void showSystemPointer(bool) override;
 	void addCursor(const std::string& filePath, int cursorId, int offx, int offy) override;


### PR DESCRIPTION
Mark `Font` reference as const in `drawText` calls. This makes `drawText` usable with `Font` objects that were marked with `const`.
