### PR TITLE
Add string conversion template methods

### DIFF
--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -17,6 +17,17 @@
 
 namespace NAS2D
 {
+	template<typename T>
+	std::string stringFrom(T value)
+	{
+		if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, const char*>) {
+			return value;
+		} else if constexpr (std::is_same_v<T, bool>) {
+			return value ? "true" : "false";
+		} else {
+			return std::to_string(value);
+		}
+	}
 
 	std::string toLowercase(std::string str);
 	std::string toUppercase(std::string str);

--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -29,6 +29,55 @@ namespace NAS2D
 		}
 	}
 
+	template<typename T>
+	T stringTo(const std::string& value) {
+		if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, const char*>) {
+			return value;
+		} else if constexpr (std::is_same_v<T, bool>) {
+			return
+				value == "true" ? true :
+				value == "false" ? false :
+				throw std::invalid_argument("Value must be 'true' or 'false': " + std::string{value});
+		} else if constexpr (std::is_same_v<T, long double>) {
+			return std::stold(value);
+		} else if constexpr (std::is_same_v<T, double>) {
+			return std::stod(value);
+		} else if constexpr (std::is_same_v<T, float>) {
+			return std::stof(value);
+		} else if constexpr (std::is_same_v<T, long long>) {
+			return std::stoll(value);
+		} else if constexpr (std::is_same_v<T, long>) {
+			return std::stol(value);
+		} else if constexpr (std::is_same_v<T, int>) {
+			return std::stoi(value);
+		} else if constexpr (std::is_same_v<T, unsigned long long>) {
+			return std::stoull(value);
+		} else if constexpr (std::is_same_v<T, unsigned long>) {
+			return std::stoul(value);
+		} else if constexpr (std::is_integral_v<T> && std::is_signed_v<T>) {
+			const auto integerValue = std::stoi(value);
+			if constexpr (
+				std::numeric_limits<int>::max() > std::numeric_limits<T>::max() ||
+				std::numeric_limits<int>::min() < std::numeric_limits<T>::min()
+			) {
+				if (integerValue > std::numeric_limits<T>::max() || integerValue < std::numeric_limits<T>::min()) {
+					throw std::out_of_range("Value out of range: " + value);
+				}
+			}
+			return static_cast<T>(integerValue);
+		} else if constexpr (std::is_integral_v<T> && std::is_unsigned_v<T>) {
+			const auto integerValue = std::stoul(value);
+			if constexpr (std::numeric_limits<unsigned long>::max() > std::numeric_limits<T>::max()) {
+				if (integerValue > std::numeric_limits<T>::max()) {
+					throw std::out_of_range("Value out of range: " + value);
+				}
+			}
+			return static_cast<T>(integerValue);
+		} else {
+			static_assert(true, "Unsupported type");
+		}
+	}
+
 	std::string toLowercase(std::string str);
 	std::string toUppercase(std::string str);
 	std::vector<std::string> split(std::string str, char delim = ',');

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -100,6 +100,21 @@ TEST(String, stringDataString) {
 	EXPECT_THAT(NAS2D::stringFrom<float>(NAS2D::stringTo<float>("1.0")), testing::StartsWith("1.0"));
 }
 
+TEST(String, dataStringData) {
+	EXPECT_EQ("Some string value", NAS2D::stringTo<std::string>(NAS2D::stringFrom<std::string>("Some string value")));
+
+	EXPECT_EQ(false, NAS2D::stringTo<bool>(NAS2D::stringFrom<bool>(false)));
+	EXPECT_EQ(true, NAS2D::stringTo<bool>(NAS2D::stringFrom<bool>(true)));
+
+	EXPECT_EQ(-1, NAS2D::stringTo<int>(NAS2D::stringFrom<int>(-1)));
+	EXPECT_EQ(0, NAS2D::stringTo<int>(NAS2D::stringFrom<int>(0)));
+	EXPECT_EQ(1, NAS2D::stringTo<int>(NAS2D::stringFrom<int>(1)));
+
+	EXPECT_EQ(-1, NAS2D::stringTo<float>(NAS2D::stringFrom<float>(-1)));
+	EXPECT_EQ(0, NAS2D::stringTo<float>(NAS2D::stringFrom<float>(0)));
+	EXPECT_EQ(1, NAS2D::stringTo<float>(NAS2D::stringFrom<float>(1)));
+}
+
 
 TEST(String, split) {
 	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::split("a,b,c"));

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -41,6 +41,52 @@ TEST(String, stringFrom) {
 	EXPECT_THAT(NAS2D::stringFrom(0.0l), testing::StartsWith("0.0"));
 }
 
+TEST(String, stringTo) {
+	EXPECT_EQ("SomeStringValue", NAS2D::stringTo<std::string>("SomeStringValue"));
+	EXPECT_EQ("SomeStringValue", NAS2D::stringTo<std::string>(std::string{"SomeStringValue"}));
+
+	EXPECT_THROW(NAS2D::stringTo<bool>(""), std::invalid_argument);
+	EXPECT_THROW(NAS2D::stringTo<bool>("random text"), std::invalid_argument);
+	EXPECT_EQ(false, NAS2D::stringTo<bool>("false"));
+	EXPECT_EQ(true, NAS2D::stringTo<bool>("true"));
+
+	EXPECT_THROW(NAS2D::stringTo<char>(std::to_string(std::numeric_limits<char>::min() - 1)), std::out_of_range);
+	EXPECT_THROW(NAS2D::stringTo<char>(std::to_string(std::numeric_limits<char>::max() + 1)), std::out_of_range);
+	EXPECT_EQ(char{0}, NAS2D::stringTo<char>("0"));
+	using signedChar = signed char;
+	EXPECT_EQ(signedChar{-1}, NAS2D::stringTo<signedChar>("-1"));
+	EXPECT_EQ(signedChar{0}, NAS2D::stringTo<signedChar>("0"));
+	using unsignedChar = unsigned char;
+	EXPECT_EQ(unsignedChar{0}, NAS2D::stringTo<unsignedChar>("0"));
+
+	EXPECT_THROW(NAS2D::stringTo<short>(std::to_string(std::numeric_limits<short>::min() - 1)), std::out_of_range);
+	EXPECT_THROW(NAS2D::stringTo<short>(std::to_string(std::numeric_limits<short>::max() + 1)), std::out_of_range);
+	EXPECT_EQ(short{-1}, NAS2D::stringTo<short>("-1"));
+	EXPECT_EQ(short{0}, NAS2D::stringTo<short>("0"));
+	using unsignedShort = unsigned short;
+	EXPECT_EQ(unsignedShort{0}, NAS2D::stringTo<unsignedShort>("0"));
+
+	EXPECT_EQ(int{-1}, NAS2D::stringTo<int>("-1"));
+	EXPECT_EQ(int{0}, NAS2D::stringTo<int>("0"));
+	using unsignedInt = unsigned int;
+	EXPECT_EQ(unsignedInt{0}, NAS2D::stringTo<unsignedInt>("0"));
+
+	EXPECT_EQ(long{-1}, NAS2D::stringTo<long>("-1"));
+	EXPECT_EQ(long{0}, NAS2D::stringTo<long>("0"));
+	using unsignedLong = unsigned long;
+	EXPECT_EQ(unsignedLong{0}, NAS2D::stringTo<unsignedLong>("0"));
+
+	using longLong = long long;
+	EXPECT_EQ(longLong{-1}, NAS2D::stringTo<longLong>("-1"));
+	EXPECT_EQ(longLong{0}, NAS2D::stringTo<longLong>("0"));
+	using unsignedLongLong = unsigned long long;
+	EXPECT_EQ(unsignedLongLong{0}, NAS2D::stringTo<unsignedLongLong>("0"));
+
+	EXPECT_EQ(0.0f, NAS2D::stringTo<float>("0.0"));
+	EXPECT_EQ(0.0, NAS2D::stringTo<double>("0.0"));
+	EXPECT_EQ(0.0l, NAS2D::stringTo<long double>("0.0"));
+}
+
 TEST(String, split) {
 	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::split("a,b,c"));
 	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split("abc"));

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -87,6 +87,20 @@ TEST(String, stringTo) {
 	EXPECT_EQ(0.0l, NAS2D::stringTo<long double>("0.0"));
 }
 
+TEST(String, stringDataString) {
+	EXPECT_EQ("Some string value", NAS2D::stringFrom<std::string>(NAS2D::stringTo<std::string>("Some string value")));
+
+	EXPECT_EQ("false", NAS2D::stringFrom<bool>(NAS2D::stringTo<bool>("false")));
+	EXPECT_EQ("true", NAS2D::stringFrom<bool>(NAS2D::stringTo<bool>("true")));
+
+	EXPECT_EQ("-1", NAS2D::stringFrom<int>(NAS2D::stringTo<int>("-1")));
+	EXPECT_EQ("0", NAS2D::stringFrom<int>(NAS2D::stringTo<int>("0")));
+
+	EXPECT_THAT(NAS2D::stringFrom<float>(NAS2D::stringTo<float>("-1.0")), testing::StartsWith("-1.0"));
+	EXPECT_THAT(NAS2D::stringFrom<float>(NAS2D::stringTo<float>("1.0")), testing::StartsWith("1.0"));
+}
+
+
 TEST(String, split) {
 	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::split("a,b,c"));
 	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split("abc"));

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -4,6 +4,43 @@
 #include <gtest/gtest.h>
 
 
+TEST(String, stringFrom) {
+	EXPECT_EQ("SomeStringValue", NAS2D::stringFrom("SomeStringValue"));
+	EXPECT_EQ("SomeStringValue", NAS2D::stringFrom(std::string{"SomeStringValue"}));
+
+	EXPECT_EQ("false", NAS2D::stringFrom(false));
+	EXPECT_EQ("true", NAS2D::stringFrom(true));
+
+	using signedChar = signed char;
+	using unsignedChar = unsigned char;
+	EXPECT_EQ("-1", NAS2D::stringFrom(signedChar{-1}));
+	EXPECT_EQ("0", NAS2D::stringFrom(signedChar{0}));
+	EXPECT_EQ("0", NAS2D::stringFrom(unsignedChar{0}));
+	EXPECT_EQ("0", NAS2D::stringFrom(char{0}));
+
+	using unsignedShort = unsigned short;
+	EXPECT_EQ("-1", NAS2D::stringFrom(short{-1}));
+	EXPECT_EQ("0", NAS2D::stringFrom(short{0}));
+	EXPECT_EQ("0", NAS2D::stringFrom(unsignedShort{0}));
+
+	EXPECT_EQ("-1", NAS2D::stringFrom(-1));
+	EXPECT_EQ("0", NAS2D::stringFrom(0));
+	EXPECT_EQ("1", NAS2D::stringFrom(1u));
+
+	EXPECT_EQ("-1", NAS2D::stringFrom(-1l));
+	EXPECT_EQ("0", NAS2D::stringFrom(0l));
+	EXPECT_EQ("1", NAS2D::stringFrom(1ul));
+
+	EXPECT_EQ("-1", NAS2D::stringFrom(-1ll));
+	EXPECT_EQ("0", NAS2D::stringFrom(0ll));
+	EXPECT_EQ("1", NAS2D::stringFrom(1ull));
+
+	// Ignore precision beyond one decimal place
+	EXPECT_THAT(NAS2D::stringFrom(0.0f), testing::StartsWith("0.0"));
+	EXPECT_THAT(NAS2D::stringFrom(0.0), testing::StartsWith("0.0"));
+	EXPECT_THAT(NAS2D::stringFrom(0.0l), testing::StartsWith("0.0"));
+}
+
 TEST(String, split) {
 	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::split("a,b,c"));
 	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split("abc"));


### PR DESCRIPTION
Add string conversion template methods to convert various primitive data types to and from strings.

These new methods will be used in updates to serialization code. In particular, they will be the basis for a `Dictionary` class, that supports holding arbitrary data types, but which can be easily serialized in text format. This will be similar to `std::map`, but with data type conversion support for the values.

The `Dictionary` class can then be used to refactor the XML file processing code, and make much of it independent of the serialization format. Potentially data could be serialized to JSON or INI files instead.

Edit: Reference: #542
