### PR TITLE
Add Dictionary class

### DIFF
--- a/NAS2D/Dictionary.h
+++ b/NAS2D/Dictionary.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "StringUtils.h"
+#include <map>
+
+
+namespace NAS2D {
+	class Dictionary
+	{
+	public:
+		template <typename T = std::string>
+		T get(const std::string& key) const
+		{
+			return stringTo<T>(mDictionary.at(key));
+		}
+
+		template <typename T = std::string>
+		void set(const std::string& key, T value)
+		{
+			mDictionary[key] = stringFrom<T>(value);
+		}
+
+	private:
+		std::map<std::string, std::string> mDictionary;
+	};
+}

--- a/test/Dictionary.test.cpp
+++ b/test/Dictionary.test.cpp
@@ -1,0 +1,21 @@
+#include "NAS2D/Dictionary.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+
+TEST(Dictionary, setGet) {
+	NAS2D::Dictionary dictionary;
+
+	// Set some test values
+	dictionary.set("Key1", "Some string value");
+	dictionary.set("Key2", std::string{"Another string value"});
+	dictionary.set("Key3", true);
+	dictionary.set("Key4", 1);
+
+	// Read back typed values
+	EXPECT_EQ("Some string value", dictionary.get("Key1"));
+	EXPECT_EQ("Another string value", dictionary.get("Key2"));
+	EXPECT_EQ(true, dictionary.get<bool>("Key3"));
+	EXPECT_EQ(1, dictionary.get<int>("Key4"));
+}

--- a/test/Dictionary.test.cpp
+++ b/test/Dictionary.test.cpp
@@ -18,4 +18,6 @@ TEST(Dictionary, setGet) {
 	EXPECT_EQ("Another string value", dictionary.get("Key2"));
 	EXPECT_EQ(true, dictionary.get<bool>("Key3"));
 	EXPECT_EQ(1, dictionary.get<int>("Key4"));
+
+	EXPECT_THROW(dictionary.get("KeyDoesNotExist"), std::out_of_range);
 }


### PR DESCRIPTION
Reference: #634

Add start of a `Dictionary` class.

For now, this is just the implementation of simple `get` and `set` methods, with built-in type conversion.

Left out:
- Default values
- Getting a list of keys
- Iteration support

Those features are being deferred to the future. Having some basic working code first may allow for greater experimentation, and perhaps a better overall design.
