### PR TITLE
Remove joinSkipEmpty overload with no delimiter

### DIFF
--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -140,20 +140,6 @@ std::string join(std::vector<std::string> strs, char delim)
 	result.shrink_to_fit();
 	return result;
 }
-std::string joinSkipEmpty(std::vector<std::string> strs)
-{
-	const auto acc_op = [](const std::size_t& a, const std::string& b) noexcept->std::size_t { return a + b.size(); };
-	auto total_size = std::accumulate(std::begin(strs), std::end(strs), std::size_t{0u}, acc_op);
-	std::string result;
-	result.reserve(total_size);
-	for (const auto& s : strs)
-	{
-		if (s.empty()) { continue; }
-		result += s;
-	}
-	result.shrink_to_fit();
-	return result;
-}
 
 std::string joinSkipEmpty(std::vector<std::string> strs, char delim)
 {

--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -86,7 +86,6 @@ namespace NAS2D
 	std::pair<std::string, std::string> splitOnLast(const std::string& str, char delim);
 	std::string join(std::vector<std::string> strs);
 	std::string join(std::vector<std::string> strs, char delim);
-	std::string joinSkipEmpty(std::vector<std::string> strs);
 	std::string joinSkipEmpty(std::vector<std::string> strs, char delim);
 	std::string trimWhitespace(std::string string);
 	bool startsWith(std::string_view string, std::string_view start) noexcept;


### PR DESCRIPTION
Remove `joinSkipEmpty` overload with no delimiter.

If no delimiter is being passed, the method is identical to `join`. Skipping empty strings is the same as concatenating an empty string when no delimiter is being inserted between them.
