### PR TITLE
Remove joinSkipEmpty

### DIFF
--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -141,27 +141,6 @@ std::string join(std::vector<std::string> strs, char delim)
 	return result;
 }
 
-std::string joinSkipEmpty(std::vector<std::string> strs, char delim)
-{
-	const auto acc_op = [](const std::size_t& a, const std::string& b) noexcept->std::size_t { return a + std::size_t{1u} + b.size(); };
-	auto total_size = std::accumulate(std::begin(strs), std::end(strs), std::size_t{0u}, acc_op);
-	std::string result;
-	result.reserve(total_size);
-
-	for (auto iter = std::begin(strs); iter != std::end(strs); ++iter)
-	{
-		if ((*iter).empty()) { continue; }
-		result += (*iter);
-		if (iter + 1 != std::end(strs))
-		{
-			result.push_back(delim);
-		}
-	}
-
-	result.shrink_to_fit();
-	return result;
-}
-
 std::string trimWhitespace(std::string string)
 {
 	const auto first_non_space = string.find_first_not_of(" \r\n\t\v\f");

--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -86,7 +86,6 @@ namespace NAS2D
 	std::pair<std::string, std::string> splitOnLast(const std::string& str, char delim);
 	std::string join(std::vector<std::string> strs);
 	std::string join(std::vector<std::string> strs, char delim);
-	std::string joinSkipEmpty(std::vector<std::string> strs, char delim);
 	std::string trimWhitespace(std::string string);
 	bool startsWith(std::string_view string, std::string_view start) noexcept;
 	bool endsWith(std::string_view string, std::string_view end) noexcept;


### PR DESCRIPTION
There appears to be no uses of this method. If we have use for the code, we can always bring it back from history.

Additionally, the method appears to be highly specialized, so may not be the most appropriate for the library. There is also a sufficient workaround, in that a vector can be filtered of empty elements first, before a regular join is performed. This may have slightly lower efficiency, though is hard to tell without measuring.
