### PR TITLE
Remove splitSkipEmpty

### DIFF
--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -63,23 +63,6 @@ std::vector<std::string> split(std::string str, char delim /*= ','*/)
 	result.shrink_to_fit();
 	return result;
 }
-std::vector<std::string> splitSkipEmpty(std::string str, char delim /*= ','*/)
-{
-	const auto potentialCount = static_cast<std::size_t>(1 + std::count(std::begin(str), std::end(str), delim));
-	StringList result{};
-	result.reserve(potentialCount);
-
-	std::istringstream ss(str);
-
-	std::string curString{};
-	while (std::getline(ss, curString, delim))
-	{
-		if (curString.empty()) { continue; }
-		result.push_back(curString);
-	}
-	result.shrink_to_fit();
-	return result;
-}
 
 std::pair<std::string, std::string> splitOnFirst(const std::string& str, char delim)
 {

--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -81,7 +81,6 @@ namespace NAS2D
 	std::string toLowercase(std::string str);
 	std::string toUppercase(std::string str);
 	std::vector<std::string> split(std::string str, char delim = ',');
-	std::vector<std::string> splitSkipEmpty(std::string str, char delim = ',');
 	std::pair<std::string, std::string> splitOnFirst(const std::string& str, char delim);
 	std::pair<std::string, std::string> splitOnLast(const std::string& str, char delim);
 	std::string join(std::vector<std::string> strs);

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -131,19 +131,3 @@ TEST(String, split) {
 	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::split("ab.c", '.'));
 	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::split("abc.", '.'));
 }
-
-TEST(String, splitSkipEmpty) {
-	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitSkipEmpty("a,b,c"));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc"));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty(",abc"));
-	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitSkipEmpty("a,bc"));
-	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitSkipEmpty("ab,c"));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc,"));
-
-	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::splitSkipEmpty("a.b.c", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty(".abc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::splitSkipEmpty("a.bc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::splitSkipEmpty("ab.c", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::splitSkipEmpty("abc.", '.'));
-}


### PR DESCRIPTION
This method isn't used. If we really need it, we can bring it back from history.

Additionally, the method seems too highly specialized for the library. If a workaround is needed, a user could potentially use split, and then filter the results to remove empty entries. That may be less efficient, though hard to say how much of an impact it would have without measuring it.
