### PR TITLE
Add ContainerUtils

### DIFF
--- a/NAS2D/ContainerUtils.h
+++ b/NAS2D/ContainerUtils.h
@@ -1,0 +1,24 @@
+#pragma once
+
+
+#include <vector>
+#include <type_traits>
+
+
+namespace NAS2D {
+	namespace ContainerOperators {
+		template <typename T>
+		std::vector<T>& operator+=(std::vector<T>& container1, const std::vector<T>& container2)
+		{
+			container1.reserve(container1.size() + container2.size());
+			container1.insert(container1.end(), container2.begin(), container2.end());
+			return container1;
+		}
+
+		template <typename T>
+		std::vector<T> operator+(std::vector<T> container1, const std::vector<T>& container2)
+		{
+			return container1 += container2;
+		}
+	}
+}

--- a/NAS2D/ContainerUtils.h
+++ b/NAS2D/ContainerUtils.h
@@ -2,7 +2,7 @@
 
 
 #include <vector>
-#include <type_traits>
+#include <algorithm>
 
 
 namespace NAS2D {
@@ -19,6 +19,28 @@ namespace NAS2D {
 		std::vector<T> operator+(std::vector<T> container1, const std::vector<T>& container2)
 		{
 			return container1 += container2;
+		}
+
+		template <typename T>
+		std::vector<T>& operator-=(std::vector<T>& container1, const std::vector<T>& container2)
+		{
+			container1.erase(
+				std::remove_if(
+					container1.begin(),
+					container1.end(),
+					[&container2](const T& value){
+						return std::find(container2.begin(), container2.end(), value) != container2.end();
+					}
+				),
+				container1.end()
+			);
+			return container1;
+		}
+
+		template <typename T>
+		std::vector<T> operator-(std::vector<T> container1, const std::vector<T>& container2)
+		{
+			return container1 -= container2;
 		}
 	}
 }

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -220,6 +220,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Configuration.h" />
+    <ClInclude Include="ContainerUtils.h" />
     <ClInclude Include="Delegate.h" />
     <ClInclude Include="Documentation.h" />
     <ClInclude Include="EventHandler.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -161,6 +161,9 @@
     <ClInclude Include="Configuration.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ContainerUtils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="Delegate.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/test/ContainerUtils.test.cpp
+++ b/test/ContainerUtils.test.cpp
@@ -35,3 +35,32 @@ TEST(Container, VectorAdd) {
 		EXPECT_EQ((std::vector{1, 2, 3, 4}), a + b);
 	}
 }
+
+TEST(Container, VectorSelfSubtract) {
+	const std::vector b{2, 3};
+
+	{
+		std::vector a{1, 2, 3, 4};
+		EXPECT_EQ((std::vector{1, 4}), NAS2D::ContainerOperators::operator-=(a, b));
+		EXPECT_EQ((std::vector{1, 4}), a);
+	}
+
+	{
+		std::vector a{1, 2, 3, 4};
+		using namespace NAS2D::ContainerOperators;
+		EXPECT_EQ((std::vector{1, 4}), a -= b);
+		EXPECT_EQ((std::vector{1, 4}), a);
+	}
+}
+
+TEST(Container, VectorSubtract) {
+	const std::vector a{1, 2, 3, 4};
+	const std::vector b{2, 3};
+
+	EXPECT_EQ((std::vector{1, 4}), NAS2D::ContainerOperators::operator-(a, b));
+
+	{
+		using namespace NAS2D::ContainerOperators;
+		EXPECT_EQ((std::vector{1, 4}), a - b);
+	}
+}

--- a/test/ContainerUtils.test.cpp
+++ b/test/ContainerUtils.test.cpp
@@ -1,0 +1,37 @@
+#include "NAS2D/ContainerUtils.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+#include <list>
+
+
+TEST(Container, VectorSelfAdd) {
+	const std::vector b{3, 4};
+
+	{
+		std::vector a{1, 2};
+		EXPECT_EQ((std::vector{1, 2, 3, 4}), NAS2D::ContainerOperators::operator+=(a, b));
+		EXPECT_EQ((std::vector{1, 2, 3, 4}), a);
+	}
+
+	{
+		std::vector a{1, 2};
+		using namespace NAS2D::ContainerOperators;
+		EXPECT_EQ((std::vector{1, 2, 3, 4}), a += b);
+		EXPECT_EQ((std::vector{1, 2, 3, 4}), a);
+	}
+}
+
+TEST(Container, VectorAdd) {
+	const std::vector a{1, 2};
+	const std::vector b{3, 4};
+
+	EXPECT_EQ((std::vector{1, 2, 3, 4}), NAS2D::ContainerOperators::operator+(a, b));
+
+	{
+		using namespace NAS2D::ContainerOperators;
+		EXPECT_EQ((std::vector{1, 2, 3, 4}), a + b);
+	}
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -50,6 +50,7 @@
     <ClCompile Include="Renderer/Rectangle.test.cpp" />
     <ClCompile Include="Renderer/Vector.test.cpp" />
     <ClCompile Include="Resources/Image.test.cpp" />
+    <ClCompile Include="ContainerUtils.test.cpp" />
     <ClCompile Include="Delegate.test.cpp" />
     <ClCompile Include="Filesystem.test.cpp" />
     <ClCompile Include="MathUtils.test.cpp" />


### PR DESCRIPTION
Add operators for `std::vector` addition and subtraction.

Operators are contained in the namespace `NAS2D::ContainerOperators`. That allows the operators to be imported, without importing all of `NAS2D`. It also avoids polluting the global namespace unless requested.

Example from unit test code of both prefixed and imported namespace access:
```cpp
TEST(Container, VectorAdd) {
	const std::vector a{1, 2};
	const std::vector b{3, 4};

	EXPECT_EQ((std::vector{1, 2, 3, 4}), NAS2D::ContainerOperators::operator+(a, b));

	{
		using namespace NAS2D::ContainerOperators;
		EXPECT_EQ((std::vector{1, 2, 3, 4}), a + b);
	}
}
```

----

These operators could potentially be extended for other [standard library container](https://en.cppreference.com/w/cpp/container) types, or custom types. It could also allow for mixed types, such as `std::vector` + `std::list` (returning the type on the left).

Of course, such extensions should make use of guards, so the overloads don't capture silly things like `std::vector` + `5`. They should also be guarded so they don't interfere with other operator overloads the client may have defined or be using. Adding guards to open up the operations to arbitrary container types, while limiting things to only container types, including possibly custom user defined container types, would require fairly complex template guards. Something that won't be addressed at this time.

Without worrying about guards, more container types could be allowed by changing `std::vector<T>` to simply `T`. To allow for mixed types, introduce an additional template parameter type `U` for the second parameter. This of course will match anything without a `std::enable_if` or similar guard, and so could interfere with all operator overloads, for any types, not just container types.
