### PR TITLE
Use `std::string_view` for `trimWhitespace` parameter

### DIFF
--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -124,7 +124,7 @@ std::string join(const std::vector<std::string>& strs, char delim)
 	return result;
 }
 
-std::string trimWhitespace(const std::string& string)
+std::string trimWhitespace(std::string_view string)
 {
 	const auto first_non_space = string.find_first_not_of(" \r\n\t\v\f");
 	if (first_non_space == std::string::npos)
@@ -132,7 +132,7 @@ std::string trimWhitespace(const std::string& string)
 		return std::string{};
 	}
 	const auto last_non_space = string.find_last_not_of(" \r\n\t\v\f");
-	return string.substr(first_non_space, last_non_space - first_non_space + 1);
+	return std::string{string.substr(first_non_space, last_non_space - first_non_space + 1)};
 }
 
 bool startsWith(std::string_view string, std::string_view start) noexcept

--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -85,7 +85,7 @@ namespace NAS2D
 	std::pair<std::string, std::string> splitOnLast(const std::string& str, char delim);
 	std::string join(const std::vector<std::string>& strs);
 	std::string join(const std::vector<std::string>& strs, char delim);
-	std::string trimWhitespace(const std::string& string);
+	std::string trimWhitespace(std::string_view string);
 	bool startsWith(std::string_view string, std::string_view start) noexcept;
 	bool endsWith(std::string_view string, std::string_view end) noexcept;
 	bool startsWith(std::string_view string, char start) noexcept;


### PR DESCRIPTION
Use `std::string_view` for `trimWhitespace` parameter

----

We could potentially also use `std::string_view` for the return value. The lifetime would be at least as long as the parameter, which would provide enough time to allow the result to be safely captured, even if the parameter was a temporary. It would however require explicit capture to a `std::string` if the parameter was a temporary. Failure to do so would result in a dangling `std::string_view`. As such, it may be safer to keep the return value as a `std::string`.