### PR TITLE
Add Dictionary::keys() method

### DIFF
--- a/NAS2D/Dictionary.h
+++ b/NAS2D/Dictionary.h
@@ -20,6 +20,17 @@ namespace NAS2D {
 			mDictionary[key] = stringFrom<T>(value);
 		}
 
+		std::vector<std::string> keys() const
+		{
+			std::vector<std::string> result;
+			result.reserve(mDictionary.size());
+			for (const auto& pair : mDictionary)
+			{
+				result.push_back(pair.first);
+			}
+			return result;
+		}
+
 	private:
 		std::map<std::string, std::string> mDictionary;
 	};

--- a/test/Dictionary.test.cpp
+++ b/test/Dictionary.test.cpp
@@ -21,3 +21,15 @@ TEST(Dictionary, setGet) {
 
 	EXPECT_THROW(dictionary.get("KeyDoesNotExist"), std::out_of_range);
 }
+
+TEST(Dictionary, keys) {
+	NAS2D::Dictionary dictionary;
+
+	// Set some test values
+	dictionary.set("Key1", "Some string value");
+	dictionary.set("Key2", std::string{"Another string value"});
+	dictionary.set("Key3", true);
+	dictionary.set("Key4", 1);
+
+	EXPECT_EQ((std::vector<std::string>{"Key1", "Key2", "Key3", "Key4"}), dictionary.keys());
+}


### PR DESCRIPTION
Add `Dictionary::keys()` method.

This can be used when a `Dictionary` contains arbitrary key values, where there is no known predefined list of keys.
