### PR TITLE
Add mpg123 option to sdl2-mixer install with vcpkg

### DIFF
--- a/InstallVcpkgDeps.bat
+++ b/InstallVcpkgDeps.bat
@@ -16,4 +16,4 @@ if not defined PLATFORM (
 )
 
 :Install
-vcpkg install --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[dynamic-load,libflac,libmodplug,libvorbis,opusfile] gtest
+vcpkg install --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[dynamic-load,libflac,mpg123,libmodplug,libvorbis,opusfile] gtest


### PR DESCRIPTION
An install problem was recently fixed that allows this to be enabled now.