### PR TITLE
Comment out GL shader language check

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -705,7 +705,7 @@ void RendererOpenGL::initGL()
 
 	if (glShadingLanguageVersion.empty())
 	{
-		throw renderer_no_glsl();
+		//throw renderer_no_glsl();
 	}
 
 	glEnable(GL_TEXTURE_2D);


### PR DESCRIPTION
We don't appear to be relying on GL shading language, so we probably shouldn't abort when the feature isn't present. In particular, running the game in a Windows VM triggers this exception, which prevents the game from loading. Commenting it out allows the game to run largely fine.

I've chosen to comment this out for now, until we figure out what to do with it. Either implement features that require it, or hopefully remove the check, as not a required feature.

I've noted when run on a Windows VM that certain background images don't load, though I'm told that's to do with texture dimensions not being a power of 2. If that can be verified as the cause, then perhaps the check done here can be removed.
