### PR TITLE
Allow join with arbitrary length delimiters

### DIFF
--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -110,8 +110,12 @@ std::string join(const std::vector<std::string>& strs, char delim)
 
 	if (!strs.empty())
 	{
-		const auto acc_op = [](std::size_t a, const std::string& b) noexcept { return a + b.size(); };
-		const auto totalStringSize = std::accumulate(std::begin(strs), std::end(strs), std::size_t{0u}, acc_op);
+		const auto totalStringSize = std::accumulate(
+			std::begin(strs),
+			std::end(strs),
+			std::size_t{0u},
+			[](std::size_t a, const std::string& b) noexcept { return a + b.size(); }
+		);
 		const auto delimiterSize = strs.size() - 1;
 		result.reserve(totalStringSize + delimiterSize);
 

--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -104,7 +104,7 @@ std::string join(const std::vector<std::string>& strs)
 	return result;
 }
 
-std::string join(const std::vector<std::string>& strs, char delim)
+std::string join(const std::vector<std::string>& strs, std::string_view delimiter)
 {
 	std::string result;
 
@@ -116,13 +116,13 @@ std::string join(const std::vector<std::string>& strs, char delim)
 			std::size_t{},
 			[](std::size_t a, const std::string& b) noexcept { return a + b.size(); }
 		);
-		const auto delimiterSize = strs.size() - 1;
+		const auto delimiterSize = (strs.size() - 1) * delimiter.size();
 		result.reserve(totalStringSize + delimiterSize);
 
 		result += strs.front();
 		for (auto iter = std::begin(strs) + 1; iter != std::end(strs); ++iter)
 		{
-			result.push_back(delim);
+			result += delimiter;
 			result += (*iter);
 		}
 	}

--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -90,20 +90,6 @@ std::pair<std::string, std::string> splitOnLast(const std::string& str, char del
 	}
 }
 
-std::string join(const std::vector<std::string>& strs)
-{
-	const auto acc_op = [](const std::size_t& a, const std::string& b) noexcept->std::size_t { return a + b.size(); };
-	auto total_size = std::accumulate(std::begin(strs), std::end(strs), std::size_t{0u}, acc_op);
-	std::string result;
-	result.reserve(total_size);
-	for (const auto& s : strs)
-	{
-		result += s;
-	}
-	result.shrink_to_fit();
-	return result;
-}
-
 std::string join(const std::vector<std::string>& strs, std::string_view delimiter)
 {
 	std::string result;

--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -111,8 +111,9 @@ std::string join(const std::vector<std::string>& strs, char delim)
 	if (!strs.empty())
 	{
 		const auto acc_op = [](std::size_t a, const std::string& b) noexcept { return a + b.size(); };
-		auto total_size = std::accumulate(std::begin(strs), std::end(strs), std::size_t{0u}, acc_op) + strs.size() - 1;
-		result.reserve(total_size);
+		const auto totalStringSize = std::accumulate(std::begin(strs), std::end(strs), std::size_t{0u}, acc_op);
+		const auto delimiterSize = strs.size() - 1;
+		result.reserve(totalStringSize + delimiterSize);
 
 		result += strs.front();
 		for (auto iter = std::begin(strs) + 1; iter != std::end(strs); ++iter)

--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -113,7 +113,7 @@ std::string join(const std::vector<std::string>& strs, char delim)
 		const auto totalStringSize = std::accumulate(
 			std::begin(strs),
 			std::end(strs),
-			std::size_t{0u},
+			std::size_t{},
 			[](std::size_t a, const std::string& b) noexcept { return a + b.size(); }
 		);
 		const auto delimiterSize = strs.size() - 1;

--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -83,8 +83,7 @@ namespace NAS2D
 	std::vector<std::string> split(const std::string& str, char delim = ',');
 	std::pair<std::string, std::string> splitOnFirst(const std::string& str, char delim);
 	std::pair<std::string, std::string> splitOnLast(const std::string& str, char delim);
-	std::string join(const std::vector<std::string>& strs);
-	std::string join(const std::vector<std::string>& strs, std::string_view delimiter);
+	std::string join(const std::vector<std::string>& strs, std::string_view delimiter = {});
 	std::string trimWhitespace(std::string_view string);
 	bool startsWith(std::string_view string, std::string_view start) noexcept;
 	bool endsWith(std::string_view string, std::string_view end) noexcept;

--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -84,7 +84,7 @@ namespace NAS2D
 	std::pair<std::string, std::string> splitOnFirst(const std::string& str, char delim);
 	std::pair<std::string, std::string> splitOnLast(const std::string& str, char delim);
 	std::string join(const std::vector<std::string>& strs);
-	std::string join(const std::vector<std::string>& strs, char delim);
+	std::string join(const std::vector<std::string>& strs, std::string_view delimiter);
 	std::string trimWhitespace(std::string_view string);
 	bool startsWith(std::string_view string, std::string_view start) noexcept;
 	bool endsWith(std::string_view string, std::string_view end) noexcept;

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -146,4 +146,6 @@ TEST(String, join) {
 	EXPECT_EQ("a,b,c", NAS2D::join(NAS2D::StringList{"a", "b", "c"}, ","));
 
 	EXPECT_EQ("a,,c", NAS2D::join(NAS2D::StringList{"a", "", "c"}, ","));
+
+	EXPECT_EQ("a, b, c", NAS2D::join(NAS2D::StringList{"a", "b", "c"}, ", "));
 }

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -140,10 +140,10 @@ TEST(String, join) {
 
 	EXPECT_EQ("ac", NAS2D::join(NAS2D::StringList{"a", "", "c"}));
 
-	EXPECT_EQ("", NAS2D::join(NAS2D::StringList{}, ','));
-	EXPECT_EQ("a", NAS2D::join(NAS2D::StringList{"a"}, ','));
-	EXPECT_EQ("a,b", NAS2D::join(NAS2D::StringList{"a", "b"}, ','));
-	EXPECT_EQ("a,b,c", NAS2D::join(NAS2D::StringList{"a", "b", "c"}, ','));
+	EXPECT_EQ("", NAS2D::join(NAS2D::StringList{}, ","));
+	EXPECT_EQ("a", NAS2D::join(NAS2D::StringList{"a"}, ","));
+	EXPECT_EQ("a,b", NAS2D::join(NAS2D::StringList{"a", "b"}, ","));
+	EXPECT_EQ("a,b,c", NAS2D::join(NAS2D::StringList{"a", "b", "c"}, ","));
 
-	EXPECT_EQ("a,,c", NAS2D::join(NAS2D::StringList{"a", "", "c"}, ','));
+	EXPECT_EQ("a,,c", NAS2D::join(NAS2D::StringList{"a", "", "c"}, ","));
 }


### PR DESCRIPTION
Have the `join` method take a `delimiter` of arbitrary length. Setting a default values to a zero length delimiter means the two function overloads can be collapsed to a single implementation.

----

I was tempted to replace the `for` loop with a call to `std::accumulate` to build the `result` string, similar to how the size is calculated. Though I quickly realized that wouldn't play well with the `reserve` call, as it would create a new `std::string` object, and so could defeat the purpose of the first `std::accumulate`.
