### PR TITLE
Add generic getKeys method

### DIFF
--- a/NAS2D/ContainerUtils.h
+++ b/NAS2D/ContainerUtils.h
@@ -43,4 +43,17 @@ namespace NAS2D {
 			return container1 -= container2;
 		}
 	}
+
+
+	template <typename T>
+	std::vector<typename T::key_type> getKeys(const T& map)
+	{
+		std::vector<typename T::key_type> result;
+		result.reserve(map.size());
+		for (const auto& pair : map)
+		{
+			result.push_back(pair.first);
+		}
+		return result;
+	}
 }

--- a/NAS2D/Dictionary.h
+++ b/NAS2D/Dictionary.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "StringUtils.h"
+#include "ContainerUtils.h"
 #include <map>
 
 
@@ -22,13 +23,7 @@ namespace NAS2D {
 
 		std::vector<std::string> keys() const
 		{
-			std::vector<std::string> result;
-			result.reserve(mDictionary.size());
-			for (const auto& pair : mDictionary)
-			{
-				result.push_back(pair.first);
-			}
-			return result;
+			return getKeys(mDictionary);
 		}
 
 	private:

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -9,6 +9,7 @@
 // ==================================================================================
 
 #include "Sprite.h"
+#include "../ContainerUtils.h"
 #include "../Version.h"
 #include "../Xml/Xml.h"
 
@@ -193,14 +194,7 @@ float Sprite::rotation() const
  */
 StringList Sprite::actions() const
 {
-	StringList list;
-
-	for (const auto& pair : mActions)
-	{
-		list.push_back(pair.first);
-	}
-
-	return list;
+	return getKeys(mActions);
 }
 
 

--- a/test/ContainerUtils.test.cpp
+++ b/test/ContainerUtils.test.cpp
@@ -5,6 +5,8 @@
 
 #include <vector>
 #include <list>
+#include <map>
+#include <unordered_map>
 
 
 TEST(Container, VectorSelfAdd) {
@@ -62,5 +64,35 @@ TEST(Container, VectorSubtract) {
 	{
 		using namespace NAS2D::ContainerOperators;
 		EXPECT_EQ((std::vector{1, 4}), a - b);
+	}
+}
+
+TEST(Container, getKeys) {
+	EXPECT_EQ((std::vector<std::string>{}), NAS2D::getKeys(std::map<std::string, int>{}));
+	EXPECT_EQ((std::vector<std::string>{"Key1"}), NAS2D::getKeys(std::map<std::string, int>{{"Key1", 1}}));
+	EXPECT_EQ((std::vector<std::string>{"Key1", "Key2"}), NAS2D::getKeys(std::map<std::string, int>{{"Key1", 1}, {"Key2", 2}}));
+
+	EXPECT_EQ((std::vector<int>{}), NAS2D::getKeys(std::map<int, int>{}));
+	EXPECT_EQ((std::vector<int>{1}), NAS2D::getKeys(std::map<int, int>{{1, 10}}));
+	EXPECT_EQ((std::vector<int>{1, 2}), NAS2D::getKeys(std::map<int, int>{{1, 10}, {2, 20}}));
+
+	EXPECT_EQ((std::vector<int>{}), NAS2D::getKeys(std::multimap<int, int>{}));
+	EXPECT_EQ((std::vector<int>{1}), NAS2D::getKeys(std::multimap<int, int>{{1, 10}}));
+	EXPECT_EQ((std::vector<int>{1, 2}), NAS2D::getKeys(std::multimap<int, int>{{1, 10}, {2, 20}}));
+
+	EXPECT_EQ((std::vector<int>{}), NAS2D::getKeys(std::unordered_map<int, int>{}));
+	EXPECT_EQ((std::vector<int>{1}), NAS2D::getKeys(std::unordered_map<int, int>{{1, 10}}));
+	{
+		auto result = NAS2D::getKeys(std::unordered_map<int, int>{{1, 10}, {2, 20}});
+		std::sort(std::begin(result), std::end(result));
+		EXPECT_EQ((std::vector<int>{1, 2}), result);
+	}
+
+	EXPECT_EQ((std::vector<int>{}), NAS2D::getKeys(std::unordered_multimap<int, int>{}));
+	EXPECT_EQ((std::vector<int>{1}), NAS2D::getKeys(std::unordered_multimap<int, int>{{1, 10}}));
+	{
+		auto result = NAS2D::getKeys(std::unordered_multimap<int, int>{{1, 10}, {2, 20}});
+		std::sort(std::begin(result), std::end(result));
+		EXPECT_EQ((std::vector<int>{1, 2}), result);
 	}
 }


### PR DESCRIPTION
Add generic `getKeys` method, to get a `std::vector` of the keys in a container, such as `std::map`.

Works for other container types that also provide the necessary features:
- `key_type` alias
- `size()` member function
- range-for iteration support
- iterated value has a `.first` property of `key_type` (or convertible to it)

In particular, these containers meet the requirements:
- `std::map`
- `std::unordered_map`
- `std::multimap`
- `std::unordered_multimap`
