### PR TITLE
Dictionary add to combine dictionaries

### DIFF
--- a/NAS2D/Dictionary.cpp
+++ b/NAS2D/Dictionary.cpp
@@ -1,0 +1,19 @@
+#include "Dictionary.h"
+
+
+namespace NAS2D {
+	Dictionary& Dictionary::operator+=(const Dictionary& other)
+	{
+		for (const auto& [key, value] : other.mDictionary)
+		{
+			mDictionary[key] = value;
+		}
+		return *this;
+	}
+
+
+	Dictionary operator+(Dictionary lhs, const Dictionary& rhs)
+	{
+		return lhs += rhs;
+	}
+}

--- a/NAS2D/Dictionary.h
+++ b/NAS2D/Dictionary.h
@@ -9,6 +9,9 @@ namespace NAS2D {
 	class Dictionary
 	{
 	public:
+		Dictionary& operator+=(const Dictionary& other);
+
+
 		template <typename T = std::string>
 		T get(const std::string& key) const
 		{
@@ -29,4 +32,7 @@ namespace NAS2D {
 	private:
 		std::map<std::string, std::string> mDictionary;
 	};
+
+
+	Dictionary operator+(Dictionary lhs, const Dictionary& rhs);
 }

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -179,6 +179,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Configuration.cpp" />
+    <ClCompile Include="Dictionary.cpp" />
     <ClCompile Include="EventHandler.cpp" />
     <ClCompile Include="Exception.cpp" />
     <ClCompile Include="Filesystem.cpp" />
@@ -222,6 +223,7 @@
     <ClInclude Include="Configuration.h" />
     <ClInclude Include="ContainerUtils.h" />
     <ClInclude Include="Delegate.h" />
+    <ClInclude Include="Dictionary.h" />
     <ClInclude Include="Documentation.h" />
     <ClInclude Include="EventHandler.h" />
     <ClInclude Include="Exception.h" />

--- a/test/Dictionary.test.cpp
+++ b/test/Dictionary.test.cpp
@@ -33,3 +33,36 @@ TEST(Dictionary, keys) {
 
 	EXPECT_EQ((std::vector<std::string>{"Key1", "Key2", "Key3", "Key4"}), dictionary.keys());
 }
+
+TEST(Dictionary, OperatorAdd) {
+	// Simple combination
+	{
+		NAS2D::Dictionary dictionary1;
+		NAS2D::Dictionary dictionary2;
+
+		dictionary1.set("Key1", 1);
+		dictionary2.set("Key2", 2);
+
+		const auto dictionaryCombined = dictionary1 + dictionary2;
+
+		EXPECT_EQ(1, dictionaryCombined.get<int>("Key1"));
+		EXPECT_EQ(2, dictionaryCombined.get<int>("Key2"));
+	}
+
+	// Right hand side overwrites left hand side
+	{
+		NAS2D::Dictionary dictionary1;
+		NAS2D::Dictionary dictionary2;
+
+		dictionary1.set("Key1", 1);
+		dictionary1.set("Key2", 2);
+		dictionary2.set("Key2", 10);
+		dictionary2.set("Key3", 20);
+
+		const auto dictionaryCombined = dictionary1 + dictionary2;
+
+		EXPECT_EQ(1, dictionaryCombined.get<int>("Key1"));
+		EXPECT_EQ(10, dictionaryCombined.get<int>("Key2"));
+		EXPECT_EQ(20, dictionaryCombined.get<int>("Key3"));
+	}
+}


### PR DESCRIPTION
Add addition operators (`+` and `+=`) to `Dictionary` class, allowing entries from two dictionaries to be combined. In the event of a conflict, the entry from the right hand side will overwrite the entry from the left hand side.

Add the `Dictionary` class files to the Visual Studio project. This seems to have been accidentally left out during an earlier commit.
