### PR TITLE
Use Dictionary objects to read Configuration

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -300,7 +300,7 @@ bool Configuration::readConfig(const std::string& filePath)
 			 section != nullptr;
 			 section = section->nextSiblingElement())
 		{
-			if (section->value() == "graphics") { parseGraphics(section); }
+			if (section->value() == "graphics") { parseGraphics(ParseXmlElementAttributesToDictionary(*section)); }
 			else if (section->value() == "audio") { parseAudio(section); }
 			else if (section->value() == "options") { parseOptions(section); }
 			else if (section->type() == XmlNode::NodeType::XML_COMMENT) {} // Ignore comments
@@ -320,20 +320,15 @@ bool Configuration::readConfig(const std::string& filePath)
  *
  * \todo	Check for sane configurations, particularly screen resolution.
  */
-void Configuration::parseGraphics(XmlElement* element)
+void Configuration::parseGraphics(const Dictionary& dictionary)
 {
-	const XmlAttribute* attribute = element->firstAttribute();
-	while (attribute)
-	{
-		if (attribute->name() == GRAPHICS_CFG_SCREEN_WIDTH) { attribute->queryIntValue(mScreenWidth); }
-		else if (attribute->name() == GRAPHICS_CFG_SCREEN_HEIGHT) { attribute->queryIntValue(mScreenHeight); }
-		else if (attribute->name() == GRAPHICS_CFG_SCREEN_DEPTH) { attribute->queryIntValue(mScreenBpp); }
-		else if (attribute->name() == GRAPHICS_CFG_FULLSCREEN) { fullscreen(toLowercase(attribute->value()) == "true"); }
-		else if (attribute->name() == GRAPHICS_CFG_VSYNC) { vsync(toLowercase(attribute->value()) == "true"); }
-		else { std::cout << "Unexpected attribute '" << attribute->name() << "' found in '" << element->value() << "'." << std::endl; }
+	ReportProblemNames(dictionary.keys(), {GRAPHICS_CFG_SCREEN_WIDTH, GRAPHICS_CFG_SCREEN_HEIGHT, GRAPHICS_CFG_SCREEN_DEPTH, GRAPHICS_CFG_FULLSCREEN, GRAPHICS_CFG_VSYNC});
 
-		attribute = attribute->next();
-	}
+	mScreenWidth = dictionary.get<int>(GRAPHICS_CFG_SCREEN_WIDTH);
+	mScreenHeight = dictionary.get<int>(GRAPHICS_CFG_SCREEN_HEIGHT);
+	mScreenBpp = dictionary.get<int>(GRAPHICS_CFG_SCREEN_DEPTH);
+	fullscreen(dictionary.get<bool>(GRAPHICS_CFG_FULLSCREEN));
+	vsync(dictionary.get<bool>(GRAPHICS_CFG_VSYNC));
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -9,6 +9,7 @@
 // ==================================================================================
 
 #include "Configuration.h"
+#include "Dictionary.h"
 #include "ContainerUtils.h"
 #include "Filesystem.h"
 #include "Utility.h"
@@ -74,6 +75,19 @@ namespace {
 		{
 			throw std::runtime_error("Missing required names: {" + join(missing, ", ") +"}, unexpected names: {" + join(unexpected, ", ") + "}");
 		}
+	}
+
+
+	Dictionary ParseXmlElementAttributesToDictionary(const XmlElement& element)
+	{
+		Dictionary dictionary;
+
+		for (const auto* attribute = element.firstAttribute(); attribute; attribute = attribute->next())
+		{
+			dictionary.set(attribute->name(), attribute->value());
+		}
+
+		return dictionary;
 	}
 }
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -9,6 +9,7 @@
 // ==================================================================================
 
 #include "Configuration.h"
+#include "ContainerUtils.h"
 #include "Filesystem.h"
 #include "Utility.h"
 #include "Xml/Xml.h"
@@ -54,6 +55,28 @@ const std::string GRAPHICS_CFG_SCREEN_HEIGHT = "screenheight";
 const std::string GRAPHICS_CFG_SCREEN_DEPTH = "bitdepth";
 const std::string GRAPHICS_CFG_FULLSCREEN = "fullscreen";
 const std::string GRAPHICS_CFG_VSYNC = "vsync";
+
+
+namespace {
+	void ReportProblemNames(
+		const std::vector<std::string>& names,
+		const std::vector<std::string>& required,
+		const std::vector<std::string>& optional = {}
+	) {
+		using namespace ContainerOperators;
+
+		const auto expected = required + optional;
+
+		const auto missing = names - required;
+		const auto unexpected = names - expected;
+
+		if (!missing.empty() || !unexpected.empty())
+		{
+			throw std::runtime_error("Missing required names: {" + join(missing, ", ") +"}, unexpected names: {" + join(unexpected, ", ") + "}");
+		}
+	}
+}
+
 
 /**
  * D'tor

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -333,7 +333,7 @@ void Configuration::parseAudio(const Dictionary& dictionary)
 	}
 	if (mBufferLength < AUDIO_BUFFER_MIN_SIZE || mBufferLength > AUDIO_BUFFER_MAX_SIZE)
 	{
-		audioBufferSize(std::clamp(mBufferLength, AUDIO_BUFFER_MIN_SIZE, AUDIO_BUFFER_MAX_SIZE));
+		audioBufferSize(mBufferLength);
 	}
 }
 
@@ -590,7 +590,7 @@ void Configuration::audioMusicVolume(int volume)
  */
 void Configuration::audioBufferSize(int size)
 {
-	mBufferLength = size;
+	mBufferLength = std::clamp(size, AUDIO_BUFFER_MIN_SIZE, AUDIO_BUFFER_MAX_SIZE);
 	mOptionChanged = true;
 }
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -89,6 +89,35 @@ namespace {
 
 		return dictionary;
 	}
+
+
+	Dictionary ParseOptionsToDictionary(const XmlElement& element)
+	{
+		Dictionary dictionary;
+
+		for (const auto* setting = element.firstChildElement(); setting; setting = setting->nextSiblingElement())
+		{
+			if (setting->value() != "option")
+			{
+				throw std::runtime_error("Unexpected tag found in configuration on row: " + std::to_string(setting->row()) + "  <" + setting->value() + ">");
+			}
+
+			const auto optionDictionary = ParseXmlElementAttributesToDictionary(*setting);
+			ReportProblemNames(optionDictionary.keys(), {"name", "value"});
+
+			const auto name = optionDictionary.get("name");
+			const auto value = optionDictionary.get("value");
+
+			if (name.empty() || value.empty())
+			{
+				throw std::runtime_error("Invalid name/value pair in <option> tag in configuration file on row: " + std::to_string(setting->row()));
+			}
+
+			dictionary.set(name, value);
+		}
+
+		return dictionary;
+	}
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -278,31 +278,13 @@ bool Configuration::readConfig(const std::string& filePath)
 {
 	File xmlFile = Utility<Filesystem>::get().open(filePath);
 
-	XmlDocument config;
-	config.parse(xmlFile.raw_bytes());
-	if (config.error())
-	{
-		std::cout << "Error parsing configuration file '" << filePath << "' on Row " << config.errorRow() << ", Column " << config.errorCol() << ": " << config.errorDesc() << std::endl;
-		return false;
-	}
-	else
-	{
-		XmlElement* root = config.firstChildElement("configuration");
-		if (!root)
-		{
-			std::cout << "'" << filePath << "' doesn't contain a '<configuration>' tag." << std::endl;
-			return false;
-		}
+	// Start parsing through the Config.xml file.
+	const auto sections = ParseXmlSections(xmlFile.raw_bytes(), "configuration");
+	ReportProblemNames(getKeys(sections), {"graphics", "audio", "options"});
 
-
-		// Start parsing through the Config.xml file.
-		const auto sections = ParseXmlSections(*root);
-		ReportProblemNames(getKeys(sections), {"graphics", "audio", "options"});
-
-		parseGraphics(sections.at("graphics"));
-		parseAudio(sections.at("audio"));
-		parseOptions(sections.at("options"));
-	}
+	parseGraphics(sections.at("graphics"));
+	parseAudio(sections.at("audio"));
+	parseOptions(sections.at("options"));
 
 	return true;
 }

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -301,7 +301,7 @@ bool Configuration::readConfig(const std::string& filePath)
 			 section = section->nextSiblingElement())
 		{
 			if (section->value() == "graphics") { parseGraphics(ParseXmlElementAttributesToDictionary(*section)); }
-			else if (section->value() == "audio") { parseAudio(section); }
+			else if (section->value() == "audio") { parseAudio(ParseXmlElementAttributesToDictionary(*section)); }
 			else if (section->value() == "options") { parseOptions(section); }
 			else if (section->type() == XmlNode::NodeType::XML_COMMENT) {} // Ignore comments
 			else
@@ -338,66 +338,38 @@ void Configuration::parseGraphics(const Dictionary& dictionary)
  * \note	If any values are invalid or non-existant, this
  *			function will set default values.
  */
-void Configuration::parseAudio(XmlElement* element)
+void Configuration::parseAudio(const Dictionary& dictionary)
 {
-	const XmlAttribute* attribute = element->firstAttribute();
-	while (attribute)
+	ReportProblemNames(dictionary.keys(), {AUDIO_CFG_MIXRATE, AUDIO_CFG_CHANNELS, AUDIO_CFG_SFX_VOLUME, AUDIO_CFG_MUS_VOLUME, AUDIO_CFG_BUFFER_SIZE, AUDIO_CFG_MIXER});
+
+	mMixRate = dictionary.get<int>(AUDIO_CFG_MIXRATE);
+	mStereoChannels = dictionary.get<int>(AUDIO_CFG_CHANNELS);
+	mSfxVolume = dictionary.get<int>(AUDIO_CFG_SFX_VOLUME);
+	mMusicVolume = dictionary.get<int>(AUDIO_CFG_MUS_VOLUME);
+	mBufferLength = dictionary.get<int>(AUDIO_CFG_BUFFER_SIZE);
+	mMixerName = dictionary.get(AUDIO_CFG_MIXER);
+
+	if (mMixRate != AUDIO_LOW_QUALITY && mMixRate != AUDIO_MEDIUM_QUALITY && mMixRate != AUDIO_HIGH_QUALITY)
 	{
-		if (attribute->name() == AUDIO_CFG_MIXRATE)
-		{
-			attribute->queryIntValue(mMixRate);
-			if (mMixRate != AUDIO_LOW_QUALITY && mMixRate != AUDIO_MEDIUM_QUALITY && mMixRate != AUDIO_HIGH_QUALITY)
-			{
-				std::cout << "Invalid audio mixrate setting '" << mMixRate << "'. Expected 11025, 22050 or 44100. Setting to default of 22050." << std::endl;
-				audioMixRate(AUDIO_MEDIUM_QUALITY);
-			}
-		}
-		else if (attribute->name() == AUDIO_CFG_CHANNELS)
-		{
-			attribute->queryIntValue(mStereoChannels);
-
-			if (mStereoChannels != AUDIO_MONO && mStereoChannels != AUDIO_STEREO)
-			{
-				std::cout << "Invalid audio channels setting '" << mStereoChannels << "'. Expected 1 or 2. Setting to default of 2." << std::endl;
-				audioStereoChannels(AUDIO_STEREO);
-			}
-		}
-		else if (attribute->name() == AUDIO_CFG_SFX_VOLUME)
-		{
-			attribute->queryIntValue(mSfxVolume);
-
-			if (mSfxVolume < AUDIO_SFX_MIN_VOLUME || mSfxVolume > AUDIO_SFX_MAX_VOLUME)
-			{
-				audioSfxVolume(mSfxVolume);
-			}
-		}
-		else if (attribute->name() == AUDIO_CFG_MUS_VOLUME)
-		{
-			attribute->queryIntValue(mMusicVolume);
-
-			if (mMusicVolume < AUDIO_MUSIC_MIN_VOLUME || mMusicVolume > AUDIO_MUSIC_MAX_VOLUME)
-			{
-				audioMusicVolume(mMusicVolume);
-			}
-		}
-		else if (attribute->name() == AUDIO_CFG_BUFFER_SIZE)
-		{
-			attribute->queryIntValue(mBufferLength);
-			if (mBufferLength < AUDIO_BUFFER_MIN_SIZE || mBufferLength > AUDIO_BUFFER_MAX_SIZE)
-			{
-				audioBufferSize(std::clamp(mBufferLength, AUDIO_BUFFER_MIN_SIZE, AUDIO_BUFFER_MAX_SIZE));
-			}
-		}
-		else if (attribute->name() == AUDIO_CFG_MIXER)
-		{
-			mMixerName = attribute->value();
-		}
-		else
-		{
-			std::cout << "Unexpected attribute '" << attribute->name() << "' found in '" << element->value() << "'." << std::endl;
-		}
-
-		attribute = attribute->next();
+		std::cout << "Invalid audio mixrate setting '" << mMixRate << "'. Expected 11025, 22050 or 44100. Setting to default of 22050." << std::endl;
+		audioMixRate(AUDIO_MEDIUM_QUALITY);
+	}
+	if (mStereoChannels != AUDIO_MONO && mStereoChannels != AUDIO_STEREO)
+	{
+		std::cout << "Invalid audio channels setting '" << mStereoChannels << "'. Expected 1 or 2. Setting to default of 2." << std::endl;
+		audioStereoChannels(AUDIO_STEREO);
+	}
+	if (mSfxVolume < AUDIO_SFX_MIN_VOLUME || mSfxVolume > AUDIO_SFX_MAX_VOLUME)
+	{
+		audioSfxVolume(mSfxVolume);
+	}
+	if (mMusicVolume < AUDIO_MUSIC_MIN_VOLUME || mMusicVolume > AUDIO_MUSIC_MAX_VOLUME)
+	{
+		audioMusicVolume(mMusicVolume);
+	}
+	if (mBufferLength < AUDIO_BUFFER_MIN_SIZE || mBufferLength > AUDIO_BUFFER_MAX_SIZE)
+	{
+		audioBufferSize(std::clamp(mBufferLength, AUDIO_BUFFER_MIN_SIZE, AUDIO_BUFFER_MAX_SIZE));
 	}
 }
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -133,6 +133,26 @@ namespace {
 
 		return sections;
 	}
+
+
+	std::map<std::string, Dictionary> ParseXmlSections(const std::string& xmlString, const std::string& sectionName)
+	{
+		XmlDocument xmlDocument;
+		xmlDocument.parse(xmlString.c_str());
+
+		if (xmlDocument.error())
+		{
+			throw std::runtime_error("Error parsing XML file on (Row " + std::to_string(xmlDocument.errorRow()) + ", Column " + std::to_string(xmlDocument.errorCol()) + "): " + xmlDocument.errorDesc());
+		}
+
+		XmlElement* root = xmlDocument.firstChildElement(sectionName);
+		if (!root)
+		{
+			throw std::runtime_error("XML file does not contain tag: " + sectionName);
+		}
+
+		return ParseXmlSections(*root);
+	}
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -315,12 +315,10 @@ void Configuration::parseAudio(const Dictionary& dictionary)
 
 	if (mMixRate != AUDIO_LOW_QUALITY && mMixRate != AUDIO_MEDIUM_QUALITY && mMixRate != AUDIO_HIGH_QUALITY)
 	{
-		std::cout << "Invalid audio mixrate setting '" << mMixRate << "'. Expected 11025, 22050 or 44100. Setting to default of 22050." << std::endl;
 		audioMixRate(AUDIO_MEDIUM_QUALITY);
 	}
 	if (mStereoChannels != AUDIO_MONO && mStereoChannels != AUDIO_STEREO)
 	{
-		std::cout << "Invalid audio channels setting '" << mStereoChannels << "'. Expected 1 or 2. Setting to default of 2." << std::endl;
 		audioStereoChannels(AUDIO_STEREO);
 	}
 	if (mSfxVolume < AUDIO_SFX_MIN_VOLUME || mSfxVolume > AUDIO_SFX_MAX_VOLUME)

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -290,11 +290,6 @@ bool Configuration::readConfig(const std::string& filePath)
 }
 
 
-/**
- * Parse the <graphics> tab.
- *
- * \todo	Check for sane configurations, particularly screen resolution.
- */
 void Configuration::parseGraphics(const Dictionary& dictionary)
 {
 	ReportProblemNames(dictionary.keys(), {GRAPHICS_CFG_SCREEN_WIDTH, GRAPHICS_CFG_SCREEN_HEIGHT, GRAPHICS_CFG_SCREEN_DEPTH, GRAPHICS_CFG_FULLSCREEN, GRAPHICS_CFG_VSYNC});
@@ -307,12 +302,6 @@ void Configuration::parseGraphics(const Dictionary& dictionary)
 }
 
 
-/**
- * Parses audio information from an XML node.
- *
- * \note	If any values are invalid or non-existant, this
- *			function will set default values.
- */
 void Configuration::parseAudio(const Dictionary& dictionary)
 {
 	ReportProblemNames(dictionary.keys(), {AUDIO_CFG_MIXRATE, AUDIO_CFG_CHANNELS, AUDIO_CFG_SFX_VOLUME, AUDIO_CFG_MUS_VOLUME, AUDIO_CFG_BUFFER_SIZE, AUDIO_CFG_MIXER});
@@ -349,11 +338,6 @@ void Configuration::parseAudio(const Dictionary& dictionary)
 }
 
 
-/**
- * Parses program options from an XML node.
- *
- * \note	Use of void pointer in declaration to avoid implementation details in header.
- */
 void Configuration::parseOptions(const Dictionary& dictionary)
 {
 	for (const auto& key : dictionary.keys())

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -296,19 +296,12 @@ bool Configuration::readConfig(const std::string& filePath)
 
 
 		// Start parsing through the Config.xml file.
-		for (auto section = root->firstChildElement();
-			 section != nullptr;
-			 section = section->nextSiblingElement())
-		{
-			if (section->value() == "graphics") { parseGraphics(ParseXmlElementAttributesToDictionary(*section)); }
-			else if (section->value() == "audio") { parseAudio(ParseXmlElementAttributesToDictionary(*section)); }
-			else if (section->value() == "options") { parseOptions(ParseXmlElementAttributesToDictionary(*section)); }
-			else if (section->type() == XmlNode::NodeType::XML_COMMENT) {} // Ignore comments
-			else
-			{
-				std::cout << "Unexpected tag '<" << section->value() << ">' found in '" << filePath << "' on row " << section->row() << "." << std::endl;
-			}
-		}
+		const auto sections = ParseXmlSections(*root);
+		ReportProblemNames(getKeys(sections), {"graphics", "audio", "options"});
+
+		parseGraphics(sections.at("graphics"));
+		parseAudio(sections.at("audio"));
+		parseOptions(sections.at("options"));
 	}
 
 	return true;

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -302,7 +302,7 @@ bool Configuration::readConfig(const std::string& filePath)
 		{
 			if (section->value() == "graphics") { parseGraphics(ParseXmlElementAttributesToDictionary(*section)); }
 			else if (section->value() == "audio") { parseAudio(ParseXmlElementAttributesToDictionary(*section)); }
-			else if (section->value() == "options") { parseOptions(section); }
+			else if (section->value() == "options") { parseOptions(ParseXmlElementAttributesToDictionary(*section)); }
 			else if (section->type() == XmlNode::NodeType::XML_COMMENT) {} // Ignore comments
 			else
 			{
@@ -379,48 +379,11 @@ void Configuration::parseAudio(const Dictionary& dictionary)
  *
  * \note	Use of void pointer in declaration to avoid implementation details in header.
  */
-void Configuration::parseOptions(XmlElement* element)
+void Configuration::parseOptions(const Dictionary& dictionary)
 {
-	for (auto setting = element->firstChildElement();
-		 setting != nullptr;
-		 setting = setting->nextSiblingElement())
+	for (const auto& key : dictionary.keys())
 	{
-		if (setting->value() == "option")
-		{
-			const XmlAttribute* attribute = setting->firstAttribute();
-
-			std::string name, value;
-			while (attribute)
-			{
-				if (attribute->name() == "name")
-				{
-					name = attribute->value();
-				}
-				else if (attribute->name() == "value")
-				{
-					value = attribute->value();
-				}
-				else
-				{
-					std::cout << "Unexpected attribute '" << attribute->name() << "' found in '" << element->value() << "'." << std::endl;
-				}
-
-				attribute = attribute->next();
-			}
-
-			if (name.empty() || value.empty())
-			{
-				std::cout << "Invalid name/value pair in <option> tag in configuration file on row " << setting->row() << ". This option will be ignored." << std::endl;
-			}
-			else
-			{
-				mOptions[name] = value;
-			}
-		}
-		else
-		{
-			std::cout << "Unexpected tag '<" << setting->value() << ">' found in configuration on row " << setting->row() << "." << std::endl;
-		}
+		mOptions[key] = dictionary.get(key);
 	}
 }
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -118,6 +118,21 @@ namespace {
 
 		return dictionary;
 	}
+
+
+	std::map<std::string, Dictionary> ParseXmlSections(const XmlElement& element)
+	{
+		std::map<std::string, Dictionary> sections;
+
+		for (auto childElement = element.firstChildElement(); childElement; childElement = childElement->nextSiblingElement())
+		{
+			if (childElement->type() == XmlNode::NodeType::XML_COMMENT) { continue; } // Ignore comments
+
+			sections[childElement->value()] = ParseXmlElementAttributesToDictionary(*childElement) + ParseOptionsToDictionary(*childElement);
+		}
+
+		return sections;
+	}
 }
 
 

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -12,8 +12,10 @@
 #include <string>
 #include <map>
 
+
 namespace NAS2D {
 
+class Dictionary;
 
 namespace Xml {
 	class XmlElement;
@@ -89,7 +91,7 @@ private:
 
 	bool readConfig(const std::string& filePath);
 
-	void parseGraphics(Xml::XmlElement* node);
+	void parseGraphics(const Dictionary& dictionary);
 	void parseAudio(Xml::XmlElement* node);
 	void parseOptions(Xml::XmlElement* node);
 

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -17,10 +17,6 @@ namespace NAS2D {
 
 class Dictionary;
 
-namespace Xml {
-	class XmlElement;
-}
-
 
 /**
  * \class Configuration
@@ -93,7 +89,7 @@ private:
 
 	void parseGraphics(const Dictionary& dictionary);
 	void parseAudio(const Dictionary& dictionary);
-	void parseOptions(Xml::XmlElement* node);
+	void parseOptions(const Dictionary& dictionary);
 
 	Options mOptions{};
 

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -92,7 +92,7 @@ private:
 	bool readConfig(const std::string& filePath);
 
 	void parseGraphics(const Dictionary& dictionary);
-	void parseAudio(Xml::XmlElement* node);
+	void parseAudio(const Dictionary& dictionary);
 	void parseOptions(Xml::XmlElement* node);
 
 	Options mOptions{};


### PR DESCRIPTION
Use `Dictionary` objects to read `Configuration`.

This decouples much of the `Configuration` parsing from the XML format. This addresses the file read side of things. File writing will be addressed separately.
