### PR TITLE
Add unit test for exception when stringTo is provided empty strings

### DIFF
--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -52,6 +52,7 @@ TEST(String, stringTo) {
 
 	EXPECT_THROW(NAS2D::stringTo<char>(std::to_string(std::numeric_limits<char>::min() - 1)), std::out_of_range);
 	EXPECT_THROW(NAS2D::stringTo<char>(std::to_string(std::numeric_limits<char>::max() + 1)), std::out_of_range);
+	EXPECT_THROW(NAS2D::stringTo<char>(""), std::invalid_argument);
 	EXPECT_EQ(char{0}, NAS2D::stringTo<char>("0"));
 	using signedChar = signed char;
 	EXPECT_EQ(signedChar{-1}, NAS2D::stringTo<signedChar>("-1"));
@@ -61,27 +62,34 @@ TEST(String, stringTo) {
 
 	EXPECT_THROW(NAS2D::stringTo<short>(std::to_string(std::numeric_limits<short>::min() - 1)), std::out_of_range);
 	EXPECT_THROW(NAS2D::stringTo<short>(std::to_string(std::numeric_limits<short>::max() + 1)), std::out_of_range);
+	EXPECT_THROW(NAS2D::stringTo<short>(""), std::invalid_argument);
 	EXPECT_EQ(short{-1}, NAS2D::stringTo<short>("-1"));
 	EXPECT_EQ(short{0}, NAS2D::stringTo<short>("0"));
 	using unsignedShort = unsigned short;
 	EXPECT_EQ(unsignedShort{0}, NAS2D::stringTo<unsignedShort>("0"));
 
+	EXPECT_THROW(NAS2D::stringTo<int>(""), std::invalid_argument);
 	EXPECT_EQ(int{-1}, NAS2D::stringTo<int>("-1"));
 	EXPECT_EQ(int{0}, NAS2D::stringTo<int>("0"));
 	using unsignedInt = unsigned int;
 	EXPECT_EQ(unsignedInt{0}, NAS2D::stringTo<unsignedInt>("0"));
 
+	EXPECT_THROW(NAS2D::stringTo<long>(""), std::invalid_argument);
 	EXPECT_EQ(long{-1}, NAS2D::stringTo<long>("-1"));
 	EXPECT_EQ(long{0}, NAS2D::stringTo<long>("0"));
 	using unsignedLong = unsigned long;
 	EXPECT_EQ(unsignedLong{0}, NAS2D::stringTo<unsignedLong>("0"));
 
 	using longLong = long long;
+	EXPECT_THROW(NAS2D::stringTo<longLong>(""), std::invalid_argument);
 	EXPECT_EQ(longLong{-1}, NAS2D::stringTo<longLong>("-1"));
 	EXPECT_EQ(longLong{0}, NAS2D::stringTo<longLong>("0"));
 	using unsignedLongLong = unsigned long long;
 	EXPECT_EQ(unsignedLongLong{0}, NAS2D::stringTo<unsignedLongLong>("0"));
 
+	EXPECT_THROW(NAS2D::stringTo<float>(""), std::invalid_argument);
+	EXPECT_THROW(NAS2D::stringTo<double>(""), std::invalid_argument);
+	EXPECT_THROW(NAS2D::stringTo<long double>(""), std::invalid_argument);
 	EXPECT_EQ(0.0f, NAS2D::stringTo<float>("0.0"));
 	EXPECT_EQ(0.0, NAS2D::stringTo<double>("0.0"));
 	EXPECT_EQ(0.0l, NAS2D::stringTo<long double>("0.0"));


### PR DESCRIPTION
Fill out missing behaviour specification, to ensure an exception is thrown when an empty string is converted to a numeric value.
