### PR TITLE
Add MixerSDL constructor taking Options struct

### DIFF
--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -38,7 +38,7 @@ namespace {
 
 	MixerSDL::Options ReadConfigurationOptions()
 	{
-		Configuration& configuration = Utility<Configuration>::get();
+		const auto& configuration = Utility<Configuration>::get();
 		return {
 			configuration.audioMixRate(),
 			configuration.audioStereoChannels(),

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -34,13 +34,31 @@ namespace {
 	// Global so it can be accessed without capturing `this`
 	Signals::Signal<> musicFinished;
 	// ==================================================================================
+
+
+	MixerSDL::Options ReadConfigurationOptions()
+	{
+		Configuration& configuration = Utility<Configuration>::get();
+		return {
+			configuration.audioMixRate(),
+			configuration.audioStereoChannels(),
+			configuration.audioSfxVolume(),
+			configuration.audioMusicVolume(),
+			configuration.audioBufferSize()
+		};
+	}
 }
 
 
 /*
  * C'tor.
  */
-MixerSDL::MixerSDL()
+MixerSDL::MixerSDL() : MixerSDL(ReadConfigurationOptions())
+{
+}
+
+
+MixerSDL::MixerSDL(const Options& options)
 {
 	std::cout << "Initializing Mixer... ";
 
@@ -49,15 +67,13 @@ MixerSDL::MixerSDL()
 		throw mixer_backend_init_failure(SDL_GetError());
 	}
 
-	Configuration& c = Utility<Configuration>::get();
-
-	if (Mix_OpenAudio(c.audioMixRate(), MIX_DEFAULT_FORMAT, c.audioStereoChannels(), c.audioBufferSize()))
+	if (Mix_OpenAudio(options.mixRate, MIX_DEFAULT_FORMAT, options.numChannels, options.bufferSize))
 	{
 		throw mixer_backend_init_failure(Mix_GetError());
 	}
 
-	soundVolume(c.audioSfxVolume());
-	musicVolume(c.audioMusicVolume());
+	soundVolume(options.sfxVolume);
+	musicVolume(options.musicVolume);
 
 	musicFinished.connect(this, &MixerSDL::onMusicFinished);
 	Mix_HookMusicFinished([](){ musicFinished(); });

--- a/NAS2D/Mixer/MixerSDL.h
+++ b/NAS2D/Mixer/MixerSDL.h
@@ -26,7 +26,17 @@ namespace NAS2D {
 class MixerSDL : public Mixer
 {
 public:
+	struct Options
+	{
+		int mixRate;
+		int numChannels;
+		int sfxVolume;
+		int musicVolume;
+		int bufferSize;
+	};
+
 	MixerSDL();
+	MixerSDL(const Options& options);
 	MixerSDL(const MixerSDL&) = delete;
 	MixerSDL& operator=(const MixerSDL&) = delete;
 	MixerSDL(MixerSDL&&) = default;


### PR DESCRIPTION
Have the default constructor build a `Options` struct from the global `Configuration` object, and delegate to the constructor taking an `Options` struct.

Since constructor delegation requires using the initializer list, the code to build the `Options` struct from the global `Configuration` is moved to a function that can be easily called inline from within the constructor initializer list. The body of the constructor would be too late to be usable.
