### PR TITLE
Add RendererOpenGL constructor taking Options struct

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -66,6 +66,17 @@ namespace {
 		const auto apiResult = glGetString(name);
 		return apiResult ? reinterpret_cast<const char*>(apiResult) : "";
 	}
+
+
+	RendererOpenGL::Options ReadConfigurationOptions()
+	{
+		const auto& configuration = Utility<Configuration>::get();
+		return {
+			{configuration.graphicsWidth(), configuration.graphicsHeight()},
+			configuration.fullscreen(),
+			configuration.vsync()
+		};
+	}
 }
 
 
@@ -85,12 +96,16 @@ GLuint generate_fbo(Image& image);
  *
  * \param title	Title of the application window.
  */
-RendererOpenGL::RendererOpenGL(const std::string& title) : Renderer(title)
+RendererOpenGL::RendererOpenGL(const std::string& title) : RendererOpenGL(title, ReadConfigurationOptions())
+{
+}
+
+
+RendererOpenGL::RendererOpenGL(const std::string& title, const Options& options) : Renderer(title)
 {
 	std::cout << "Starting OpenGL Renderer:" << std::endl;
 
-	Configuration& cf = Utility<Configuration>::get();
-	initVideo({cf.graphicsWidth(), cf.graphicsHeight()}, cf.fullscreen(), cf.vsync());
+	initVideo(options.resolution, options.fullscreen, options.vsync);
 }
 
 

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -26,8 +26,16 @@ namespace NAS2D {
 class RendererOpenGL: public Renderer
 {
 public:
+	struct Options
+	{
+		Vector<int> resolution;
+		bool fullscreen;
+		bool vsync;
+	};
+
 	RendererOpenGL() = delete;
 	explicit RendererOpenGL(const std::string& title);
+	RendererOpenGL(const std::string& title, const Options& options);
 	RendererOpenGL(const RendererOpenGL& other) = delete;
 	RendererOpenGL(RendererOpenGL&& other) = delete;
 	RendererOpenGL& operator=(const RendererOpenGL& rhs) = delete;


### PR DESCRIPTION
Reference: #652 for the corresponding change to `MixerSDL`

Have the default constructor build a `Options` struct from the global `Configuration` object, and delegate to the constructor taking an `Options` struct.

Since constructor delegation requires using the initializer list, the code to build the `Options` struct from the global `Configuration` is moved to a function that can be easily called inline from within the constructor initializer list. The body of the constructor would be too late to be usable.
