### PR TITLE
Remove Point and Rectangle type aliases

### DIFF
--- a/NAS2D/Renderer/Point.h
+++ b/NAS2D/Renderer/Point.h
@@ -97,13 +97,6 @@ private:
 };
 
 
-using Point_2d = Point<int>;
-extern template struct Point<int>;
-
-using Point_2df = Point<float>;
-extern template struct Point<float>;
-
-
 template <typename BaseType>
 Point(BaseType, BaseType) -> Point<BaseType>;
 

--- a/NAS2D/Renderer/Rectangle.h
+++ b/NAS2D/Renderer/Rectangle.h
@@ -170,13 +170,6 @@ private:
 };
 
 
-using Rectangle_2d = Rectangle<int>;
-extern template struct Rectangle<int>;
-
-using Rectangle_2df = Rectangle<float>;
-extern template struct Rectangle<float>;
-
-
 template <typename BaseType>
 Rectangle(BaseType, BaseType, BaseType, BaseType) -> Rectangle<BaseType>;
 


### PR DESCRIPTION
Remove `Point` and `Rectangle` type aliases. These are no longer being used.
- `Point_2d`
- `Point_2df`
- `Rectangle_2d`
- `Rectangle_2df`
