### PR TITLE
Add missing header include for <stdexcept>

### DIFF
--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -14,6 +14,8 @@
 #include <string_view>
 #include <utility>
 #include <vector>
+#include <stdexcept>
+
 
 namespace NAS2D
 {


### PR DESCRIPTION
Some methods potentially `throw` exceptions, and so should include the header that defines those exceptions.
