### PR TITLE
Refactor Configuration::save to use Dictionary

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -153,6 +153,19 @@ namespace {
 
 		return ParseXmlSections(*root);
 	}
+
+
+	XmlElement* DictionaryToXmlElementAttributes(const std::string& tagName, const Dictionary& dictionary)
+	{
+		XmlElement* element = new XmlElement(tagName.c_str());
+
+		for (const auto& key : dictionary.keys())
+		{
+			element->attribute(key, dictionary.get(key));
+		}
+
+		return element;
+	}
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -181,6 +181,19 @@ namespace {
 
 		return element;
 	}
+
+
+	XmlElement* SectionsToXmlElement(const std::string& tagName, const std::map<std::string, Dictionary>& sections)
+	{
+		XmlElement* element = new XmlElement(tagName);
+
+		for (const auto& [key, dictionary] : sections)
+		{
+			element->linkEndChild(DictionaryToXmlElementAttributes(key, dictionary));
+		}
+
+		return element;
+	}
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -250,16 +250,12 @@ void Configuration::save()
 	XmlComment* comment = new XmlComment("Automatically generated Configuration file.");
 	doc.linkEndChild(comment);
 
-	XmlElement* root = new XmlElement("configuration");
-	doc.linkEndChild(root);
-
 	Dictionary graphics;
 	graphics.set("screenwidth", mScreenWidth);
 	graphics.set("screenheight", mScreenHeight);
 	graphics.set("bitdepth", mScreenBpp);
 	graphics.set("fullscreen", mFullScreen);
 	graphics.set("vsync", mVSync);
-	root->linkEndChild(DictionaryToXmlElementAttributes("graphics", graphics));
 
 	Dictionary audio;
 	audio.set("mixrate", mMixRate);
@@ -268,7 +264,9 @@ void Configuration::save()
 	audio.set("musicvolume", mMusicVolume);
 	audio.set("bufferlength", mBufferLength);
 	audio.set("mixer", mMixerName);
-	root->linkEndChild(DictionaryToXmlElementAttributes("audio", audio));
+
+	auto* root = SectionsToXmlElement("configuration", std::map<std::string, Dictionary>{{"graphics", graphics}, {"audio", audio}});
+	doc.linkEndChild(root);
 
 	// Options
 	root->linkEndChild(DictionaryToXmlElementOptions("options", mOptions));

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -253,22 +253,22 @@ void Configuration::save()
 	XmlElement* root = new XmlElement("configuration");
 	doc.linkEndChild(root);
 
-	XmlElement* graphics = new XmlElement("graphics");
-	graphics->attribute("screenwidth", mScreenWidth);
-	graphics->attribute("screenheight", mScreenHeight);
-	graphics->attribute("bitdepth", mScreenBpp);
-	graphics->attribute("fullscreen", mFullScreen ? "true" : "false");
-	graphics->attribute("vsync", mVSync ? "true" : "false");
-	root->linkEndChild(graphics);
+	Dictionary graphics;
+	graphics.set("screenwidth", mScreenWidth);
+	graphics.set("screenheight", mScreenHeight);
+	graphics.set("bitdepth", mScreenBpp);
+	graphics.set("fullscreen", mFullScreen);
+	graphics.set("vsync", mVSync);
+	root->linkEndChild(DictionaryToXmlElementAttributes("graphics", graphics));
 
-	XmlElement* audio = new XmlElement("audio");
-	audio->attribute("mixrate", mMixRate);
-	audio->attribute("channels", mStereoChannels);
-	audio->attribute("sfxvolume", mSfxVolume);
-	audio->attribute("musicvolume", mMusicVolume);
-	audio->attribute("bufferlength", mBufferLength);
-	audio->attribute("mixer", mMixerName);
-	root->linkEndChild(audio);
+	Dictionary audio;
+	audio.set("mixrate", mMixRate);
+	audio.set("channels", mStereoChannels);
+	audio.set("sfxvolume", mSfxVolume);
+	audio.set("musicvolume", mMusicVolume);
+	audio.set("bufferlength", mBufferLength);
+	audio.set("mixer", mMixerName);
+	root->linkEndChild(DictionaryToXmlElementAttributes("audio", audio));
 
 	// Options
 	XmlElement* options = new XmlElement("options");

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -271,16 +271,7 @@ void Configuration::save()
 	root->linkEndChild(DictionaryToXmlElementAttributes("audio", audio));
 
 	// Options
-	XmlElement* options = new XmlElement("options");
-	root->linkEndChild(options);
-
-	for (const auto& key : mOptions.keys())
-	{
-		XmlElement* option = new XmlElement("option");
-		option->attribute("name", key);
-		option->attribute("value", mOptions.get(key));
-		options->linkEndChild(option);
-	}
+	root->linkEndChild(DictionaryToXmlElementOptions("options", mOptions));
 
 	// Write out the XML file.
 	XmlMemoryBuffer buff;

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -166,6 +166,21 @@ namespace {
 
 		return element;
 	}
+
+
+	XmlElement* DictionaryToXmlElementOptions(const std::string& tagName, const Dictionary& dictionary)
+	{
+		XmlElement* element = new XmlElement(tagName.c_str());
+
+		for (const auto& key : dictionary.keys())
+		{
+			XmlElement* option = new XmlElement("option");
+			option->attribute("name", key);
+			option->attribute("value", dictionary.get(key));
+		}
+
+		return element;
+	}
 }
 
 


### PR DESCRIPTION
Refactor `Configuration::save` to use `Dictionary` objects.

This makes it consistent with the `Configuration::load` changes.
