### PR TITLE
Fix Configuration bug for empty default values

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -555,9 +555,10 @@ void Configuration::option(const std::string& option, const std::string& value, 
  */
 std::string Configuration::option(const std::string& key)
 {
-	if (mOptions.has(key))
+	if (!mOptions.has(key))
 	{
 		mOptionChanged = true;
+		mOptions.set(key, std::string{});
 	}
 
 	return mOptions.get(key);


### PR DESCRIPTION
Seems a conditional was reversed. In addition, the new code didn't create empty default entries for unknown keys, and raised exceptions when a lookup was done for a nonexistent key.
