### PR TITLE
Configuration defaults

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -59,6 +59,17 @@ const std::string GRAPHICS_CFG_VSYNC = "vsync";
 
 
 namespace {
+	std::map<std::string, Dictionary> merge(const std::map<std::string, Dictionary>& defaults, const std::map<std::string, Dictionary>& priorityValues)
+	{
+		std::map<std::string, Dictionary> results = defaults;
+		for (const auto& [key, dictionary] : priorityValues)
+		{
+			results[key] += dictionary;
+		}
+		return results;
+	}
+
+
 	void ReportProblemNames(
 		const std::vector<std::string>& names,
 		const std::vector<std::string>& required,

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -320,7 +320,8 @@ bool Configuration::readConfig(const std::string& filePath)
 	File xmlFile = Utility<Filesystem>::get().open(filePath);
 
 	// Start parsing through the Config.xml file.
-	const auto sections = ParseXmlSections(xmlFile.raw_bytes(), "configuration");
+	const auto loadedSections = ParseXmlSections(xmlFile.raw_bytes(), "configuration");
+	const auto sections = merge(mDefaults, loadedSections);
 	ReportProblemNames(getKeys(sections), {"graphics", "audio", "options"});
 
 	parseGraphics(sections.at("graphics"));

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -26,8 +26,8 @@ namespace NAS2D {
 class Configuration
 {
 public:
-
 	Configuration() = default;
+	Configuration(std::map<std::string, Dictionary> defaults) : mDefaults{std::move(defaults)} {}
 	Configuration(const Configuration&) = delete;
 	Configuration& operator=(const Configuration&) = delete;
 	Configuration(Configuration&&) = delete;
@@ -86,6 +86,7 @@ private:
 	void parseAudio(const Dictionary& dictionary);
 	void parseOptions(const Dictionary& dictionary);
 
+	const std::map<std::string, Dictionary> mDefaults{};
 	Dictionary mOptions{};
 
 	int mScreenWidth{800};


### PR DESCRIPTION
Allow `Configuration` class to be initialized with default values.

Related: #661
