### PR TITLE
Upgrade GCC-8 compiler from 8.3 to 8.4 in Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
       - build-and-test
   build-linux-gcc8:
     docker:
-      - image: outpostuniverse/nas2d-gcc8:1.0
+      - image: outpostuniverse/nas2d-gcc8:1.1
     steps:
       - checkout
       - build-and-test

--- a/docker/nas2d-gcc8.Dockerfile
+++ b/docker/nas2d-gcc8.Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:18.04
 # Includes tools to build download, unpack, and build source packages
 # Includes tools needed for primary CircleCI containers
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    g++-8=8.3.0-* \
+    g++-8=8.4.0-* \
     dpkg-dev=1.19.0.* \
     make=4.1-* \
     cmake=3.10.2-* \

--- a/makefile
+++ b/makefile
@@ -219,7 +219,7 @@ ImageName := nas2d
 ImageVersion := 1.4
 
 ImageName_gcc8 := nas2d-gcc8
-ImageVersion_gcc8 := 1.0
+ImageVersion_gcc8 := 1.1
 
 ImageName_clang := nas2d-clang
 ImageVersion_clang := 1.0


### PR DESCRIPTION
This resolves ambiguity when converting custom types to `std::string` with `static_cast`. In particular, work on `StringValue` ran into a problem here, which the update resolves.
