### PR TITLE
Add StringValue class

### DIFF
--- a/NAS2D/Dictionary.cpp
+++ b/NAS2D/Dictionary.cpp
@@ -1,8 +1,14 @@
 #include "Dictionary.h"
 #include "ContainerUtils.h"
 
+#include <utility>
+
 
 namespace NAS2D {
+	Dictionary::Dictionary(std::map<std::string, StringValue> initialEntries) : mDictionary{std::move(initialEntries)}
+	{}
+
+
 	bool Dictionary::operator==(const Dictionary& other) const
 	{
 		return mDictionary == other.mDictionary;

--- a/NAS2D/Dictionary.h
+++ b/NAS2D/Dictionary.h
@@ -9,7 +9,7 @@ namespace NAS2D {
 	{
 	public:
 		Dictionary() = default;
-		Dictionary(std::map<std::string, StringValue> initialEntries) : mDictionary{initialEntries} {}
+		Dictionary(std::map<std::string, StringValue> initialEntries);
 
 		bool operator==(const Dictionary& other) const;
 		bool operator!=(const Dictionary& other) const;

--- a/NAS2D/Dictionary.h
+++ b/NAS2D/Dictionary.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "StringUtils.h"
+#include "StringValue.h"
 #include <map>
 
 
@@ -9,7 +9,7 @@ namespace NAS2D {
 	{
 	public:
 		Dictionary() = default;
-		Dictionary(std::initializer_list<std::pair<const std::string, std::string>> initialEntries) : mDictionary{initialEntries} {}
+		Dictionary(std::map<std::string, StringValue> initialEntries) : mDictionary{initialEntries} {}
 
 		bool operator==(const Dictionary& other) const;
 		bool operator!=(const Dictionary& other) const;
@@ -20,13 +20,13 @@ namespace NAS2D {
 		template <typename T = std::string>
 		T get(const std::string& key) const
 		{
-			return stringTo<T>(mDictionary.at(key));
+			return mDictionary.at(key).to<T>();
 		}
 
 		template <typename T = std::string>
 		void set(const std::string& key, T value)
 		{
-			mDictionary[key] = stringFrom<T>(value);
+			mDictionary[key].from(value);
 		}
 
 		void erase(const std::string& key);
@@ -35,7 +35,7 @@ namespace NAS2D {
 		std::vector<std::string> keys() const;
 
 	private:
-		std::map<std::string, std::string> mDictionary;
+		std::map<std::string, StringValue> mDictionary;
 	};
 
 

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -257,6 +257,7 @@
     <ClInclude Include="State.h" />
     <ClInclude Include="StateManager.h" />
     <ClInclude Include="StringUtils.h" />
+    <ClInclude Include="StringValue.h" />
     <ClInclude Include="Timer.h" />
     <ClInclude Include="Trig.h" />
     <ClInclude Include="Utility.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -308,6 +308,9 @@
     <ClInclude Include="StringUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="StringValue.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="MathUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/NAS2D/StringValue.h
+++ b/NAS2D/StringValue.h
@@ -11,7 +11,7 @@ namespace NAS2D {
 
 		StringValue() = default;
 		template <typename T>
-		explicit StringValue(T newValue) : value{stringFrom<T>(newValue)} {}
+		StringValue(T newValue) : value{stringFrom<T>(newValue)} {}
 
 		bool operator==(const StringValue& other) const { return value == other.value; }
 		bool operator!=(const StringValue& other) const { return !(*this == other); }

--- a/NAS2D/StringValue.h
+++ b/NAS2D/StringValue.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "StringUtils.h"
+
+
+namespace NAS2D {
+	struct StringValue
+	{
+		std::string value;
+
+
+		StringValue() = default;
+		template <typename T>
+		explicit StringValue(T newValue) : value{stringFrom<T>(newValue)} {}
+
+		template <typename T>
+		operator T() const { return stringTo<T>(value); }
+
+		template <typename T>
+		T to() const { return stringTo<T>(value); }
+		template <typename T>
+		StringValue& from(T newValue) { value = stringFrom<T>(newValue); return *this; }
+	};
+}

--- a/NAS2D/StringValue.h
+++ b/NAS2D/StringValue.h
@@ -13,6 +13,9 @@ namespace NAS2D {
 		template <typename T>
 		explicit StringValue(T newValue) : value{stringFrom<T>(newValue)} {}
 
+		bool operator==(const StringValue& other) const { return value == other.value; }
+		bool operator!=(const StringValue& other) const { return !(*this == other); }
+
 		template <typename T>
 		operator T() const { return stringTo<T>(value); }
 

--- a/test/Dictionary.test.cpp
+++ b/test/Dictionary.test.cpp
@@ -5,7 +5,7 @@
 
 
 TEST(Dictionary, ConstructorInitialEntries) {
-	NAS2D::Dictionary dictionary{{"Key1", "Value1"}, {"Key2", "Value2"}};
+	NAS2D::Dictionary dictionary{{{"Key1", "Value1"}, {"Key2", "Value2"}}};
 
 	EXPECT_EQ("Value1", dictionary.get("Key1"));
 	EXPECT_EQ("Value2", dictionary.get("Key2"));
@@ -14,10 +14,10 @@ TEST(Dictionary, ConstructorInitialEntries) {
 }
 
 TEST(Dictionary, OperatorEquality) {
-	NAS2D::Dictionary dictionary1{{"Key1", "Value1"}};
-	NAS2D::Dictionary dictionary2{{"Key1", "Value1"}};
-	NAS2D::Dictionary dictionary3{{"Key1", "Value10"}};
-	NAS2D::Dictionary dictionary4{{"Key10", "Value1"}};
+	NAS2D::Dictionary dictionary1{{{"Key1", "Value1"}}};
+	NAS2D::Dictionary dictionary2{{{"Key1", "Value1"}}};
+	NAS2D::Dictionary dictionary3{{{"Key1", "Value10"}}};
+	NAS2D::Dictionary dictionary4{{{"Key10", "Value1"}}};
 
 	EXPECT_EQ(dictionary1, dictionary1);
 	EXPECT_EQ(dictionary1, dictionary2);

--- a/test/StringValue.test.cpp
+++ b/test/StringValue.test.cpp
@@ -21,6 +21,24 @@ TEST(StringValue, Constructor) {
 	EXPECT_THAT(NAS2D::StringValue{0.0}.value, testing::StartsWith("0.0"));
 }
 
+TEST(StringValue, OperatorComparison) {
+	// Identical constructor types
+	EXPECT_EQ(NAS2D::StringValue{}, NAS2D::StringValue{});
+	EXPECT_EQ(NAS2D::StringValue{"Value"}, NAS2D::StringValue{"Value"});
+	EXPECT_EQ(NAS2D::StringValue{false}, NAS2D::StringValue{false});
+	EXPECT_EQ(NAS2D::StringValue{true}, NAS2D::StringValue{true});
+	EXPECT_EQ(NAS2D::StringValue{-1}, NAS2D::StringValue{-1});
+	EXPECT_EQ(NAS2D::StringValue{0}, NAS2D::StringValue{0});
+	EXPECT_EQ(NAS2D::StringValue{1}, NAS2D::StringValue{1});
+
+	// Mixed constructor types
+	EXPECT_EQ(NAS2D::StringValue{"false"}, NAS2D::StringValue{false});
+	EXPECT_EQ(NAS2D::StringValue{"true"}, NAS2D::StringValue{true});
+	EXPECT_EQ(NAS2D::StringValue{"-1"}, NAS2D::StringValue{-1});
+	EXPECT_EQ(NAS2D::StringValue{"0"}, NAS2D::StringValue{0});
+	EXPECT_EQ(NAS2D::StringValue{"1"}, NAS2D::StringValue{1});
+}
+
 TEST(StringValue, OperatorConversion) {
 	// Explicit conversion
 	EXPECT_EQ(false, static_cast<bool>(NAS2D::StringValue{false}));

--- a/test/StringValue.test.cpp
+++ b/test/StringValue.test.cpp
@@ -1,0 +1,56 @@
+#include "NAS2D/StringValue.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+
+TEST(StringValue, Constructor) {
+	EXPECT_EQ("", NAS2D::StringValue{}.value);
+	EXPECT_EQ("", NAS2D::StringValue{""}.value);
+	EXPECT_EQ("", NAS2D::StringValue{std::string{}}.value);
+	EXPECT_EQ("Some string value", NAS2D::StringValue{"Some string value"}.value);
+
+	EXPECT_EQ("false", NAS2D::StringValue{false}.value);
+	EXPECT_EQ("true", NAS2D::StringValue{true}.value);
+
+	EXPECT_EQ("-1", NAS2D::StringValue{-1}.value);
+	EXPECT_EQ("0", NAS2D::StringValue{0}.value);
+	EXPECT_EQ("1", NAS2D::StringValue{1}.value);
+
+	// Ignore precision beyond one decimal place
+	EXPECT_THAT(NAS2D::StringValue{0.0}.value, testing::StartsWith("0.0"));
+}
+
+TEST(StringValue, OperatorConversion) {
+	// Explicit conversion
+	EXPECT_EQ(false, static_cast<bool>(NAS2D::StringValue{false}));
+	EXPECT_EQ(true, static_cast<bool>(NAS2D::StringValue{true}));
+	EXPECT_EQ(0, static_cast<int>(NAS2D::StringValue{0}));
+
+	// Implicit conversion
+	EXPECT_EQ(false, bool{NAS2D::StringValue{false}});
+	EXPECT_EQ(true, bool{NAS2D::StringValue{true}});
+	EXPECT_EQ(-1, int{NAS2D::StringValue{-1}});
+	EXPECT_EQ(0, int{NAS2D::StringValue{0}});
+	EXPECT_EQ(1, int{NAS2D::StringValue{1}});
+	EXPECT_EQ(0.0, int{NAS2D::StringValue{0.0}});
+}
+
+TEST(StringValue, to) {
+	EXPECT_EQ(false, NAS2D::StringValue{false}.to<bool>());
+	EXPECT_EQ(true, NAS2D::StringValue{true}.to<bool>());
+	EXPECT_EQ(-1, NAS2D::StringValue{-1}.to<int>());
+	EXPECT_EQ(0, NAS2D::StringValue{0}.to<int>());
+	EXPECT_EQ(1, NAS2D::StringValue{1}.to<int>());
+	EXPECT_EQ(0.0, NAS2D::StringValue{0.0}.to<double>());
+}
+
+TEST(StringValue, from) {
+	NAS2D::StringValue s;
+	EXPECT_EQ("false", s.from<bool>(false).value);
+	EXPECT_EQ("true", s.from<bool>(true).value);
+	EXPECT_EQ("-1", s.from<int>(-1).value);
+	EXPECT_EQ("0", s.from<int>(0).value);
+	EXPECT_EQ("1", s.from<int>(1).value);
+	EXPECT_THAT(s.from<double>(0.0).value, testing::StartsWith("0.0"));
+}

--- a/test/StringValue.test.cpp
+++ b/test/StringValue.test.cpp
@@ -3,6 +3,21 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <vector>
+#include <map>
+
+
+TEST(StringValue, ContainerInitialization) {
+	std::vector<NAS2D::StringValue> vect{"", "1", "11"};
+	EXPECT_EQ("", vect[0].to<std::string>());
+	EXPECT_EQ(1, vect[1].to<int>());
+	EXPECT_EQ(11, vect[2].to<int>());
+
+	std::map<std::string, NAS2D::StringValue> someMap{{"abc", "def"}, {"1", 11}};
+	EXPECT_EQ("def", someMap.at("abc").to<std::string>());
+	EXPECT_EQ(11, someMap.at("1").to<int>());
+}
+
 
 TEST(StringValue, Constructor) {
 	EXPECT_EQ("", NAS2D::StringValue{}.value);

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -56,6 +56,7 @@
     <ClCompile Include="MathUtils.test.cpp" />
     <ClCompile Include="Signal.test.cpp" />
     <ClCompile Include="StringUtils.test.cpp" />
+    <ClCompile Include="StringValue.test.cpp" />
     <ClCompile Include="Utility.test.cpp" />
     <ClCompile Include="Version.test.cpp" />
   </ItemGroup>


### PR DESCRIPTION
Add `StringValue` class.

This should be a better solution than `Dictionary`, as it will allow initializing with proper data types, rather than forcing initialization with string typed values. Effectively the type conversion support has moved from the collection of values, to the values themselves. Eventually `Dictionary` can be replaced with a regular `std::map` of `StringValue`.
