### PR TITLE
Refactor Configuration class to make it more testable

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -276,7 +276,7 @@ void Configuration::load(const std::string& filePath)
 /**
  * Saves the Configuration to an XML file.
  */
-void Configuration::save()
+void Configuration::save() const
 {
 	XmlDocument doc;
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -223,6 +223,24 @@ Configuration::~Configuration()
 
 
 /**
+ * Reads a given XML configuration file.
+ *
+ * \param fileData	Name of an XML Configuration file to be read.
+ */
+void Configuration::loadData(const std::string& fileData)
+{
+	// Start parsing through the Config.xml file.
+	const auto loadedSections = ParseXmlSections(fileData, "configuration");
+	const auto sections = merge(mDefaults, loadedSections);
+	ReportProblemNames(getKeys(sections), {"graphics", "audio", "options"});
+
+	parseGraphics(sections.at("graphics"));
+	parseAudio(sections.at("audio"));
+	parseOptions(sections.at("options"));
+}
+
+
+/**
  * Loads a configuration file.
  *
  * \param	filePath	A string indicating the file to load and process for configuration.
@@ -311,24 +329,6 @@ void Configuration::setDefaultValues()
 	mMusicVolume = AUDIO_MUSIC_VOLUME;
 	mBufferLength = AUDIO_BUFFER_SIZE;
 	mOptionChanged = true;
-}
-
-
-/**
- * Reads a given XML configuration file.
- *
- * \param fileData	Name of an XML Configuration file to be read.
- */
-void Configuration::loadData(const std::string& fileData)
-{
-	// Start parsing through the Config.xml file.
-	const auto loadedSections = ParseXmlSections(fileData, "configuration");
-	const auto sections = merge(mDefaults, loadedSections);
-	ReportProblemNames(getKeys(sections), {"graphics", "audio", "options"});
-
-	parseGraphics(sections.at("graphics"));
-	parseAudio(sections.at("audio"));
-	parseOptions(sections.at("options"));
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -274,9 +274,9 @@ void Configuration::load(const std::string& filePath)
 
 
 /**
- * Saves the Configuration to an XML file.
+ * Saves the Configuration to an XML string
  */
-void Configuration::save() const
+std::string Configuration::saveData() const
 {
 	XmlDocument doc;
 
@@ -308,7 +308,16 @@ void Configuration::save() const
 	XmlMemoryBuffer buff;
 	doc.accept(&buff);
 
-	Utility<Filesystem>::get().write(File(buff.buffer(), mConfigPath));
+	return buff.buffer();
+}
+
+
+/**
+ * Saves the Configuration to an XML file.
+ */
+void Configuration::save() const
+{
+	Utility<Filesystem>::get().write(File(saveData(), mConfigPath));
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -241,7 +241,9 @@ void Configuration::load(const std::string& filePath)
 	else
 	{
 		try {
-			readConfig(filePath); // Read in the Config File.
+			// Read in the Config File.
+			File xmlFile = Utility<Filesystem>::get().open(filePath);
+			readConfig(xmlFile.raw_bytes());
 			std::cout << "done." << std::endl;
 		}
 		catch (const std::runtime_error& e) {
@@ -315,14 +317,12 @@ void Configuration::setDefaultValues()
 /**
  * Reads a given XML configuration file.
  *
- * \param filePath	Name of an XML Configuration file to be read.
+ * \param fileData	Name of an XML Configuration file to be read.
  */
-void Configuration::readConfig(const std::string& filePath)
+void Configuration::readConfig(const std::string& fileData)
 {
-	File xmlFile = Utility<Filesystem>::get().open(filePath);
-
 	// Start parsing through the Config.xml file.
-	const auto loadedSections = ParseXmlSections(xmlFile.raw_bytes(), "configuration");
+	const auto loadedSections = ParseXmlSections(fileData, "configuration");
 	const auto sections = merge(mDefaults, loadedSections);
 	ReportProblemNames(getKeys(sections), {"graphics", "audio", "options"});
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -243,7 +243,7 @@ void Configuration::load(const std::string& filePath)
 		try {
 			// Read in the Config File.
 			File xmlFile = Utility<Filesystem>::get().open(filePath);
-			readConfig(xmlFile.raw_bytes());
+			loadData(xmlFile.raw_bytes());
 			std::cout << "done." << std::endl;
 		}
 		catch (const std::runtime_error& e) {
@@ -319,7 +319,7 @@ void Configuration::setDefaultValues()
  *
  * \param fileData	Name of an XML Configuration file to be read.
  */
-void Configuration::readConfig(const std::string& fileData)
+void Configuration::loadData(const std::string& fileData)
 {
 	// Start parsing through the Config.xml file.
 	const auto loadedSections = ParseXmlSections(fileData, "configuration");

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -315,9 +315,18 @@ std::string Configuration::saveData() const
 /**
  * Saves the Configuration to an XML file.
  */
+void Configuration::save(const std::string& filePath) const
+{
+	Utility<Filesystem>::get().write(File(saveData(), filePath));
+}
+
+
+/**
+ * Saves the Configuration to the XML file used during load.
+ */
 void Configuration::save() const
 {
-	Utility<Filesystem>::get().write(File(saveData(), mConfigPath));
+	save(mConfigPath);
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -238,14 +238,16 @@ void Configuration::load(const std::string& filePath)
 		std::cout << "configuration file '" << filePath << "' does not exist. Using default options." << std::endl;
 		mOptionChanged = true;
 	}
-	else if (!readConfig(filePath)) // Read in the Config File.
-	{
-		mOptionChanged = true;
-		std::cout << "unable to process '" << filePath << "'. Using default options." << std::endl;
-	}
 	else
 	{
-		std::cout << "done." << std::endl;
+		try {
+			readConfig(filePath); // Read in the Config File.
+			std::cout << "done." << std::endl;
+		}
+		catch (const std::runtime_error& e) {
+			mOptionChanged = true;
+			std::cout << "unable to process '" << filePath << "'. Using default options. Error: " << e.what() << std::endl;
+		}
 	}
 
 }

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -317,7 +317,7 @@ void Configuration::setDefaultValues()
  *
  * \param filePath	Name of an XML Configuration file to be read.
  */
-bool Configuration::readConfig(const std::string& filePath)
+void Configuration::readConfig(const std::string& filePath)
 {
 	File xmlFile = Utility<Filesystem>::get().open(filePath);
 
@@ -329,8 +329,6 @@ bool Configuration::readConfig(const std::string& filePath)
 	parseGraphics(sections.at("graphics"));
 	parseAudio(sections.at("audio"));
 	parseOptions(sections.at("options"));
-
-	return true;
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -215,7 +215,14 @@ Configuration::~Configuration()
 {
 	if(mOptionChanged)
 	{
-		save();
+		try
+		{
+			save();
+		}
+		catch (const std::runtime_error& e)
+		{
+			std::cout << "Error saving configuration data: " << e.what() << std::endl;
+		}
 	}
 
 	std::cout << "Configuration Terminated." << std::endl;

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -34,8 +34,9 @@ public:
 	Configuration& operator=(Configuration&&) = delete;
 	~Configuration();
 
-	void save();
+	void loadData(const std::string& fileData);
 	void load(const std::string& filePath);
+	void save();
 
 	// Video Options
 	int graphicsWidth() const { return mScreenWidth; }
@@ -80,8 +81,6 @@ public:
 
 protected:
 private:
-	void loadData(const std::string& fileData);
-
 	void parseGraphics(const Dictionary& dictionary);
 	void parseAudio(const Dictionary& dictionary);
 	void parseOptions(const Dictionary& dictionary);

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -37,6 +37,7 @@ public:
 	void loadData(const std::string& fileData);
 	void load(const std::string& filePath);
 	std::string saveData() const;
+	void save(const std::string& filePath) const;
 	void save() const;
 
 	// Video Options

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -36,6 +36,7 @@ public:
 
 	void loadData(const std::string& fileData);
 	void load(const std::string& filePath);
+	std::string saveData() const;
 	void save() const;
 
 	// Video Options

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -80,7 +80,7 @@ public:
 
 protected:
 private:
-	void readConfig(const std::string& filePath);
+	void readConfig(const std::string& fileData);
 
 	void parseGraphics(const Dictionary& dictionary);
 	void parseAudio(const Dictionary& dictionary);

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -36,7 +36,7 @@ public:
 
 	void loadData(const std::string& fileData);
 	void load(const std::string& filePath);
-	void save();
+	void save() const;
 
 	// Video Options
 	int graphicsWidth() const { return mScreenWidth; }

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -80,7 +80,7 @@ public:
 
 protected:
 private:
-	void readConfig(const std::string& fileData);
+	void loadData(const std::string& fileData);
 
 	void parseGraphics(const Dictionary& dictionary);
 	void parseAudio(const Dictionary& dictionary);

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -80,7 +80,7 @@ public:
 
 protected:
 private:
-	bool readConfig(const std::string& filePath);
+	void readConfig(const std::string& filePath);
 
 	void parseGraphics(const Dictionary& dictionary);
 	void parseAudio(const Dictionary& dictionary);


### PR DESCRIPTION
Split the `load` and `save` methods so the `loadData` and `saveData` methods can read and write using memory buffers. This should help with unit testing.

Add exception handling around the `save()` call in the destructor. The `save()` method can potentially raise exceptions, and exceptions raised from a destructor can terminate a program. In general, it is not possible to catch exceptions safely from a destructor, which is not allowed to fail.
