### PR TITLE
Remove config auto save

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -324,15 +324,6 @@ void Configuration::save(const std::string& filePath) const
 
 
 /**
- * Saves the Configuration to the XML file used during load.
- */
-void Configuration::save() const
-{
-	save(mConfigPath);
-}
-
-
-/**
  * Sets default values for all important values.
  */
 void Configuration::setDefaultValues()

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -324,7 +324,14 @@ std::string Configuration::saveData() const
  */
 void Configuration::save(const std::string& filePath) const
 {
-	Utility<Filesystem>::get().write(File(saveData(), filePath));
+	try
+	{
+		Utility<Filesystem>::get().write(File(saveData(), filePath));
+	}
+	catch (const std::runtime_error& e)
+	{
+		throw std::runtime_error("Error saving configuration file: '" + filePath + "'  Error: " + e.what());
+	}
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -213,18 +213,6 @@ namespace {
  */
 Configuration::~Configuration()
 {
-	if(mOptionChanged)
-	{
-		try
-		{
-			save();
-		}
-		catch (const std::runtime_error& e)
-		{
-			std::cout << "Error saving configuration data: " << e.what() << std::endl;
-		}
-	}
-
 	std::cout << "Configuration Terminated." << std::endl;
 }
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -244,8 +244,6 @@ void Configuration::load(const std::string& filePath)
 {
 	std::cout << "Initializing Configuration... ";
 
-	mConfigPath = filePath;
-
 	if (!Utility<Filesystem>::get().exists(filePath))
 	{
 		std::cout << "configuration file '" << filePath << "' does not exist. Using default options." << std::endl;

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -38,7 +38,6 @@ public:
 	void load(const std::string& filePath);
 	std::string saveData() const;
 	void save(const std::string& filePath) const;
-	void save() const;
 
 	// Video Options
 	int graphicsWidth() const { return mScreenWidth; }

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -103,8 +103,6 @@ private:
 	int mBufferLength{1024};
 	std::string mMixerName{"SDL"};
 
-	std::string mConfigPath{};
-
 	bool mOptionChanged{false};
 };
 


### PR DESCRIPTION
Remove auto saving from the `Configuration` destructor. Instead, the client should explicitly call `Configuration::save` before object destruction.

This change gives better control over when configuration data is saved, and to what file.

----

References:
https://github.com/OutpostUniverse/OPHD/pull/423
https://github.com/lairworks/nas2d-core/pull/666