### PR TITLE
Fix Configuration defaults

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <utility>
 
 using namespace NAS2D;
 using namespace NAS2D::Xml;
@@ -206,6 +207,11 @@ namespace {
 		return element;
 	}
 }
+
+
+Configuration::Configuration(std::map<std::string, Dictionary> defaults) :
+	mDefaults{std::move(defaults)}
+{}
 
 
 /**

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -211,7 +211,20 @@ namespace {
 
 Configuration::Configuration(std::map<std::string, Dictionary> defaults) :
 	mDefaults{std::move(defaults)}
-{}
+{
+	if (mDefaults.find("graphics") != mDefaults.end())
+	{
+		parseGraphics(mDefaults.at("graphics"));
+	}
+	if (mDefaults.find("audio") != mDefaults.end())
+	{
+		parseAudio(mDefaults.at("audio"));
+	}
+	if (mDefaults.find("options") != mDefaults.end())
+	{
+		parseOptions(mDefaults.at("options"));
+	}
+}
 
 
 /**

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -27,7 +27,7 @@ class Configuration
 {
 public:
 	Configuration() = default;
-	Configuration(std::map<std::string, Dictionary> defaults) : mDefaults{std::move(defaults)} {}
+	Configuration(std::map<std::string, Dictionary> defaults);
 	Configuration(const Configuration&) = delete;
 	Configuration& operator=(const Configuration&) = delete;
 	Configuration(Configuration&&) = delete;

--- a/test/Configuration.test.cpp
+++ b/test/Configuration.test.cpp
@@ -1,0 +1,66 @@
+#include "NAS2D/Configuration.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+
+TEST(Configuration, loadData) {
+	NAS2D::Configuration config{
+		std::map<std::string, NAS2D::Dictionary>{
+			{
+				{
+					"graphics",
+					{{
+						{"screenwidth", 1000},
+						{"screenheight", 700},
+						{"bitdepth", 32},
+						{"fullscreen", false},
+						{"vsync", true}
+					}}
+				},
+				{
+					"options",
+					{{
+						{"skip-splash", false},
+						{"maximized", true},
+						{"Key1", "Some string value"},
+						{"Key2", true},
+						{"Key3", -1}
+					}}
+				}
+			}
+		}
+	};
+
+	// Defaults (before data load)
+	EXPECT_EQ("Some string value", config.option("Key1"));
+	EXPECT_EQ("true", config.option("Key2"));
+	EXPECT_EQ("-1", config.option("Key3"));
+
+	config.loadData(
+		R"(
+			<!--Automatically generated Configuration file.-->
+			<configuration>
+				<audio mixer="SDL" musicvolume="100" sfxvolume="128" channels="2" mixrate="22050" bufferlength="1024" />
+				<graphics screenheight="700" screenwidth="1000" bitdepth="32" fullscreen="false" vsync="false" />
+				<options Key3="1" Key4="0" />
+			</configuration>
+		)"
+	);
+
+	// Defaults (after data load)
+	EXPECT_EQ("Some string value", config.option("Key1"));
+	EXPECT_EQ("true", config.option("Key2"));
+	// Default overwritten by data load
+	EXPECT_EQ("1", config.option("Key3"));
+
+	// Fresh loaded values
+	EXPECT_EQ("SDL", config.mixer());
+	EXPECT_EQ(100, config.audioMusicVolume());
+	EXPECT_EQ(128, config.audioSfxVolume());
+	EXPECT_EQ(22050, config.audioMixRate());
+	EXPECT_EQ(1024, config.audioBufferSize());
+
+	// Nonexistent keys return empty string
+	EXPECT_EQ("", config.option("NonExistentKey"));
+}


### PR DESCRIPTION
Reference: https://github.com/OutpostUniverse/OPHD/issues/422

Allow `Configuration` default values to be usable before data is loaded, and if data fails to load.

This adds the requirement that if any default values are specified for a section, then all required keys for that section are specified.
