### PR TITLE
Fix options writing

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -312,10 +312,8 @@ std::string Configuration::saveData() const
 	audio.set("mixer", mMixerName);
 
 	auto* root = SectionsToXmlElement("configuration", std::map<std::string, Dictionary>{{"graphics", graphics}, {"audio", audio}});
-	doc.linkEndChild(root);
-
-	// Options
 	root->linkEndChild(DictionaryToXmlElementOptions("options", mOptions));
+	doc.linkEndChild(root);
 
 	// Write out the XML file.
 	XmlMemoryBuffer buff;

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -233,7 +233,6 @@ Configuration::Configuration(std::map<std::string, Dictionary> defaults) :
  */
 Configuration::~Configuration()
 {
-	std::cout << "Configuration Terminated." << std::endl;
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -229,14 +229,6 @@ Configuration::Configuration(std::map<std::string, Dictionary> defaults) :
 
 
 /**
- * D'tor
- */
-Configuration::~Configuration()
-{
-}
-
-
-/**
  * Reads a given XML configuration file.
  *
  * \param fileData	Name of an XML Configuration file to be read.

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -189,6 +189,7 @@ namespace {
 			XmlElement* option = new XmlElement("option");
 			option->attribute("name", key);
 			option->attribute("value", dictionary.get(key));
+			element->linkEndChild(option);
 		}
 
 		return element;

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -32,7 +32,7 @@ public:
 	Configuration& operator=(const Configuration&) = delete;
 	Configuration(Configuration&&) = delete;
 	Configuration& operator=(Configuration&&) = delete;
-	~Configuration();
+	~Configuration() = default;
 
 	void loadData(const std::string& fileData);
 	void load(const std::string& filePath);


### PR DESCRIPTION
Reference: https://github.com/OutpostUniverse/OPHD/issues/422

Fix bad code that was not properly writing the `option` tags to the output file. This led to bugs where game options were not being saved.

----

Remove console output from library during `Configuration` destruction. The output was impacting unit tests.
