### PR TITLE
Use `std::unique_ptr` to manage internal StateManager object

### DIFF
--- a/NAS2D/StateManager.cpp
+++ b/NAS2D/StateManager.cpp
@@ -38,7 +38,6 @@ StateManager::~StateManager()
 	if (mActiveState)
 	{
 		Utility<EventHandler>::get().disconnectAll();
-		delete mActiveState;
 	}
 }
 
@@ -63,10 +62,8 @@ void StateManager::setState(State* state)
 
 	if (mForceStopAudio) { Utility<Mixer>::get().stopAllAudio(); }
 
-	delete mActiveState;
-
 	// Initialize the new one
-	mActiveState = state;
+	mActiveState.reset(state);
 	mActiveState->initialize();
 
 	mActive = true;
@@ -87,7 +84,7 @@ bool StateManager::update()
 		{
 			mActive = false;
 		}
-		else if (nextState != mActiveState)
+		else if (nextState != mActiveState.get())
 		{
 			setState(nextState);
 		}

--- a/NAS2D/StateManager.h
+++ b/NAS2D/StateManager.h
@@ -13,6 +13,9 @@
 #include "State.h"
 #include "Utility.h"
 
+#include <memory>
+
+
 namespace NAS2D {
 
 /**
@@ -40,7 +43,7 @@ public:
 private:
 	void handleQuit();
 
-	State *mActiveState;
+	std::unique_ptr<State> mActiveState;
 	bool mActive;
 	bool mForceStopAudio = true;
 };


### PR DESCRIPTION
Reference: #590
