### PR TITLE
Configuration Dictionary store

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -421,6 +421,36 @@ void Configuration::parseOptions(const Dictionary& dictionary)
 }
 
 
+int Configuration::graphicsWidth() const
+{
+	return mSettings.at("graphics").get<int>(GRAPHICS_CFG_SCREEN_WIDTH);
+}
+
+
+int Configuration::graphicsHeight() const
+{
+	return mSettings.at("graphics").get<int>(GRAPHICS_CFG_SCREEN_HEIGHT);
+}
+
+
+int Configuration::graphicsColorDepth() const
+{
+	return mSettings.at("graphics").get<int>(GRAPHICS_CFG_SCREEN_DEPTH);
+}
+
+
+bool Configuration::fullscreen() const
+{
+	return mSettings.at("graphics").get<bool>(GRAPHICS_CFG_FULLSCREEN);
+}
+
+
+bool Configuration::vsync() const
+{
+	return mSettings.at("graphics").get<bool>(GRAPHICS_CFG_VSYNC);
+}
+
+
 /**
  * Sets the screen width.
  *

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -211,7 +211,8 @@ namespace {
 
 
 Configuration::Configuration(std::map<std::string, Dictionary> defaults) :
-	mDefaults{std::move(defaults)}
+	mDefaults{std::move(defaults)},
+	mSettings{mDefaults}
 {
 	if (mDefaults.find("graphics") != mDefaults.end())
 	{
@@ -237,12 +238,12 @@ void Configuration::loadData(const std::string& fileData)
 {
 	// Start parsing through the Config.xml file.
 	mLoadedSettings = ParseXmlSections(fileData, "configuration");
-	const auto sections = merge(mDefaults, mLoadedSettings);
-	ReportProblemNames(getKeys(sections), {"graphics", "audio", "options"});
+	mSettings = merge(mDefaults, mLoadedSettings);
+	ReportProblemNames(getKeys(mSettings), {"graphics", "audio", "options"});
 
-	parseGraphics(sections.at("graphics"));
-	parseAudio(sections.at("audio"));
-	parseOptions(sections.at("options"));
+	parseGraphics(mSettings.at("graphics"));
+	parseAudio(mSettings.at("audio"));
+	parseOptions(mSettings.at("options"));
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -480,6 +480,7 @@ void Configuration::audioMixRate(int mixrate)
 	}
 
 	mMixRate = mixrate;
+	mSettings["audio"].set(AUDIO_CFG_MIXRATE, mixrate);
 }
 
 
@@ -493,6 +494,7 @@ void Configuration::audioMixRate(int mixrate)
 void Configuration::mixer(const std::string& mixer)
 {
 	mMixerName = mixer;
+	mSettings["audio"].set(AUDIO_CFG_MIXER, mixer);
 }
 
 
@@ -503,7 +505,9 @@ void Configuration::mixer(const std::string& mixer)
  */
 void Configuration::audioStereoChannels(int channels)
 {
-	mStereoChannels = std::clamp(channels, AUDIO_MONO, AUDIO_STEREO);
+	channels = std::clamp(channels, AUDIO_MONO, AUDIO_STEREO);
+	mStereoChannels = channels;
+	mSettings["audio"].set(AUDIO_CFG_CHANNELS, channels);
 }
 
 
@@ -514,7 +518,9 @@ void Configuration::audioStereoChannels(int channels)
  */
 void Configuration::audioSfxVolume(int volume)
 {
-	mSfxVolume = std::clamp(volume, AUDIO_SFX_MIN_VOLUME, AUDIO_SFX_MAX_VOLUME);
+	volume = std::clamp(volume, AUDIO_SFX_MIN_VOLUME, AUDIO_SFX_MAX_VOLUME);
+	mSfxVolume = volume;
+	mSettings["audio"].set(AUDIO_CFG_SFX_VOLUME, volume);
 }
 
 
@@ -526,7 +532,9 @@ void Configuration::audioSfxVolume(int volume)
  */
 void Configuration::audioMusicVolume(int volume)
 {
-	mMusicVolume = std::clamp(volume, AUDIO_MUSIC_MIN_VOLUME, AUDIO_MUSIC_MAX_VOLUME);
+	volume = std::clamp(volume, AUDIO_MUSIC_MIN_VOLUME, AUDIO_MUSIC_MAX_VOLUME);
+	mMusicVolume = volume;
+	mSettings["audio"].set(AUDIO_CFG_MUS_VOLUME, volume);
 }
 
 
@@ -539,7 +547,9 @@ void Configuration::audioMusicVolume(int volume)
  */
 void Configuration::audioBufferSize(int size)
 {
-	mBufferLength = std::clamp(size, AUDIO_BUFFER_MIN_SIZE, AUDIO_BUFFER_MAX_SIZE);
+	size = std::clamp(size, AUDIO_BUFFER_MIN_SIZE, AUDIO_BUFFER_MAX_SIZE);
+	mBufferLength = size;
+	mSettings["audio"].set(AUDIO_CFG_BUFFER_SIZE, size);
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -340,12 +340,6 @@ void Configuration::save(const std::string& filePath) const
  */
 void Configuration::setDefaultValues()
 {
-	mMixRate = AUDIO_MEDIUM_QUALITY;
-	mStereoChannels = AUDIO_STEREO;
-	mSfxVolume = AUDIO_SFX_VOLUME;
-	mMusicVolume = AUDIO_MUSIC_VOLUME;
-	mBufferLength = AUDIO_BUFFER_SIZE;
-
 	mSettings["graphics"] += defaultGraphics;
 	mSettings["audio"] += defaultAudio;
 }
@@ -361,32 +355,31 @@ void Configuration::parseAudio(const Dictionary& dictionary)
 {
 	ReportProblemNames(dictionary.keys(), {AUDIO_CFG_MIXRATE, AUDIO_CFG_CHANNELS, AUDIO_CFG_SFX_VOLUME, AUDIO_CFG_MUS_VOLUME, AUDIO_CFG_BUFFER_SIZE, AUDIO_CFG_MIXER});
 
-	mMixRate = dictionary.get<int>(AUDIO_CFG_MIXRATE);
-	mStereoChannels = dictionary.get<int>(AUDIO_CFG_CHANNELS);
-	mSfxVolume = dictionary.get<int>(AUDIO_CFG_SFX_VOLUME);
-	mMusicVolume = dictionary.get<int>(AUDIO_CFG_MUS_VOLUME);
-	mBufferLength = dictionary.get<int>(AUDIO_CFG_BUFFER_SIZE);
-	mMixerName = dictionary.get(AUDIO_CFG_MIXER);
+	const auto mixRate = dictionary.get<int>(AUDIO_CFG_MIXRATE);
+	const auto stereoChannels = dictionary.get<int>(AUDIO_CFG_CHANNELS);
+	const auto sfxVolume = dictionary.get<int>(AUDIO_CFG_SFX_VOLUME);
+	const auto musicVolume = dictionary.get<int>(AUDIO_CFG_MUS_VOLUME);
+	const auto bufferLength = dictionary.get<int>(AUDIO_CFG_BUFFER_SIZE);
 
-	if (mMixRate != AUDIO_LOW_QUALITY && mMixRate != AUDIO_MEDIUM_QUALITY && mMixRate != AUDIO_HIGH_QUALITY)
+	if (mixRate != AUDIO_LOW_QUALITY && mixRate != AUDIO_MEDIUM_QUALITY && mixRate != AUDIO_HIGH_QUALITY)
 	{
 		audioMixRate(AUDIO_MEDIUM_QUALITY);
 	}
-	if (mStereoChannels != AUDIO_MONO && mStereoChannels != AUDIO_STEREO)
+	if (stereoChannels != AUDIO_MONO && stereoChannels != AUDIO_STEREO)
 	{
 		audioStereoChannels(AUDIO_STEREO);
 	}
-	if (mSfxVolume < AUDIO_SFX_MIN_VOLUME || mSfxVolume > AUDIO_SFX_MAX_VOLUME)
+	if (sfxVolume < AUDIO_SFX_MIN_VOLUME || sfxVolume > AUDIO_SFX_MAX_VOLUME)
 	{
-		audioSfxVolume(mSfxVolume);
+		audioSfxVolume(sfxVolume);
 	}
-	if (mMusicVolume < AUDIO_MUSIC_MIN_VOLUME || mMusicVolume > AUDIO_MUSIC_MAX_VOLUME)
+	if (musicVolume < AUDIO_MUSIC_MIN_VOLUME || musicVolume > AUDIO_MUSIC_MAX_VOLUME)
 	{
-		audioMusicVolume(mMusicVolume);
+		audioMusicVolume(musicVolume);
 	}
-	if (mBufferLength < AUDIO_BUFFER_MIN_SIZE || mBufferLength > AUDIO_BUFFER_MAX_SIZE)
+	if (bufferLength < AUDIO_BUFFER_MIN_SIZE || bufferLength > AUDIO_BUFFER_MAX_SIZE)
 	{
-		audioBufferSize(mBufferLength);
+		audioBufferSize(bufferLength);
 	}
 }
 
@@ -537,7 +530,6 @@ void Configuration::audioMixRate(int mixrate)
 		mixrate = AUDIO_MEDIUM_QUALITY;
 	}
 
-	mMixRate = mixrate;
 	mSettings["audio"].set(AUDIO_CFG_MIXRATE, mixrate);
 }
 
@@ -551,7 +543,6 @@ void Configuration::audioMixRate(int mixrate)
  */
 void Configuration::mixer(const std::string& mixer)
 {
-	mMixerName = mixer;
 	mSettings["audio"].set(AUDIO_CFG_MIXER, mixer);
 }
 
@@ -564,7 +555,6 @@ void Configuration::mixer(const std::string& mixer)
 void Configuration::audioStereoChannels(int channels)
 {
 	channels = std::clamp(channels, AUDIO_MONO, AUDIO_STEREO);
-	mStereoChannels = channels;
 	mSettings["audio"].set(AUDIO_CFG_CHANNELS, channels);
 }
 
@@ -577,7 +567,6 @@ void Configuration::audioStereoChannels(int channels)
 void Configuration::audioSfxVolume(int volume)
 {
 	volume = std::clamp(volume, AUDIO_SFX_MIN_VOLUME, AUDIO_SFX_MAX_VOLUME);
-	mSfxVolume = volume;
 	mSettings["audio"].set(AUDIO_CFG_SFX_VOLUME, volume);
 }
 
@@ -591,7 +580,6 @@ void Configuration::audioSfxVolume(int volume)
 void Configuration::audioMusicVolume(int volume)
 {
 	volume = std::clamp(volume, AUDIO_MUSIC_MIN_VOLUME, AUDIO_MUSIC_MAX_VOLUME);
-	mMusicVolume = volume;
 	mSettings["audio"].set(AUDIO_CFG_MUS_VOLUME, volume);
 }
 
@@ -606,7 +594,6 @@ void Configuration::audioMusicVolume(int volume)
 void Configuration::audioBufferSize(int size)
 {
 	size = std::clamp(size, AUDIO_BUFFER_MIN_SIZE, AUDIO_BUFFER_MAX_SIZE);
-	mBufferLength = size;
 	mSettings["audio"].set(AUDIO_CFG_BUFFER_SIZE, size);
 }
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -59,6 +59,24 @@ const std::string GRAPHICS_CFG_FULLSCREEN = "fullscreen";
 const std::string GRAPHICS_CFG_VSYNC = "vsync";
 
 
+const Dictionary defaultAudio{{
+	{AUDIO_CFG_MIXER, AUDIO_MIXER},
+	{AUDIO_CFG_MUS_VOLUME, AUDIO_MUSIC_VOLUME},
+	{AUDIO_CFG_SFX_VOLUME, AUDIO_SFX_VOLUME},
+	{AUDIO_CFG_CHANNELS, AUDIO_STEREO},
+	{AUDIO_CFG_MIXRATE, AUDIO_MEDIUM_QUALITY},
+	{AUDIO_CFG_BUFFER_SIZE, AUDIO_BUFFER_SIZE}
+}};
+
+const Dictionary defaultGraphics{{
+	{GRAPHICS_CFG_SCREEN_WIDTH, GRAPHICS_WIDTH},
+	{GRAPHICS_CFG_SCREEN_HEIGHT, GRAPHICS_HEIGHT},
+	{GRAPHICS_CFG_SCREEN_DEPTH, GRAPHICS_BITDEPTH},
+	{GRAPHICS_CFG_FULLSCREEN, GRAPHICS_FULLSCREEN},
+	{GRAPHICS_CFG_VSYNC, GRAPHICS_VSYNC}
+}};
+
+
 namespace {
 	std::map<std::string, Dictionary> merge(const std::map<std::string, Dictionary>& defaults, const std::map<std::string, Dictionary>& priorityValues)
 	{

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -516,6 +516,42 @@ void Configuration::vsync(bool vsync)
 }
 
 
+int Configuration::audioMixRate() const
+{
+	return mSettings.at("audio").get<int>(AUDIO_CFG_MIXRATE);
+}
+
+
+int Configuration::audioStereoChannels() const
+{
+	return mSettings.at("audio").get<int>(AUDIO_CFG_CHANNELS);
+}
+
+
+int Configuration::audioSfxVolume() const
+{
+	return mSettings.at("audio").get<int>(AUDIO_CFG_SFX_VOLUME);
+}
+
+
+int Configuration::audioMusicVolume() const
+{
+	return mSettings.at("audio").get<int>(AUDIO_CFG_MUS_VOLUME);
+}
+
+
+int Configuration::audioBufferSize() const
+{
+	return mSettings.at("audio").get<int>(AUDIO_CFG_BUFFER_SIZE);
+}
+
+
+std::string Configuration::mixer() const
+{
+	return mSettings.at("audio").get(AUDIO_CFG_MIXER);
+}
+
+
 /**
  * Sets the audio mixrate.
  *

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -240,10 +240,6 @@ Configuration::Configuration(std::map<std::string, Dictionary> defaults) :
 	{
 		parseAudio(mDefaults.at("audio"));
 	}
-	if (mDefaults.find("options") != mDefaults.end())
-	{
-		parseOptions(mDefaults.at("options"));
-	}
 }
 
 
@@ -261,7 +257,6 @@ void Configuration::loadData(const std::string& fileData)
 
 	parseGraphics(mSettings.at("graphics"));
 	parseAudio(mSettings.at("audio"));
-	parseOptions(mSettings.at("options"));
 }
 
 
@@ -360,12 +355,6 @@ void Configuration::parseAudio(const Dictionary& dictionary)
 	audioSfxVolume(dictionary.get<int>(AUDIO_CFG_SFX_VOLUME));
 	audioMusicVolume(dictionary.get<int>(AUDIO_CFG_MUS_VOLUME));
 	audioBufferSize(dictionary.get<int>(AUDIO_CFG_BUFFER_SIZE));
-}
-
-
-void Configuration::parseOptions(const Dictionary& dictionary)
-{
-	mSettings.at("options") = dictionary;
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -363,6 +363,9 @@ void Configuration::setDefaultValues()
 	mSfxVolume = AUDIO_SFX_VOLUME;
 	mMusicVolume = AUDIO_MUSIC_VOLUME;
 	mBufferLength = AUDIO_BUFFER_SIZE;
+
+	mSettings["graphics"] += defaultGraphics;
+	mSettings["audio"] += defaultAudio;
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -304,20 +304,8 @@ std::string Configuration::saveData() const
 	XmlComment* comment = new XmlComment("Automatically generated Configuration file.");
 	doc.linkEndChild(comment);
 
-	Dictionary graphics;
-	graphics.set("screenwidth", mScreenWidth);
-	graphics.set("screenheight", mScreenHeight);
-	graphics.set("bitdepth", mScreenBpp);
-	graphics.set("fullscreen", mFullScreen);
-	graphics.set("vsync", mVSync);
-
-	Dictionary audio;
-	audio.set("mixrate", mMixRate);
-	audio.set("channels", mStereoChannels);
-	audio.set("sfxvolume", mSfxVolume);
-	audio.set("musicvolume", mMusicVolume);
-	audio.set("bufferlength", mBufferLength);
-	audio.set("mixer", mMixerName);
+	const auto& graphics = mSettings.at("graphics");
+	const auto& audio = mSettings.at("audio");
 
 	auto* root = SectionsToXmlElement("configuration", std::map<std::string, Dictionary>{{"graphics", graphics}, {"audio", audio}});
 	root->linkEndChild(DictionaryToXmlElementOptions("options", mOptions));

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -59,7 +59,7 @@ const std::string GRAPHICS_CFG_FULLSCREEN = "fullscreen";
 const std::string GRAPHICS_CFG_VSYNC = "vsync";
 
 
-const Dictionary defaultAudio{{
+const Dictionary Configuration::defaultAudio{{
 	{AUDIO_CFG_MIXER, AUDIO_MIXER},
 	{AUDIO_CFG_MUS_VOLUME, AUDIO_MUSIC_VOLUME},
 	{AUDIO_CFG_SFX_VOLUME, AUDIO_SFX_VOLUME},
@@ -68,7 +68,7 @@ const Dictionary defaultAudio{{
 	{AUDIO_CFG_BUFFER_SIZE, AUDIO_BUFFER_SIZE}
 }};
 
-const Dictionary defaultGraphics{{
+const Dictionary Configuration::defaultGraphics{{
 	{GRAPHICS_CFG_SCREEN_WIDTH, GRAPHICS_WIDTH},
 	{GRAPHICS_CFG_SCREEN_HEIGHT, GRAPHICS_HEIGHT},
 	{GRAPHICS_CFG_SCREEN_DEPTH, GRAPHICS_BITDEPTH},

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -236,8 +236,8 @@ Configuration::Configuration(std::map<std::string, Dictionary> defaults) :
 void Configuration::loadData(const std::string& fileData)
 {
 	// Start parsing through the Config.xml file.
-	const auto loadedSections = ParseXmlSections(fileData, "configuration");
-	const auto sections = merge(mDefaults, loadedSections);
+	mLoadedSettings = ParseXmlSections(fileData, "configuration");
+	const auto sections = merge(mDefaults, mLoadedSettings);
 	ReportProblemNames(getKeys(sections), {"graphics", "audio", "options"});
 
 	parseGraphics(sections.at("graphics"));

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -355,32 +355,11 @@ void Configuration::parseAudio(const Dictionary& dictionary)
 {
 	ReportProblemNames(dictionary.keys(), {AUDIO_CFG_MIXRATE, AUDIO_CFG_CHANNELS, AUDIO_CFG_SFX_VOLUME, AUDIO_CFG_MUS_VOLUME, AUDIO_CFG_BUFFER_SIZE, AUDIO_CFG_MIXER});
 
-	const auto mixRate = dictionary.get<int>(AUDIO_CFG_MIXRATE);
-	const auto stereoChannels = dictionary.get<int>(AUDIO_CFG_CHANNELS);
-	const auto sfxVolume = dictionary.get<int>(AUDIO_CFG_SFX_VOLUME);
-	const auto musicVolume = dictionary.get<int>(AUDIO_CFG_MUS_VOLUME);
-	const auto bufferLength = dictionary.get<int>(AUDIO_CFG_BUFFER_SIZE);
-
-	if (mixRate != AUDIO_LOW_QUALITY && mixRate != AUDIO_MEDIUM_QUALITY && mixRate != AUDIO_HIGH_QUALITY)
-	{
-		audioMixRate(AUDIO_MEDIUM_QUALITY);
-	}
-	if (stereoChannels != AUDIO_MONO && stereoChannels != AUDIO_STEREO)
-	{
-		audioStereoChannels(AUDIO_STEREO);
-	}
-	if (sfxVolume < AUDIO_SFX_MIN_VOLUME || sfxVolume > AUDIO_SFX_MAX_VOLUME)
-	{
-		audioSfxVolume(sfxVolume);
-	}
-	if (musicVolume < AUDIO_MUSIC_MIN_VOLUME || musicVolume > AUDIO_MUSIC_MAX_VOLUME)
-	{
-		audioMusicVolume(musicVolume);
-	}
-	if (bufferLength < AUDIO_BUFFER_MIN_SIZE || bufferLength > AUDIO_BUFFER_MAX_SIZE)
-	{
-		audioBufferSize(bufferLength);
-	}
+	audioMixRate(dictionary.get<int>(AUDIO_CFG_MIXRATE));
+	audioStereoChannels(dictionary.get<int>(AUDIO_CFG_CHANNELS));
+	audioSfxVolume(dictionary.get<int>(AUDIO_CFG_SFX_VOLUME));
+	audioMusicVolume(dictionary.get<int>(AUDIO_CFG_MUS_VOLUME));
+	audioBufferSize(dictionary.get<int>(AUDIO_CFG_BUFFER_SIZE));
 }
 
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -308,7 +308,7 @@ std::string Configuration::saveData() const
 	const auto& audio = mSettings.at("audio");
 
 	auto* root = SectionsToXmlElement("configuration", std::map<std::string, Dictionary>{{"graphics", graphics}, {"audio", audio}});
-	root->linkEndChild(DictionaryToXmlElementOptions("options", mOptions));
+	root->linkEndChild(DictionaryToXmlElementOptions("options", mSettings.at("options")));
 	doc.linkEndChild(root);
 
 	// Write out the XML file.
@@ -365,7 +365,7 @@ void Configuration::parseAudio(const Dictionary& dictionary)
 
 void Configuration::parseOptions(const Dictionary& dictionary)
 {
-	mOptions = dictionary;
+	mSettings.at("options") = dictionary;
 }
 
 
@@ -589,12 +589,12 @@ void Configuration::audioBufferSize(int size)
  */
 void Configuration::option(const std::string& option, const std::string& value, bool overwrite)
 {
-	if (!overwrite && mOptions.has(option))
+	if (!overwrite && mSettings.at("options").has(option))
 	{
 		return;
 	}
 
-	mOptions.set(option, value);
+	mSettings.at("options").set(option, value);
 }
 
 
@@ -610,12 +610,12 @@ void Configuration::option(const std::string& option, const std::string& value, 
  */
 std::string Configuration::option(const std::string& key)
 {
-	if (!mOptions.has(key))
+	if (!mSettings.at("options").has(key))
 	{
-		mOptions.set(key, std::string{});
+		mSettings.at("options").set(key, std::string{});
 	}
 
-	return mOptions.get(key);
+	return mSettings.at("options").get(key);
 }
 
 
@@ -629,8 +629,8 @@ std::string Configuration::option(const std::string& key)
  */
 void Configuration::deleteOption(const std::string& option)
 {
-	if (mOptions.has(option))
+	if (mSettings.at("options").has(option))
 	{
-		mOptions.erase(option);
+		mSettings.at("options").erase(option);
 	}
 }

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -340,12 +340,6 @@ void Configuration::save(const std::string& filePath) const
  */
 void Configuration::setDefaultValues()
 {
-	mScreenWidth = GRAPHICS_WIDTH;
-	mScreenHeight = GRAPHICS_HEIGHT;
-	mScreenBpp = GRAPHICS_BITDEPTH;
-	mFullScreen = GRAPHICS_FULLSCREEN;
-	mVSync = GRAPHICS_VSYNC;
-
 	mMixRate = AUDIO_MEDIUM_QUALITY;
 	mStereoChannels = AUDIO_STEREO;
 	mSfxVolume = AUDIO_SFX_VOLUME;
@@ -360,12 +354,6 @@ void Configuration::setDefaultValues()
 void Configuration::parseGraphics(const Dictionary& dictionary)
 {
 	ReportProblemNames(dictionary.keys(), {GRAPHICS_CFG_SCREEN_WIDTH, GRAPHICS_CFG_SCREEN_HEIGHT, GRAPHICS_CFG_SCREEN_DEPTH, GRAPHICS_CFG_FULLSCREEN, GRAPHICS_CFG_VSYNC});
-
-	mScreenWidth = dictionary.get<int>(GRAPHICS_CFG_SCREEN_WIDTH);
-	mScreenHeight = dictionary.get<int>(GRAPHICS_CFG_SCREEN_HEIGHT);
-	mScreenBpp = dictionary.get<int>(GRAPHICS_CFG_SCREEN_DEPTH);
-	fullscreen(dictionary.get<bool>(GRAPHICS_CFG_FULLSCREEN));
-	vsync(dictionary.get<bool>(GRAPHICS_CFG_VSYNC));
 }
 
 
@@ -446,7 +434,6 @@ bool Configuration::vsync() const
  */
 void Configuration::graphicsWidth(int width)
 {
-	mScreenWidth = width;
 	mSettings["graphics"].set(GRAPHICS_CFG_SCREEN_WIDTH, width);
 }
 
@@ -458,7 +445,6 @@ void Configuration::graphicsWidth(int width)
  */
 void Configuration::graphicsHeight(int height)
 {
-	mScreenHeight = height;
 	mSettings["graphics"].set(GRAPHICS_CFG_SCREEN_HEIGHT, height);
 }
 
@@ -470,7 +456,6 @@ void Configuration::graphicsHeight(int height)
  */
 void Configuration::graphicsColorDepth(int bpp)
 {
-	mScreenBpp = bpp;
 	mSettings["graphics"].set(GRAPHICS_CFG_SCREEN_DEPTH, bpp);
 }
 
@@ -482,7 +467,6 @@ void Configuration::graphicsColorDepth(int bpp)
  */
 void Configuration::fullscreen(bool fullscreen)
 {
-	mFullScreen = fullscreen;
 	mSettings["graphics"].set(GRAPHICS_CFG_FULLSCREEN, fullscreen);
 }
 
@@ -499,7 +483,6 @@ void Configuration::fullscreen(bool fullscreen)
  */
 void Configuration::vsync(bool vsync)
 {
-	mVSync = vsync;
 	mSettings["graphics"].set(GRAPHICS_CFG_VSYNC, vsync);
 }
 

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -408,6 +408,7 @@ void Configuration::parseOptions(const Dictionary& dictionary)
 void Configuration::graphicsWidth(int width)
 {
 	mScreenWidth = width;
+	mSettings["graphics"].set(GRAPHICS_CFG_SCREEN_WIDTH, width);
 }
 
 
@@ -419,6 +420,7 @@ void Configuration::graphicsWidth(int width)
 void Configuration::graphicsHeight(int height)
 {
 	mScreenHeight = height;
+	mSettings["graphics"].set(GRAPHICS_CFG_SCREEN_HEIGHT, height);
 }
 
 
@@ -430,6 +432,7 @@ void Configuration::graphicsHeight(int height)
 void Configuration::graphicsColorDepth(int bpp)
 {
 	mScreenBpp = bpp;
+	mSettings["graphics"].set(GRAPHICS_CFG_SCREEN_DEPTH, bpp);
 }
 
 
@@ -441,6 +444,7 @@ void Configuration::graphicsColorDepth(int bpp)
 void Configuration::fullscreen(bool fullscreen)
 {
 	mFullScreen = fullscreen;
+	mSettings["graphics"].set(GRAPHICS_CFG_FULLSCREEN, fullscreen);
 }
 
 
@@ -457,6 +461,7 @@ void Configuration::fullscreen(bool fullscreen)
 void Configuration::vsync(bool vsync)
 {
 	mVSync = vsync;
+	mSettings["graphics"].set(GRAPHICS_CFG_VSYNC, vsync);
 }
 
 

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -87,7 +87,6 @@ private:
 	const std::map<std::string, Dictionary> mDefaults{};
 	std::map<std::string, Dictionary> mLoadedSettings{};
 	std::map<std::string, Dictionary> mSettings{};
-	Dictionary mOptions{};
 };
 
 } // namespace

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -89,13 +89,6 @@ private:
 	std::map<std::string, Dictionary> mSettings{};
 	Dictionary mOptions{};
 
-	int mScreenWidth{800};
-	int mScreenHeight{600};
-	int mScreenBpp{32};
-
-	bool mFullScreen{false};
-	bool mVSync{false};
-
 	int mMixRate{22050};
 	int mStereoChannels{2};
 	int mSfxVolume{128};

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -26,6 +26,10 @@ namespace NAS2D {
 class Configuration
 {
 public:
+	static const Dictionary defaultAudio;
+	static const Dictionary defaultGraphics;
+
+
 	Configuration() = default;
 	Configuration(std::map<std::string, Dictionary> defaults);
 	Configuration(const Configuration&) = delete;

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -82,7 +82,6 @@ protected:
 private:
 	void parseGraphics(const Dictionary& dictionary);
 	void parseAudio(const Dictionary& dictionary);
-	void parseOptions(const Dictionary& dictionary);
 
 	const std::map<std::string, Dictionary> mDefaults{};
 	std::map<std::string, Dictionary> mLoadedSettings{};

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -88,13 +88,6 @@ private:
 	std::map<std::string, Dictionary> mLoadedSettings{};
 	std::map<std::string, Dictionary> mSettings{};
 	Dictionary mOptions{};
-
-	int mMixRate{22050};
-	int mStereoChannels{2};
-	int mSfxVolume{128};
-	int mMusicVolume{100};
-	int mBufferLength{1024};
-	std::string mMixerName{"SDL"};
 };
 
 } // namespace

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -58,12 +58,12 @@ public:
 
 
 	// Audio Options
-	int audioMixRate() const { return mMixRate; }
-	int audioStereoChannels() const { return mStereoChannels; }
-	int audioSfxVolume() const { return mSfxVolume; }
-	int audioMusicVolume() const { return mMusicVolume; }
-	int audioBufferSize() const { return mBufferLength; }
-	const std::string& mixer() const { return mMixerName; }
+	int audioMixRate() const;
+	int audioStereoChannels() const;
+	int audioSfxVolume() const;
+	int audioMusicVolume() const;
+	int audioBufferSize() const;
+	std::string mixer() const;
 
 	void audioMixRate(int mixrate);
 	void audioStereoChannels(int channels);

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -82,6 +82,7 @@ private:
 
 	const std::map<std::string, Dictionary> mDefaults{};
 	std::map<std::string, Dictionary> mLoadedSettings{};
+	std::map<std::string, Dictionary> mSettings{};
 	Dictionary mOptions{};
 
 	int mScreenWidth{800};

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -44,11 +44,11 @@ public:
 	void save(const std::string& filePath) const;
 
 	// Video Options
-	int graphicsWidth() const { return mScreenWidth; }
-	int graphicsHeight() const { return mScreenHeight; }
-	int graphicsColorDepth() const { return mScreenBpp; }
-	bool fullscreen() const { return mFullScreen; }
-	bool vsync() const { return mVSync; }
+	int graphicsWidth() const;
+	int graphicsHeight() const;
+	int graphicsColorDepth() const;
+	bool fullscreen() const;
+	bool vsync() const;
 
 	void graphicsWidth(int width);
 	void graphicsHeight(int height);

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -81,6 +81,7 @@ private:
 	void parseOptions(const Dictionary& dictionary);
 
 	const std::map<std::string, Dictionary> mDefaults{};
+	std::map<std::string, Dictionary> mLoadedSettings{};
 	Dictionary mOptions{};
 
 	int mScreenWidth{800};

--- a/test/Configuration.test.cpp
+++ b/test/Configuration.test.cpp
@@ -10,13 +10,7 @@ TEST(Configuration, loadData) {
 			{
 				{
 					"graphics",
-					{{
-						{"screenwidth", 1000},
-						{"screenheight", 700},
-						{"bitdepth", 32},
-						{"fullscreen", false},
-						{"vsync", true}
-					}}
+					NAS2D::Configuration::defaultGraphics
 				},
 				{
 					"options",


### PR DESCRIPTION
Store data directly in `Dictionary` objects within `Configuration`, rather than parsed out into member variables.

This simplifies loading and saving of data. Long term, it moves towards treating all possible settings in a consistent manner, including settings which are unknown to the NAS2D library, and having no specially treated settings.
