### PR TITLE
Remove deprecated Mixer::musicComplete() method

### DIFF
--- a/NAS2D/Mixer/Mixer.cpp
+++ b/NAS2D/Mixer/Mixer.cpp
@@ -30,12 +30,6 @@ void Mixer::resumeAllAudio()
 }
 
 
-Signals::Signal<>& Mixer::musicComplete()
-{
-	return mMusicComplete;
-}
-
-
 void Mixer::addMusicCompleteHandler(Signals::Signal<>::DelegateType handler)
 {
 	return mMusicComplete.connect(handler);

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -160,13 +160,6 @@ public:
 	 */
 	virtual int musicVolume() const = 0;
 
-	/**
-	 * Gets a reference to a Signals::Signal<>, a signal raised
-	 * when a Music track has finished playing.
-	 */
-	 [[deprecated("Deprecated: Please use addMusicCompleteHandler and removeMusicCompleteHandler")]]
-	Signals::Signal<>& musicComplete();
-
 	void addMusicCompleteHandler(Signals::Signal<>::DelegateType handler);
 	void removeMusicCompleteHandler(Signals::Signal<>::DelegateType handler);
 


### PR DESCRIPTION
Remove deprecated `Mixer::musicComplete()` method.

The `musicComplete` method doesn't appear to be used anymore, and has long had replacement functionality in:
- `addMusicCompleteHandler`
- `removeMusicCompleteHandler`

In particular, these two new methods protect against gaining access to the underlying `Signal` object, and emitting signals at inappropriate times.
