### PR TITLE
Remove saving volume settings in MixerSDL destructor

### DIFF
--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -87,10 +87,6 @@ MixerSDL::MixerSDL(const Options& options)
  */
 MixerSDL::~MixerSDL()
 {
-	// Save current volume levels in the Configuration.
-	Utility<Configuration>::get().audioSfxVolume(soundVolume());
-	Utility<Configuration>::get().audioMusicVolume(musicVolume());
-
 	stopAllAudio();
 
 	Mix_CloseAudio();


### PR DESCRIPTION
Saving settings should be done manually before the object is destructed.

Actually, the configuration data should probably be updated and/or saved when the setting is changed. That way a crash or sudden program termination won't cause a setting change to be forgotten.

----

The code being removed wasn't really used. No project had support to change the audio settings. There was some experimental code added to OPHD to change audio settings, but it stored new settings as soon as they were set, and so didn't need extra support from within `Mixer`.
