### PR TITLE
Remove Mixer methods mute and unmute

### DIFF
--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -108,16 +108,6 @@ public:
 	virtual bool musicPlaying() const = 0;
 
 	/**
-	 * Mutes all audio.
-	 */
-	virtual void mute() = 0;
-
-	/**
-	 * Unmutes all audio.
-	 */
-	virtual void unmute() = 0;
-
-	/**
 	 * Stops all music and sound.
 	 */
 	void stopAllAudio();

--- a/NAS2D/Mixer/MixerNull.cpp
+++ b/NAS2D/Mixer/MixerNull.cpp
@@ -35,12 +35,6 @@ namespace NAS2D
 		return false;
 	}
 
-	void MixerNull::mute()
-	{}
-
-	void MixerNull::unmute()
-	{}
-
 	void MixerNull::soundVolume(int /*level*/)
 	{}
 

--- a/NAS2D/Mixer/MixerNull.h
+++ b/NAS2D/Mixer/MixerNull.h
@@ -22,9 +22,6 @@ namespace NAS2D
 
 		bool musicPlaying() const override;
 
-		void mute() override;
-		void unmute() override;
-
 		void soundVolume(int level) override;
 		void musicVolume(int level) override;
 

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -197,17 +197,3 @@ int MixerSDL::musicVolume() const
 {
 	return Mix_VolumeMusic(-1);
 }
-
-
-void MixerSDL::mute()
-{
-	musicVolume(0);
-	soundVolume(0);
-}
-
-
-void MixerSDL::unmute()
-{
-	musicVolume(Mix_VolumeMusic(-1));
-	soundVolume(Mix_Volume(-1, -1));
-}

--- a/NAS2D/Mixer/MixerSDL.h
+++ b/NAS2D/Mixer/MixerSDL.h
@@ -66,9 +66,6 @@ public:
 	int soundVolume() const override;
 	int musicVolume() const override;
 
-	void mute() override;
-	void unmute() override;
-
 private:
 	void onMusicFinished();
 };


### PR DESCRIPTION
These aren't being used, and could be handled by higher level code through other methods. Additionally the MixerSDL code was defective in that `unmute` did not restore the previous volume from before `mute` was called.
