### PR TITLE
Add config operator subscript

### DIFF
--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -38,6 +38,9 @@ public:
 	Configuration& operator=(Configuration&&) = delete;
 	~Configuration() = default;
 
+	const Dictionary& operator[](const std::string& key) const { return mSettings.at(key); }
+	Dictionary& operator[](const std::string& key) { return mSettings.at(key); }
+
 	void loadData(const std::string& fileData);
 	void load(const std::string& filePath);
 	std::string saveData() const;

--- a/NAS2D/Dictionary.cpp
+++ b/NAS2D/Dictionary.cpp
@@ -19,6 +19,16 @@ namespace NAS2D {
 		return !(*this == other);
 	}
 
+	const StringValue& Dictionary::operator[](const std::string& key) const
+	{
+		return mDictionary.at(key);
+	}
+
+	StringValue& Dictionary::operator[](const std::string& key)
+	{
+		return mDictionary[key];
+	}
+
 	Dictionary& Dictionary::operator+=(const Dictionary& other)
 	{
 		for (const auto& [key, value] : other.mDictionary)

--- a/NAS2D/Dictionary.h
+++ b/NAS2D/Dictionary.h
@@ -14,6 +14,9 @@ namespace NAS2D {
 		bool operator==(const Dictionary& other) const;
 		bool operator!=(const Dictionary& other) const;
 
+		const StringValue& operator[](const std::string& key) const;
+		StringValue& operator[](const std::string& key);
+
 		Dictionary& operator+=(const Dictionary& other);
 
 

--- a/test/Configuration.test.cpp
+++ b/test/Configuration.test.cpp
@@ -4,6 +4,35 @@
 #include <gtest/gtest.h>
 
 
+TEST(Configuration, OperatorSubscript) {
+	{
+		const NAS2D::Configuration config{
+			std::map<std::string, NAS2D::Dictionary>{
+				{{"graphics", NAS2D::Configuration::defaultGraphics}}
+			}
+		};
+		auto& value = config["graphics"];
+
+		EXPECT_TRUE((std::is_same_v<const NAS2D::Dictionary&, decltype(value)>));
+		EXPECT_EQ(value, NAS2D::Configuration::defaultGraphics);
+	}
+
+	{
+		NAS2D::Configuration config{
+			std::map<std::string, NAS2D::Dictionary>{
+				{{"graphics", NAS2D::Configuration::defaultGraphics}}
+			}
+		};
+		auto& value = config["graphics"];
+
+		EXPECT_TRUE((std::is_same_v<NAS2D::Dictionary&, decltype(value)>));
+		EXPECT_EQ(value, NAS2D::Configuration::defaultGraphics);
+
+		EXPECT_NO_THROW(config["graphics"]["customAttribute"] = "custom value");
+		EXPECT_NE(value, NAS2D::Configuration::defaultGraphics);
+	}
+}
+
 TEST(Configuration, loadData) {
 	NAS2D::Configuration config{
 		std::map<std::string, NAS2D::Dictionary>{

--- a/test/Dictionary.test.cpp
+++ b/test/Dictionary.test.cpp
@@ -42,6 +42,27 @@ TEST(Dictionary, OperatorEquality) {
 	EXPECT_EQ(dictionary3, dictionary4);
 }
 
+TEST(Dictionary, OperatorSubscript) {
+	{
+		const NAS2D::Dictionary dictionary{{{"Key1", "Value1"}}};;
+		auto& value = dictionary["Key1"];
+
+		EXPECT_TRUE((std::is_same_v<const NAS2D::StringValue&, decltype(value)>));
+		EXPECT_EQ("Value1", value.to<std::string>());
+	}
+
+	{
+		NAS2D::Dictionary dictionary{{{"Key1", "Value1"}}};
+		auto& value = dictionary["Key1"];
+
+		EXPECT_TRUE((std::is_same_v<NAS2D::StringValue&, decltype(value)>));
+		EXPECT_EQ("Value1", value.to<std::string>());
+
+		EXPECT_NO_THROW(dictionary["Key1"] = "Value2");
+		EXPECT_EQ("Value2", value.to<std::string>());
+	}
+}
+
 TEST(Dictionary, setGet) {
 	NAS2D::Dictionary dictionary;
 


### PR DESCRIPTION
Add config operator subscript support. Allows for both read-only and write access, depending on if the base object is marked `const` or not.
