### PR TITLE
Add missing `<limits>` header to StringUtils

### DIFF
--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <memory>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <utility>


### PR DESCRIPTION
The `<limits>` header is needed for [`std::numeric_limits`](https://en.cppreference.com/w/cpp/types/numeric_limits). It's absense was detected while compiling on Arch Linux.

Related: #679
