### PR TITLE
Makefile distribution detect

### DIFF
--- a/makefile
+++ b/makefile
@@ -186,7 +186,9 @@ DISTRIBUTION = $(subst Linux,$(LINUX_DISTRIBUTION),$(CURRENT_OS))
 
 .PHONY: install-dependencies
 install-dependencies:
-	@echo "\nDetected distribution: $(DISTRIBUTION)\n"
+	@echo
+	@echo "Detected distribution: $(DISTRIBUTION)"
+	@echo
 	$(MAKE) "install-dependencies-$(DISTRIBUTION)"
 
 ## Ubuntu ##

--- a/makefile
+++ b/makefile
@@ -198,12 +198,12 @@ install-dependencies-ubuntu:
 .PHONY: install-dependencies-centos
 install-dependencies-centos: | install-repos-centos
 	# Install development packages (-y answers "yes" to prompts)
-	yum -y install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel physfs-devel
+	yum --assumeyes install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel physfs-devel
 .PHONY: install-repos-centos
 install-repos-centos:
 	# Default CentOS repositories only contain SDL1
 	# For SDL2 use EPEL repo (EPEL = Extra Packages for Enterprise Linux)
-	yum install epel-release
+	yum --assumeyes install epel-release
 
 ## Arch Linux ##
 .PHONY: install-dependencies-arch

--- a/makefile
+++ b/makefile
@@ -180,7 +180,7 @@ cppclean:
 
 RELEASE_FILES = $(wildcard /etc/*-release)
 RELEASE_FILE_TAGS = $(patsubst /etc/%-release,%,$(RELEASE_FILES))
-RELEASE_SETTING_NAME = $(shell '$(SHELL)' -c '. $(RELEASE_FILES) && echo $${ID}')
+RELEASE_SETTING_NAME = $(shell '$(SHELL)' -c '. /etc/os-release && echo $${ID}')
 LINUX_DISTRIBUTION = $(or $(RELEASE_SETTING_NAME),$(RELEASE_FILE_TAGS),Unknown)
 DISTRIBUTION = $(subst Linux,$(LINUX_DISTRIBUTION),$(CURRENT_OS))
 

--- a/makefile
+++ b/makefile
@@ -194,7 +194,7 @@ install-dependencies:
 ## Ubuntu ##
 .PHONY: install-dependencies-ubuntu
 install-dependencies-ubuntu:
-	apt install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev libphysfs-dev
+	apt --yes install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev libphysfs-dev
 
 ## CentOS ##
 .PHONY: install-dependencies-centos

--- a/makefile
+++ b/makefile
@@ -189,32 +189,26 @@ install-dependencies:
 	@echo "\nDetected distribution: $(DISTRIBUTION)\n"
 	$(MAKE) "install-dependencies-$(DISTRIBUTION)"
 
-## Arch Linux ##
-
-.PHONY: install-dependencies-arch
-install-dependencies-arch:
-	pacman -S sdl2 sdl2_mixer sdl2_image sdl2_ttf glew physfs
-
-
 ## Ubuntu ##
-
 .PHONY: install-dependencies-ubuntu
 install-dependencies-ubuntu:
 	apt install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev libphysfs-dev
 
-
 ## CentOS ##
-
+.PHONY: install-dependencies-centos
+install-dependencies-centos:
+	# Install development packages (-y answers "yes" to prompts)
+	yum -y install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel physfs-devel
 .PHONY: install-repos-centos
 install-repos-centos:
 	# Default CentOS repositories only contain SDL1
 	# For SDL2 use EPEL repo (EPEL = Extra Packages for Enterprise Linux)
 	yum install epel-release
 
-.PHONY: install-dependencies-centos
-install-dependencies-centos:
-	# Install development packages (-y answers "yes" to prompts)
-	yum -y install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel physfs-devel
+## Arch Linux ##
+.PHONY: install-dependencies-arch
+install-dependencies-arch:
+	pacman -S sdl2 sdl2_mixer sdl2_image sdl2_ttf glew physfs
 
 
 #### Docker related build rules ####

--- a/makefile
+++ b/makefile
@@ -187,19 +187,19 @@ DISTRIBUTION = $(subst Linux,$(LINUX_DISTRIBUTION),$(CURRENT_OS))
 .PHONY: install-dependencies
 install-dependencies:
 	@echo "\nDetected distribution: $(DISTRIBUTION)\n"
-	$(MAKE) "install-deps-$(DISTRIBUTION)"
+	$(MAKE) "install-dependencies-$(DISTRIBUTION)"
 
 ## Arch Linux ##
 
-.PHONY: install-deps-arch
-install-deps-arch:
+.PHONY: install-dependencies-arch
+install-dependencies-arch:
 	pacman -S sdl2 sdl2_mixer sdl2_image sdl2_ttf glew physfs
 
 
 ## Ubuntu ##
 
-.PHONY: install-deps-ubuntu
-install-deps-ubuntu:
+.PHONY: install-dependencies-ubuntu
+install-dependencies-ubuntu:
 	apt install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev libphysfs-dev
 
 
@@ -211,8 +211,8 @@ install-repos-centos:
 	# For SDL2 use EPEL repo (EPEL = Extra Packages for Enterprise Linux)
 	yum install epel-release
 
-.PHONY: install-deps-centos
-install-deps-centos:
+.PHONY: install-dependencies-centos
+install-dependencies-centos:
 	# Install development packages (-y answers "yes" to prompts)
 	yum -y install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel physfs-devel
 

--- a/makefile
+++ b/makefile
@@ -210,7 +210,7 @@ install-dependencies-repository-centos:
 ## Arch Linux ##
 .PHONY: install-dependencies-arch
 install-dependencies-arch:
-	pacman -S sdl2 sdl2_mixer sdl2_image sdl2_ttf glew physfs
+	pacman --sync sdl2 sdl2_mixer sdl2_image sdl2_ttf glew physfs
 
 
 #### Docker related build rules ####

--- a/makefile
+++ b/makefile
@@ -196,7 +196,7 @@ install-dependencies-ubuntu:
 
 ## CentOS ##
 .PHONY: install-dependencies-centos
-install-dependencies-centos:
+install-dependencies-centos: | install-repos-centos
 	# Install development packages (-y answers "yes" to prompts)
 	yum -y install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel physfs-devel
 .PHONY: install-repos-centos

--- a/makefile
+++ b/makefile
@@ -198,11 +198,11 @@ install-dependencies-ubuntu:
 
 ## CentOS ##
 .PHONY: install-dependencies-centos
-install-dependencies-centos: | install-repos-centos
+install-dependencies-centos: | install-dependencies-repository-centos
 	# Install development packages (-y answers "yes" to prompts)
 	yum --assumeyes install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel physfs-devel
-.PHONY: install-repos-centos
-install-repos-centos:
+.PHONY: install-dependencies-repository-centos
+install-dependencies-repository-centos:
 	# Default CentOS repositories only contain SDL1
 	# For SDL2 use EPEL repo (EPEL = Extra Packages for Enterprise Linux)
 	yum --assumeyes install epel-release

--- a/makefile
+++ b/makefile
@@ -179,7 +179,7 @@ cppclean:
 # should be similar.
 
 RELEASE_FILES = $(wildcard /etc/*-release)
-RELEASE_FILE_TAGS = $(patsubst /etc/%-release,%,$(RELEASE_FILES))
+RELEASE_FILE_TAGS = $(filter-out os lsb,$(patsubst /etc/%-release,%,$(RELEASE_FILES)))
 RELEASE_SETTING_NAME = $(shell '$(SHELL)' -c '. /etc/os-release && echo $${ID}')
 LINUX_DISTRIBUTION = $(or $(RELEASE_SETTING_NAME),$(RELEASE_FILE_TAGS),Unknown)
 DISTRIBUTION = $(subst Linux,$(LINUX_DISTRIBUTION),$(CURRENT_OS))

--- a/makefile
+++ b/makefile
@@ -210,7 +210,7 @@ install-dependencies-repository-centos:
 ## Arch Linux ##
 .PHONY: install-dependencies-arch
 install-dependencies-arch:
-	pacman --sync sdl2 sdl2_mixer sdl2_image sdl2_ttf glew physfs
+	pacman --sync --refresh sdl2 sdl2_mixer sdl2_image sdl2_ttf glew physfs
 
 
 #### Docker related build rules ####

--- a/makefile
+++ b/makefile
@@ -178,6 +178,16 @@ cppclean:
 # Only a few common Linux distributions are covered. Other distributions
 # should be similar.
 
+RELEASE_FILES = $(wildcard /etc/*-release)
+RELEASE_FILE_TAGS = $(patsubst /etc/%-release,%,$(RELEASE_FILES))
+RELEASE_SETTING_NAME = $(shell '$(SHELL)' -c '. $(RELEASE_FILES) && echo $${ID}')
+LINUX_DISTRIBUTION = $(or $(RELEASE_SETTING_NAME),$(RELEASE_FILE_TAGS),Unknown)
+DISTRIBUTION = $(subst Linux,$(LINUX_DISTRIBUTION),$(CURRENT_OS))
+
+.PHONY: install-dependencies
+install-dependencies:
+	@echo "\nDetected distribution: $(DISTRIBUTION)\n"
+	$(MAKE) "install-deps-$(DISTRIBUTION)"
 
 ## Arch Linux ##
 


### PR DESCRIPTION
Reference: #679

Add top level `install-dependencies` target to the `makefile`, which will auto detect the distribution and run an appropriate distribution specific install rule.

----

Does not address MacOS specific dependency install rules.

----

Side note: Some of the distribution specific install steps could perhaps use a bit of maintenance. In particular, the CentOS rules are for CentOS 7, and don't work well for CentOS 8. Keeping the setup rules up to date might be aided by Docker images for building and testing.
