### PR TITLE
Add Darwin dependency install rule

### DIFF
--- a/makefile
+++ b/makefile
@@ -212,6 +212,11 @@ install-dependencies-repository-centos:
 install-dependencies-arch:
 	pacman --sync --refresh sdl2 sdl2_mixer sdl2_image sdl2_ttf glew physfs
 
+## MacOS ##
+.PHONY: install-dependencies-darwin
+install-dependencies-darwin:
+	brew install physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew
+
 
 #### Docker related build rules ####
 


### PR DESCRIPTION
Closes #679

Should allow dependencies to be installed on MacOS by running:
```
make install-dependencies
```

Admittedly testing of this new rule is a bit light. The CircleCI MacOS build runs these same steps manually, before the code is checked out. Since this is done before code checkout, it's not possible to use the rules from the `makefile` stored with the code.
