### PR TITLE
Remove unneeded use of `startPoint()`

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -660,7 +660,7 @@ void RendererOpenGL::onResize(int w, int h)
 
 void RendererOpenGL::setViewport(const Rectangle<int>& viewport)
 {
-	glViewport(viewport.startPoint().x(), viewport.startPoint().y(), viewport.width(), viewport.height());
+	glViewport(viewport.x(), viewport.y(), viewport.width(), viewport.height());
 }
 
 


### PR DESCRIPTION
Remove unneeded use of `startPoint()` on `Rectangle` instance.
