### PR TITLE
Fix overflow warning in Font code

### DIFF
--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -359,7 +359,7 @@ namespace {
 		{
 			for (int col = 0; col < GLYPH_MATRIX_SIZE; col++)
 			{
-				std::size_t glyph = static_cast<std::size_t>((row * GLYPH_MATRIX_SIZE) + col);
+				std::size_t glyph = static_cast<std::size_t>(row) * GLYPH_MATRIX_SIZE + col;
 
 				// HACK HACK HACK!
 				// Apparently glyph zero has no size with some fonts and so SDL_TTF complains about it.
@@ -413,7 +413,7 @@ namespace {
 		{
 			for (int col = 0; col < GLYPH_MATRIX_SIZE; col++)
 			{
-				const std::size_t glyph = static_cast<std::size_t>((row * GLYPH_MATRIX_SIZE) + col);
+				const std::size_t glyph = static_cast<std::size_t>(row) * GLYPH_MATRIX_SIZE + col;
 
 				glyphMetricsList[glyph].uvX = static_cast<float>(col * characterSize.x) / static_cast<float>(textureSize.x);
 				glyphMetricsList[glyph].uvY = static_cast<float>(row * characterSize.y) / static_cast<float>(textureSize.y);


### PR DESCRIPTION
Compiling on Windows with Visual Studio was generating the following warnings:
```
C:\projects\nas2d-core\NAS2D\Resources\Font.cpp(362): warning C26451: Arithmetic overflow: Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2). [C:\projects\nas2d-core\NAS2D\NAS2D.vcxproj]
C:\projects\nas2d-core\NAS2D\Resources\Font.cpp(362): warning C26451: Arithmetic overflow: Using operator '*' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '*' to avoid overflow (io.2). [C:\projects\nas2d-core\NAS2D\NAS2D.vcxproj]
C:\projects\nas2d-core\NAS2D\Resources\Font.cpp(416): warning C26451: Arithmetic overflow: Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2). [C:\projects\nas2d-core\NAS2D\NAS2D.vcxproj]
C:\projects\nas2d-core\NAS2D\Resources\Font.cpp(416): warning C26451: Arithmetic overflow: Using operator '*' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '*' to avoid overflow (io.2). [C:\projects\nas2d-core\NAS2D\NAS2D.vcxproj]
```

Re-ordering so the cast happens earlier fixes the warnings.
