### PR TITLE
Add Rectangle size and startPoint setters

### DIFF
--- a/NAS2D/Renderer/Rectangle.h
+++ b/NAS2D/Renderer/Rectangle.h
@@ -82,6 +82,16 @@ struct Rectangle
 		return (mW == 0) || (mH == 0);
 	}
 
+	void size(NAS2D::Vector<BaseType> newSize) {
+		mW = newSize.x;
+		mH = newSize.y;
+	}
+
+	void startPoint(NAS2D::Point<BaseType> newStartPoint) {
+		mX = newStartPoint.x();
+		mY = newStartPoint.y();
+	}
+
 	template <typename NewBaseType>
 	operator Rectangle<NewBaseType>() const {
 		return {

--- a/test/Renderer/Rectangle.test.cpp
+++ b/test/Renderer/Rectangle.test.cpp
@@ -42,6 +42,18 @@ TEST(Rectangle, crossYPoint) {
 	EXPECT_EQ((NAS2D::Point<int>{1, 6}), (NAS2D::Rectangle{1, 2, 3, 4}.crossYPoint()));
 }
 
+TEST(Rectangle, sizeSet) {
+	NAS2D::Rectangle rect{1, 2, 3, 4};
+	EXPECT_NO_THROW(rect.size({5, 6}));
+	EXPECT_EQ((NAS2D::Rectangle{1, 2, 5, 6}), rect);
+}
+
+TEST(Rectangle, startPointSet) {
+	NAS2D::Rectangle rect{1, 2, 3, 4};
+	EXPECT_NO_THROW(rect.startPoint({5, 6}));
+	EXPECT_EQ((NAS2D::Rectangle{5, 6, 3, 4}), rect);
+}
+
 TEST(Rectangle, operatorType) {
 	EXPECT_EQ((NAS2D::Rectangle<int>{0, 0, 1, 1}), static_cast<NAS2D::Rectangle<int>>(NAS2D::Rectangle<float>{0.0, 0.0, 1.0, 1.0}));
 	EXPECT_EQ((NAS2D::Rectangle<int>{1, 2, 3, 4}), static_cast<NAS2D::Rectangle<int>>(NAS2D::Rectangle<float>{1.0, 2.0, 3.0, 4.0}));


### PR DESCRIPTION
Add setter methods for:
- `Rectangle::size`
- `Rectangle::startPoint`

----

This also raises the question on how `Rectangle` should be structured internally. Currently it consists of effectively 4 fields for:
- `x`
- `y`
- `width`
- `height`

Potentially this could be updated to packed internal structure:
- `Point startPoint`
- `Vector size`

That would remove the need for get/set methods if those fields were to become public.

Reference: #302
