### PR TITLE
Use Point deduction guide in unit tests

### DIFF
--- a/test/Renderer/Point.test.cpp
+++ b/test/Renderer/Point.test.cpp
@@ -3,39 +3,39 @@
 
 
 TEST(Point, DefaultConstructibleZeroInit) {
-	EXPECT_EQ((NAS2D::Point<int>{0, 0}), NAS2D::Point<int>{});
+	EXPECT_EQ((NAS2D::Point{0, 0}), NAS2D::Point<int>{});
 }
 
 TEST(Point, OperatorEqualNotEqual) {
-	EXPECT_EQ((NAS2D::Point<int>{1, 1}), (NAS2D::Point<int>{1, 1}));
-	EXPECT_EQ((NAS2D::Point<int>{2, 2}), (NAS2D::Point<int>{2, 2}));
+	EXPECT_EQ((NAS2D::Point{1, 1}), (NAS2D::Point{1, 1}));
+	EXPECT_EQ((NAS2D::Point{2, 2}), (NAS2D::Point{2, 2}));
 
-	EXPECT_NE((NAS2D::Point<int>{1, 1}), (NAS2D::Point<int>{1, 2}));
-	EXPECT_NE((NAS2D::Point<int>{1, 1}), (NAS2D::Point<int>{2, 1}));
+	EXPECT_NE((NAS2D::Point{1, 1}), (NAS2D::Point{1, 2}));
+	EXPECT_NE((NAS2D::Point{1, 1}), (NAS2D::Point{2, 1}));
 }
 
 TEST(Point, SelfAddVector) {
-	NAS2D::Point<int> point{1, 1};
+	NAS2D::Point point{1, 1};
 	EXPECT_EQ(&point, &(point += NAS2D::Vector{1, 2}));
-	EXPECT_EQ((NAS2D::Point<int>{2, 3}), point);
+	EXPECT_EQ((NAS2D::Point{2, 3}), point);
 }
 
 TEST(Point, SelfSubtractVector) {
-	NAS2D::Point<int> point{2, 5};
+	NAS2D::Point point{2, 5};
 	EXPECT_EQ(&point, &(point -= NAS2D::Vector{1, 3}));
-	EXPECT_EQ((NAS2D::Point<int>{1, 2}), point);
+	EXPECT_EQ((NAS2D::Point{1, 2}), point);
 }
 
 TEST(Vector, AddVector) {
-	EXPECT_EQ((NAS2D::Point<int>{2, 3}), (NAS2D::Point<int>{1, 1}) + (NAS2D::Vector{1, 2}));
+	EXPECT_EQ((NAS2D::Point{2, 3}), (NAS2D::Point<int>{1, 1}) + (NAS2D::Vector{1, 2}));
 }
 
 TEST(Vector, SubtractVector) {
-	EXPECT_EQ((NAS2D::Point<int>{1, 2}), (NAS2D::Point<int>{2, 5}) - (NAS2D::Vector{1, 3}));
+	EXPECT_EQ((NAS2D::Point{1, 2}), (NAS2D::Point<int>{2, 5}) - (NAS2D::Vector{1, 3}));
 }
 
 TEST(Vector, SubtractPointToVector) {
-	EXPECT_EQ((NAS2D::Vector{1, 1}), (NAS2D::Point<int>{2, 3}) - (NAS2D::Point<int>{1, 2}));
+	EXPECT_EQ((NAS2D::Vector{1, 1}), (NAS2D::Point<int>{2, 3}) - (NAS2D::Point{1, 2}));
 }
 
 TEST(Point, OperatorType) {

--- a/test/Renderer/Rectangle.test.cpp
+++ b/test/Renderer/Rectangle.test.cpp
@@ -3,13 +3,13 @@
 
 
 TEST(Rectangle, CreatePointVector) {
-	EXPECT_EQ((NAS2D::Rectangle{0, 0, 1, 1}), NAS2D::Rectangle<int>::Create(NAS2D::Point<int>{0, 0}, NAS2D::Vector{1, 1}));
-	EXPECT_EQ((NAS2D::Rectangle{1, 1, 2, 3}), NAS2D::Rectangle<int>::Create(NAS2D::Point<int>{1, 1}, NAS2D::Vector{2, 3}));
+	EXPECT_EQ((NAS2D::Rectangle{0, 0, 1, 1}), NAS2D::Rectangle<int>::Create(NAS2D::Point{0, 0}, NAS2D::Vector{1, 1}));
+	EXPECT_EQ((NAS2D::Rectangle{1, 1, 2, 3}), NAS2D::Rectangle<int>::Create(NAS2D::Point{1, 1}, NAS2D::Vector{2, 3}));
 }
 
 TEST(Rectangle, CreatePointPoint) {
-	EXPECT_EQ((NAS2D::Rectangle{0, 0, 1, 1}), NAS2D::Rectangle<int>::Create(NAS2D::Point<int>{0, 0}, NAS2D::Point<int>{1, 1}));
-	EXPECT_EQ((NAS2D::Rectangle{1, 1, 1, 2}), NAS2D::Rectangle<int>::Create(NAS2D::Point<int>{1, 1}, NAS2D::Point<int>{2, 3}));
+	EXPECT_EQ((NAS2D::Rectangle{0, 0, 1, 1}), NAS2D::Rectangle<int>::Create(NAS2D::Point{0, 0}, NAS2D::Point{1, 1}));
+	EXPECT_EQ((NAS2D::Rectangle{1, 1, 1, 2}), NAS2D::Rectangle<int>::Create(NAS2D::Point{1, 1}, NAS2D::Point{2, 3}));
 }
 
 TEST(Rectangle, size) {
@@ -19,27 +19,27 @@ TEST(Rectangle, size) {
 }
 
 TEST(Rectangle, startPoint) {
-	EXPECT_EQ((NAS2D::Point<int>{0, 0}), (NAS2D::Rectangle{0, 0, 0, 0}.startPoint()));
-	EXPECT_EQ((NAS2D::Point<int>{0, 0}), (NAS2D::Rectangle{0, 0, 1, 1}.startPoint()));
-	EXPECT_EQ((NAS2D::Point<int>{1, 2}), (NAS2D::Rectangle{1, 2, 3, 4}.startPoint()));
+	EXPECT_EQ((NAS2D::Point{0, 0}), (NAS2D::Rectangle{0, 0, 0, 0}.startPoint()));
+	EXPECT_EQ((NAS2D::Point{0, 0}), (NAS2D::Rectangle{0, 0, 1, 1}.startPoint()));
+	EXPECT_EQ((NAS2D::Point{1, 2}), (NAS2D::Rectangle{1, 2, 3, 4}.startPoint()));
 }
 
 TEST(Rectangle, endPoint) {
-	EXPECT_EQ((NAS2D::Point<int>{0, 0}), (NAS2D::Rectangle{0, 0, 0, 0}.endPoint()));
-	EXPECT_EQ((NAS2D::Point<int>{1, 1}), (NAS2D::Rectangle{0, 0, 1, 1}.endPoint()));
-	EXPECT_EQ((NAS2D::Point<int>{4, 6}), (NAS2D::Rectangle{1, 2, 3, 4}.endPoint()));
+	EXPECT_EQ((NAS2D::Point{0, 0}), (NAS2D::Rectangle{0, 0, 0, 0}.endPoint()));
+	EXPECT_EQ((NAS2D::Point{1, 1}), (NAS2D::Rectangle{0, 0, 1, 1}.endPoint()));
+	EXPECT_EQ((NAS2D::Point{4, 6}), (NAS2D::Rectangle{1, 2, 3, 4}.endPoint()));
 }
 
 TEST(Rectangle, crossXPoint) {
-	EXPECT_EQ((NAS2D::Point<int>{0, 0}), (NAS2D::Rectangle{0, 0, 0, 0}.crossXPoint()));
-	EXPECT_EQ((NAS2D::Point<int>{1, 0}), (NAS2D::Rectangle{0, 0, 1, 1}.crossXPoint()));
-	EXPECT_EQ((NAS2D::Point<int>{4, 2}), (NAS2D::Rectangle{1, 2, 3, 4}.crossXPoint()));
+	EXPECT_EQ((NAS2D::Point{0, 0}), (NAS2D::Rectangle{0, 0, 0, 0}.crossXPoint()));
+	EXPECT_EQ((NAS2D::Point{1, 0}), (NAS2D::Rectangle{0, 0, 1, 1}.crossXPoint()));
+	EXPECT_EQ((NAS2D::Point{4, 2}), (NAS2D::Rectangle{1, 2, 3, 4}.crossXPoint()));
 }
 
 TEST(Rectangle, crossYPoint) {
-	EXPECT_EQ((NAS2D::Point<int>{0, 0}), (NAS2D::Rectangle{0, 0, 0, 0}.crossYPoint()));
-	EXPECT_EQ((NAS2D::Point<int>{0, 1}), (NAS2D::Rectangle{0, 0, 1, 1}.crossYPoint()));
-	EXPECT_EQ((NAS2D::Point<int>{1, 6}), (NAS2D::Rectangle{1, 2, 3, 4}.crossYPoint()));
+	EXPECT_EQ((NAS2D::Point{0, 0}), (NAS2D::Rectangle{0, 0, 0, 0}.crossYPoint()));
+	EXPECT_EQ((NAS2D::Point{0, 1}), (NAS2D::Rectangle{0, 0, 1, 1}.crossYPoint()));
+	EXPECT_EQ((NAS2D::Point{1, 6}), (NAS2D::Rectangle{1, 2, 3, 4}.crossYPoint()));
 }
 
 TEST(Rectangle, sizeSet) {


### PR DESCRIPTION
Remove explicit `BaseType` for `Point` in unit tests, where the compiler can deduce the type from the constructor parameters.

Maintain explicit types for the type conversion tests.

There was one oddity with the addition and subtraction expression tests, where GCC produced an error when not given an explicit type. Other compilers handled the omission there fine. For the sake of compatibility the explicit type was maintained for those expressions.
