### PR TITLE
Make Point fields public

### DIFF
--- a/NAS2D/Renderer/Point.h
+++ b/NAS2D/Renderer/Point.h
@@ -18,51 +18,45 @@ namespace NAS2D {
 
 template <typename BaseType>
 struct Point {
-	Point() = default;
-	Point(const Point& point) = default;
-	Point& operator=(const Point& other) = default;
-
-	Point(BaseType x, BaseType y) :
-		mX(x),
-		mY(y)
-	{}
+	BaseType x = 0;
+	BaseType y = 0;
 
 	bool operator==(const Point& point) const {
-		return (mX == point.mX) && (mY == point.mY);
+		return (x == point.x) && (y == point.y);
 	}
 	bool operator!=(const Point& point) const {
 		return !(*this == point);
 	}
 
 	Point& operator+=(const Vector<BaseType>& vector) {
-		mX += vector.x;
-		mY += vector.y;
+		x += vector.x;
+		y += vector.y;
 		return *this;
 	}
 
 	Point& operator-=(const Vector<BaseType>& vector) {
-		mX -= vector.x;
-		mY -= vector.y;
+		x -= vector.x;
+		y -= vector.y;
 		return *this;
 	}
 
 	Point operator+(const Vector<BaseType>& vector) const {
-		return {mX + vector.x, mY + vector.y};
+		return {x + vector.x, y + vector.y};
 	}
 
 	Point operator-(const Vector<BaseType>& vector) const {
-		return {mX - vector.x, mY - vector.y};
+		return {x - vector.x, y - vector.y};
 	}
 
 	Vector<BaseType> operator-(const Point& point) const {
-		return {mX - point.mX, mY - point.mY};
+		return {x - point.x, y - point.y};
 	}
 
 	template <typename NewBaseType>
 	operator Point<NewBaseType>() const {
 		return {
-			static_cast<NewBaseType>(mX),
-			static_cast<NewBaseType>(mY)
+			static_cast<NewBaseType>(x),
+			static_cast<NewBaseType>(y)
 		};
 	}
 
@@ -70,30 +64,6 @@ struct Point {
 	Point<NewBaseType> to() const {
 		return static_cast<Point<NewBaseType>>(*this);
 	}
-
-	void x(BaseType x) {
-		mX = x;
-	}
-	BaseType x() const {
-		return mX;
-	}
-	BaseType& x() {
-		return mX;
-	}
-
-	void y(BaseType y) {
-		mY = y;
-	}
-	BaseType y() const {
-		return mY;
-	}
-	BaseType& y() {
-		return mY;
-	}
-
-private:
-	BaseType mX = 0;
-	BaseType mY = 0;
 };
 
 

--- a/NAS2D/Renderer/Rectangle.h
+++ b/NAS2D/Renderer/Rectangle.h
@@ -34,8 +34,8 @@ struct Rectangle
 	// Factory method
 	static Rectangle<BaseType> Create(Point<BaseType> startPoint, Vector<BaseType> size) {
 		return {
-			startPoint.x(),
-			startPoint.y(),
+			startPoint.x,
+			startPoint.y,
 			size.x,
 			size.y
 		};
@@ -44,10 +44,10 @@ struct Rectangle
 	// Factory method
 	static Rectangle<BaseType> Create(Point<BaseType> startPoint, Point<BaseType> endPoint) {
 		return {
-			startPoint.x(),
-			startPoint.y(),
-			endPoint.x() - startPoint.x(),
-			endPoint.y() - startPoint.y()
+			startPoint.x,
+			startPoint.y,
+			endPoint.x - startPoint.x,
+			endPoint.y - startPoint.y
 		};
 	}
 
@@ -88,8 +88,8 @@ struct Rectangle
 	}
 
 	void startPoint(NAS2D::Point<BaseType> newStartPoint) {
-		mX = newStartPoint.x();
-		mY = newStartPoint.y();
+		mX = newStartPoint.x;
+		mY = newStartPoint.y;
 	}
 
 	template <typename NewBaseType>
@@ -110,8 +110,8 @@ struct Rectangle
 	// Start point inclusive (x, y), endpoint exclusive (x + width, y + height)
 	// Area in interval notation: [x .. x + width), [y .. y + height)
 	bool contains(const Point<BaseType>& point) const {
-		auto px = point.x();
-		auto py = point.y();
+		auto px = point.x;
+		auto py = point.y;
 		return ((mX <= px) && (px < mX + mW)) && ((mY <= py) && (py < mY + mH));
 	}
 

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -64,7 +64,7 @@ void Renderer::title(const std::string& title)
 
 void Renderer::drawImage(Image& image, Point<float> position, float scale, Color color)
 {
-	drawImage(image, position.x(), position.y(), scale, color.red, color.green, color.blue, color.alpha);
+	drawImage(image, position.x, position.y, scale, color.red, color.green, color.blue, color.alpha);
 }
 
 
@@ -90,7 +90,7 @@ void Renderer::drawSubImage(Image& image, Point<float> raster, Rectangle<float> 
 
 void Renderer::drawSubImage(Image& image, Point<float> raster, Point<float> position, Vector<float> size, const Color& color)
 {
-	drawSubImage(image, raster.x(), raster.y(), position.x(), position.y(), size.x, size.y, color);
+	drawSubImage(image, raster.x, raster.y, position.x, position.y, size.x, size.y, color);
 }
 
 
@@ -119,7 +119,7 @@ void Renderer::drawSubImageRotated(Image& image, Point<float> raster, Rectangle<
 
 void Renderer::drawSubImageRotated(Image& image, Point<float> raster, Point<float> position, Vector<float> size, float degrees, const Color& color)
 {
-	drawSubImageRotated(image, raster.x(), raster.y(), position.x(), position.y(), size.x, size.y, degrees, color);
+	drawSubImageRotated(image, raster.x, raster.y, position.x, position.y, size.x, size.y, degrees, color);
 }
 
 
@@ -144,7 +144,7 @@ void Renderer::drawSubImageRotated(Image& image, float rasterX, float rasterY, f
 
 void Renderer::drawImageRotated(Image& image, Point<float> position, float degrees, const Color& color, float scale)
 {
-	drawImageRotated(image, position.x(), position.y(), degrees, color, scale);
+	drawImageRotated(image, position.x, position.y, degrees, color, scale);
 }
 
 
@@ -172,7 +172,7 @@ void Renderer::drawImageStretched(Image& image, Rectangle<float> rect, Color col
 
 void Renderer::drawImageStretched(Image& image, Point<float> position, Vector<float> size, Color color)
 {
-	drawImageStretched(image, position.x(), position.y(), size.x, size.y, color);
+	drawImageStretched(image, position.x, position.y, size.x, size.y, color);
 }
 
 
@@ -200,7 +200,7 @@ void Renderer::drawImageRepeated(Image& image, Rectangle<float> rect)
 
 void Renderer::drawImageRepeated(Image& image, Point<float> position, Vector<float> size)
 {
-	drawImageRepeated(image, position.x(), position.y(), size.x, size.y);
+	drawImageRepeated(image, position.x, position.y, size.x, size.y);
 }
 
 
@@ -221,7 +221,7 @@ void Renderer::drawImageRect(Rectangle<float> rect, ImageList& images)
 
 void Renderer::drawImageRect(Point<float> position, Vector<float> size, ImageList& images)
 {
-	drawImageRect(position.x(), position.y(), size.x, size.y, images);
+	drawImageRect(position.x, position.y, size.x, size.y, images);
 }
 
 
@@ -261,7 +261,7 @@ void Renderer::drawImageRect(float x, float y, float w, float h, ImageList &imag
 
 void Renderer::drawImageRect(Point<float> position, Vector<float> size, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight)
 {
-	drawImageRect(position.x(), position.y(), size.x, size.y, topLeft, top, topRight, left, center, right, bottomLeft, bottom, bottomRight);
+	drawImageRect(position.x, position.y, size.x, size.y, topLeft, top, topRight, left, center, right, bottomLeft, bottom, bottomRight);
 }
 
 /**
@@ -288,7 +288,7 @@ void Renderer::drawImageRect(float x, float y, float w, float h, Image& topLeft,
 
 void Renderer::drawPoint(Point<float> position, const Color& color)
 {
-	drawPoint(position.x(), position.y(), color);
+	drawPoint(position.x, position.y, color);
 }
 
 
@@ -307,7 +307,7 @@ void Renderer::drawPoint(float x, float y, const Color& color)
 
 void Renderer::drawLine(Point<float> startPosition, Point<float> endPosition, const Color& color, int line_width)
 {
-	drawLine(startPosition.x(), startPosition.y(), endPosition.x(), endPosition.y(), color, line_width);
+	drawLine(startPosition.x, startPosition.y, endPosition.x, endPosition.y, color, line_width);
 }
 
 
@@ -371,7 +371,7 @@ void Renderer::drawBoxFilled(const Rectangle<float>& rect, uint8_t r, uint8_t g,
 
 void Renderer::drawCircle(Point<float> position, float radius, Color color, int num_segments, Vector<float> scale)
 {
-	drawCircle(position.x(), position.y(), radius, color.red, color.green, color.blue, color.alpha, num_segments, scale.x, scale.y);
+	drawCircle(position.x, position.y, radius, color.red, color.green, color.blue, color.alpha, num_segments, scale.x, scale.y);
 }
 
 
@@ -383,7 +383,7 @@ void Renderer::drawGradient(Rectangle<float> rect, const Color& c1, const Color&
 
 void Renderer::drawGradient(Point<float> position, Vector<float> size, const Color& c1, const Color& c2, const Color& c3, const Color& c4)
 {
-	drawGradient(position.x(), position.y(), size.x, size.y, c1, c2, c3, c4);
+	drawGradient(position.x, position.y, size.x, size.y, c1, c2, c3, c4);
 }
 
 
@@ -415,15 +415,15 @@ void Renderer::drawGradient(float x, float y, float w, float h, const Color& c1,
 
 void Renderer::drawText(const Font& font, std::string_view text, Point<float> position, Color color)
 {
-	drawText(font, text, position.x(), position.y(), color.red, color.green, color.blue, color.alpha);
+	drawText(font, text, position.x, position.y, color.red, color.green, color.blue, color.alpha);
 }
 
 
 void Renderer::drawTextShadow(const Font& font, std::string_view text, Point<float> position, Vector<float> shadowOffset, Color textColor, Color shadowColor)
 {
 	const auto shadowPosition = position + shadowOffset;
-	drawText(font, text, shadowPosition.x(), shadowPosition.y(), shadowColor.red, shadowColor.green, shadowColor.blue, shadowColor.alpha);
-	drawText(font, text, position.x(), position.y(), textColor.red, textColor.green, textColor.blue, textColor.alpha);
+	drawText(font, text, shadowPosition.x, shadowPosition.y, shadowColor.red, shadowColor.green, shadowColor.blue, shadowColor.alpha);
+	drawText(font, text, position.x, position.y, textColor.red, textColor.green, textColor.blue, textColor.alpha);
 }
 
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -310,7 +310,7 @@ void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const P
 	glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, imageIdMap[destination.name()].texture_id, 0);
 	// Flip the Y axis to keep images drawing correctly.
-	fillVertexArray(dstPoint.x(), static_cast<float>(destination.height()) - dstPoint.y(), static_cast<float>(clipSize.x), static_cast<float>(-clipSize.y));
+	fillVertexArray(dstPoint.x, static_cast<float>(destination.height()) - dstPoint.y, static_cast<float>(clipSize.x), static_cast<float>(-clipSize.y));
 
 	drawVertexArray(imageIdMap[source.name()].texture_id);
 	glBindTexture(GL_TEXTURE_2D, imageIdMap[destination.name()].texture_id);
@@ -572,7 +572,7 @@ float RendererOpenGL::width() const
 {
 	if ((SDL_GetWindowFlags(underlyingWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP)
 	{
-		return desktopResolution.x();
+		return desktopResolution.x;
 	}
 
 	return mResolution.x;
@@ -583,7 +583,7 @@ float RendererOpenGL::height() const
 {
 	if ((SDL_GetWindowFlags(underlyingWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP)
 	{
-		return desktopResolution.y();
+		return desktopResolution.y;
 	}
 
 	return mResolution.y;
@@ -669,7 +669,7 @@ void RendererOpenGL::setOrthoProjection(const Rectangle<float>& orthoBounds)
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
 	const auto bounds = orthoBounds.to<double>();
-	glOrtho(bounds.startPoint().x(), bounds.endPoint().x(), bounds.endPoint().y(), bounds.startPoint().y(), -1.0, 1.0);
+	glOrtho(bounds.startPoint().x, bounds.endPoint().x, bounds.endPoint().y, bounds.startPoint().y, -1.0, 1.0);
 	glMatrixMode(GL_MODELVIEW);
 }
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -271,7 +271,7 @@ int Image::center_y() const
  */
 Color Image::pixelColor(Point<int> point) const
 {
-	return pixelColor(point.x(), point.y());
+	return pixelColor(point.x, point.y);
 }
 
 


### PR DESCRIPTION
Reference: #302

Switch `Point` from class like object with private fields to struct like object with public fields.

We seem to be finally close enough with refactoring that this is doable without too much pain when updating OPHD. Though not so far along that I want to handle both `Point` and `Rectangle` in the same step.

