### PR TITLE
Add getAngle

### DIFF
--- a/NAS2D/Trig.cpp
+++ b/NAS2D/Trig.cpp
@@ -36,7 +36,7 @@ float degToRad(float degree)
  */
 float radToDeg(float rad)
 {
-	return rad * -RAD2DEG;
+	return rad * RAD2DEG;
 }
 
 
@@ -45,7 +45,7 @@ float radToDeg(float rad)
  */
 float angleFromPoints(float x, float y, float x2, float y2)
 {
-	return 90.0f - radToDeg(std::atan2(y2 - y, x2 - x));
+	return 90.0f + radToDeg(std::atan2(y2 - y, x2 - x));
 }
 
 
@@ -57,7 +57,7 @@ float angleFromPoints(float x, float y, float x2, float y2)
  */
 float getAngle(Vector<float> direction)
 {
-	return 90.0f - radToDeg(std::atan2(direction.y, direction.x));
+	return 90.0f + radToDeg(std::atan2(direction.y, direction.x));
 }
 
 

--- a/NAS2D/Trig.cpp
+++ b/NAS2D/Trig.cpp
@@ -50,6 +50,18 @@ float angleFromPoints(float x, float y, float x2, float y2)
 
 
 /**
+ * Gets the angle of a direction vector
+ *
+ * An angle of 0 corresponds to "up" in screen coordinates {0, -1},
+ * and increases moving clockwise.
+ */
+float getAngle(Vector<float> direction)
+{
+	return 90.0f - radToDeg(std::atan2(direction.y, direction.x));
+}
+
+
+/**
  * Gets a directional vector from an angle in degrees.
  *
  * Assumes screen coordinates (origin is top left).

--- a/NAS2D/Trig.cpp
+++ b/NAS2D/Trig.cpp
@@ -41,11 +41,11 @@ float radToDeg(float rad)
 
 
 /**
- * Gets the angle of a line in degrees given two points.
+ * Gets the angle of a line in radians given two points.
  */
 float angleFromPoints(float x, float y, float x2, float y2)
 {
-	return radToDeg(std::atan2(y2 - y, x2 - x));
+	return std::atan2(y2 - y, x2 - x);
 }
 
 
@@ -54,16 +54,16 @@ float angleFromPoints(float x, float y, float x2, float y2)
  */
 float getAngle(Vector<float> direction)
 {
-	return radToDeg(std::atan2(direction.y, direction.x));
+	return std::atan2(direction.y, direction.x);
 }
 
 
 /**
- * Gets a directional vector from an angle in degrees.
+ * Gets a directional vector from an angle in radians.
  */
-Vector<float> getDirectionVector(float angle)
+Vector<float> getDirectionVector(float radian)
 {
-	return {std::cos(degToRad(angle)), std::sin(degToRad(angle))};
+	return {std::cos(radian), std::sin(radian)};
 }
 
 }

--- a/NAS2D/Trig.cpp
+++ b/NAS2D/Trig.cpp
@@ -45,31 +45,25 @@ float radToDeg(float rad)
  */
 float angleFromPoints(float x, float y, float x2, float y2)
 {
-	return 90.0f + radToDeg(std::atan2(y2 - y, x2 - x));
+	return radToDeg(std::atan2(y2 - y, x2 - x));
 }
 
 
 /**
  * Gets the angle of a direction vector
- *
- * An angle of 0 corresponds to "up" in screen coordinates {0, -1},
- * and increases moving clockwise.
  */
 float getAngle(Vector<float> direction)
 {
-	return 90.0f + radToDeg(std::atan2(direction.y, direction.x));
+	return radToDeg(std::atan2(direction.y, direction.x));
 }
 
 
 /**
  * Gets a directional vector from an angle in degrees.
- *
- * Assumes screen coordinates (origin is top left).
- * Angle of 0 corresponds to up, and increases clockwise.
  */
 Vector<float> getDirectionVector(float angle)
 {
-	return {std::sin(degToRad(angle)), -std::cos(degToRad(angle))};
+	return {std::cos(degToRad(angle)), std::sin(degToRad(angle))};
 }
 
 }

--- a/NAS2D/Trig.h
+++ b/NAS2D/Trig.h
@@ -23,6 +23,7 @@ extern const float RAD2DEG;
 float degToRad(float degree);
 float radToDeg(float rad);
 float angleFromPoints(float x, float y, float x2, float y2);
+float getAngle(Vector<float> direction);
 Vector<float> getDirectionVector(float angle);
 
 }

--- a/test/Trig.test.cpp
+++ b/test/Trig.test.cpp
@@ -30,3 +30,10 @@ TEST(Trig, getDirectionVector) {
 	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(270.0f));
 	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(-90.0f));
 }
+
+TEST(Trig, vectorToAngleToVector) {
+	EXPECT_EQ((NAS2D::Vector{1, 0}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector{1, 0})));
+	EXPECT_EQ((NAS2D::Vector{0, 1}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector{0, 1})));
+	EXPECT_EQ((NAS2D::Vector{-1, 0}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector{-1, 0})));
+	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector{0, -1})));
+}

--- a/test/Trig.test.cpp
+++ b/test/Trig.test.cpp
@@ -13,12 +13,12 @@ TEST(Trig, degToRadToDeg) {
 }
 
 TEST(Trig, getAngle) {
-	EXPECT_EQ(90.0f, (getAngle(NAS2D::Vector{0, 0})));
+	EXPECT_EQ(0.0f, (getAngle(NAS2D::Vector{0, 0})));
 
-	EXPECT_EQ(0.0f, (getAngle(NAS2D::Vector{0, -1})));
-	EXPECT_EQ(90.0f, (getAngle(NAS2D::Vector{1, 0})));
-	EXPECT_EQ(180.0f, (getAngle(NAS2D::Vector{0, 1})));
-	EXPECT_EQ(270.0f, (getAngle(NAS2D::Vector{-1, 0})));
+	EXPECT_EQ(0.0f, (getAngle(NAS2D::Vector{1, 0})));
+	EXPECT_EQ(90.0f, (getAngle(NAS2D::Vector{0, 1})));
+	EXPECT_EQ(180.0f, (getAngle(NAS2D::Vector{-1, 0})));
+	EXPECT_EQ(-90.0f, (getAngle(NAS2D::Vector{0, -1})));
 
-	EXPECT_EQ(135.0f, (getAngle(NAS2D::Vector{1.0, 1.0})));
+	EXPECT_EQ(45.0f, (getAngle(NAS2D::Vector{1.0, 1.0})));
 }

--- a/test/Trig.test.cpp
+++ b/test/Trig.test.cpp
@@ -13,14 +13,14 @@ TEST(Trig, degToRadToDeg) {
 }
 
 TEST(Trig, getAngle) {
-	EXPECT_EQ(0.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{0, 0})));
+	EXPECT_FLOAT_EQ(0.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{0, 0})));
 
-	EXPECT_EQ(0.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{1, 0})));
-	EXPECT_EQ(90.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{0, 1})));
-	EXPECT_EQ(180.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{-1, 0})));
-	EXPECT_EQ(-90.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{0, -1})));
+	EXPECT_FLOAT_EQ(0.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{1, 0})));
+	EXPECT_FLOAT_EQ(90.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{0, 1})));
+	EXPECT_FLOAT_EQ(180.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{-1, 0})));
+	EXPECT_FLOAT_EQ(-90.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{0, -1})));
 
-	EXPECT_EQ(45.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{1.0, 1.0})));
+	EXPECT_FLOAT_EQ(45.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{1.0, 1.0})));
 }
 
 TEST(Trig, getDirectionVector) {

--- a/test/Trig.test.cpp
+++ b/test/Trig.test.cpp
@@ -22,3 +22,11 @@ TEST(Trig, getAngle) {
 
 	EXPECT_EQ(45.0f, (getAngle(NAS2D::Vector{1.0, 1.0})));
 }
+
+TEST(Trig, getDirectionVector) {
+	EXPECT_EQ((NAS2D::Vector{1, 0}), NAS2D::getDirectionVector(0.0f));
+	EXPECT_EQ((NAS2D::Vector{0, 1}), NAS2D::getDirectionVector(90.0f));
+	EXPECT_EQ((NAS2D::Vector{-1, 0}), NAS2D::getDirectionVector(180.0f));
+	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(270.0f));
+	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(-90.0f));
+}

--- a/test/Trig.test.cpp
+++ b/test/Trig.test.cpp
@@ -4,6 +4,14 @@
 #include <gtest/gtest.h>
 
 
+TEST(Trig, degToRadToDeg) {
+	EXPECT_FLOAT_EQ(0.0f, NAS2D::degToRad(NAS2D::radToDeg(0.0f)));
+	EXPECT_FLOAT_EQ(90.0f, NAS2D::degToRad(NAS2D::radToDeg(90.0f)));
+	EXPECT_FLOAT_EQ(180.0f, NAS2D::degToRad(NAS2D::radToDeg(180.0f)));
+	EXPECT_FLOAT_EQ(270.0f, NAS2D::degToRad(NAS2D::radToDeg(270.0f)));
+	EXPECT_FLOAT_EQ(-90.0f, NAS2D::degToRad(NAS2D::radToDeg(-90.0f)));
+}
+
 TEST(Trig, getAngle) {
 	EXPECT_EQ(90.0f, (getAngle(NAS2D::Vector{0, 0})));
 

--- a/test/Trig.test.cpp
+++ b/test/Trig.test.cpp
@@ -13,22 +13,22 @@ TEST(Trig, degToRadToDeg) {
 }
 
 TEST(Trig, getAngle) {
-	EXPECT_EQ(0.0f, (getAngle(NAS2D::Vector{0, 0})));
+	EXPECT_EQ(0.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{0, 0})));
 
-	EXPECT_EQ(0.0f, (getAngle(NAS2D::Vector{1, 0})));
-	EXPECT_EQ(90.0f, (getAngle(NAS2D::Vector{0, 1})));
-	EXPECT_EQ(180.0f, (getAngle(NAS2D::Vector{-1, 0})));
-	EXPECT_EQ(-90.0f, (getAngle(NAS2D::Vector{0, -1})));
+	EXPECT_EQ(0.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{1, 0})));
+	EXPECT_EQ(90.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{0, 1})));
+	EXPECT_EQ(180.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{-1, 0})));
+	EXPECT_EQ(-90.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{0, -1})));
 
-	EXPECT_EQ(45.0f, (getAngle(NAS2D::Vector{1.0, 1.0})));
+	EXPECT_EQ(45.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{1.0, 1.0})));
 }
 
 TEST(Trig, getDirectionVector) {
-	EXPECT_EQ((NAS2D::Vector{1, 0}), NAS2D::getDirectionVector(0.0f));
-	EXPECT_EQ((NAS2D::Vector{0, 1}), NAS2D::getDirectionVector(90.0f));
-	EXPECT_EQ((NAS2D::Vector{-1, 0}), NAS2D::getDirectionVector(180.0f));
-	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(270.0f));
-	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(-90.0f));
+	EXPECT_EQ((NAS2D::Vector{1, 0}), NAS2D::getDirectionVector(NAS2D::degToRad(0.0f)));
+	EXPECT_EQ((NAS2D::Vector{0, 1}), NAS2D::getDirectionVector(NAS2D::degToRad(90.0f)));
+	EXPECT_EQ((NAS2D::Vector{-1, 0}), NAS2D::getDirectionVector(NAS2D::degToRad(180.0f)));
+	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(NAS2D::degToRad(270.0f)));
+	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(NAS2D::degToRad(-90.0f)));
 }
 
 TEST(Trig, vectorToAngleToVector) {

--- a/test/Trig.test.cpp
+++ b/test/Trig.test.cpp
@@ -1,0 +1,16 @@
+#include "NAS2D/Trig.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+
+TEST(Trig, getAngle) {
+	EXPECT_EQ(90.0f, (getAngle(NAS2D::Vector{0, 0})));
+
+	EXPECT_EQ(0.0f, (getAngle(NAS2D::Vector{0, -1})));
+	EXPECT_EQ(90.0f, (getAngle(NAS2D::Vector{1, 0})));
+	EXPECT_EQ(180.0f, (getAngle(NAS2D::Vector{0, 1})));
+	EXPECT_EQ(270.0f, (getAngle(NAS2D::Vector{-1, 0})));
+
+	EXPECT_EQ(135.0f, (getAngle(NAS2D::Vector{1.0, 1.0})));
+}


### PR DESCRIPTION
Closes #690

Add new Trig method `getAngle`, which converts a `NAS2D::Vector<float>` to a `float` angle in degrees.

----

We may want to consider using radians by default, or tagging methods with either Rad or Deg, possibly providing both alternatives.

We may want to consider what coordinate system should be used, such as a Cartesian coordinate system or a screen coordinate system. In particular, which direction corresponds to angle 0 (up? right?), and which direction does the angle increase (clockwise? counterclockwise?).

We may want to consider renaming the methods to improve consistency and clarity.
