### PR TITLE
Remove unpacked parameter method angleFromPoints

### DIFF
--- a/NAS2D/Trig.cpp
+++ b/NAS2D/Trig.cpp
@@ -41,15 +41,6 @@ float radToDeg(float rad)
 
 
 /**
- * Gets the angle of a line in radians given two points.
- */
-float angleFromPoints(float x, float y, float x2, float y2)
-{
-	return std::atan2(y2 - y, x2 - x);
-}
-
-
-/**
  * Gets the angle of a direction vector
  */
 float getAngle(Vector<float> direction)

--- a/NAS2D/Trig.h
+++ b/NAS2D/Trig.h
@@ -22,7 +22,6 @@ extern const float RAD2DEG;
 
 float degToRad(float degree);
 float radToDeg(float rad);
-float angleFromPoints(float x, float y, float x2, float y2);
 float getAngle(Vector<float> direction);
 Vector<float> getDirectionVector(float angle);
 


### PR DESCRIPTION
Remove unpacked parameter method `angleFromPoints`.

This method is no longer used. Use `getAngle` instead.

Reference: #692, https://github.com/lairworks/nas2d-tests/pull/50