### PR TITLE
Update Package.bat to work with paths containing spaces

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -82,7 +82,7 @@
       <Message>Installing vcpkg dependencies</Message>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>..\Package.bat $(TargetPath) $(Platform) $(Configuration)</Command>
+      <Command>..\Package.bat "$(TargetPath)" "$(Platform)" "$(Configuration)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -108,7 +108,7 @@
       <Message>Installing vcpkg dependencies</Message>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>..\Package.bat $(TargetPath) $(Platform) $(Configuration)</Command>
+      <Command>..\Package.bat "$(TargetPath)" "$(Platform)" "$(Configuration)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -141,7 +141,7 @@
       <Message>Installing vcpkg dependencies</Message>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>..\Package.bat $(TargetPath) $(Platform) $(Configuration)</Command>
+      <Command>..\Package.bat "$(TargetPath)" "$(Platform)" "$(Configuration)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -174,7 +174,7 @@
       <Message>Installing vcpkg dependencies</Message>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>..\Package.bat $(TargetPath) $(Platform) $(Configuration)</Command>
+      <Command>..\Package.bat "$(TargetPath)" "$(Platform)" "$(Configuration)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Package.bat
+++ b/Package.bat
@@ -4,9 +4,9 @@ set "ProjectName=NAS2D"
 set "OutputFolder=Temporary\"
 set "PackageFolder=%OutputFolder%Package\"
 
-set "TargetPath=%1"
-set "Platform=%2"
-set "Configuration=%3"
+set "TargetPath=%~1"
+set "Platform=%~2"
+set "Configuration=%~3"
 
 
 for /f %%i in ('git describe --tags --dirty') do set Version=%%i

--- a/Package.bat
+++ b/Package.bat
@@ -1,18 +1,18 @@
 @echo off
 
-set ProjectName=NAS2D
-set OutputFolder=Temporary\
-set PackageFolder=%OutputFolder%Package\
+set "ProjectName=NAS2D"
+set "OutputFolder=Temporary\"
+set "PackageFolder=%OutputFolder%Package\"
 
-set TargetPath=%1
-set Platform=%2
-set Configuration=%3
+set "TargetPath=%1"
+set "Platform=%2"
+set "Configuration=%3"
 
 
 for /f %%i in ('git describe --tags --dirty') do set Version=%%i
 
-set Config=Windows.%Platform%.%Configuration%
-set PackageName=nas2d-%Version%-%Config%.zip
+set "Config=Windows.%Platform%.%Configuration%"
+set "PackageName=nas2d-%Version%-%Config%.zip"
 
 cd /D "%~dp0"
 xcopy /y /q "%TargetPath%" "%PackageFolder%"


### PR DESCRIPTION
Closes #684

Could someone running Windows please confirm this fixes packaging when the repository is in a folder with a path containing spaces?
