### PR TITLE
Use packed overloads in Renderer::drawImageRect

### DIFF
--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -215,13 +215,18 @@ void Renderer::drawSubImageRepeated(Image& image, float rasterX, float rasterY, 
 
 void Renderer::drawImageRect(Rectangle<float> rect, ImageList& images)
 {
-	drawImageRect(rect.startPoint(), rect.size(), images);
+	if (images.size() != 9)
+	{
+		throw std::runtime_error("Must pass 9 images to drawImageRect, but images.size() == " + std::to_string(images.size()));
+	}
+
+	drawImageRect(rect.x, rect.y, rect.width, rect.height, images[0], images[1], images[2], images[3], images[4], images[5], images[6], images[7], images[8]);
 }
 
 
 void Renderer::drawImageRect(Point<float> position, Vector<float> size, ImageList& images)
 {
-	drawImageRect(position.x, position.y, size.x, size.y, images);
+	drawImageRect({position.x, position.y, size.x, size.y}, images);
 }
 
 
@@ -251,11 +256,7 @@ void Renderer::drawImageRect(Point<float> position, Vector<float> size, ImageLis
  */
 void Renderer::drawImageRect(float x, float y, float w, float h, ImageList &images)
 {
-	// We need 9 images in order to render a rectangle, one for each corner, one for each edge and one for the background.
-	if (images.size() == 9)
-	{
-		drawImageRect(x, y, w, h, images[0], images[1], images[2], images[3], images[4], images[5], images[6], images[7], images[8]);
-	}
+	drawImageRect({x, y, w, h}, images);
 }
 
 

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -270,19 +270,19 @@ void Renderer::drawImageRect(Point<float> position, Vector<float> size, Image& t
 void Renderer::drawImageRect(float x, float y, float w, float h, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight)
 {
 	// Draw the center area if it's defined.
-	drawImageRepeated(center, x + topLeft.width(), y + topLeft.height(), w - topRight.width() - topLeft.width(), h - topLeft.height() - bottomLeft.height());
+	drawImageRepeated(center, {x + topLeft.width(), y + topLeft.height(), w - topRight.width() - topLeft.width(), h - topLeft.height() - bottomLeft.height()});
 
 	// Draw the sides
-	drawImageRepeated(top, x + static_cast<float>(topLeft.width()), y, w - static_cast<float>(topLeft.width()) - static_cast<float>(topRight.width()), static_cast<float>(top.height()));
-	drawImageRepeated(bottom, x + static_cast<float>(bottomLeft.width()), y + h - static_cast<float>(bottom.height()), w - static_cast<float>(bottomLeft.width()) - bottomRight.width(), static_cast<float>(bottom.height()));
-	drawImageRepeated(left, x, y + static_cast<float>(topLeft.height()), static_cast<float>(left.width()), h - static_cast<float>(topLeft.height()) - static_cast<float>(bottomLeft.height()));
-	drawImageRepeated(right, x + w - static_cast<float>(right.width()), y + static_cast<float>(topRight.height()), static_cast<float>(right.width()), h - static_cast<float>(topRight.height()) - static_cast<float>(bottomRight.height()));
+	drawImageRepeated(top, {x + static_cast<float>(topLeft.width()), y, w - static_cast<float>(topLeft.width()) - static_cast<float>(topRight.width()), static_cast<float>(top.height())});
+	drawImageRepeated(bottom, {x + static_cast<float>(bottomLeft.width()), y + h - static_cast<float>(bottom.height()), w - static_cast<float>(bottomLeft.width()) - bottomRight.width(), static_cast<float>(bottom.height())});
+	drawImageRepeated(left, {x, y + static_cast<float>(topLeft.height()), static_cast<float>(left.width()), h - static_cast<float>(topLeft.height()) - static_cast<float>(bottomLeft.height())});
+	drawImageRepeated(right, {x + w - static_cast<float>(right.width()), y + static_cast<float>(topRight.height()), static_cast<float>(right.width()), h - static_cast<float>(topRight.height()) - static_cast<float>(bottomRight.height())});
 
 	// Draw the corners
-	drawImage(topLeft, x, y);
-	drawImage(topRight, x + w - topRight.width(), y);
-	drawImage(bottomLeft, x, y + h - bottomLeft.height());
-	drawImage(bottomRight, x + w - bottomRight.width(), y + h - bottomRight.height());
+	drawImage(topLeft, {x, y});
+	drawImage(topRight, {x + w - topRight.width(), y});
+	drawImage(bottomLeft, {x, y + h - bottomLeft.height()});
+	drawImage(bottomRight, {x + w - bottomRight.width(), y + h - bottomRight.height()});
 }
 
 

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -220,7 +220,7 @@ void Renderer::drawImageRect(Rectangle<float> rect, ImageList& images)
 		throw std::runtime_error("Must pass 9 images to drawImageRect, but images.size() == " + std::to_string(images.size()));
 	}
 
-	drawImageRect(rect.x, rect.y, rect.width, rect.height, images[0], images[1], images[2], images[3], images[4], images[5], images[6], images[7], images[8]);
+	drawImageRect({rect.x, rect.y, rect.width, rect.height}, images[0], images[1], images[2], images[3], images[4], images[5], images[6], images[7], images[8]);
 }
 
 
@@ -286,7 +286,7 @@ void Renderer::drawImageRect(Rectangle<float> rect, Image& topLeft, Image& top, 
 
 void Renderer::drawImageRect(Point<float> position, Vector<float> size, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight)
 {
-	drawImageRect(position.x, position.y, size.x, size.y, topLeft, top, topRight, left, center, right, bottomLeft, bottom, bottomRight);
+	drawImageRect({position.x, position.y, size.x, size.y}, topLeft, top, topRight, left, center, right, bottomLeft, bottom, bottomRight);
 }
 
 /**

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -260,6 +260,30 @@ void Renderer::drawImageRect(float x, float y, float w, float h, ImageList &imag
 }
 
 
+void Renderer::drawImageRect(Rectangle<float> rect, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight)
+{
+	const auto p1 = rect.startPoint() + topLeft.size();
+	const auto p2 = rect.crossXPoint() + topRight.size().reflectX();
+	const auto p3 = rect.crossYPoint() + bottomLeft.size().reflectY();
+	const auto p4 = rect.endPoint() - bottomRight.size();
+
+	// Draw the center area if it's defined.
+	drawImageRepeated(center, Rectangle<float>::Create(p1, p4));
+
+	// Draw the sides
+	drawImageRepeated(top, Rectangle<float>::Create({p1.x, rect.y}, p2));
+	drawImageRepeated(bottom, Rectangle<float>::Create(p3, Point{p4.x, rect.endPoint().y}));
+	drawImageRepeated(left, Rectangle<float>::Create({rect.x, p1.y}, p3));
+	drawImageRepeated(right, Rectangle<float>::Create(p2, Point{rect.endPoint().x, p4.y}));
+
+	// Draw the corners
+	drawImage(topLeft, rect.startPoint());
+	drawImage(topRight, {p2.x, rect.y});
+	drawImage(bottomLeft, {rect.x, p3.y});
+	drawImage(bottomRight, p4);
+}
+
+
 void Renderer::drawImageRect(Point<float> position, Vector<float> size, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight)
 {
 	drawImageRect(position.x, position.y, size.x, size.y, topLeft, top, topRight, left, center, right, bottomLeft, bottom, bottomRight);
@@ -270,20 +294,7 @@ void Renderer::drawImageRect(Point<float> position, Vector<float> size, Image& t
  */
 void Renderer::drawImageRect(float x, float y, float w, float h, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight)
 {
-	// Draw the center area if it's defined.
-	drawImageRepeated(center, {x + topLeft.width(), y + topLeft.height(), w - topRight.width() - topLeft.width(), h - topLeft.height() - bottomLeft.height()});
-
-	// Draw the sides
-	drawImageRepeated(top, {x + static_cast<float>(topLeft.width()), y, w - static_cast<float>(topLeft.width()) - static_cast<float>(topRight.width()), static_cast<float>(top.height())});
-	drawImageRepeated(bottom, {x + static_cast<float>(bottomLeft.width()), y + h - static_cast<float>(bottom.height()), w - static_cast<float>(bottomLeft.width()) - bottomRight.width(), static_cast<float>(bottom.height())});
-	drawImageRepeated(left, {x, y + static_cast<float>(topLeft.height()), static_cast<float>(left.width()), h - static_cast<float>(topLeft.height()) - static_cast<float>(bottomLeft.height())});
-	drawImageRepeated(right, {x + w - static_cast<float>(right.width()), y + static_cast<float>(topRight.height()), static_cast<float>(right.width()), h - static_cast<float>(topRight.height()) - static_cast<float>(bottomRight.height())});
-
-	// Draw the corners
-	drawImage(topLeft, {x, y});
-	drawImage(topRight, {x + w - topRight.width(), y});
-	drawImage(bottomLeft, {x, y + h - bottomLeft.height()});
-	drawImage(bottomRight, {x + w - bottomRight.width(), y + h - bottomRight.height()});
+	drawImageRect({x, y, w, h}, topLeft, top, topRight, left, center, right, bottomLeft, bottom, bottomRight);
 }
 
 

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -87,6 +87,7 @@ public:
 	void drawImageRect(Rectangle<float> rect, ImageList& images);
 	void drawImageRect(Point<float> position, Vector<float> size, ImageList& images);
 	void drawImageRect(float x, float y, float w, float h, ImageList& images);
+	void drawImageRect(Rectangle<float> rect, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);
 	void drawImageRect(Point<float> position, Vector<float> size, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);
 	void drawImageRect(float x, float y, float w, float h, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);
 


### PR DESCRIPTION
Use packed parameter method overloads in `Renderer::drawImageRect` implementation, and make the more packed version the primary.

There was a bit of a snag about using the most packed `ImageList` version. There was no way to efficiently pack a `std::vector<Image>` (non reference `Image`) from `Image` references, without copying the `Image` objects. Indeed, `std::vector` and `std::array` are not able to contain reference types. As such, the unpacked `ImageList` overload is the primary.

Reference: #36, #37, #601, #697
