### PR TITLE
Add Color::alphaFade method

### DIFF
--- a/NAS2D/Renderer/Color.cpp
+++ b/NAS2D/Renderer/Color.cpp
@@ -54,3 +54,8 @@ bool Color::operator!=(Color other) const
 {
 	return !(*this == other);
 }
+
+Color Color::alphaFade(uint8_t newAlpha) const
+{
+	return {red, green, blue, newAlpha};
+}

--- a/NAS2D/Renderer/Color.h
+++ b/NAS2D/Renderer/Color.h
@@ -29,6 +29,8 @@ struct Color
 	bool operator==(Color other) const;
 	bool operator!=(Color other) const;
 
+	Color alphaFade(uint8_t newAlpha) const;
+
 
 	static const Color Black;
 	static const Color Blue;

--- a/test/Renderer/Color.test.cpp
+++ b/test/Renderer/Color.test.cpp
@@ -13,3 +13,21 @@ TEST(Color, OperatorCompare) {
 	EXPECT_NE((NAS2D::Color{0, 0, 1, 0}), (NAS2D::Color{0, 0, 0, 0}));
 	EXPECT_NE((NAS2D::Color{0, 0, 0, 1}), (NAS2D::Color{0, 0, 0, 0}));
 }
+
+TEST(Color, alphaFade) {
+	EXPECT_EQ((NAS2D::Color{255, 255, 255, 255}), NAS2D::Color::White.alphaFade(255));
+	EXPECT_EQ((NAS2D::Color{255, 255, 255, 128}), NAS2D::Color::White.alphaFade(128));
+	EXPECT_EQ((NAS2D::Color{255, 255, 255, 0}), NAS2D::Color::White.alphaFade(0));
+
+	EXPECT_EQ((NAS2D::Color{255, 0, 0, 255}), NAS2D::Color::Red.alphaFade(255));
+	EXPECT_EQ((NAS2D::Color{255, 0, 0, 128}), NAS2D::Color::Red.alphaFade(128));
+	EXPECT_EQ((NAS2D::Color{255, 0, 0, 0}), NAS2D::Color::Red.alphaFade(0));
+
+	EXPECT_EQ((NAS2D::Color{0, 255, 0, 255}), NAS2D::Color::Green.alphaFade(255));
+	EXPECT_EQ((NAS2D::Color{0, 255, 0, 128}), NAS2D::Color::Green.alphaFade(128));
+	EXPECT_EQ((NAS2D::Color{0, 255, 0, 0}), NAS2D::Color::Green.alphaFade(0));
+
+	EXPECT_EQ((NAS2D::Color{0, 0, 255, 255}), NAS2D::Color::Blue.alphaFade(255));
+	EXPECT_EQ((NAS2D::Color{0, 0, 255, 128}), NAS2D::Color::Blue.alphaFade(128));
+	EXPECT_EQ((NAS2D::Color{0, 0, 255, 0}), NAS2D::Color::Blue.alphaFade(0));
+}


### PR DESCRIPTION
Add `Color::alphaFade` method, which can return a new `Color` object (does not modify the original), with the same `red`, `green`, and `blue` components, but with a modified `alpha` channel.

This can be used to derive a new faded color from an existing color, without having to manually unpack and repack color fields.
