### PR TITLE
Renderer size int BaseType

### DIFF
--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -579,16 +579,16 @@ void Renderer::minimum_size(int width, int height)
 /**
  * Gets the center coordinates of the screen.
  */
-Point<float> Renderer::center() const
+Point<int> Renderer::center() const
 {
-	return Point<float>{} + mResolution / 2;
+	return Point{0, 0} + mResolution / 2;
 }
 
 
 /**
  * Gets the center X-Coordinate of the screen.
  */
-float Renderer::center_x() const
+int Renderer::center_x() const
 {
 	return width() / 2;
 }
@@ -597,7 +597,7 @@ float Renderer::center_x() const
 /**
  * Gets the center Y-Coordinate of the screen.
  */
-float Renderer::center_y() const
+int Renderer::center_y() const
 {
 	return height() / 2;
 }

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -570,6 +570,12 @@ void Renderer::size(int width, int height)
 }
 
 
+void Renderer::minimum_size(int width, int height)
+{
+	minimumSize({width, height});
+}
+
+
 /**
  * Gets the center coordinates of the screen.
  */

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -564,6 +564,12 @@ int Renderer::height() const
 }
 
 
+void Renderer::size(int width, int height)
+{
+	size({width, height});
+}
+
+
 /**
  * Gets the center coordinates of the screen.
  */

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -644,7 +644,7 @@ void Renderer::setResolution(const Vector<float>& newResolution)
 {
 	if (!fullscreen())
 	{
-		mResolution = {newResolution.x, newResolution.y};
+		mResolution = newResolution;
 	}
 }
 

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -552,13 +552,13 @@ void Renderer::clearScreen(uint8_t r, uint8_t g, uint8_t b)
 }
 
 
-float Renderer::width() const
+int Renderer::width() const
 {
 	return size().x;
 }
 
 
-float Renderer::height() const
+int Renderer::height() const
 {
 	return size().y;
 }
@@ -635,7 +635,7 @@ void Renderer::update()
 
 	if (mCurrentFade > 0.0f)
 	{
-		drawBoxFilled({0, 0, width(), height()}, mFadeColor.alphaFade(static_cast<uint8_t>(mCurrentFade)));
+		drawBoxFilled(Rectangle<int>::Create({0, 0}, size()), mFadeColor.alphaFade(static_cast<uint8_t>(mCurrentFade)));
 	}
 }
 

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -552,12 +552,15 @@ void Renderer::clearScreen(uint8_t r, uint8_t g, uint8_t b)
 }
 
 
-/**
- * Gets the current screen resolution as a Vector.
- */
-Vector<float> Renderer::size() const
+float Renderer::width() const
 {
-	return mResolution;
+	return size().x;
+}
+
+
+float Renderer::height() const
+{
+	return size().y;
 }
 
 

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -136,10 +136,10 @@ public:
 	virtual void clearScreen(Color color = Color::Black) = 0;
 	void clearScreen(uint8_t r, uint8_t g, uint8_t b);
 
-	virtual float width() const = 0;
-	virtual float height() const = 0;
+	float width() const;
+	float height() const;
 
-	Vector<float> size() const;
+	virtual Vector<float> size() const = 0;
 	virtual void size(int w, int h) = 0;
 
 	virtual void minimum_size(int w, int h) = 0;

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -146,9 +146,9 @@ public:
 	virtual void minimumSize(Vector<int> newSize) = 0;
 	void minimum_size(int width, int height);
 
-	Point<float> center() const;
-	float center_x() const;
-	float center_y() const;
+	Point<int> center() const;
+	int center_x() const;
+	int center_y() const;
 
 	virtual void clipRect(const Rectangle<float>& rect) = 0;
 	void clipRect(float x, float y, float width, float height);

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -136,10 +136,10 @@ public:
 	virtual void clearScreen(Color color = Color::Black) = 0;
 	void clearScreen(uint8_t r, uint8_t g, uint8_t b);
 
-	float width() const;
-	float height() const;
+	int width() const;
+	int height() const;
 
-	virtual Vector<float> size() const = 0;
+	virtual Vector<int> size() const = 0;
 	virtual void size(int w, int h) = 0;
 
 	virtual void minimum_size(int w, int h) = 0;

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -143,7 +143,8 @@ public:
 	virtual void size(Vector<int> newSize) = 0;
 	void size(int width, int height);
 
-	virtual void minimum_size(int w, int h) = 0;
+	virtual void minimumSize(Vector<int> newSize) = 0;
+	void minimum_size(int width, int height);
 
 	Point<float> center() const;
 	float center_x() const;

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -169,7 +169,7 @@ protected:
 
 	void driverName(const std::string& name);
 
-	Vector<float> mResolution{1600,900}; /**< Screen resolution. Reasonable default in 2019*/
+	Vector<int> mResolution{1600,900}; /**< Screen resolution. Reasonable default in 2019*/
 
 private:
 	enum class FadeType

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -140,7 +140,8 @@ public:
 	int height() const;
 
 	virtual Vector<int> size() const = 0;
-	virtual void size(int w, int h) = 0;
+	virtual void size(Vector<int> newSize) = 0;
+	void size(int width, int height);
 
 	virtual void minimum_size(int w, int h) = 0;
 

--- a/NAS2D/Renderer/RendererNull.h
+++ b/NAS2D/Renderer/RendererNull.h
@@ -53,9 +53,7 @@ public:
 
 	void clearScreen(Color = Color::Black) override {}
 
-	float width() const override { return 0.0f; }
-	float height() const override { return 0.0f; }
-
+	Vector<float> size() const override { return {}; }
 	void size(int, int) override {}
 	void minimum_size(int, int) override {}
 

--- a/NAS2D/Renderer/RendererNull.h
+++ b/NAS2D/Renderer/RendererNull.h
@@ -55,7 +55,7 @@ public:
 
 	Vector<int> size() const override { return {}; }
 	void size(Vector<int>) override {}
-	void minimum_size(int, int) override {}
+	void minimumSize(Vector<int>) override {}
 
 	void fullscreen(bool, bool = false) override {}
 	bool fullscreen() const override { return false; }

--- a/NAS2D/Renderer/RendererNull.h
+++ b/NAS2D/Renderer/RendererNull.h
@@ -54,7 +54,7 @@ public:
 	void clearScreen(Color = Color::Black) override {}
 
 	Vector<int> size() const override { return {}; }
-	void size(int, int) override {}
+	void size(Vector<int>) override {}
 	void minimum_size(int, int) override {}
 
 	void fullscreen(bool, bool = false) override {}

--- a/NAS2D/Renderer/RendererNull.h
+++ b/NAS2D/Renderer/RendererNull.h
@@ -53,7 +53,7 @@ public:
 
 	void clearScreen(Color = Color::Black) override {}
 
-	Vector<float> size() const override { return {}; }
+	Vector<int> size() const override { return {}; }
 	void size(int, int) override {}
 	void minimum_size(int, int) override {}
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -589,10 +589,10 @@ void RendererOpenGL::size(Vector<int> newSize)
 }
 
 
-void RendererOpenGL::minimum_size(int w, int h)
+void RendererOpenGL::minimumSize(Vector<int> newSize)
 {
-	SDL_SetWindowMinimumSize(underlyingWindow, w, h);
-	onResize(w, h);
+	SDL_SetWindowMinimumSize(underlyingWindow, newSize.x, newSize.y);
+	onResize(newSize.x, newSize.y);
 }
 
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -581,10 +581,10 @@ Vector<int> RendererOpenGL::size() const
 }
 
 
-void RendererOpenGL::size(int w, int h)
+void RendererOpenGL::size(Vector<int> newSize)
 {
-	SDL_SetWindowSize(underlyingWindow, w, h);
-	onResize(w, h);
+	SDL_SetWindowSize(underlyingWindow, newSize.x, newSize.y);
+	onResize(newSize.x, newSize.y);
 	SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 }
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -782,7 +782,7 @@ void RendererOpenGL::initVideo(Vector<int> resolution, bool fullscreen, bool vsy
 		throw std::runtime_error("Unable to get desktop dislay mode: " + std::string(SDL_GetError()));
 	}
 
-	desktopResolution = {static_cast<float>(dm.w), static_cast<float>(dm.h)};
+	desktopResolution = Vector{dm.w, dm.h};
 }
 
 std::vector<DisplayDesc> RendererOpenGL::getDisplayModes() const

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -570,7 +570,7 @@ void RendererOpenGL::update()
 }
 
 
-Vector<float> RendererOpenGL::size() const
+Vector<int> RendererOpenGL::size() const
 {
 	if ((SDL_GetWindowFlags(underlyingWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP)
 	{

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -570,25 +570,14 @@ void RendererOpenGL::update()
 }
 
 
-float RendererOpenGL::width() const
+Vector<float> RendererOpenGL::size() const
 {
 	if ((SDL_GetWindowFlags(underlyingWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP)
 	{
-		return desktopResolution.x;
+		return desktopResolution;
 	}
 
-	return mResolution.x;
-}
-
-
-float RendererOpenGL::height() const
-{
-	if ((SDL_GetWindowFlags(underlyingWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP)
-	{
-		return desktopResolution.y;
-	}
-
-	return mResolution.y;
+	return mResolution;
 }
 
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -771,7 +771,7 @@ void RendererOpenGL::initVideo(Vector<int> resolution, bool fullscreen, bool vsy
 		throw std::runtime_error("Unable to get desktop dislay mode: " + std::string(SDL_GetError()));
 	}
 
-	desktopResolution = Vector{dm.w, dm.h};
+	desktopResolution = {dm.w, dm.h};
 }
 
 std::vector<DisplayDesc> RendererOpenGL::getDisplayModes() const

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -104,7 +104,7 @@ private:
 	void onResize(int w, int h);
 
 
-	Point<float> desktopResolution;
+	Vector<float> desktopResolution;
 
 	std::map<int, SDL_Cursor*> cursors;
 };

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -77,7 +77,7 @@ public:
 
 	Vector<int> size() const override;
 	void size(Vector<int> newSize) override;
-	void minimum_size(int w, int h) override;
+	void minimumSize(Vector<int> newSize) override;
 
 	void fullscreen(bool fs, bool maintain = false) override;
 	bool fullscreen() const override;

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -75,9 +75,7 @@ public:
 
 	void clearScreen(Color color = Color::Black) override;
 
-	float width() const override;
-	float height() const override;
-
+	Vector<float> size() const override;
 	void size(int w, int h) override;
 	void minimum_size(int w, int h) override;
 

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -76,7 +76,7 @@ public:
 	void clearScreen(Color color = Color::Black) override;
 
 	Vector<int> size() const override;
-	void size(int w, int h) override;
+	void size(Vector<int> newSize) override;
 	void minimum_size(int w, int h) override;
 
 	void fullscreen(bool fs, bool maintain = false) override;

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -102,7 +102,7 @@ private:
 	void onResize(int w, int h);
 
 
-	Vector<float> desktopResolution;
+	Vector<int> desktopResolution;
 
 	std::map<int, SDL_Cursor*> cursors;
 };

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -75,7 +75,7 @@ public:
 
 	void clearScreen(Color color = Color::Black) override;
 
-	Vector<float> size() const override;
+	Vector<int> size() const override;
 	void size(int w, int h) override;
 	void minimum_size(int w, int h) override;
 


### PR DESCRIPTION
Mark `Renderer::size` getter as the primary `virtual` method instead of `width` and `height`, and change the `BaseType` from `float` to `int`.

This change can generate type conversion warnings in downstream projects, so may cause them to fail if warnings as errors is enabled.
