### PR TITLE
Remove width height

### DIFF
--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -552,18 +552,6 @@ void Renderer::clearScreen(uint8_t r, uint8_t g, uint8_t b)
 }
 
 
-int Renderer::width() const
-{
-	return size().x;
-}
-
-
-int Renderer::height() const
-{
-	return size().y;
-}
-
-
 void Renderer::size(int width, int height)
 {
 	size({width, height});
@@ -590,7 +578,7 @@ Point<int> Renderer::center() const
  */
 int Renderer::center_x() const
 {
-	return width() / 2;
+	return size().x / 2;
 }
 
 
@@ -599,7 +587,7 @@ int Renderer::center_x() const
  */
 int Renderer::center_y() const
 {
-	return height() / 2;
+	return size().y / 2;
 }
 
 

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -136,9 +136,6 @@ public:
 	virtual void clearScreen(Color color = Color::Black) = 0;
 	void clearScreen(uint8_t r, uint8_t g, uint8_t b);
 
-	int width() const;
-	int height() const;
-
 	virtual Vector<int> size() const = 0;
 	virtual void size(Vector<int> newSize) = 0;
 	void size(int width, int height);

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -259,7 +259,7 @@ void RendererOpenGL::drawSubImageRepeated(Image& image, const Rectangle<float>& 
 	float heightReach = source.height / (destination.height - destination.y);
 
 	glEnable(GL_SCISSOR_TEST);
-	glScissor(static_cast<int>(source.x), static_cast<int>(RendererOpenGL::height() - source.y - source.height), static_cast<int>(source.width), static_cast<int>(source.height));
+	glScissor(static_cast<int>(source.x), static_cast<int>(size().y - source.y - source.height), static_cast<int>(source.width), static_cast<int>(source.height));
 
 
 	for (std::size_t row = 0; row <= heightReach; ++row)
@@ -310,7 +310,7 @@ void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const P
 	glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, imageIdMap[destination.name()].texture_id, 0);
 	// Flip the Y axis to keep images drawing correctly.
-	fillVertexArray(dstPoint.x, static_cast<float>(destination.height()) - dstPoint.y, static_cast<float>(clipSize.x), static_cast<float>(-clipSize.y));
+	fillVertexArray(dstPoint.x, static_cast<float>(destination.size().y) - dstPoint.y, static_cast<float>(clipSize.x), static_cast<float>(-clipSize.y));
 
 	drawVertexArray(imageIdMap[source.name()].texture_id);
 	glBindTexture(GL_TEXTURE_2D, imageIdMap[destination.name()].texture_id);
@@ -550,7 +550,7 @@ void RendererOpenGL::clipRect(const Rectangle<float>& rect)
 	}
 
 	const auto intRect = rect.to<int>();
-	glScissor(intRect.x, static_cast<int>(RendererOpenGL::height()) - intRect.y - intRect.height, intRect.width, intRect.height);
+	glScissor(intRect.x, static_cast<int>(size().y) - intRect.y - intRect.height, intRect.width, intRect.height);
 
 	glEnable(GL_SCISSOR_TEST);
 }
@@ -607,7 +607,7 @@ void RendererOpenGL::fullscreen(bool fs, bool maintain)
 	else
 	{
 		SDL_SetWindowFullscreen(underlyingWindow, 0);
-		SDL_SetWindowSize(underlyingWindow, static_cast<int>(width()), static_cast<int>(height()));
+		SDL_SetWindowSize(underlyingWindow, static_cast<int>(size().x), static_cast<int>(size().y));
 		SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 	}
 }
@@ -687,7 +687,7 @@ void RendererOpenGL::initGL()
 	glClear(GL_COLOR_BUFFER_BIT);
 	glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
 
-	onResize(static_cast<int>(width()), static_cast<int>(height()));
+	onResize(static_cast<int>(size().x), static_cast<int>(size().y));
 
 	glShadeModel(GL_SMOOTH);
 	glEnable(GL_COLOR_MATERIAL);

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -71,7 +71,7 @@ Image::Image() : Resource(DEFAULT_IMAGE_NAME)
 Image::Image(int width, int height) : Resource(ARBITRARY_IMAGE_NAME)
 {
 	name(ARBITRARY_IMAGE_NAME + std::to_string(++IMAGE_ARBITRARY));
-	_size = Vector{width, height};
+	mSize = Vector{width, height};
 
 	// Update resource management.
 	imageIdMap[name()].texture_id = 0;
@@ -105,7 +105,7 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) : Resource(
 
 	SDL_Surface* surface = SDL_CreateRGBSurfaceFrom(buffer, width, height, bytesPerPixel * 4, 0, 0, 0, 0, SDL_BYTEORDER == SDL_BIG_ENDIAN ? 0x000000FF : 0xFF000000);
 
-	_size = Vector{width, height};
+	mSize = Vector{width, height};
 
 	unsigned int texture_id = generateTexture(buffer, bytesPerPixel, width, height);
 
@@ -123,7 +123,7 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) : Resource(
  *
  * \param	src		Image to copy.
  */
-Image::Image(const Image &src) : Resource(src.name()), _size(src._size)
+Image::Image(const Image &src) : Resource(src.name()), mSize(src.mSize)
 {
 	if (!src.loaded())
 	{
@@ -156,7 +156,7 @@ Image& Image::operator=(const Image& rhs)
 	updateImageReferenceCount(name());
 
 	name(rhs.name());
-	_size = rhs._size;
+	mSize = rhs.mSize;
 
 	auto it = imageIdMap.find(name());
 	if (it == imageIdMap.end())
@@ -180,7 +180,7 @@ void Image::load()
 {
 	if (checkTextureId(name()))
 	{
-		_size = Vector{imageIdMap[name()].w, imageIdMap[name()].h};
+		mSize = Vector{imageIdMap[name()].w, imageIdMap[name()].h};
 		loaded(true);
 		return;
 	}
@@ -203,14 +203,14 @@ void Image::load()
 		return;
 	}
 
-	_size = Vector{surface->w, surface->h};
+	mSize = Vector{surface->w, surface->h};
 
 	unsigned int texture_id = generateTexture(surface->pixels, surface->format->BytesPerPixel, surface->w, surface->h);
 
 	// Add generated texture id to texture ID map.
 	imageIdMap[name()].texture_id = texture_id;
-	imageIdMap[name()].w = _size.x;
-	imageIdMap[name()].h = _size.y;
+	imageIdMap[name()].w = mSize.x;
+	imageIdMap[name()].h = mSize.y;
 	imageIdMap[name()].ref_count++;
 
 	imageIdMap[name()].surface = surface;
@@ -224,25 +224,25 @@ void Image::load()
  */
 Vector<int> Image::size() const
 {
-	return _size;
+	return mSize;
 }
 
 
 Vector<int> Image::center() const
 {
-	return _size / 2;
+	return mSize / 2;
 }
 
 
 int Image::center_x() const
 {
-	return _size.x / 2;
+	return mSize.x / 2;
 }
 
 
 int Image::center_y() const
 {
-	return _size.y / 2;
+	return mSize.y / 2;
 }
 
 
@@ -265,7 +265,7 @@ Color Image::pixelColor(Point<int> point) const
  */
 Color Image::pixelColor(int x, int y) const
 {
-	if (x < 0 || x >= _size.x || y < 0 || y >= _size.y)
+	if (x < 0 || x >= mSize.x || y < 0 || y >= mSize.y)
 	{
 		return Color::Black;
 	}

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -209,8 +209,8 @@ void Image::load()
 
 	// Add generated texture id to texture ID map.
 	imageIdMap[name()].texture_id = texture_id;
-	imageIdMap[name()].w = width();
-	imageIdMap[name()].h = height();
+	imageIdMap[name()].w = _size.x;
+	imageIdMap[name()].h = _size.y;
 	imageIdMap[name()].ref_count++;
 
 	imageIdMap[name()].surface = surface;
@@ -231,24 +231,6 @@ Vector<int> Image::size() const
 Vector<int> Image::center() const
 {
 	return _size / 2;
-}
-
-
-/**
- * Gets the width in pixels of the image.
- */
-int Image::width() const
-{
-	return _size.x;
-}
-
-
-/**
- * Gets the height in pixels of the image.
- */
-int Image::height() const
-{
-	return _size.y;
 }
 
 
@@ -283,7 +265,7 @@ Color Image::pixelColor(Point<int> point) const
  */
 Color Image::pixelColor(int x, int y) const
 {
-	if (x < 0 || x >= width() || y < 0 || y >= height())
+	if (x < 0 || x >= _size.x || y < 0 || y >= _size.y)
 	{
 		return Color::Black;
 	}

--- a/NAS2D/Resources/Image.h
+++ b/NAS2D/Resources/Image.h
@@ -64,7 +64,7 @@ private:
 	void load() override;
 
 private:
-	Vector<int> _size; /**< Width/Height information about the Image. */
+	Vector<int> mSize; /**< Width/Height information about the Image. */
 };
 
 

--- a/NAS2D/Resources/Image.h
+++ b/NAS2D/Resources/Image.h
@@ -54,9 +54,6 @@ public:
 	Vector<int> size() const;
 	Vector<int> center() const;
 
-	int width() const;
-	int height() const;
-
 	int center_x() const;
 	int center_y() const;
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -474,14 +474,14 @@ void Sprite::processFrames(const std::string& action, void* _node)
 			}
 
 			// X-Coordinate
-			if ( x < 0 || x > mImageSheets.find(sheetId)->second.width())
+			if ( x < 0 || x > mImageSheets.find(sheetId)->second.size().x)
 			{
 				cout << "Value 'x' is out of bounds." << endTag(currentRow, name()) << endl;
 				continue;
 			}
 
 			// Y-Coordinate
-			if (y < 0 || y > mImageSheets.find(sheetId)->second.height())
+			if (y < 0 || y > mImageSheets.find(sheetId)->second.size().y)
 			{
 				cout << "Value 'y' is out of bounds." << endTag(currentRow, name()) << endl;
 				continue;
@@ -494,7 +494,7 @@ void Sprite::processFrames(const std::string& action, void* _node)
 				cout << "'width' value must be greater than 0." << endTag(currentRow, name()) << endl;
 				continue;
 			}
-			else if (x + width > mImageSheets.find(sheetId)->second.width())
+			else if (x + width > mImageSheets.find(sheetId)->second.size().x)
 			{
 				cout << "'x' + 'width' value exceeds dimensions of specified imagesheet." << endTag(currentRow, name()) << endl;
 				continue;
@@ -507,7 +507,7 @@ void Sprite::processFrames(const std::string& action, void* _node)
 				cout << "'height' value must be greater than 0." << endTag(currentRow, name()) << endl;
 				continue;
 			}
-			else if (y + height > mImageSheets.find(sheetId)->second.height())
+			else if (y + height > mImageSheets.find(sheetId)->second.size().y)
 			{
 				cout << "'y' + 'height' value exceeds dimensions of specified imagesheet." << endTag(currentRow, name()) << endl;
 				continue;


### PR DESCRIPTION
Remove `width()`/`height()` methods from `Renderer`, `Sprite`, and `Image`. Use the `size()` method and then specific component instead.

References:
https://github.com/OutpostUniverse/OPHD/issues/536
https://github.com/OutpostUniverse/OPHD/pull/540
