### PR TITLE
Remove Renderer unpacked overloads

### DIFF
--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -63,174 +63,6 @@ void Renderer::title(const std::string& title)
 
 
 /**
- * Draws an Image to the screen.
- *
- * \param	image	A reference to an Image Resource.
- * \param	x		X-Coordinate of the Image to draw.
- * \param	y		Y-Coordinate of the Image to draw.
- * \param	scale	Scale to draw the Image at. Default is 1.0 (no scaling).
- */
-void Renderer::drawImage(Image& image, float x, float y, float scale)
-{
-	drawImage(image, {x, y}, scale);
-}
-
-
-void Renderer::drawImage(Image& image, float x, float y, float scale, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	drawImage(image, {x, y}, scale, {r, g, b, a});
-}
-
-
-void Renderer::drawSubImage(Image& image, Point<float> raster, Point<float> position, Vector<float> size, Color color)
-{
-	drawSubImage(image, raster, {position.x, position.y, size.x, size.y}, color);
-}
-
-
-/**
- * Draws a portion of a given Image to the screen.
- *
- * \param	image		A refernece to an Image Resource.
- * \param	rasterX		X-Coordinate to draw the Image at.
- * \param	rasterY		Y-Coordinate to draw the Image at.
- * \param	x			X-Coordinate of the area to start getting pixel data from.
- * \param	y			Y-Coordinate of the area to start getting pixel data from.
- * \param	width		Width of the area to start getting pixel data from.
- * \param	height		Height of the area to start getting pixel data from.
- */
-void Renderer::drawSubImage(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, Color color)
-{
-	drawSubImage(image, {rasterX, rasterY}, {x, y, width, height}, color);
-}
-
-
-void Renderer::drawSubImage(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	drawSubImage(image, {rasterX, rasterY}, {x, y, width, height}, {r, g, b, a});
-}
-
-
-void Renderer::drawSubImageRotated(Image& image, Point<float> raster, Point<float> position, Vector<float> size, float degrees, Color color)
-{
-	drawSubImageRotated(image, raster, {position.x, position.y, size.x, size.y}, degrees, color);
-}
-
-
-/**
- * Draws a portion of a given Image to the screen with optional rotation.
- *
- * \param	image		A refernece to an Image Resource.
- * \param	rasterX		X-Coordinate to draw the Image at.
- * \param	rasterY		Y-Coordinate to draw the Image at.
- * \param	x			X-Coordinate of the area to start getting pixel data from.
- * \param	y			Y-Coordinate of the area to start getting pixel data from.
- * \param	width		Width of the area to start getting pixel data from.
- * \param	height		Height of the area to start getting pixel data from.
- * \param	degrees		Angle of rotation in degrees.
- * \param	color		Color to tint the Image with. Default is COLOR_NORMAL (full bright, no color tinting).
- */
-void Renderer::drawSubImageRotated(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, float degrees, Color color)
-{
-	drawSubImageRotated(image, {rasterX, rasterY}, {x, y, width, height}, degrees, color);
-}
-
-
-void Renderer::drawSubImageRotated(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, float degrees, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	drawSubImageRotated(image, {rasterX, rasterY}, {x, y, width, height}, degrees, {r, g, b, a});
-}
-
-
-/**
- * Draws a rotated and scaled image.
- *
- * \param	image	A reference to an Image Resource.
- * \param	x		X-Coordinate to draw the Image at.
- * \param	y		Y-Coordinate to draw the Image at.
- * \param	degrees	Angle of rotation in degrees (0.0 - 360.0).
- * \param	color	Color to tint the Image with. Default is COLOR_NORMAL (full bright, no color tinting).
- * \param	scale	Scale to draw the Image at. Default is 1.0 (no scaling).
- */
-void Renderer::drawImageRotated(Image& image, float x, float y, float degrees, Color color, float scale)
-{
-	drawImageRotated(image, {x, y}, degrees, color, scale);
-}
-
-
-void Renderer::drawImageRotated(Image& image, float x, float y, float degrees, uint8_t r, uint8_t g, uint8_t b, uint8_t a, float scale)
-{
-	drawImageRotated(image, {x, y}, degrees, {r, g, b, a}, scale);
-}
-
-
-void Renderer::drawImageStretched(Image& image, Point<float> position, Vector<float> size, Color color)
-{
-	drawImageStretched(image, {position.x, position.y, size.x, size.y}, color);
-}
-
-
-/**
- * Draws a stretched image using a Color color structure.
- *
- * \param	image	A reference to an Image Resource.
- * \param	x		X-Coordinate to draw the Image at.
- * \param	y		Y-Coordinate to draw the Image at.
- * \param	w		Width to use for drawing the Image.
- * \param	h		Height to use for drawing the Image.
- * \param	color	Color to tint the Image with. Default is COLOR_NORMAL (full bright, no color tinting).
- */
-void Renderer::drawImageStretched(Image& image, float x, float y, float w, float h, Color color)
-{
-	drawImageStretched(image, {x, y, w, h}, color);
-}
-
-
-void Renderer::drawImageStretched(Image& image, float x, float y, float w, float h, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	drawImageStretched(image, {x, y, w, h}, {r, g, b, a});
-}
-
-
-void Renderer::drawImageRepeated(Image& image, Point<float> position, Vector<float> size)
-{
-	drawImageRepeated(image, {position.x, position.y, size.x, size.y});
-}
-
-
-void Renderer::drawImageRepeated(Image& image, float x, float y, float w, float h)
-{
-	drawImageRepeated(image, {x, y, w, h});
-}
-
-
-/**
- * Draws part of an Image repeated over a rectangular area.
- */
-void Renderer::drawSubImageRepeated(Image& image, float rasterX, float rasterY, float w, float h, float subX, float subY, float subW, float subH)
-{
-	drawSubImageRepeated(image, {rasterX, rasterY, w, h}, {subX, subY, subW, subH});
-}
-
-
-void Renderer::drawImageRect(Rectangle<float> rect, ImageList& images)
-{
-	if (images.size() != 9)
-	{
-		throw std::runtime_error("Must pass 9 images to drawImageRect, but images.size() == " + std::to_string(images.size()));
-	}
-
-	drawImageRect({rect.x, rect.y, rect.width, rect.height}, images[0], images[1], images[2], images[3], images[4], images[5], images[6], images[7], images[8]);
-}
-
-
-void Renderer::drawImageRect(Point<float> position, Vector<float> size, ImageList& images)
-{
-	drawImageRect({position.x, position.y, size.x, size.y}, images);
-}
-
-
-/**
  * Draws a rectangle using a set of images.
  *
  * This function expects an ImageList with 9 images in it: four corners,
@@ -248,15 +80,17 @@ void Renderer::drawImageRect(Point<float> position, Vector<float> size, ImageLis
  * +---+---+---+
  * \endcode
  *
- * \param	x		X-Coordinate to start drawing the image rect at.
- * \param	y		X-Coordinate to start drawing the image rect at.
- * \param	w		Width of the image rect.
- * \param	h		Height of the image rect.
+ * \param	rect	Area to draw the image rect at.
  * \param	images	A set of 9 images used to draw the image rect.
  */
-void Renderer::drawImageRect(float x, float y, float w, float h, ImageList &images)
+void Renderer::drawImageRect(Rectangle<float> rect, ImageList& images)
 {
-	drawImageRect({x, y, w, h}, images);
+	if (images.size() != 9)
+	{
+		throw std::runtime_error("Must pass 9 images to drawImageRect, but images.size() == " + std::to_string(images.size()));
+	}
+
+	drawImageRect({rect.x, rect.y, rect.width, rect.height}, images[0], images[1], images[2], images[3], images[4], images[5], images[6], images[7], images[8]);
 }
 
 
@@ -284,180 +118,11 @@ void Renderer::drawImageRect(Rectangle<float> rect, Image& topLeft, Image& top, 
 }
 
 
-void Renderer::drawImageRect(Point<float> position, Vector<float> size, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight)
-{
-	drawImageRect({position.x, position.y, size.x, size.y}, topLeft, top, topRight, left, center, right, bottomLeft, bottom, bottomRight);
-}
-
-/**
- * Comment me!
- */
-void Renderer::drawImageRect(float x, float y, float w, float h, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight)
-{
-	drawImageRect({x, y, w, h}, topLeft, top, topRight, left, center, right, bottomLeft, bottom, bottomRight);
-}
-
-
-/**
- * Draws a single Pixel to the primary surface.
- *
- * \param	x		X-Coordinate of the pixel to draw.
- * \param	y		Y-Coordinate of the pixel to draw.
- * \param	color	A Color.
- */
-void Renderer::drawPoint(float x, float y, Color color)
-{
-	drawPoint({x, y}, color);
-}
-
-
-void Renderer::drawPoint(float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	drawPoint({x, y}, {r, g, b, a});
-}
-
-
-/**
- * Draws a line from (x, y) - (x2, y2) on the primary surface.
- *
- * \param	x			X-Coordinate of the start of the line.
- * \param	y			Y-Coordinate of the start of the line.
- * \param	x2			X-Coordinate of the end of the line.
- * \param	y2			Y-Coordinate of the end of the line.
- * \param	color		A Color.
- * \param	line_width	Width, in pixels, of the line to draw.
- */
-void Renderer::drawLine(float x, float y, float x2, float y2, Color color, int line_width)
-{
-	drawLine({x, y}, {x2, y2}, color, line_width);
-}
-
-
-void Renderer::drawLine(float x, float y, float x2, float y2, uint8_t r, uint8_t g, uint8_t b, uint8_t a, int line_width)
-{
-	drawLine({x, y}, {x2, y2}, {r, g, b, a}, line_width);
-}
-
-
-/**
- * Draws a hollow box on the primary surface.
- *
- * \param	rect	A reference to a Rectangle<float> defining the box dimensions.
- * \param	r		Red Color Value. Must be between 0 - 255.
- * \param	g		Green Color Value. Must be between 0 - 255.
- * \param	b		Blue Color Value. Must be between 0 - 255.
- * \param	a		Alpha Value. Must be between 0 - 255.
- */
-void Renderer::drawBox(const Rectangle<float>& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	drawBox(rect, {r, g, b, a});
-}
-
-
-void Renderer::drawBox(float x, float y, float w, float h, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	drawBox({x, y, w, h}, {r, g, b, a});
-}
-
-
-/**
- * Fills a given area with a solid color.
- *
- * \param	rect	A reference to a Rectangle<float> defining the box dimensions.
- * \param	r		Red Color Value. Must be between 0 - 255.
- * \param	g		Green Color Value. Must be between 0 - 255.
- * \param	b		Blue Color Value. Must be between 0 - 255.
- * \param	a		Alpha Value. Must be between 0 - 255.
- */
-void Renderer::drawBoxFilled(const Rectangle<float>& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	drawBoxFilled(rect, {r, g, b, a});
-}
-
-
-void Renderer::drawBoxFilled(float x, float y, float width, float height, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	drawBoxFilled({x, y, width, height}, {r, g, b, a});
-}
-
-
-void Renderer::drawCircle(float x, float y, float radius, uint8_t r, uint8_t g, uint8_t b, uint8_t a, int num_segments, float scale_x, float scale_y)
-{
-	drawCircle({x, y}, radius, {r, g, b, a}, num_segments, {scale_x, scale_y});
-}
-
-
-void Renderer::drawGradient(Point<float> position, Vector<float> size, Color c1, Color c2, Color c3, Color c4)
-{
-	drawGradient({position.x, position.y, size.x, size.y}, c1, c2, c3, c4);
-}
-
-
-/**
- * Draws a rectangular area with a color gradient.
- *
- * Each point of the rectangular area can be given a different color value to
- * produce a variety of effects. The vertex orders are as follows:
- *
- * 1-----4
- * |     |
- * |     |
- * 2-----3
- *
- * \param	x	X-Position of the rectangular area to draw.
- * \param	y	Y-Position of the rectangular area to draw.
- * \param	w	Width of the rectangular area to draw.
- * \param	h	Height of the rectangular area to draw.
- * \param	c1	A Color color value used for point 1.
- * \param	c2	A Color color value used for point 2.
- * \param	c3	A Color color value used for point 3.
- * \param	c4	A Color color value used for point 4.
- */
-void Renderer::drawGradient(float x, float y, float w, float h, Color c1, Color c2, Color c3, Color c4)
-{
-	drawGradient({x, y, w, h}, c1, c2, c3, c4);
-}
-
-
-void Renderer::drawGradient(float x, float y, float w, float h, uint8_t r1, uint8_t g1, uint8_t b1, uint8_t a1, uint8_t r2, uint8_t g2, uint8_t b2, uint8_t a2, uint8_t r3, uint8_t g3, uint8_t b3, uint8_t a3, uint8_t r4, uint8_t g4, uint8_t b4, uint8_t a4)
-{
-	drawGradient({x, y, w, h}, {r1, g1, b1, a1}, {r2, g2, b2, a2}, {r3, g3, b3, a3}, {r4, g4, b4, a4});
-}
-
-
-void Renderer::drawText(const Font& font, std::string_view text, float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	drawText(font, text, {x, y}, {r, g, b, a});
-}
-
-
 void Renderer::drawTextShadow(const Font& font, std::string_view text, Point<float> position, Vector<float> shadowOffset, Color textColor, Color shadowColor)
 {
 	const auto shadowPosition = position + shadowOffset;
 	drawText(font, text, shadowPosition, shadowColor);
 	drawText(font, text, position, textColor);
-}
-
-
-/**
- * Renders a text string with a drop shadow.
- *
- * \param font		A reference to a Font Resource.
- * \param text		The text to draw.
- * \param x			X-Coordinate to render text string.
- * \param y			Y-Coordinate to render text string.
- * \param distance	Distance in pixels the drop shadow should be rendered.
- * \param r			Red color value between 0 - 255.
- * \param g			Green color value between 0 - 255.
- * \param b			Blue color value between 0 - 255.
- * \param sr		Red color value between 0 - 255.
- * \param sg		Green color value between 0 - 255.
- * \param sb		Blue color value between 0 - 255.
- * \param a			Alpha color value between 0 - 255.
- */
-void Renderer::drawTextShadow(const Font& font, std::string_view text, float x, float y, int distance, uint8_t r, uint8_t g, uint8_t b, uint8_t sr, uint8_t sg, uint8_t sb, uint8_t a )
-{
-	drawTextShadow(font, text, {x, y}, Vector{distance, distance}, {r, g, b, a}, {sr, sg, sb, a});
 }
 
 
@@ -544,27 +209,6 @@ Signals::Signal<>& Renderer::fadeComplete()
 
 
 /**
- * Clears the screen with a given Color.
- */
-void Renderer::clearScreen(uint8_t r, uint8_t g, uint8_t b)
-{
-	clearScreen({r, g, b});
-}
-
-
-void Renderer::size(int width, int height)
-{
-	size({width, height});
-}
-
-
-void Renderer::minimum_size(int width, int height)
-{
-	minimumSize({width, height});
-}
-
-
-/**
  * Gets the center coordinates of the screen.
  */
 Point<int> Renderer::center() const
@@ -588,17 +232,6 @@ int Renderer::center_x() const
 int Renderer::center_y() const
 {
 	return size().y / 2;
-}
-
-
-/**
- * Sets a rectangular area of the screen outside of which nothing is drawn.
- *
- * \see clipRectClear()
- */
-void Renderer::clipRect(float x, float y, float width, float height)
-{
-	clipRect({x, y, width, height});
 }
 
 

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -218,24 +218,6 @@ Point<int> Renderer::center() const
 
 
 /**
- * Gets the center X-Coordinate of the screen.
- */
-int Renderer::center_x() const
-{
-	return size().x / 2;
-}
-
-
-/**
- * Gets the center Y-Coordinate of the screen.
- */
-int Renderer::center_y() const
-{
-	return size().y / 2;
-}
-
-
-/**
  * Clears the clipping rectangle.
  */
 void Renderer::clipRectClear()

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -55,34 +55,12 @@ public:
 	virtual void window_icon(const std::string& path) = 0;
 
 	virtual void drawImage(Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) = 0;
-	void drawImage(Image& image, float x, float y, float scale = 1.0f);
-	void drawImage(Image& image, float x, float y, float scale, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-
 	virtual void drawSubImage(Image& image, Point<float> raster, Rectangle<float> subImageRect, Color color = Color::Normal) = 0;
-	void drawSubImage(Image& image, Point<float> raster, Point<float> position, Vector<float> size, Color color = Color::Normal);
-	void drawSubImage(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, Color color = Color::Normal);
-	void drawSubImage(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-
 	virtual void drawSubImageRotated(Image& image, Point<float> raster, Rectangle<float> subImageRect, float degrees, Color color = Color::Normal) = 0;
-	void drawSubImageRotated(Image& image, Point<float> raster, Point<float> position, Vector<float> size, float degrees, Color color = Color::Normal);
-	void drawSubImageRotated(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, float degrees, Color color = Color::Normal);
-	void drawSubImageRotated(Image& image, float rasterX, float rasterY, float x, float y, float width, float height, float degrees, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-
 	virtual void drawImageRotated(Image& image, Point<float> position, float degrees, Color color = Color::Normal, float scale = 1.0f) = 0;
-	void drawImageRotated(Image& image, float x, float y, float degrees, Color color = Color::Normal, float scale = 1.0f);
-	void drawImageRotated(Image& image, float x, float y, float degrees, uint8_t r, uint8_t g, uint8_t b, uint8_t a, float scale = 1.0f);
-
 	virtual void drawImageStretched(Image& image, Rectangle<float> rect, Color color = Color::Normal) = 0;
-	void drawImageStretched(Image& image, Point<float> position, Vector<float> size, Color color = Color::Normal);
-	void drawImageStretched(Image& image, float x, float y, float w, float h, Color color = Color::Normal);
-	void drawImageStretched(Image& image, float x, float y, float w, float h, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-
 	virtual void drawImageRepeated(Image& image, Rectangle<float> rect) = 0;
-	void drawImageRepeated(Image& image, Point<float> position, Vector<float> size);
-	void drawImageRepeated(Image& image, float x, float y, float w, float h);
-	
 	virtual void drawSubImageRepeated(Image& image, const Rectangle<float>& source, const Rectangle<float>& destination) = 0;
-	void drawSubImageRepeated(Image& image, float rasterX, float rasterY, float w, float h, float subX, float subY, float subW, float subH);
 
 	void drawImageRect(Rectangle<float> rect, ImageList& images);
 	void drawImageRect(Point<float> position, Vector<float> size, ImageList& images);
@@ -94,33 +72,26 @@ public:
 	virtual void drawImageToImage(Image& source, Image& destination, const Point<float>& dstPoint) = 0;
 
 	virtual void drawPoint(Point<float> position, Color color = Color::White) = 0;
-	void drawPoint(float x, float y, Color color = Color::White);
-	void drawPoint(float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
-
 	virtual void drawLine(Point<float> startPosition, Point<float> endPosition, Color color = Color::White, int line_width = 1) = 0;
-	void drawLine(float x, float y, float x2, float y2, Color color = Color::White, int line_width = 1);
-	void drawLine(float x, float y, float x2, float y2, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255, int line_width = 1);
-
 	virtual void drawBox(const Rectangle<float>& rect, Color color = Color::White) = 0;
-	void drawBox(const Rectangle<float>& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
-	void drawBox(float x, float y, float w, float h, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
-
 	virtual void drawBoxFilled(const Rectangle<float>& rect, Color color = Color::White) = 0;
-	void drawBoxFilled(const Rectangle<float>& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
-	void drawBoxFilled(float x, float y, float width, float height, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
-
 	virtual void drawCircle(Point<float> position, float radius, Color color, int num_segments = 10, Vector<float> scale = Vector{1.0f, 1.0f}) = 0;
-	void drawCircle(float x, float y, float radius, uint8_t r, uint8_t g, uint8_t b, uint8_t a, int num_segments = 10, float scale_x = 1.0f, float scale_y = 1.0f);
 
+	/**
+	 * Draws a rectangular area with a color gradient.
+	 *
+	 * Each point of the rectangular area can be given a different color value to
+	 * produce a variety of effects. The vertex orders are as follows:
+	 *
+	 * 1-----4
+	 * |     |
+	 * |     |
+	 * 2-----3
+	 */
 	virtual void drawGradient(Rectangle<float> rect, Color c1, Color c2, Color c3, Color c4) = 0;
-	void drawGradient(Point<float> position, Vector<float> size, Color c1, Color c2, Color c3, Color c4);
-	void drawGradient(float x, float y, float w, float h, Color c1, Color c2, Color c3, Color c4);
-	void drawGradient(float x, float y, float w, float h, uint8_t r1, uint8_t g1, uint8_t b1, uint8_t a1, uint8_t r2, uint8_t g2, uint8_t b2, uint8_t a2, uint8_t r3, uint8_t g3, uint8_t b3, uint8_t a3, uint8_t r4, uint8_t g4, uint8_t b4, uint8_t a4);
 
 	virtual void drawText(const Font& font, std::string_view text, Point<float> position, Color color = Color::White) = 0;
-	void drawText(const Font& font, std::string_view text, float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
 	void drawTextShadow(const Font& font, std::string_view text, Point<float> position, Vector<float> shadowOffset, Color textColor, Color shadowColor);
-	void drawTextShadow(const Font& font, std::string_view text, float x, float y, int sDistance, uint8_t r, uint8_t g, uint8_t b, uint8_t sr, uint8_t sg, uint8_t sb, uint8_t a = 255);
 
 	void fadeColor(Color color);
 	void fadeIn(float delayTime);
@@ -134,21 +105,22 @@ public:
 	virtual void setCursor(int cursorId) = 0;
 
 	virtual void clearScreen(Color color = Color::Black) = 0;
-	void clearScreen(uint8_t r, uint8_t g, uint8_t b);
 
 	virtual Vector<int> size() const = 0;
 	virtual void size(Vector<int> newSize) = 0;
-	void size(int width, int height);
 
 	virtual void minimumSize(Vector<int> newSize) = 0;
-	void minimum_size(int width, int height);
 
 	Point<int> center() const;
 	int center_x() const;
 	int center_y() const;
 
+	/**
+	 * Sets a rectangular area of the screen outside of which nothing is drawn.
+	 *
+	 * \see clipRectClear()
+	 */
 	virtual void clipRect(const Rectangle<float>& rect) = 0;
-	void clipRect(float x, float y, float width, float height);
 	void clipRectClear();
 
 	virtual void fullscreen(bool fs, bool maintain = false) = 0;

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -112,8 +112,6 @@ public:
 	virtual void minimumSize(Vector<int> newSize) = 0;
 
 	Point<int> center() const;
-	int center_x() const;
-	int center_y() const;
 
 	/**
 	 * Sets a rectangular area of the screen outside of which nothing is drawn.


### PR DESCRIPTION
Remove unpacked `Renderer` method overloads.

The unpacked overloads are no longer used by downstream projects:
- OPHD
- nas2d-tests
- OP2-Landlord

Removing the unused methods reduces code bulk and maintenance effort.

----

Edit: No functionality is being removed. The packed version of each overload set was kept, while the unpacked overloads of each set were removed.
