### PR TITLE
Remove unpacked Renderer::drawImageRect overloads

### DIFF
--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -63,11 +63,7 @@ public:
 	virtual void drawSubImageRepeated(Image& image, const Rectangle<float>& source, const Rectangle<float>& destination) = 0;
 
 	void drawImageRect(Rectangle<float> rect, ImageList& images);
-	void drawImageRect(Point<float> position, Vector<float> size, ImageList& images);
-	void drawImageRect(float x, float y, float w, float h, ImageList& images);
 	void drawImageRect(Rectangle<float> rect, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);
-	void drawImageRect(Point<float> position, Vector<float> size, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);
-	void drawImageRect(float x, float y, float w, float h, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);
 
 	virtual void drawImageToImage(Image& source, Image& destination, const Point<float>& dstPoint) = 0;
 


### PR DESCRIPTION
Remove declarations for unpacked `Renderer::drawImageRect` overloads.

Seems the implementations were removed in #707, but the declarations for the methods were not removed. This completes the removal of both defintions and declarations.
