### PR TITLE
Refactor RendererOpenGL file methods

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -484,7 +484,7 @@ void RendererOpenGL::drawText(const Font& font, std::string_view text, Point<flo
 		GlyphMetrics& gm = gml[std::clamp<std::size_t>(static_cast<uint8_t>(character), 0, 255)];
 
 		fillVertexArray({position.x + offset, position.y, static_cast<float>(font.glyphCellWidth()), static_cast<float>(font.glyphCellHeight())});
-		fillTextureArray(Rectangle<GLfloat>::Create(Point{gm.uvX, gm.uvY}, Point{gm.uvW, gm.uvH}));
+		fillTextureArray({gm.uvX, gm.uvY, gm.uvW, gm.uvH});
 
 		drawVertexArray(fontMap[font.name()].texture_id, false);
 		offset += gm.advance + gm.minX;

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -146,8 +146,8 @@ void RendererOpenGL::drawSubImage(Image& image, Point<float> raster, Rectangle<f
 	fillTextureArray({
 		subImageRect.x / imageSize.x,
 		subImageRect.y / imageSize.y,
-		(subImageRect.x + subImageRect.width) / imageSize.x,
-		(subImageRect.y + subImageRect.height) / imageSize.y
+		subImageRect.width / imageSize.x,
+		subImageRect.height / imageSize.y
 	});
 
 	drawVertexArray(imageIdMap[image.name()].texture_id, false);
@@ -174,8 +174,8 @@ void RendererOpenGL::drawSubImageRotated(Image& image, Point<float> raster, Rect
 	fillTextureArray({
 		subImageRect.x / imageSize.x,
 		subImageRect.y / imageSize.y,
-		(subImageRect.x + subImageRect.width) / imageSize.x,
-		(subImageRect.y + subImageRect.height) / imageSize.y
+		subImageRect.width / imageSize.x,
+		subImageRect.height / imageSize.y
 	});
 
 	drawVertexArray(imageIdMap[image.name()].texture_id, false);
@@ -484,7 +484,7 @@ void RendererOpenGL::drawText(const Font& font, std::string_view text, Point<flo
 		GlyphMetrics& gm = gml[std::clamp<std::size_t>(static_cast<uint8_t>(character), 0, 255)];
 
 		fillVertexArray({position.x + offset, position.y, static_cast<float>(font.glyphCellWidth()), static_cast<float>(font.glyphCellHeight())});
-		fillTextureArray({gm.uvX, gm.uvY, gm.uvW, gm.uvH});
+		fillTextureArray(Rectangle<GLfloat>::Create(Point{gm.uvX, gm.uvY}, Point{gm.uvW, gm.uvH}));
 
 		drawVertexArray(fontMap[font.name()].texture_id, false);
 		offset += gm.advance + gm.minX;
@@ -893,7 +893,7 @@ void fillVertexArray(Rectangle<GLfloat> rect)
 void fillTextureArray(Rectangle<GLfloat> textureRect)
 {
 	const auto p1 = textureRect.startPoint();
-	const auto p2 = textureRect.size();
+	const auto p2 = textureRect.endPoint();
 
 	textureCoordArray[0] = p1.x; textureCoordArray[1] = p1.y;
 	textureCoordArray[2] = p1.x; textureCoordArray[3] = p2.y;

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -61,6 +61,13 @@ namespace {
 	GLfloat textureCoordArray[12] = {}; /**< Texture coordinate array for quad drawing functions (all blitter functions). */
 
 
+	void fillVertexArray(Rectangle<GLfloat> rect);
+	void fillTextureArray(Rectangle<GLfloat> textureRect);
+	void drawVertexArray(GLuint textureId, bool useDefaultTextureCoords = true);
+
+	void line(Point<float> p1, Point<float> p2, float lineWidth, Color color);
+	GLuint generate_fbo(Image& image);
+
 	std::string glString(GLenum name)
 	{
 		const auto apiResult = glGetString(name);
@@ -78,15 +85,6 @@ namespace {
 		};
 	}
 }
-
-
-// MODULE LEVEL FUNCTIONS
-void fillVertexArray(Rectangle<GLfloat> rect);
-void fillTextureArray(Rectangle<GLfloat> textureRect);
-void drawVertexArray(GLuint textureId, bool useDefaultTextureCoords = true);
-
-void line(Point<float> p1, Point<float> p2, float lineWidth, Color color);
-GLuint generate_fbo(Image& image);
 
 
 /**
@@ -821,6 +819,7 @@ Vector<int> RendererOpenGL::getWindowClientArea() const noexcept
 // = NON PUBLIC IMPLEMENTATION
 // ==================================================================================
 
+namespace {
 /**
  * Generates an OpenGL Frame Buffer Object.
  */
@@ -1087,4 +1086,6 @@ void line(Point<float> p1, Point<float> p2, float lineWidth, Color color)
 		glColorPointer(4, GL_FLOAT, 0, line_color2);
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, 12);
 	}
+}
+
 }

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -423,8 +423,8 @@ namespace {
 
 				glyphMetricsList[glyph].uvX = static_cast<float>(col * characterSize.x) / static_cast<float>(textureSize.x);
 				glyphMetricsList[glyph].uvY = static_cast<float>(row * characterSize.y) / static_cast<float>(textureSize.y);
-				glyphMetricsList[glyph].uvW = glyphMetricsList[glyph].uvX + static_cast<float>(characterSize.x) / static_cast<float>(textureSize.x);
-				glyphMetricsList[glyph].uvH = glyphMetricsList[glyph].uvY + static_cast<float>(characterSize.y) / static_cast<float>(textureSize.y);
+				glyphMetricsList[glyph].uvW = static_cast<float>(characterSize.x) / static_cast<float>(textureSize.x);
+				glyphMetricsList[glyph].uvH = static_cast<float>(characterSize.y) / static_cast<float>(textureSize.y);
 			}
 		}
 	}


### PR DESCRIPTION
Use `Rectangle` parameters rather than unpacked values. Adjust `Font` drawing for symmetry to use {point, size} rectangles, rather than {point, point} style rectangles. Move file scope methods into unnamed namespace.
