### PR TITLE
Add Vector::skewBy and Vector::skewInverseBy

### DIFF
--- a/NAS2D/Renderer/Vector.h
+++ b/NAS2D/Renderer/Vector.h
@@ -66,6 +66,17 @@ struct Vector {
 		return {x / scalar, y / scalar};
 	}
 
+	Vector skewBy(const Vector& other) const {
+		return {x * other.x, y * other.y};
+	}
+
+	Vector skewInverseBy(const Vector& other) const {
+		if (other.x == 0 || other.y == 0) {
+			throw std::domain_error("Cannot skewInverseBy a vector with a zero component");
+		}
+		return {x / other.x, y / other.y};
+	}
+
 	BaseType lengthSquared() const {
 		return (x * x) + (y * y);
 	}

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -79,6 +79,38 @@ TEST(Vector, DivideScalar) {
 	EXPECT_THROW((NAS2D::Vector{2, 4} /= 0), std::domain_error);
 }
 
+TEST(Vector, skewBy) {
+	EXPECT_EQ((NAS2D::Vector{1, 0}), (NAS2D::Vector{1, 1}.skewBy(NAS2D::Vector{1, 0})));
+	EXPECT_EQ((NAS2D::Vector{2, 3}), (NAS2D::Vector{1, 1}.skewBy(NAS2D::Vector{2, 3})));
+	EXPECT_EQ((NAS2D::Vector{4, 6}), (NAS2D::Vector{1, 1}.skewBy(NAS2D::Vector{4, 6})));
+
+	EXPECT_EQ((NAS2D::Vector{2, 0}), (NAS2D::Vector{2, 1}.skewBy(NAS2D::Vector{1, 0})));
+	EXPECT_EQ((NAS2D::Vector{4, 3}), (NAS2D::Vector{2, 1}.skewBy(NAS2D::Vector{2, 3})));
+	EXPECT_EQ((NAS2D::Vector{8, 6}), (NAS2D::Vector{2, 1}.skewBy(NAS2D::Vector{4, 6})));
+
+	EXPECT_EQ((NAS2D::Vector{1, 0}), (NAS2D::Vector{1, 2}.skewBy(NAS2D::Vector{1, 0})));
+	EXPECT_EQ((NAS2D::Vector{2, 6}), (NAS2D::Vector{1, 2}.skewBy(NAS2D::Vector{2, 3})));
+	EXPECT_EQ((NAS2D::Vector{4, 12}), (NAS2D::Vector{1, 2}.skewBy(NAS2D::Vector{4, 6})));
+}
+
+TEST(Vector, skewInverseBy) {
+	EXPECT_THROW((NAS2D::Vector{1, 1}.skewInverseBy(NAS2D::Vector{0, 0})), std::domain_error);
+	EXPECT_THROW((NAS2D::Vector{1, 1}.skewInverseBy(NAS2D::Vector{0, 1})), std::domain_error);
+	EXPECT_THROW((NAS2D::Vector{1, 1}.skewInverseBy(NAS2D::Vector{1, 0})), std::domain_error);
+
+	EXPECT_EQ((NAS2D::Vector{8, 4}), (NAS2D::Vector{8, 8}.skewInverseBy(NAS2D::Vector{1, 2})));
+	EXPECT_EQ((NAS2D::Vector{4, 2}), (NAS2D::Vector{8, 8}.skewInverseBy(NAS2D::Vector{2, 4})));
+	EXPECT_EQ((NAS2D::Vector{2, 1}), (NAS2D::Vector{8, 8}.skewInverseBy(NAS2D::Vector{3, 5})));
+
+	EXPECT_EQ((NAS2D::Vector{9, 2}), (NAS2D::Vector{9, 6}.skewInverseBy(NAS2D::Vector{1, 3})));
+	EXPECT_EQ((NAS2D::Vector{3, 3}), (NAS2D::Vector{9, 6}.skewInverseBy(NAS2D::Vector{3, 2})));
+	EXPECT_EQ((NAS2D::Vector{2, 1}), (NAS2D::Vector{9, 6}.skewInverseBy(NAS2D::Vector{4, 5})));
+
+	EXPECT_EQ((NAS2D::Vector{4, 2}), (NAS2D::Vector{8, 6}.skewInverseBy(NAS2D::Vector{2, 3})));
+	EXPECT_EQ((NAS2D::Vector{2, 3}), (NAS2D::Vector{8, 6}.skewInverseBy(NAS2D::Vector{4, 2})));
+	EXPECT_EQ((NAS2D::Vector{2, 1}), (NAS2D::Vector{8, 6}.skewInverseBy(NAS2D::Vector{3, 5})));
+}
+
 TEST(Vector, lengthSquared) {
 	// Test a few simple vectors
 	for (int i = 0; i < 10; ++i) {


### PR DESCRIPTION
Add `Vector::skewBy` and `Vector::skewInverseBy` methods. These perform component wise multiplication or division of two `Vector` objects.

I was tempted to overload `operator*` and `operator/` for this, but figured such uses of those operators were not common, and might not be well understood. A longer name helps better describe the purpose.
