### PR TITLE
Add VectorSizeRange and PointInRectangleRange

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -241,6 +241,7 @@
     <ClInclude Include="Renderer\Color.h" />
     <ClInclude Include="Renderer\Point.h" />
     <ClInclude Include="Renderer\Vector.h" />
+    <ClInclude Include="Renderer\VectorSizeRange.h" />
     <ClInclude Include="Renderer\Rectangle.h" />
     <ClInclude Include="Renderer\Renderer.h" />
     <ClInclude Include="Renderer\RendererOpenGL.h" />

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -240,6 +240,7 @@
     <ClInclude Include="Renderer\RendererNull.h" />
     <ClInclude Include="Renderer\Color.h" />
     <ClInclude Include="Renderer\Point.h" />
+    <ClInclude Include="Renderer\PointInRectangleRange.h" />
     <ClInclude Include="Renderer\Vector.h" />
     <ClInclude Include="Renderer\VectorSizeRange.h" />
     <ClInclude Include="Renderer\Rectangle.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -239,6 +239,9 @@
     <ClInclude Include="Renderer\Point.h">
       <Filter>Header Files\Renderer</Filter>
     </ClInclude>
+    <ClInclude Include="Renderer\PointInRectangleRange.h">
+      <Filter>Header Files\Renderer</Filter>
+    </ClInclude>
     <ClInclude Include="Renderer\Vector.h">
       <Filter>Header Files\Renderer</Filter>
     </ClInclude>

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -242,6 +242,9 @@
     <ClInclude Include="Renderer\Vector.h">
       <Filter>Header Files\Renderer</Filter>
     </ClInclude>
+    <ClInclude Include="Renderer\VectorSizeRange.h">
+      <Filter>Header Files\Renderer</Filter>
+    </ClInclude>
     <ClInclude Include="Renderer\Rectangle.h">
       <Filter>Header Files\Renderer</Filter>
     </ClInclude>

--- a/NAS2D/Renderer/PointInRectangleRange.h
+++ b/NAS2D/Renderer/PointInRectangleRange.h
@@ -1,0 +1,69 @@
+#pragma once
+
+
+#include "VectorSizeRange.h"
+#include "Rectangle.h"
+#include "Vector.h"
+#include "Point.h"
+
+
+namespace NAS2D {
+
+
+template <typename BaseType>
+class PointInRectangleRange {
+public:
+	class Iterator {
+	public:
+		Iterator(const Rectangle<BaseType>& rect, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
+			mIterator(rect.size(), initial),
+			mStartPoint(rect.startPoint())
+		{}
+		Iterator(const Iterator& other) = default;
+		Iterator& operator=(const Iterator& other) = default;
+
+		Iterator& operator++() {
+			++mIterator;
+			return *this;
+		}
+
+		Iterator& operator--() {
+			--mIterator;
+			return *this;
+		}
+
+		bool operator==(const Iterator& other) {
+			return **this == *other;
+		}
+
+		bool operator!=(const Iterator& other) {
+			return !(*this == other);
+		}
+
+		Point<BaseType> operator*() const {
+			return mStartPoint + *mIterator;
+		}
+
+	private:
+		typename VectorSizeRange<BaseType>::Iterator mIterator;
+		const Point<BaseType> mStartPoint;
+	};
+
+
+	PointInRectangleRange(Rectangle<BaseType> rect) :
+		mRect(rect)
+	{}
+
+	Iterator begin() const {
+		return Iterator{mRect};
+	}
+
+	Iterator end() const {
+		return Iterator{mRect, Vector<BaseType>{0, mRect.height}};
+	}
+
+private:
+	const Rectangle<BaseType> mRect;
+};
+
+} // namespace

--- a/NAS2D/Renderer/VectorSizeRange.h
+++ b/NAS2D/Renderer/VectorSizeRange.h
@@ -1,0 +1,74 @@
+#pragma once
+
+
+#include "Vector.h"
+
+
+namespace NAS2D {
+
+
+template <typename BaseType>
+class VectorSizeRange {
+public:
+	class Iterator {
+	public:
+		Iterator(const Vector<BaseType>& size, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
+			mCurrent(initial),
+			mSize(size)
+		{}
+		Iterator(const Iterator& other) = default;
+		Iterator& operator=(const Iterator& other) = default;
+
+		Iterator& operator++() {
+			++mCurrent.x;
+			if (mCurrent.x >= mSize.x) {
+				mCurrent.x = 0;
+				++mCurrent.y;
+			}
+			return *this;
+		}
+
+		Iterator& operator--() {
+			if (mCurrent.x <= 0) {
+				mCurrent.x = mSize.x;
+				--mCurrent.y;
+			}
+			--mCurrent.x;
+			return *this;
+		}
+
+		bool operator==(const Iterator& other) {
+			return mCurrent == other.mCurrent;
+		}
+
+		bool operator!=(const Iterator& other) {
+			return !(*this == other);
+		}
+
+		Vector<BaseType> operator*() const {
+			return mCurrent;
+		}
+
+	private:
+		Vector<BaseType> mCurrent;
+		const Vector<BaseType> mSize;
+	};
+
+
+	VectorSizeRange(Vector<BaseType> size) :
+		mSize(size)
+	{}
+
+	Iterator begin() const {
+		return Iterator{mSize};
+	}
+
+	Iterator end() const {
+		return Iterator{mSize, Vector<BaseType>{0, mSize.y}};
+	}
+
+private:
+	const Vector<BaseType> mSize;
+};
+
+} // namespace

--- a/test/Renderer/PointInRectangleRange.test.cpp
+++ b/test/Renderer/PointInRectangleRange.test.cpp
@@ -1,0 +1,36 @@
+#include "NAS2D/Renderer/PointInRectangleRange.h"
+#include <gtest/gtest.h>
+#include <vector>
+
+
+TEST(PointInRectangleRange, Iteration) {
+	using Items = std::vector<NAS2D::Point<int>>;
+
+	const auto pointRange1 = NAS2D::PointInRectangleRange{NAS2D::Rectangle{0, 0, 0, 0}};
+	const auto pointRange2 = NAS2D::PointInRectangleRange{NAS2D::Rectangle{1, 1, 1, 1}};
+	const auto pointRange3 = NAS2D::PointInRectangleRange{NAS2D::Rectangle{4, 5, 2, 3}};
+
+	// Dereference produces the expected starting value
+	// (Later tests also proves the range is restartable)
+	EXPECT_EQ((NAS2D::Point{0, 0}), *pointRange1.begin());
+	EXPECT_EQ((NAS2D::Point{1, 1}), *pointRange2.begin());
+	EXPECT_EQ((NAS2D::Point{4, 5}), *pointRange3.begin());
+
+	// Test head of range for expected values
+	EXPECT_EQ((NAS2D::Point{4, 5}), *pointRange3.begin());
+	EXPECT_EQ((NAS2D::Point{5, 5}), *++pointRange3.begin());
+	EXPECT_EQ((NAS2D::Point{4, 6}), *++++pointRange3.begin());
+	EXPECT_EQ((NAS2D::Point{5, 6}), *++++++pointRange3.begin());
+
+	// Range-for syntax is supported
+	const auto fillByRangeFor = [](auto pointRange) {
+		Items collection;
+		for (const auto point : pointRange) {
+			collection.push_back(point);
+		}
+		return collection;
+	};
+	EXPECT_EQ(fillByRangeFor(pointRange1), (Items{}));
+	EXPECT_EQ(fillByRangeFor(pointRange2), (Items{{1, 1}}));
+	EXPECT_EQ(fillByRangeFor(pointRange3), (Items{{4, 5}, {5, 5}, {4, 6}, {5, 6}, {4, 7}, {5, 7}}));
+}

--- a/test/Renderer/VectorSizeRange.test.cpp
+++ b/test/Renderer/VectorSizeRange.test.cpp
@@ -1,0 +1,30 @@
+#include "NAS2D/Renderer/VectorSizeRange.h"
+#include <gtest/gtest.h>
+#include <vector>
+
+
+TEST(VectorSizeRange, Iteration) {
+	using Items = std::vector<NAS2D::Vector<int>>;
+
+	const auto vectorRange1 = NAS2D::VectorSizeRange{NAS2D::Vector{0, 0}};
+	const auto vectorRange2 = NAS2D::VectorSizeRange{NAS2D::Vector{1, 1}};
+	const auto vectorRange3 = NAS2D::VectorSizeRange{NAS2D::Vector{2, 3}};
+
+	// Dereference produces the expected starting value
+	// (Later tests also proves the range is restartable)
+	EXPECT_EQ((NAS2D::Vector{0, 0}), *vectorRange1.begin());
+	EXPECT_EQ((NAS2D::Vector{0, 0}), *vectorRange2.begin());
+	EXPECT_EQ((NAS2D::Vector{0, 0}), *vectorRange3.begin());
+
+	// Range-for syntax is supported
+	const auto fillByRangeFor = [](auto vectorRange) {
+		Items collection;
+		for (const auto vector : vectorRange) {
+			collection.push_back(vector);
+		}
+		return collection;
+	};
+	EXPECT_EQ(fillByRangeFor(vectorRange1), (Items{}));
+	EXPECT_EQ(fillByRangeFor(vectorRange2), (Items{{0, 0}}));
+	EXPECT_EQ(fillByRangeFor(vectorRange3), (Items{{0, 0}, {1, 0}, {0, 1}, {1, 1}, {0, 2}, {1, 2}}));
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -49,6 +49,7 @@
     <ClCompile Include="Renderer/Point.test.cpp" />
     <ClCompile Include="Renderer/Rectangle.test.cpp" />
     <ClCompile Include="Renderer/Vector.test.cpp" />
+    <ClCompile Include="Renderer/VectorSizeRange.test.cpp" />
     <ClCompile Include="Resources/Image.test.cpp" />
     <ClCompile Include="ContainerUtils.test.cpp" />
     <ClCompile Include="Delegate.test.cpp" />

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <ClCompile Include="Renderer/Color.test.cpp" />
     <ClCompile Include="Renderer/Point.test.cpp" />
+    <ClCompile Include="Renderer/PointInRectangleRange.test.cpp" />
     <ClCompile Include="Renderer/Rectangle.test.cpp" />
     <ClCompile Include="Renderer/Vector.test.cpp" />
     <ClCompile Include="Renderer/VectorSizeRange.test.cpp" />


### PR DESCRIPTION
Add `VectorSizeRange` and `PointInRectangleRange` classes, to support easy iteration over sizes and areas.

```cpp
const auto size = NAS2D::Vector{2, 3};
for (const auto offset : VectorSizeRange(size)) {
  doSomethingAt(offset); // {0, 0}, {1, 0}, {0, 1}, {1, 1}, {0, 2}, {1, 2}
}
```

```cpp
const auto rect = NAS2D::Rectangle{4, 5, 2, 3};
for (const auto point : PointInRectangleRange(rect)) {
  doSomethingAt(point); // {4, 5}, {5, 5}, {4, 6}, {5, 6}, {4, 7}, {5, 7}
}
```
