### PR TITLE
Add Point::skewBy and Point::skewInverseBy

### DIFF
--- a/NAS2D/Renderer/Point.h
+++ b/NAS2D/Renderer/Point.h
@@ -52,6 +52,17 @@ struct Point {
 		return {x - point.x, y - point.y};
 	}
 
+	Point skewBy(const Vector<BaseType>& other) const {
+		return {x * other.x, y * other.y};
+	}
+
+	Point skewInverseBy(const Vector<BaseType>& other) const {
+		if (other.x == 0 || other.y == 0) {
+			throw std::domain_error("Cannot skewInverseBy a vector with a zero component");
+		}
+		return {x / other.x, y / other.y};
+	}
+
 	template <typename NewBaseType>
 	operator Point<NewBaseType>() const {
 		return {

--- a/test/Renderer/Point.test.cpp
+++ b/test/Renderer/Point.test.cpp
@@ -38,6 +38,38 @@ TEST(Vector, SubtractPointToVector) {
 	EXPECT_EQ((NAS2D::Vector{1, 1}), (NAS2D::Point<int>{2, 3}) - (NAS2D::Point{1, 2}));
 }
 
+TEST(Point, skewBy) {
+	EXPECT_EQ((NAS2D::Point{1, 0}), (NAS2D::Point{1, 1}.skewBy(NAS2D::Vector{1, 0})));
+	EXPECT_EQ((NAS2D::Point{2, 3}), (NAS2D::Point{1, 1}.skewBy(NAS2D::Vector{2, 3})));
+	EXPECT_EQ((NAS2D::Point{4, 6}), (NAS2D::Point{1, 1}.skewBy(NAS2D::Vector{4, 6})));
+
+	EXPECT_EQ((NAS2D::Point{2, 0}), (NAS2D::Point{2, 1}.skewBy(NAS2D::Vector{1, 0})));
+	EXPECT_EQ((NAS2D::Point{4, 3}), (NAS2D::Point{2, 1}.skewBy(NAS2D::Vector{2, 3})));
+	EXPECT_EQ((NAS2D::Point{8, 6}), (NAS2D::Point{2, 1}.skewBy(NAS2D::Vector{4, 6})));
+
+	EXPECT_EQ((NAS2D::Point{1, 0}), (NAS2D::Point{1, 2}.skewBy(NAS2D::Vector{1, 0})));
+	EXPECT_EQ((NAS2D::Point{2, 6}), (NAS2D::Point{1, 2}.skewBy(NAS2D::Vector{2, 3})));
+	EXPECT_EQ((NAS2D::Point{4, 12}), (NAS2D::Point{1, 2}.skewBy(NAS2D::Vector{4, 6})));
+}
+
+TEST(Point, skewInverseBy) {
+	EXPECT_THROW((NAS2D::Point{1, 1}.skewInverseBy(NAS2D::Vector{0, 0})), std::domain_error);
+	EXPECT_THROW((NAS2D::Point{1, 1}.skewInverseBy(NAS2D::Vector{0, 1})), std::domain_error);
+	EXPECT_THROW((NAS2D::Point{1, 1}.skewInverseBy(NAS2D::Vector{1, 0})), std::domain_error);
+
+	EXPECT_EQ((NAS2D::Point{8, 4}), (NAS2D::Point{8, 8}.skewInverseBy(NAS2D::Vector{1, 2})));
+	EXPECT_EQ((NAS2D::Point{4, 2}), (NAS2D::Point{8, 8}.skewInverseBy(NAS2D::Vector{2, 4})));
+	EXPECT_EQ((NAS2D::Point{2, 1}), (NAS2D::Point{8, 8}.skewInverseBy(NAS2D::Vector{3, 5})));
+
+	EXPECT_EQ((NAS2D::Point{9, 2}), (NAS2D::Point{9, 6}.skewInverseBy(NAS2D::Vector{1, 3})));
+	EXPECT_EQ((NAS2D::Point{3, 3}), (NAS2D::Point{9, 6}.skewInverseBy(NAS2D::Vector{3, 2})));
+	EXPECT_EQ((NAS2D::Point{2, 1}), (NAS2D::Point{9, 6}.skewInverseBy(NAS2D::Vector{4, 5})));
+
+	EXPECT_EQ((NAS2D::Point{4, 2}), (NAS2D::Point{8, 6}.skewInverseBy(NAS2D::Vector{2, 3})));
+	EXPECT_EQ((NAS2D::Point{2, 3}), (NAS2D::Point{8, 6}.skewInverseBy(NAS2D::Vector{4, 2})));
+	EXPECT_EQ((NAS2D::Point{2, 1}), (NAS2D::Point{8, 6}.skewInverseBy(NAS2D::Vector{3, 5})));
+}
+
 TEST(Point, OperatorType) {
 	// Allow explicit conversion
 	EXPECT_EQ((NAS2D::Point<int>{1, 2}), static_cast<NAS2D::Point<int>>(NAS2D::Point<float>{1.0, 2.0}));


### PR DESCRIPTION
Add `Point::skewBy` and `Point::skewInverseBy` methods. These perform component wise multiplication or division of two Vector objects.

See #710 for the `Vector` equivalent.
