### PR TITLE
Fix drawSubImageRepeated

### DIFF
--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -60,7 +60,7 @@ public:
 	virtual void drawImageRotated(Image& image, Point<float> position, float degrees, Color color = Color::Normal, float scale = 1.0f) = 0;
 	virtual void drawImageStretched(Image& image, Rectangle<float> rect, Color color = Color::Normal) = 0;
 	virtual void drawImageRepeated(Image& image, Rectangle<float> rect) = 0;
-	virtual void drawSubImageRepeated(Image& image, const Rectangle<float>& source, const Rectangle<float>& destination) = 0;
+	virtual void drawSubImageRepeated(Image& image, const Rectangle<float>& destination, const Rectangle<float>& source) = 0;
 
 	void drawImageRect(Rectangle<float> rect, ImageList& images);
 	void drawImageRect(Rectangle<float> rect, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -250,16 +250,14 @@ void RendererOpenGL::drawImageRepeated(Image& image, Rectangle<float> rect)
  */
 void RendererOpenGL::drawSubImageRepeated(Image& image, const Rectangle<float>& destination, const Rectangle<float>& source)
 {
-	float widthReach = destination.width / source.width;
-	float heightReach = destination.height / source.height;
-
 	glEnable(GL_SCISSOR_TEST);
 	const auto clipRect = destination.to<int>();
 	glScissor(clipRect.x, size().y - (clipRect.y + clipRect.height), clipRect.width, clipRect.height);
 
-	for (std::size_t row = 0; row <= heightReach; ++row)
+	const auto tileCountSize = destination.size().skewInverseBy(source.size());
+	for (std::size_t row = 0; row <= tileCountSize.y; ++row)
 	{
-		for (std::size_t col = 0; col <= widthReach; ++col)
+		for (std::size_t col = 0; col <= tileCountSize.x; ++col)
 		{
 			drawSubImage(image, {destination.x + (col * source.width), destination.y + (row * source.height)}, source);
 		}

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -250,8 +250,8 @@ void RendererOpenGL::drawImageRepeated(Image& image, Rectangle<float> rect)
  */
 void RendererOpenGL::drawSubImageRepeated(Image& image, const Rectangle<float>& source, const Rectangle<float>& destination)
 {
-	float widthReach = source.width / (destination.width - destination.x);
-	float heightReach = source.height / (destination.height - destination.y);
+	float widthReach = source.width / destination.width;
+	float heightReach = source.height / destination.height;
 
 	glEnable(GL_SCISSOR_TEST);
 	const auto intSource = source.to<int>();
@@ -261,7 +261,7 @@ void RendererOpenGL::drawSubImageRepeated(Image& image, const Rectangle<float>& 
 	{
 		for (std::size_t col = 0; col <= widthReach; ++col)
 		{
-			drawSubImage(image, {source.x + (col * (destination.width - destination.x)), source.y + (row * (destination.height - destination.y))}, destination);
+			drawSubImage(image, {source.x + (col * destination.width), source.y + (row * destination.height)}, destination);
 		}
 	}
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -254,8 +254,8 @@ void RendererOpenGL::drawSubImageRepeated(Image& image, const Rectangle<float>& 
 	float heightReach = destination.height / source.height;
 
 	glEnable(GL_SCISSOR_TEST);
-	const auto intSource = destination.to<int>();
-	glScissor(intSource.x, size().y - intSource.y - intSource.height, intSource.width, intSource.height);
+	const auto clipRect = destination.to<int>();
+	glScissor(clipRect.x, size().y - (clipRect.y + clipRect.height), clipRect.width, clipRect.height);
 
 	for (std::size_t row = 0; row <= heightReach; ++row)
 	{

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -248,20 +248,20 @@ void RendererOpenGL::drawImageRepeated(Image& image, Rectangle<float> rect)
  * texture and reference it that way (bit of overhead to do a texture lookup and would
  * get unmanagable very quickly.
  */
-void RendererOpenGL::drawSubImageRepeated(Image& image, const Rectangle<float>& source, const Rectangle<float>& destination)
+void RendererOpenGL::drawSubImageRepeated(Image& image, const Rectangle<float>& destination, const Rectangle<float>& source)
 {
-	float widthReach = source.width / destination.width;
-	float heightReach = source.height / destination.height;
+	float widthReach = destination.width / source.width;
+	float heightReach = destination.height / source.height;
 
 	glEnable(GL_SCISSOR_TEST);
-	const auto intSource = source.to<int>();
+	const auto intSource = destination.to<int>();
 	glScissor(intSource.x, size().y - intSource.y - intSource.height, intSource.width, intSource.height);
 
 	for (std::size_t row = 0; row <= heightReach; ++row)
 	{
 		for (std::size_t col = 0; col <= widthReach; ++col)
 		{
-			drawSubImage(image, {source.x + (col * destination.width), source.y + (row * destination.height)}, destination);
+			drawSubImage(image, {destination.x + (col * source.width), destination.y + (row * source.height)}, source);
 		}
 	}
 

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -55,7 +55,7 @@ public:
 	void drawImageStretched(Image& image, Rectangle<float> rect, Color color = Color::Normal) override;
 
 	void drawImageRepeated(Image& image, Rectangle<float> rect) override;
-	void drawSubImageRepeated(Image& image, const Rectangle<float>& source, const Rectangle<float>& destination) override;
+	void drawSubImageRepeated(Image& image, const Rectangle<float>& destination, const Rectangle<float>& source) override;
 
 	void drawImageToImage(Image& source, Image& destination, const Point<float>& dstPoint) override;
 


### PR DESCRIPTION
Fix some inconsistent and seemingly incorrect implementation details which were recently noticed in `RendererOpenGL::drawSubImageRepeated`.

The `source` and `destination` parameters were named backwards, and then used backwards, which made for an odd looking implementation. Additionally, the source rect (previously named destination) was written as if it was a `{point1, point2}` style rect, rather than a `{point, size}` style rect.

Fixes were verified using the nas2d-tests project, which makes use of this method.
