### PR TITLE
Convert Renderer global to member

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -47,7 +47,7 @@ SDL_Window* underlyingWindow = nullptr;
 
 
 namespace {
-	SDL_GLContext oglContext; /**< Primary OpenGL render context. */
+	SDL_GLContext sdlOglContext; /**< Primary OpenGL render context. */
 
 	/** Texture coordinate pairs. Default coordinates encompassing the entire texture. */
 	const std::array<GLfloat, 12> defaultTextureCoords = {0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f};
@@ -111,7 +111,7 @@ RendererOpenGL::~RendererOpenGL()
 {
 	Utility<EventHandler>::get().windowResized().disconnect(this, &RendererOpenGL::onResize);
 
-	SDL_GL_DeleteContext(oglContext);
+	SDL_GL_DeleteContext(sdlOglContext);
 	SDL_DestroyWindow(underlyingWindow);
 	underlyingWindow = nullptr;
 	SDL_QuitSubSystem(SDL_INIT_VIDEO);
@@ -720,8 +720,8 @@ void RendererOpenGL::initVideo(Vector<int> resolution, bool fullscreen, bool vsy
 
 	mResolution = resolution.to<float>();
 
-	oglContext = SDL_GL_CreateContext(underlyingWindow);
-	if (!oglContext)
+	sdlOglContext = SDL_GL_CreateContext(underlyingWindow);
+	if (!sdlOglContext)
 	{
 		throw renderer_opengl_context_failure();
 	}

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -48,13 +48,13 @@ SDL_Window* underlyingWindow = nullptr;
 
 namespace {
 	/** Texture coordinate pairs. Default coordinates encompassing the entire texture. */
-	const std::array<GLfloat, 12> defaultTextureCoords = {0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f};
+	constexpr std::array<GLfloat, 12> DefaultTextureCoords = {0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f};
 
 
 	GLuint generate_fbo(Image& image);
 
 	std::array<GLfloat, 12> rectToQuad(Rectangle<GLfloat> rect);
-	void drawTexturedQuad(GLuint textureId, const std::array<GLfloat, 12>& verticies, const std::array<GLfloat, 12>& textureCoords = defaultTextureCoords);
+	void drawTexturedQuad(GLuint textureId, const std::array<GLfloat, 12>& verticies, const std::array<GLfloat, 12>& textureCoords = DefaultTextureCoords);
 
 	void line(Point<float> p1, Point<float> p2, float lineWidth, Color color);
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -47,8 +47,6 @@ SDL_Window* underlyingWindow = nullptr;
 
 
 namespace {
-	SDL_GLContext sdlOglContext; /**< Primary OpenGL render context. */
-
 	/** Texture coordinate pairs. Default coordinates encompassing the entire texture. */
 	const std::array<GLfloat, 12> defaultTextureCoords = {0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f};
 

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -12,6 +12,7 @@
 #include "Renderer.h"
 
 
+using SDL_GLContext = void*;
 struct SDL_Cursor;
 
 
@@ -102,8 +103,8 @@ private:
 	void onResize(int w, int h);
 
 
+	SDL_GLContext sdlOglContext; /**< Primary OpenGL render context. */
 	Vector<int> desktopResolution;
-
 	std::map<int, SDL_Cursor*> cursors;
 };
 


### PR DESCRIPTION
Convert the last remaining mutable `Renderer` global variable to a member variable.

According to [`SDL_GL_CreateContext`](https://wiki.libsdl.org/SDL_GL_CreateContext):

> SDL_GLContext is an alias for void *.

As such, a `using` clause can setup an alias in the `RendererOpenGL.h` header file, without having to include all of SDL.

----

There exists one `constexpr` initialized global constant used by `RendererOpenGL`.
