### PR TITLE
Constexpr Point Vector Rectangle

### DIFF
--- a/NAS2D/Renderer/Point.h
+++ b/NAS2D/Renderer/Point.h
@@ -21,10 +21,10 @@ struct Point {
 	BaseType x = 0;
 	BaseType y = 0;
 
-	bool operator==(const Point& point) const {
+	constexpr bool operator==(const Point& point) const {
 		return (x == point.x) && (y == point.y);
 	}
-	bool operator!=(const Point& point) const {
+	constexpr bool operator!=(const Point& point) const {
 		return !(*this == point);
 	}
 
@@ -40,23 +40,23 @@ struct Point {
 		return *this;
 	}
 
-	Point operator+(const Vector<BaseType>& vector) const {
+	constexpr Point operator+(const Vector<BaseType>& vector) const {
 		return {x + vector.x, y + vector.y};
 	}
 
-	Point operator-(const Vector<BaseType>& vector) const {
+	constexpr Point operator-(const Vector<BaseType>& vector) const {
 		return {x - vector.x, y - vector.y};
 	}
 
-	Vector<BaseType> operator-(const Point& point) const {
+	constexpr Vector<BaseType> operator-(const Point& point) const {
 		return {x - point.x, y - point.y};
 	}
 
-	Point skewBy(const Vector<BaseType>& other) const {
+	constexpr Point skewBy(const Vector<BaseType>& other) const {
 		return {x * other.x, y * other.y};
 	}
 
-	Point skewInverseBy(const Vector<BaseType>& other) const {
+	constexpr Point skewInverseBy(const Vector<BaseType>& other) const {
 		if (other.x == 0 || other.y == 0) {
 			throw std::domain_error("Cannot skewInverseBy a vector with a zero component");
 		}
@@ -64,7 +64,7 @@ struct Point {
 	}
 
 	template <typename NewBaseType>
-	operator Point<NewBaseType>() const {
+	constexpr operator Point<NewBaseType>() const {
 		return {
 			static_cast<NewBaseType>(x),
 			static_cast<NewBaseType>(y)
@@ -72,7 +72,7 @@ struct Point {
 	}
 
 	template <typename NewBaseType>
-	Point<NewBaseType> to() const {
+	constexpr Point<NewBaseType> to() const {
 		return static_cast<Point<NewBaseType>>(*this);
 	}
 };

--- a/NAS2D/Renderer/Rectangle.h
+++ b/NAS2D/Renderer/Rectangle.h
@@ -26,7 +26,7 @@ struct Rectangle
 	BaseType height = 0;
 
 	// Factory method
-	static Rectangle<BaseType> Create(Point<BaseType> startPoint, Vector<BaseType> size) {
+	constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Vector<BaseType> size) {
 		return {
 			startPoint.x,
 			startPoint.y,
@@ -36,7 +36,7 @@ struct Rectangle
 	}
 
 	// Factory method
-	static Rectangle<BaseType> Create(Point<BaseType> startPoint, Point<BaseType> endPoint) {
+	constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Point<BaseType> endPoint) {
 		return {
 			startPoint.x,
 			startPoint.y,

--- a/NAS2D/Renderer/Rectangle.h
+++ b/NAS2D/Renderer/Rectangle.h
@@ -45,34 +45,34 @@ struct Rectangle
 		};
 	}
 
-	bool operator==(const Rectangle& rect) const {
+	constexpr bool operator==(const Rectangle& rect) const {
 		return (x == rect.x) && (y == rect.y) && (width == rect.width) && (height == rect.height);
 	}
-	bool operator!=(const Rectangle& rect) const {
+	constexpr bool operator!=(const Rectangle& rect) const {
 		return !(*this == rect);
 	}
 
-	Vector<BaseType> size() const {
+	constexpr Vector<BaseType> size() const {
 		return {width, height};
 	}
 
-	Point<BaseType> startPoint() const {
+	constexpr Point<BaseType> startPoint() const {
 		return {x, y};
 	}
 
-	Point<BaseType> endPoint() const {
+	constexpr Point<BaseType> endPoint() const {
 		return Point{x, y} + Vector{width, height};
 	}
 
-	Point<BaseType> crossXPoint() const {
+	constexpr Point<BaseType> crossXPoint() const {
 		return {x + width, y};
 	}
 
-	Point<BaseType> crossYPoint() const {
+	constexpr Point<BaseType> crossYPoint() const {
 		return {x, y + height};
 	}
 
-	bool null() const {
+	constexpr bool null() const {
 		return (width == 0) || (height == 0);
 	}
 
@@ -86,16 +86,16 @@ struct Rectangle
 		y = newStartPoint.y;
 	}
 
-	Rectangle skewBy(const Vector<BaseType>& scaleFactor) const {
+	constexpr Rectangle skewBy(const Vector<BaseType>& scaleFactor) const {
 		return Create(startPoint().skewBy(scaleFactor), size().skewBy(scaleFactor));
 	}
 
-	Rectangle skewInverseBy(const Vector<BaseType>& scaleFactor) const {
+	constexpr Rectangle skewInverseBy(const Vector<BaseType>& scaleFactor) const {
 		return Create(startPoint().skewInverseBy(scaleFactor), size().skewInverseBy(scaleFactor));
 	}
 
 	template <typename NewBaseType>
-	operator Rectangle<NewBaseType>() const {
+	constexpr operator Rectangle<NewBaseType>() const {
 		return {
 			static_cast<NewBaseType>(x),
 			static_cast<NewBaseType>(y),
@@ -105,13 +105,13 @@ struct Rectangle
 	}
 
 	template <typename NewBaseType>
-	Rectangle<NewBaseType> to() const {
+	constexpr Rectangle<NewBaseType> to() const {
 		return static_cast<Rectangle<NewBaseType>>(*this);
 	}
 
 	// Start point inclusive (x, y), endpoint exclusive (x + , y + height)
 	// Area in interval notation: [x .. x + ), [y .. y + height)
-	bool contains(const Point<BaseType>& point) const {
+	constexpr bool contains(const Point<BaseType>& point) const {
 		auto px = point.x;
 		auto py = point.y;
 		return ((x <= px) && (px < x + width)) && ((y <= py) && (py < y + height));
@@ -119,18 +119,18 @@ struct Rectangle
 
 	// Start point inclusive (x, y), endpoint exclusive (x + , y + height)
 	// Area in interval notation: [x .. x + ), [y .. y + height)
-	bool overlaps(const Rectangle& rect) const {
+	constexpr bool overlaps(const Rectangle& rect) const {
 		return ((x < rect.x + rect.width) && (rect.x < x + width)) && ((y < rect.y + rect.height) && (rect.y < y + height));
 	}
 
-	BaseType center_x() const {
+	constexpr BaseType center_x() const {
 		return x + (width / 2);
 	}
-	BaseType center_y() const {
+	constexpr BaseType center_y() const {
 		return y + (height / 2);
 	}
 
-	Point<BaseType> center() const {
+	constexpr Point<BaseType> center() const {
 		return {x + (width / 2), y + (height / 2)};
 	}
 };

--- a/NAS2D/Renderer/Vector.h
+++ b/NAS2D/Renderer/Vector.h
@@ -11,10 +11,10 @@ struct Vector {
 	BaseType x = 0;
 	BaseType y = 0;
 
-	bool operator==(const Vector& vector) const {
+	constexpr bool operator==(const Vector& vector) const {
 		return (x == vector.x) && (y == vector.y);
 	}
-	bool operator!=(const Vector& vector) const {
+	constexpr bool operator!=(const Vector& vector) const {
 		return !(*this == vector);
 	}
 
@@ -29,13 +29,13 @@ struct Vector {
 		return *this;
 	}
 
-	Vector operator+(const Vector& vector) const {
+	constexpr Vector operator+(const Vector& vector) const {
 		return {
 			x + vector.x,
 			y + vector.y
 		};
 	}
-	Vector operator-(const Vector& vector) const {
+	constexpr Vector operator-(const Vector& vector) const {
 		return {
 			x - vector.x,
 			y - vector.y
@@ -56,47 +56,47 @@ struct Vector {
 		return *this;
 	}
 
-	Vector operator*(BaseType scalar) const {
+	constexpr Vector operator*(BaseType scalar) const {
 		return {x * scalar, y * scalar};
 	}
-	Vector operator/(BaseType scalar) const {
+	constexpr Vector operator/(BaseType scalar) const {
 		if (scalar == 0) {
 			throw std::domain_error("Cannot divide vector by 0");
 		}
 		return {x / scalar, y / scalar};
 	}
 
-	Vector skewBy(const Vector& other) const {
+	constexpr Vector skewBy(const Vector& other) const {
 		return {x * other.x, y * other.y};
 	}
 
-	Vector skewInverseBy(const Vector& other) const {
+	constexpr Vector skewInverseBy(const Vector& other) const {
 		if (other.x == 0 || other.y == 0) {
 			throw std::domain_error("Cannot skewInverseBy a vector with a zero component");
 		}
 		return {x / other.x, y / other.y};
 	}
 
-	BaseType lengthSquared() const {
+	constexpr BaseType lengthSquared() const {
 		return (x * x) + (y * y);
 	}
 
-	BaseType dotProduct(const Vector& other) const {
+	constexpr BaseType dotProduct(const Vector& other) const {
 		return (x * other.x) + (y * other.y);
 	}
 
 	// Reflect the x-coordinate (flip across Y-axis)
-	Vector reflectX() const {
+	constexpr Vector reflectX() const {
 		return {-x, y};
 	}
 
 	// Reflect the y-coordinate (flip across X-axis)
-	Vector reflectY() const {
+	constexpr Vector reflectY() const {
 		return {x, -y};
 	}
 
 	template <typename NewBaseType>
-	operator Vector<NewBaseType>() const {
+	constexpr operator Vector<NewBaseType>() const {
 		return {
 			static_cast<NewBaseType>(x),
 			static_cast<NewBaseType>(y)
@@ -104,7 +104,7 @@ struct Vector {
 	}
 
 	template <typename NewBaseType>
-	Vector<NewBaseType> to() const {
+	constexpr Vector<NewBaseType> to() const {
 		return static_cast<Vector<NewBaseType>>(*this);
 	}
 };


### PR DESCRIPTION
For classes `Point`, `Vector`, and `Rectangle`, mark all `const` member functions and factory functions as `constexpr`.

This enables compile time computation with these classes.
