### PR TITLE
Fixes for C++20 compatibility

### DIFF
--- a/NAS2D/Renderer/PointInRectangleRange.h
+++ b/NAS2D/Renderer/PointInRectangleRange.h
@@ -32,11 +32,11 @@ public:
 			return *this;
 		}
 
-		bool operator==(const Iterator& other) {
+		bool operator==(const Iterator& other) const {
 			return **this == *other;
 		}
 
-		bool operator!=(const Iterator& other) {
+		bool operator!=(const Iterator& other) const {
 			return !(*this == other);
 		}
 

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -255,7 +255,7 @@ void Renderer::update()
 }
 
 
-void Renderer::setResolution(const Vector<float>& newResolution)
+void Renderer::setResolution(const Vector<int>& newResolution)
 {
 	if (!fullscreen())
 	{

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -127,7 +127,7 @@ public:
 
 	virtual void setViewport(const Rectangle<int>& viewport) = 0;
 	virtual void setOrthoProjection(const Rectangle<float>& orthoBounds) = 0;
-	void setResolution(const Vector<float>& newResolution);
+	void setResolution(const Vector<int>& newResolution);
 
 protected:
 	Renderer(const std::string& appTitle);

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -733,7 +733,7 @@ void RendererOpenGL::initVideo(Vector<int> resolution, bool fullscreen, bool vsy
 		throw renderer_window_creation_failure();
 	}
 
-	mResolution = resolution.to<float>();
+	mResolution = resolution;
 
 	sdlOglContext = SDL_GL_CreateContext(underlyingWindow);
 	if (!sdlOglContext)

--- a/NAS2D/Renderer/VectorSizeRange.h
+++ b/NAS2D/Renderer/VectorSizeRange.h
@@ -37,11 +37,11 @@ public:
 			return *this;
 		}
 
-		bool operator==(const Iterator& other) {
+		bool operator==(const Iterator& other) const {
 			return mCurrent == other.mCurrent;
 		}
 
-		bool operator!=(const Iterator& other) {
+		bool operator!=(const Iterator& other) const {
 			return !(*this == other);
 		}
 

--- a/test/Trig.test.cpp
+++ b/test/Trig.test.cpp
@@ -24,16 +24,16 @@ TEST(Trig, getAngle) {
 }
 
 TEST(Trig, getDirectionVector) {
-	EXPECT_EQ((NAS2D::Vector{1, 0}), NAS2D::getDirectionVector(NAS2D::degToRad(0.0f)));
-	EXPECT_EQ((NAS2D::Vector{0, 1}), NAS2D::getDirectionVector(NAS2D::degToRad(90.0f)));
-	EXPECT_EQ((NAS2D::Vector{-1, 0}), NAS2D::getDirectionVector(NAS2D::degToRad(180.0f)));
-	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(NAS2D::degToRad(270.0f)));
-	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(NAS2D::degToRad(-90.0f)));
+	EXPECT_EQ((NAS2D::Vector{1, 0}), NAS2D::getDirectionVector(NAS2D::degToRad(0.0f)).to<int>());
+	EXPECT_EQ((NAS2D::Vector{0, 1}), NAS2D::getDirectionVector(NAS2D::degToRad(90.0f)).to<int>());
+	EXPECT_EQ((NAS2D::Vector{-1, 0}), NAS2D::getDirectionVector(NAS2D::degToRad(180.0f)).to<int>());
+	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(NAS2D::degToRad(270.0f)).to<int>());
+	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(NAS2D::degToRad(-90.0f)).to<int>());
 }
 
 TEST(Trig, vectorToAngleToVector) {
-	EXPECT_EQ((NAS2D::Vector{1, 0}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector<float>{1, 0})));
-	EXPECT_EQ((NAS2D::Vector{0, 1}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector<float>{0, 1})));
-	EXPECT_EQ((NAS2D::Vector{-1, 0}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector<float>{-1, 0})));
-	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector<float>{0, -1})));
+	EXPECT_EQ((NAS2D::Vector{1, 0}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector<float>{1, 0})).to<int>());
+	EXPECT_EQ((NAS2D::Vector{0, 1}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector<float>{0, 1})).to<int>());
+	EXPECT_EQ((NAS2D::Vector{-1, 0}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector<float>{-1, 0})).to<int>());
+	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector<float>{0, -1})).to<int>());
 }

--- a/test/Trig.test.cpp
+++ b/test/Trig.test.cpp
@@ -13,14 +13,14 @@ TEST(Trig, degToRadToDeg) {
 }
 
 TEST(Trig, getAngle) {
-	EXPECT_FLOAT_EQ(0.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{0, 0})));
+	EXPECT_FLOAT_EQ(0.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector<float>{0, 0})));
 
-	EXPECT_FLOAT_EQ(0.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{1, 0})));
-	EXPECT_FLOAT_EQ(90.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{0, 1})));
-	EXPECT_FLOAT_EQ(180.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{-1, 0})));
-	EXPECT_FLOAT_EQ(-90.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{0, -1})));
+	EXPECT_FLOAT_EQ(0.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector<float>{1, 0})));
+	EXPECT_FLOAT_EQ(90.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector<float>{0, 1})));
+	EXPECT_FLOAT_EQ(180.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector<float>{-1, 0})));
+	EXPECT_FLOAT_EQ(-90.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector<float>{0, -1})));
 
-	EXPECT_FLOAT_EQ(45.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector{1.0, 1.0})));
+	EXPECT_FLOAT_EQ(45.0f, NAS2D::radToDeg(NAS2D::getAngle(NAS2D::Vector<float>{1, 1})));
 }
 
 TEST(Trig, getDirectionVector) {
@@ -32,8 +32,8 @@ TEST(Trig, getDirectionVector) {
 }
 
 TEST(Trig, vectorToAngleToVector) {
-	EXPECT_EQ((NAS2D::Vector{1, 0}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector{1, 0})));
-	EXPECT_EQ((NAS2D::Vector{0, 1}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector{0, 1})));
-	EXPECT_EQ((NAS2D::Vector{-1, 0}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector{-1, 0})));
-	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector{0, -1})));
+	EXPECT_EQ((NAS2D::Vector{1, 0}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector<float>{1, 0})));
+	EXPECT_EQ((NAS2D::Vector{0, 1}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector<float>{0, 1})));
+	EXPECT_EQ((NAS2D::Vector{-1, 0}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector<float>{-1, 0})));
+	EXPECT_EQ((NAS2D::Vector{0, -1}), NAS2D::getDirectionVector(getAngle(NAS2D::Vector<float>{0, -1})));
 }


### PR DESCRIPTION
Fixes for a few things that came up when I did a test compile with `--std=c++20` enabled using Clang on Ubuntu 20.04.

At some point we'll also need to deprecate implicit conversion of `BaseType` for the `Point`, `Vector`, and `Rectangle` classes. though that might wait until further UI refactoring is done.
