### PR TITLE
Deprecate implicit BaseType conversion

### DIFF
--- a/NAS2D/MathUtils.cpp
+++ b/NAS2D/MathUtils.cpp
@@ -24,12 +24,11 @@ namespace NAS2D {
  */
 bool lineIntersectsCircle(const Point<int>& p, const Point<int>& q, const Point<int>& c, float r)
 {
-	const auto centerToStart = p - c;
-	const auto lineSize = q - p;
-	const auto lineSizeFloat = lineSize.to<float>();
+	const auto centerToStart = (p - c).to<float>();
+	const auto lineSize = (q - p).to<float>();
 
-	const auto t = std::clamp<float>(-centerToStart.dotProduct(lineSizeFloat) / lineSizeFloat.lengthSquared(), 0, 1);
-	const auto minDistance = lineSizeFloat * t + centerToStart;
+	const auto t = std::clamp<float>(-centerToStart.dotProduct(lineSize) / lineSize.lengthSquared(), 0, 1);
+	const auto minDistance = lineSize * t + centerToStart;
 
 	return minDistance.lengthSquared() < (r * r);
 }

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -96,10 +96,10 @@ void Renderer::drawImageRect(Rectangle<float> rect, ImageList& images)
 
 void Renderer::drawImageRect(Rectangle<float> rect, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight)
 {
-	const auto p1 = rect.startPoint() + topLeft.size();
-	const auto p2 = rect.crossXPoint() + topRight.size().reflectX();
-	const auto p3 = rect.crossYPoint() + bottomLeft.size().reflectY();
-	const auto p4 = rect.endPoint() - bottomRight.size();
+	const auto p1 = rect.startPoint() + topLeft.size().to<float>();
+	const auto p2 = rect.crossXPoint() + topRight.size().reflectX().to<float>();
+	const auto p3 = rect.crossYPoint() + bottomLeft.size().reflectY().to<float>();
+	const auto p4 = rect.endPoint() - bottomRight.size().to<float>();
 
 	// Draw the center area
 	drawImageRepeated(center, Rectangle<float>::Create(p1, p4));

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -628,9 +628,9 @@ bool RendererOpenGL::resizeable() const
 
 void RendererOpenGL::onResize(int w, int h)
 {
-	const auto dimensions = Vector{w, h}.to<float>();
+	const auto dimensions = Vector{w, h};
 	setViewport(Rectangle{0, 0, w, h});
-	setOrthoProjection(Rectangle<float>::Create(Point{0.0f, 0.0f}, dimensions));
+	setOrthoProjection(Rectangle<float>::Create(Point{0.0f, 0.0f}, dimensions.to<float>()));
 	setResolution(dimensions);
 
 }

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -147,7 +147,7 @@ void Sprite::update(Point<float> position)
 		mFrameCallback();
 	}
 
-	const auto drawPosition = position - frame.anchorOffset;
+	const auto drawPosition = position - frame.anchorOffset.to<float>();
 	const auto frameBounds = frame.bounds.to<float>();
 	Utility<Renderer>::get().drawSubImageRotated(mImageSheets[frame.sheetId], drawPosition, frameBounds, mRotationAngle, mColor);
 }

--- a/test/Renderer/Point.test.cpp
+++ b/test/Renderer/Point.test.cpp
@@ -74,10 +74,6 @@ TEST(Point, OperatorType) {
 	// Allow explicit conversion
 	EXPECT_EQ((NAS2D::Point<int>{1, 2}), static_cast<NAS2D::Point<int>>(NAS2D::Point<float>{1.0, 2.0}));
 	EXPECT_EQ((NAS2D::Point<float>{1.0, 2.0}), static_cast<NAS2D::Point<float>>(NAS2D::Point<int>{1, 2}));
-
-	// Allow implicit conversion (may be deprecated in the future)
-	EXPECT_EQ((NAS2D::Point<int>{1, 2}), (NAS2D::Point<float>{1.0, 2.0}));
-	EXPECT_EQ((NAS2D::Point<float>{1.0, 2.0}), (NAS2D::Point<int>{1, 2}));
 }
 
 TEST(Point, to) {

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -29,10 +29,6 @@ TEST(Vector, Conversion) {
 	// Allow explicit conversion
 	EXPECT_EQ((NAS2D::Vector<int>{1, 1}), static_cast<NAS2D::Vector<int>>(NAS2D::Vector<float>{1.0, 1.0}));
 	EXPECT_EQ((NAS2D::Vector<float>{1.0, 1.0}), static_cast<NAS2D::Vector<float>>(NAS2D::Vector<int>{1, 1}));
-
-	// Allow implicit conversion (may be deprecated in the future)
-	EXPECT_EQ((NAS2D::Vector<int>{1, 1}), (NAS2D::Vector<float>{1.0, 1.0}));
-	EXPECT_EQ((NAS2D::Vector<float>{1.0, 1.0}), (NAS2D::Vector<int>{1, 1}));
 }
 
 TEST(Vector, SelfAdd) {


### PR DESCRIPTION
Deprecate implicit `BaseType` conversion for `Point`, `Vector`, and `Rectangle`.

Implicit conversion was useful when transitioning the UI code to packed types. We're getting to the point where things should be cleaned up and made explicit. As such, NAS2D code has been updated to use explicit `BaseType` conversions.

As part of deprecation, the unit tests in `Point` and `Vector` which check implicit conversions have been removed. This allows for easier testing and updating of downstream projects, as conversions can be marked `explicit` to find errors in downstream projects, without also generating NAS2D library errors.

Related: #724
