### PR TITLE
Use explicit BaseType conversion in Renderer::update()

### DIFF
--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -250,7 +250,7 @@ void Renderer::update()
 
 	if (mCurrentFade > 0.0f)
 	{
-		drawBoxFilled(Rectangle<int>::Create({0, 0}, size()), mFadeColor.alphaFade(static_cast<uint8_t>(mCurrentFade)));
+		drawBoxFilled(Rectangle<float>::Create({0, 0}, size().to<float>()), mFadeColor.alphaFade(static_cast<uint8_t>(mCurrentFade)));
 	}
 }
 


### PR DESCRIPTION
Use explicit `BaseType` conversion when constructing and passing a `Rectangle` in `Renderer::update()`.

Seems this change was missed when working on #725.
