### PR TITLE
Use std::size_t type in for loop to fix MSVC overflow warning

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -360,7 +360,7 @@ void RendererOpenGL::drawCircle(Point<float> position, float radius, Color color
 
 	// During each iteration of the for loop, two indecies are accessed
 	// so we need to be sure that we step two index places for each loop.
-	for (int i = 0; i < num_segments * 2; i += 2)
+	for (std::size_t i = 0; i < verts.size(); i += 2)
 	{
 		const auto point = position + offset.skewBy(scale);
 		verts[i] = point.x;


### PR DESCRIPTION
The 64-bit MSVC build was producing the warning:

> C:\projects\nas2d-core\NAS2D\Renderer\RendererOpenGL.cpp(367): warning C26451: Arithmetic overflow: Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2). [C:\projects\nas2d-core\NAS2D\NAS2D.vcxproj]

This was caused by the subscript calculation for `verts[i + 1]`:
```cpp
	for (int i = 0; i < num_segments * 2; i += 2)
	{
		const auto point = position + offset.skewBy(scale);
		verts[i] = point.x;
		verts[i + 1] = point.y;

		// ...
```

Changing the type of `i` to be `std::size_t` should allow for appropriate sized addition for both 32-bit and 64-bit.
