### PR TITLE
Remove Image::center_x() and Image::center_y()

### DIFF
--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -231,18 +231,6 @@ Vector<int> Image::center() const
 }
 
 
-int Image::center_x() const
-{
-	return mSize.x / 2;
-}
-
-
-int Image::center_y() const
-{
-	return mSize.y / 2;
-}
-
-
 /**
  * Gets the color of a pixel at a given coordinate.
  *

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -225,12 +225,6 @@ Vector<int> Image::size() const
 }
 
 
-Vector<int> Image::center() const
-{
-	return mSize / 2;
-}
-
-
 /**
  * Gets the color of a pixel at a given coordinate.
  *

--- a/NAS2D/Resources/Image.h
+++ b/NAS2D/Resources/Image.h
@@ -54,9 +54,6 @@ public:
 	Vector<int> size() const;
 	Vector<int> center() const;
 
-	int center_x() const;
-	int center_y() const;
-
 	Color pixelColor(Point<int> point) const;
 	Color pixelColor(int x, int y) const;
 

--- a/NAS2D/Resources/Image.h
+++ b/NAS2D/Resources/Image.h
@@ -52,7 +52,6 @@ public:
 	~Image() override;
 
 	Vector<int> size() const;
-	Vector<int> center() const;
 
 	Color pixelColor(Point<int> point) const;
 	Color pixelColor(int x, int y) const;

--- a/test/Resources/Image.test.cpp
+++ b/test/Resources/Image.test.cpp
@@ -6,11 +6,3 @@ TEST(Image, size) {
 	EXPECT_EQ((NAS2D::Vector{1, 1}), NAS2D::Image(1, 1).size());
 	EXPECT_EQ((NAS2D::Vector{4, 2}), NAS2D::Image(4, 2).size());
 }
-
-TEST(Image, center) {
-	EXPECT_EQ(0, NAS2D::Image(1, 1).center().x);
-	EXPECT_EQ(0, NAS2D::Image(1, 1).center().y);
-
-	EXPECT_EQ(2, NAS2D::Image(4, 2).center().x);
-	EXPECT_EQ(1, NAS2D::Image(4, 2).center().y);
-}

--- a/test/Resources/Image.test.cpp
+++ b/test/Resources/Image.test.cpp
@@ -8,9 +8,9 @@ TEST(Image, size) {
 }
 
 TEST(Image, center) {
-	EXPECT_EQ(0, NAS2D::Image(1, 1).center_x());
-	EXPECT_EQ(0, NAS2D::Image(1, 1).center_y());
+	EXPECT_EQ(0, NAS2D::Image(1, 1).center().x);
+	EXPECT_EQ(0, NAS2D::Image(1, 1).center().y);
 
-	EXPECT_EQ(2, NAS2D::Image(4, 2).center_x());
-	EXPECT_EQ(1, NAS2D::Image(4, 2).center_y());
+	EXPECT_EQ(2, NAS2D::Image(4, 2).center().x);
+	EXPECT_EQ(1, NAS2D::Image(4, 2).center().y);
 }


### PR DESCRIPTION
Remove `Image::center_x()` and `Image::center_y()`.

Use `Image::center().x` and `Image::center().y` instead.
