### PR TITLE
Add Font::glyphCellSize() method

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -469,7 +469,8 @@ void RendererOpenGL::drawText(const Font& font, std::string_view text, Point<flo
 	{
 		GlyphMetrics& gm = gml[std::clamp<std::size_t>(static_cast<uint8_t>(character), 0, 255)];
 
-		const auto vertexArray = rectToQuad({position.x + offset, position.y, static_cast<float>(font.glyphCellWidth()), static_cast<float>(font.glyphCellHeight())});
+		const auto glyphCellSize = font.glyphCellSize().to<float>();
+		const auto vertexArray = rectToQuad({position.x + offset, position.y, glyphCellSize.x, glyphCellSize.y});
 		const auto textureCoordArray = rectToQuad(gm.uvRect);
 
 		drawTexturedQuad(fontMap[font.name()].textureId, vertexArray, textureCoordArray);

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -144,6 +144,12 @@ Font& Font::operator=(const Font& rhs)
 }
 
 
+Vector<int> Font::glyphCellSize() const
+{
+	return fontMap[name()].glyphSize;
+}
+
+
 /**
  * Gets the glyph cell width.
  */

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -150,24 +150,6 @@ Vector<int> Font::glyphCellSize() const
 }
 
 
-/**
- * Gets the glyph cell width.
- */
-int Font::glyphCellWidth() const
-{
-	return fontMap[name()].glyphSize.x;
-}
-
-
-/**
- * Gets the glyph cell height.
- */
-int Font::glyphCellHeight() const
-{
-	return fontMap[name()].glyphSize.y;
-}
-
-
 Vector<int> Font::size(std::string_view string) const
 {
 	return {width(string), height()};

--- a/NAS2D/Resources/Font.h
+++ b/NAS2D/Resources/Font.h
@@ -51,8 +51,6 @@ public:
 	unsigned int ptSize() const;
 
 	Vector<int> glyphCellSize() const;
-	int glyphCellWidth() const;
-	int glyphCellHeight() const;
 
 private:
 	void load() override {}

--- a/NAS2D/Resources/Font.h
+++ b/NAS2D/Resources/Font.h
@@ -50,6 +50,7 @@ public:
 
 	unsigned int ptSize() const;
 
+	Vector<int> glyphCellSize() const;
 	int glyphCellWidth() const;
 	int glyphCellHeight() const;
 


### PR DESCRIPTION
Add `Font::glyphCellSize()` method. Use it to replace `Font::glyphCellWidth()` and `Font::glyphCellHeight()`.
