### PR TITLE
Refactor Sprite

### DIFF
--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -100,10 +100,7 @@ void Sprite::resume()
  */
 void Sprite::setFrame(std::size_t frameIndex)
 {
-	if (mActions.find(mCurrentAction) != mActions.end())
-	{
-		mCurrentFrame = frameIndex % mActions[mCurrentAction].size();
-	}
+	mCurrentFrame = frameIndex % mActions[mCurrentAction].size();
 }
 
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -510,18 +510,15 @@ bool Sprite::validateSheetId(const std::string& sheetId, int row)
 {
 	if (sheetId.empty())
 	{
-		cout << "Frame definition has a zero-length 'sheetid' value. Frame is being ignored." << endTag(row, name()) << endl;
-		return false;
+		throw std::runtime_error("Sprite Frame definition has 'sheetid' of length zero: " + endTag(row, name()));
 	}
 	else if (mImageSheets.find(sheetId) == mImageSheets.end())
 	{
-		cout << "Frame definition references an undefined imagesheet '" << sheetId << "'." << endTag(row, name()) << endl;
-		return false;
+		throw std::runtime_error("Sprite Frame definition references undefined imagesheet: '" + sheetId + "' " + endTag(row, name()));
 	}
 	else if (!mImageSheets.find(sheetId)->second.loaded())
 	{
-		cout << "Frame definition references an imagesheet that failed to load." << endTag(row, name()) << endl;
-		return false;
+		throw std::runtime_error("Sprite Frame definition references imagesheet that failed to load: '" + sheetId + "' " + endTag(row, name()));
 	}
 
 	return true;

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -139,12 +139,12 @@ void Sprite::update(Point<float> position)
 		if (mCurrentFrame >= mActions[mCurrentAction].size())
 		{
 			mCurrentFrame = 0;
-			mFrameCallback(); // Notifiy any frame listeners that the animation sequence has completed.
+			mAnimationCompleteCallback(); // Notifiy any frame listeners that the animation sequence has completed.
 		}
 	}
 	else if (frame.frameDelay == FRAME_PAUSE)
 	{
-		mFrameCallback();
+		mAnimationCompleteCallback();
 	}
 
 	const auto drawPosition = position - frame.anchorOffset.to<float>();

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -352,8 +352,7 @@ void Sprite::addImageSheet(const std::string& id, const std::string& src, void* 
 		imagePath += src;
 		if (!fs.exists(imagePath))
 		{
-			cout << "Couldn't find '" << imagePath << "' defined in sprite file '" << name() << "'." << endl;
-			mImageSheets[toLowercase(id)]; // Add a default image
+			throw std::runtime_error("Sprite image path not found: Sprite: '" + name() + "' Image: '" + imagePath + "'");
 		}
 		else
 		{
@@ -362,7 +361,7 @@ void Sprite::addImageSheet(const std::string& id, const std::string& src, void* 
 	}
 	else
 	{
-		cout << "Image-sheet redefinition '" << id << "'." << endTag(static_cast<XmlNode*>(node)->row(), name()) << ". Imagesheet ignored." << endl;
+		throw std::runtime_error("Sprite image sheet redefinition: id: '" + id + "' " + endTag(static_cast<XmlNode*>(node)->row(), name()));
 	}
 }
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -39,20 +39,6 @@ namespace {
 
 
 /**
- * Default c'tor.
- *
- * Provided to allow sprites to be used in STL containers.
- *
- * \warning	Generally speaking, Sprites should not be instantiated
- *			with the default c'tor.
- */
-Sprite::Sprite()
-{
-	addDefaultAction();
-}
-
-
-/**
  * C'tor.
  *
  * \param filePath	File path of the Sprite definition file.
@@ -493,28 +479,6 @@ void Sprite::processFrames(const std::string& action, const void* _node)
 	else
 	{
 		throw std::runtime_error("Sprite Action contains no valid frames: " + action + " (" + name() + ")");
-	}
-}
-
-
-/**
- * Adds a 'default' action to the action list.
- *
- * \note	This function will not override a 'default' action if one has
- *			has already been specified.
- */
-void Sprite::addDefaultAction()
-{
-	if (mActions.find("default") == mActions.end())
-	{
-		auto& imageSheet = mImageSheets["default"]; // Adds a default sheet. //-V607
-
-		const auto size = imageSheet.size();
-		const auto bounds = Rectangle<int>::Create(Point{0, 0}, size);
-		const auto anchorOffset = size / 2;
-
-		FrameList frameList{SpriteFrame{"default", bounds, anchorOffset, FRAME_PAUSE}};
-		mActions["default"] = frameList;
 	}
 }
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -233,14 +233,9 @@ void Sprite::decrementFrame()
  */
 void Sprite::processXml(const std::string& filePath)
 {
-	Filesystem& fs = Utility<Filesystem>::get();
-
-	File xmlFile = fs.open(filePath);
-
 	XmlDocument xmlDoc;
+	xmlDoc.parse(Utility<Filesystem>::get().open(filePath).raw_bytes());
 
-	// Load the XML document and handle any errors if occuring
-	xmlDoc.parse(xmlFile.raw_bytes());
 	if (xmlDoc.error())
 	{
 		throw std::runtime_error("Sprite file has malformed XML: (" + name() + ") Row: " + std::to_string(xmlDoc.errorRow()) + " Column: " + std::to_string(xmlDoc.errorCol()) + " : " + xmlDoc.errorDesc());

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -455,9 +455,17 @@ void Sprite::processFrames(const std::string& action, void* _node)
 				attribute = attribute->next();
 			}
 
-			if (!validateSheetId(sheetId, currentRow))
+			if (sheetId.empty())
 			{
-				continue;
+				throw std::runtime_error("Sprite Frame definition has 'sheetid' of length zero: " + endTag(currentRow, name()));
+			}
+			else if (mImageSheets.find(sheetId) == mImageSheets.end())
+			{
+				throw std::runtime_error("Sprite Frame definition references undefined imagesheet: '" + sheetId + "' " + endTag(currentRow, name()));
+			}
+			else if (!mImageSheets.find(sheetId)->second.loaded())
+			{
+				throw std::runtime_error("Sprite Frame definition references imagesheet that failed to load: '" + sheetId + "' " + endTag(currentRow, name()));
 			}
 
 			// X-Coordinate
@@ -503,25 +511,6 @@ void Sprite::processFrames(const std::string& action, void* _node)
 	{
 		throw std::runtime_error("Sprite Action contains no valid frames: " + action + " (" + name() + ")");
 	}
-}
-
-
-bool Sprite::validateSheetId(const std::string& sheetId, int row)
-{
-	if (sheetId.empty())
-	{
-		throw std::runtime_error("Sprite Frame definition has 'sheetid' of length zero: " + endTag(row, name()));
-	}
-	else if (mImageSheets.find(sheetId) == mImageSheets.end())
-	{
-		throw std::runtime_error("Sprite Frame definition references undefined imagesheet: '" + sheetId + "' " + endTag(row, name()));
-	}
-	else if (!mImageSheets.find(sheetId)->second.loaded())
-	{
-		throw std::runtime_error("Sprite Frame definition references imagesheet that failed to load: '" + sheetId + "' " + endTag(row, name()));
-	}
-
-	return true;
 }
 
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -248,7 +248,7 @@ void Sprite::processXml(const std::string& filePath)
 	else
 	{
 		// Find the Sprite node.
-		XmlElement* xmlRootElement = docXml.firstChildElement("sprite");
+		const XmlElement* xmlRootElement = docXml.firstChildElement("sprite");
 		if (!xmlRootElement)
 		{
 			throw std::runtime_error("Sprite file does not contain required <sprite> tag: " + filePath);
@@ -283,12 +283,12 @@ void Sprite::processXml(const std::string& filePath)
  *			element in a sprite definition, these elements can appear
  *			anywhere in a Sprite XML definition.
  */
-void Sprite::processImageSheets(void* root)
+void Sprite::processImageSheets(const void* root)
 {
-	XmlElement* e = static_cast<XmlElement*>(root);
+	const XmlElement* e = static_cast<const XmlElement*>(root);
 
 	string id, src;
-	for (XmlNode* node = e->iterateChildren(nullptr);
+	for (const XmlNode* node = e->iterateChildren(nullptr);
 		node != nullptr;
 		node = e->iterateChildren(node))
 	{
@@ -329,7 +329,7 @@ void Sprite::processImageSheets(void* root)
  * \param	src		Image sheet file path.
  * \param	node	XML Node (for error information).
  */
-void Sprite::addImageSheet(const std::string& id, const std::string& src, void* node)
+void Sprite::addImageSheet(const std::string& id, const std::string& src, const void* node)
 {
 	Filesystem& fs = Utility<Filesystem>::get();
 
@@ -349,7 +349,7 @@ void Sprite::addImageSheet(const std::string& id, const std::string& src, void* 
 	}
 	else
 	{
-		throw std::runtime_error("Sprite image sheet redefinition: id: '" + id + "' " + endTag(static_cast<XmlNode*>(node)->row(), name()));
+		throw std::runtime_error("Sprite image sheet redefinition: id: '" + id + "' " + endTag(static_cast<const XmlNode*>(node)->row(), name()));
 	}
 }
 
@@ -361,11 +361,11 @@ void Sprite::addImageSheet(const std::string& id, const std::string& src, void* 
  * \note	Action names are not case sensitive. "Case", "caSe",
  *			"CASE", etc. will all be viewed as identical.
  */
-void Sprite::processActions(void* root)
+void Sprite::processActions(const void* root)
 {
-	XmlElement* element = static_cast<XmlElement*>(root);
+	const XmlElement* element = static_cast<const XmlElement*>(root);
 
-	for (XmlNode* node = element->iterateChildren(nullptr);
+	for (const XmlNode* node = element->iterateChildren(nullptr);
 		node != nullptr;
 		node = element->iterateChildren(node))
 	{
@@ -405,13 +405,13 @@ void Sprite::processActions(void* root)
 /**
  * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
  */
-void Sprite::processFrames(const std::string& action, void* _node)
+void Sprite::processFrames(const std::string& action, const void* _node)
 {
-	XmlNode* node = static_cast<XmlNode*>(_node);
+	const XmlNode* node = static_cast<const XmlNode*>(_node);
 
 	FrameList frameList;
 
-	for (XmlNode* frame = node->iterateChildren(nullptr);
+	for (const XmlNode* frame = node->iterateChildren(nullptr);
 		frame != nullptr;
 		frame = node->iterateChildren(frame))
 	{

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -448,7 +448,9 @@ void Sprite::processFrames(const std::string& action, void* _node)
 				else if (toLowercase(attribute->name()) == "height") { attribute->queryIntValue(height); }
 				else if (toLowercase(attribute->name()) == "anchorx") { attribute->queryIntValue(anchorx); }
 				else if (toLowercase(attribute->name()) == "anchory") { attribute->queryIntValue(anchory); }
-				else { std::cout << "Unexpected attribute '" << attribute->name() << "' found on row " << currentRow << std::endl; }
+				else {
+					throw std::runtime_error("Sprite frame attribute unexpected: '" + attribute->name() + "' : " + endTag(currentRow, name()));
+				}
 
 				attribute = attribute->next();
 			}
@@ -459,43 +461,27 @@ void Sprite::processFrames(const std::string& action, void* _node)
 			}
 
 			// X-Coordinate
-			if ( x < 0 || x > mImageSheets.find(sheetId)->second.size().x)
+			if (x < 0 || x > mImageSheets.find(sheetId)->second.size().x)
 			{
-				cout << "Value 'x' is out of bounds." << endTag(currentRow, name()) << endl;
-				continue;
+				throw std::runtime_error("Sprite frame attribute 'x' is out of bounds: " + endTag(currentRow, name()));
 			}
 
 			// Y-Coordinate
 			if (y < 0 || y > mImageSheets.find(sheetId)->second.size().y)
 			{
-				cout << "Value 'y' is out of bounds." << endTag(currentRow, name()) << endl;
-				continue;
+				throw std::runtime_error("Sprite frame attribute 'y' is out of bounds: " + endTag(currentRow, name()));
 			}
 
 			// Width
-			if (width < 1)
+			if (width <= 0 || width > mImageSheets.find(sheetId)->second.size().x - x)
 			{
-				width = 1;
-				cout << "'width' value must be greater than 0." << endTag(currentRow, name()) << endl;
-				continue;
-			}
-			else if (x + width > mImageSheets.find(sheetId)->second.size().x)
-			{
-				cout << "'x' + 'width' value exceeds dimensions of specified imagesheet." << endTag(currentRow, name()) << endl;
-				continue;
+				throw std::runtime_error("Sprite frame attribute 'width' is out of bounds: " + endTag(currentRow, name()));
 			}
 
 			// Height
-			if (height < 1)
+			if (height <= 0 || height > mImageSheets.find(sheetId)->second.size().y - y)
 			{
-				height = 1;
-				cout << "'height' value must be greater than 0." << endTag(currentRow, name()) << endl;
-				continue;
-			}
-			else if (y + height > mImageSheets.find(sheetId)->second.size().y)
-			{
-				cout << "'y' + 'height' value exceeds dimensions of specified imagesheet." << endTag(currentRow, name()) << endl;
-				continue;
+				throw std::runtime_error("Sprite frame attribute 'height' is out of bounds: " + endTag(currentRow, name()));
 			}
 
 			const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
@@ -504,7 +490,7 @@ void Sprite::processFrames(const std::string& action, void* _node)
 		}
 		else
 		{
-			cout << "Unexpected tag '<" << frame->value() << ">'." << endTag(currentRow, name()) << endl;
+			throw std::runtime_error("Sprite frame tag unexpected: <" + frame->value() + "> : " + endTag(currentRow, name()));
 		}
 	}
 
@@ -515,7 +501,7 @@ void Sprite::processFrames(const std::string& action, void* _node)
 	}
 	else
 	{
-		cout << "Action '" << action << "' contains no valid frames. (" << name() << ")" << endl;
+		throw std::runtime_error("Sprite Action contains no valid frames: " + action + " (" + name() + ")");
 	}
 }
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -14,6 +14,8 @@
 #include "../Xml/Xml.h"
 
 #include <iostream>
+#include <stdexcept>
+
 
 using namespace std;
 using namespace NAS2D;
@@ -235,9 +237,7 @@ void Sprite::processXml(const std::string& filePath)
 
 	if (!fs.exists(filePath))
 	{
-		cout << "Sprite file '" << filePath << "' doesn't exist." << endl;
-		addDefaultAction();
-		return;
+		throw std::runtime_error("Sprite file does not exist: " + filePath);
 	}
 
 	File xmlFile = fs.open(filePath);
@@ -245,9 +245,7 @@ void Sprite::processXml(const std::string& filePath)
 	// Load the file
 	if (xmlFile.empty())
 	{
-		cout << "Sprite file '" << filePath << "' is empty." << endl;
-		addDefaultAction();
-		return;
+		throw std::runtime_error("Sprite file is empty: " + filePath);
 	}
 
 	XmlDocument docXml;
@@ -257,9 +255,7 @@ void Sprite::processXml(const std::string& filePath)
 	docXml.parse(xmlFile.raw_bytes());
 	if (docXml.error())
 	{
-		cout << "Malformed XML. Row: " << docXml.errorRow() << " Column: " << docXml.errorCol() << ": " << docXml.errorDesc() << " (" << name() << ")" << endl;
-		addDefaultAction();
-		return;
+		throw std::runtime_error("Sprite file has malformed XML: (" + name() + ") Row: " + std::to_string(docXml.errorRow()) + " Column: " + std::to_string(docXml.errorCol()) + " : " + docXml.errorDesc());
 	}
 	else
 	{
@@ -267,24 +263,18 @@ void Sprite::processXml(const std::string& filePath)
 		xmlRootElement = docXml.firstChildElement("sprite");
 		if (!xmlRootElement)
 		{
-			cout << "Specified file '" << filePath << "' doesn't contain a <sprite> tag." << endl;
-			addDefaultAction();
-			return;
+			throw std::runtime_error("Sprite file does not contain required <sprite> tag: " + filePath);
 		}
 
 		// Get the Sprite version.
 		const XmlAttribute* version = xmlRootElement->firstAttribute();
 		if (!version || version->value().empty())
 		{
-			cout << "Root element in sprite file '" << filePath << "' doesn't define a version." << endl;
-			addDefaultAction();
-			return;
+			throw std::runtime_error("Sprite file's root element does not specify a version: " + filePath);
 		}
 		else if (version->value() != SPRITE_VERSION)
 		{
-			cout << "Sprite version mismatch (" << versionString() << ") in '" << filePath << "'. Expected (" << SPRITE_VERSION << ")." << endl;
-			addDefaultAction();
-			return;
+			throw std::runtime_error("Sprite version mismatch. Expected: " + SPRITE_VERSION + " Actualy: " + versionString());
 		}
 
 		// Note:

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -235,18 +235,7 @@ void Sprite::processXml(const std::string& filePath)
 {
 	Filesystem& fs = Utility<Filesystem>::get();
 
-	if (!fs.exists(filePath))
-	{
-		throw std::runtime_error("Sprite file does not exist: " + filePath);
-	}
-
 	File xmlFile = fs.open(filePath);
-
-	// Load the file
-	if (xmlFile.empty())
-	{
-		throw std::runtime_error("Sprite file is empty: " + filePath);
-	}
 
 	XmlDocument docXml;
 	XmlElement *xmlRootElement = nullptr;

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -135,11 +135,10 @@ void Sprite::update(Point<float> position)
 			mCurrentFrame++;
 		}
 
-		// Check that our frame count is within bounds.
 		if (mCurrentFrame >= mActions[mCurrentAction].size())
 		{
 			mCurrentFrame = 0;
-			mAnimationCompleteCallback(); // Notifiy any frame listeners that the animation sequence has completed.
+			mAnimationCompleteCallback();
 		}
 	}
 	else if (frame.frameDelay == FRAME_PAUSE)

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -238,7 +238,6 @@ void Sprite::processXml(const std::string& filePath)
 	File xmlFile = fs.open(filePath);
 
 	XmlDocument docXml;
-	XmlElement *xmlRootElement = nullptr;
 
 	// Load the XML document and handle any errors if occuring
 	docXml.parse(xmlFile.raw_bytes());
@@ -249,7 +248,7 @@ void Sprite::processXml(const std::string& filePath)
 	else
 	{
 		// Find the Sprite node.
-		xmlRootElement = docXml.firstChildElement("sprite");
+		XmlElement* xmlRootElement = docXml.firstChildElement("sprite");
 		if (!xmlRootElement)
 		{
 			throw std::runtime_error("Sprite file does not contain required <sprite> tag: " + filePath);

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -317,14 +317,12 @@ void Sprite::processImageSheets(void* root)
 
 			if (id.empty())
 			{
-				cout << "Zero-length 'id' value in Imagesheet definition." << endTag(node->row(), name()) << endl;
-				continue;
+				throw std::runtime_error("Sprite imagesheet definition has `id` of length zero: " + endTag(node->row(), name()));
 			}
 
 			if (src.empty())
 			{
-				cout << "Zero-length 'src' value in Imagesheet definition." << endTag(node->row(), name()) << endl;
-				continue;
+				throw std::runtime_error("Sprite imagesheet definition has `src` of length zero: " + endTag(node->row(), name()));
 			}
 
 			addImageSheet(id, src, node);

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -65,14 +65,10 @@ void Sprite::play(const std::string& action)
 	const auto normalizedAction = toLowercase(action);
 	if (mActions.find(normalizedAction) == mActions.end())
 	{
-		cout << "Named action '" << action << "' is not defined in '" << name() << "'." << endl;
-		mCurrentAction = DEFAULT_ACTION;
-	}
-	else
-	{
-		mCurrentAction = normalizedAction;
+		throw std::runtime_error("Sprite::play called on undefined action: '" + action + "' : " + name());
 	}
 
+	mCurrentAction = normalizedAction;
 	mCurrentFrame = 0;
 	mTimer.reset();
 	resume();

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -398,8 +398,7 @@ void Sprite::processActions(void* root)
 
 			if (action_name.empty())
 			{
-				cout << "Zero-length 'name' value in Action definition." << endTag(node->row(), name()) << endl;
-				continue;
+				throw std::runtime_error("Sprite Action definition has 'name' of length zero: " + endTag(node->row(), name()));
 			}
 
 			if (mActions.find(toLowercase(action_name)) == mActions.end())
@@ -408,7 +407,7 @@ void Sprite::processActions(void* root)
 			}
 			else
 			{
-				cout << "Redefinition of action '" << action_name << "'. First definition will be used." << endTag(node->row(), name()) << endl;
+				throw std::runtime_error("Sprite Action redefinition: '" + action_name + "' " + endTag(node->row(), name()));
 			}
 		}
 	}

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -237,18 +237,18 @@ void Sprite::processXml(const std::string& filePath)
 
 	File xmlFile = fs.open(filePath);
 
-	XmlDocument docXml;
+	XmlDocument xmlDoc;
 
 	// Load the XML document and handle any errors if occuring
-	docXml.parse(xmlFile.raw_bytes());
-	if (docXml.error())
+	xmlDoc.parse(xmlFile.raw_bytes());
+	if (xmlDoc.error())
 	{
-		throw std::runtime_error("Sprite file has malformed XML: (" + name() + ") Row: " + std::to_string(docXml.errorRow()) + " Column: " + std::to_string(docXml.errorCol()) + " : " + docXml.errorDesc());
+		throw std::runtime_error("Sprite file has malformed XML: (" + name() + ") Row: " + std::to_string(xmlDoc.errorRow()) + " Column: " + std::to_string(xmlDoc.errorCol()) + " : " + xmlDoc.errorDesc());
 	}
 	else
 	{
 		// Find the Sprite node.
-		const XmlElement* xmlRootElement = docXml.firstChildElement("sprite");
+		const XmlElement* xmlRootElement = xmlDoc.firstChildElement("sprite");
 		if (!xmlRootElement)
 		{
 			throw std::runtime_error("Sprite file does not contain required <sprite> tag: " + filePath);

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -101,7 +101,7 @@ private:
 		unsigned int frameDelay;
 	};
 
-private:
+
 	using FrameList = std::vector<SpriteFrame>;
 
 	void processXml(const std::string& filePath);
@@ -115,7 +115,7 @@ private:
 
 	void addDefaultAction();
 
-private:
+
 	static inline const std::string DEFAULT_ACTION{"default"};
 
 	std::map<std::string, Image> mImageSheets;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -105,11 +105,11 @@ private:
 	using FrameList = std::vector<SpriteFrame>;
 
 	void processXml(const std::string& filePath);
-	void processImageSheets(void* root);
-	void addImageSheet(const std::string& id, const std::string& src, void* node);
+	void processImageSheets(const void* root);
+	void addImageSheet(const std::string& id, const std::string& src, const void* node);
 
-	void processActions(void* root);
-	void processFrames(const std::string& action, void* node);
+	void processActions(const void* root);
+	void processFrames(const std::string& action, const void* node);
 
 	void addDefaultAction();
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -39,7 +39,6 @@ class Sprite
 public:
 	using Callback = Signals::Signal<>; /**< Signal used when action animations complete. */
 
-	Sprite();
 	explicit Sprite(const std::string& filePath);
 	Sprite(const Sprite& sprite) = default;
 	Sprite& operator=(const Sprite& rhs) = default;
@@ -111,15 +110,13 @@ private:
 	void processActions(const void* root);
 	void processFrames(const std::string& action, const void* node);
 
-	void addDefaultAction();
-
 
 	static inline const std::string DEFAULT_ACTION{"default"};
 
 	std::map<std::string, Image> mImageSheets;
 	std::map<std::string, FrameList> mActions;
 
-	std::string mSpriteName{"Default Constructed"};
+	std::string mSpriteName;
 	std::string mCurrentAction{DEFAULT_ACTION};
 
 	bool mPaused{false};

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -87,7 +87,7 @@ public:
 	/**
 	 * Returns a reference to the frame listener signal slot.
 	 */
-	Callback& frameCallback() { return mFrameCallback; }
+	Callback& frameCallback() { return mAnimationCompleteCallback; }
 
 	StringList actions() const;
 
@@ -137,7 +137,7 @@ private:
 	bool mPaused{false}; /**< Indicate whether or not the animation for this Sprite is paused. */
 	Timer mTimer; /**< Internal time keeper. */
 	std::size_t mCurrentFrame{0}; /**< The current frame index in the current Action's frame list. */
-	Callback mFrameCallback; /**< Callback to signal a listener whenever an animation sequence completes. */
+	Callback mAnimationCompleteCallback; /**< Callback to signal a listener whenever an animation sequence completes. */
 
 	Color mColor{Color::Normal}; /**< Color value to use for drawing the sprite. */
 	float mRotationAngle{0.0f}; /**< Angle of rotation in degrees. */

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -111,8 +111,6 @@ private:
 	void processActions(void* root);
 	void processFrames(const std::string& action, void* node);
 
-	bool validateSheetId(const std::string& sheetId, int row);
-
 	void addDefaultAction();
 
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -111,13 +111,11 @@ private:
 	void processFrames(const std::string& action, const void* node);
 
 
-	static inline const std::string DEFAULT_ACTION{"default"};
-
 	std::map<std::string, Image> mImageSheets;
 	std::map<std::string, FrameList> mActions;
 
 	std::string mSpriteName;
-	std::string mCurrentAction{DEFAULT_ACTION};
+	std::string mCurrentAction{"default"};
 
 	bool mPaused{false};
 	Timer mTimer;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -128,23 +128,19 @@ private:
 private:
 	static inline const std::string DEFAULT_ACTION{"default"};
 
-	Timer mTimer; /**< Internal time keeper. */
-
 	std::map<std::string, Image> mImageSheets; /**< Imagesheets */
 	std::map<std::string, FrameList> mActions; /**< A list of Actions and their associated Frames. */
 
 	std::string mSpriteName{"Default Constructed"}; /**< Name of this Sprite. */
 	std::string mCurrentAction{DEFAULT_ACTION}; /**< The current Action being performed. */
 
+	bool mPaused{false}; /**< Indicate whether or not the animation for this Sprite is paused. */
+	Timer mTimer; /**< Internal time keeper. */
 	std::size_t mCurrentFrame{0}; /**< The current frame index in the current Action's frame list. */
-
 	Callback mFrameCallback; /**< Callback to signal a listener whenever an animation sequence completes. */
 
 	Color mColor{Color::Normal}; /**< Color value to use for drawing the sprite. */
-
 	float mRotationAngle{0.0f}; /**< Angle of rotation in degrees. */
-
-	bool mPaused{false}; /**< Indicate whether or not the animation for this Sprite is paused. */
 };
 
 } // namespace

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -113,8 +113,6 @@ private:
 
 private:
 	using FrameList = std::vector<SpriteFrame>;
-	using ActionList = std::map<std::string, FrameList>;
-	using SheetList = std::map<std::string, Image>;
 
 	void processXml(const std::string& filePath);
 	void processImageSheets(void* root);
@@ -132,8 +130,8 @@ private:
 
 	Timer mTimer; /**< Internal time keeper. */
 
-	SheetList mImageSheets; /**< Imagesheets */
-	ActionList mActions; /**< A list of Actions and their associated Frames. */
+	std::map<std::string, Image> mImageSheets; /**< Imagesheets */
+	std::map<std::string, FrameList> mActions; /**< A list of Actions and their associated Frames. */
 
 	std::string mSpriteName{"Default Constructed"}; /**< Name of this Sprite. */
 	std::string mCurrentAction{DEFAULT_ACTION}; /**< The current Action being performed. */

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -70,23 +70,18 @@ public:
 	uint8_t alpha() const { return mColor.alpha; }
 
 	/**
-	 * Sets the color of the Sprite.
-	 *
-	 * \param	color	Reference to a Color object.
+	 * Sets the color tint of the Sprite.
 	 */
 	void color(const Color& color) { mColor = color; }
 
 	/**
-	 * Gets the color of the Sprite.
+	 * Gets the color tint of the Sprite.
 	 */
 	const Color& color() const { return mColor; }
 
 	Vector<int> size() const;
 	Point<int> origin(Point<int> point) const;
 
-	/**
-	 * Returns a reference to the frame listener signal slot.
-	 */
 	Callback& frameCallback() { return mAnimationCompleteCallback; }
 
 	StringList actions() const;
@@ -95,14 +90,9 @@ public:
 	void decrementFrame();
 
 protected:
-	/// Gets the name of the Sprite. \note Internal use only.
 	const std::string& name() const { return mSpriteName; }
 
 private:
-	/**
-	 * \struct	SpriteFrame
-	 * \brief	Contains
-	 */
 	struct SpriteFrame
 	{
 		std::string sheetId;
@@ -128,18 +118,18 @@ private:
 private:
 	static inline const std::string DEFAULT_ACTION{"default"};
 
-	std::map<std::string, Image> mImageSheets; /**< Imagesheets */
-	std::map<std::string, FrameList> mActions; /**< A list of Actions and their associated Frames. */
+	std::map<std::string, Image> mImageSheets;
+	std::map<std::string, FrameList> mActions;
 
-	std::string mSpriteName{"Default Constructed"}; /**< Name of this Sprite. */
-	std::string mCurrentAction{DEFAULT_ACTION}; /**< The current Action being performed. */
+	std::string mSpriteName{"Default Constructed"};
+	std::string mCurrentAction{DEFAULT_ACTION};
 
-	bool mPaused{false}; /**< Indicate whether or not the animation for this Sprite is paused. */
-	Timer mTimer; /**< Internal time keeper. */
-	std::size_t mCurrentFrame{0}; /**< The current frame index in the current Action's frame list. */
-	Callback mAnimationCompleteCallback; /**< Callback to signal a listener whenever an animation sequence completes. */
+	bool mPaused{false};
+	Timer mTimer;
+	std::size_t mCurrentFrame{0};
+	Callback mAnimationCompleteCallback;
 
-	Color mColor{Color::Normal}; /**< Color value to use for drawing the sprite. */
+	Color mColor{Color::Normal}; /**< Color tint to use for drawing the sprite. */
 	float mRotationAngle{0.0f}; /**< Angle of rotation in degrees. */
 };
 


### PR DESCRIPTION
General refactoring. Convert error messages to exceptions. Remove extraneous error checks. Const correct XML loading. Remove default `Sprite` constructor.
