### PR TITLE
Reduce Sprite else nesting

### DIFF
--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -219,33 +219,31 @@ void Sprite::processXml(const std::string& filePath)
 	{
 		throw std::runtime_error("Sprite file has malformed XML: (" + name() + ") Row: " + std::to_string(xmlDoc.errorRow()) + " Column: " + std::to_string(xmlDoc.errorCol()) + " : " + xmlDoc.errorDesc());
 	}
-	else
+
+	// Find the Sprite node.
+	const XmlElement* xmlRootElement = xmlDoc.firstChildElement("sprite");
+	if (!xmlRootElement)
 	{
-		// Find the Sprite node.
-		const XmlElement* xmlRootElement = xmlDoc.firstChildElement("sprite");
-		if (!xmlRootElement)
-		{
-			throw std::runtime_error("Sprite file does not contain required <sprite> tag: " + filePath);
-		}
-
-		// Get the Sprite version.
-		const XmlAttribute* version = xmlRootElement->firstAttribute();
-		if (!version || version->value().empty())
-		{
-			throw std::runtime_error("Sprite file's root element does not specify a version: " + filePath);
-		}
-		else if (version->value() != SPRITE_VERSION)
-		{
-			throw std::runtime_error("Sprite version mismatch. Expected: " + SPRITE_VERSION + " Actual: " + versionString());
-		}
-
-		// Note:
-		// Here instead of going through each element and calling a processing function to handle
-		// it, we just iterate through all nodes to find sprite sheets. This allows us to define
-		// image sheets anywhere in the sprite file.
-		processImageSheets(xmlRootElement);
-		processActions(xmlRootElement);
+		throw std::runtime_error("Sprite file does not contain required <sprite> tag: " + filePath);
 	}
+
+	// Get the Sprite version.
+	const XmlAttribute* version = xmlRootElement->firstAttribute();
+	if (!version || version->value().empty())
+	{
+		throw std::runtime_error("Sprite file's root element does not specify a version: " + filePath);
+	}
+	if (version->value() != SPRITE_VERSION)
+	{
+		throw std::runtime_error("Sprite version mismatch. Expected: " + SPRITE_VERSION + " Actual: " + versionString());
+	}
+
+	// Note:
+	// Here instead of going through each element and calling a processing function to handle
+	// it, we just iterate through all nodes to find sprite sheets. This allows us to define
+	// image sheets anywhere in the sprite file.
+	processImageSheets(xmlRootElement);
+	processActions(xmlRootElement);
 }
 
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -379,90 +379,85 @@ void Sprite::processFrames(const std::string& action, const void* _node)
 	{
 		int currentRow = frame->row();
 
-		if (frame->value() == "frame" && frame->toElement())
-		{
-			string sheetId;
-			int delay = 0;
-			int x = 0, y = 0;
-			int width = 0, height = 0;
-			int anchorx = 0, anchory = 0;
-
-			const XmlAttribute* attribute = frame->toElement()->firstAttribute();
-			while (attribute)
-			{
-				if (toLowercase(attribute->name()) == "sheetid") { sheetId = attribute->value(); }
-				else if (toLowercase(attribute->name()) == "delay") { attribute->queryIntValue(delay); }
-				else if (toLowercase(attribute->name()) == "x") { attribute->queryIntValue(x); }
-				else if (toLowercase(attribute->name()) == "y") { attribute->queryIntValue(y); }
-				else if (toLowercase(attribute->name()) == "width") { attribute->queryIntValue(width); }
-				else if (toLowercase(attribute->name()) == "height") { attribute->queryIntValue(height); }
-				else if (toLowercase(attribute->name()) == "anchorx") { attribute->queryIntValue(anchorx); }
-				else if (toLowercase(attribute->name()) == "anchory") { attribute->queryIntValue(anchory); }
-				else {
-					throw std::runtime_error("Sprite frame attribute unexpected: '" + attribute->name() + "' : " + endTag(currentRow, name()));
-				}
-
-				attribute = attribute->next();
-			}
-
-			if (sheetId.empty())
-			{
-				throw std::runtime_error("Sprite Frame definition has 'sheetid' of length zero: " + endTag(currentRow, name()));
-			}
-			const auto iterator = mImageSheets.find(sheetId);
-			if (iterator == mImageSheets.end())
-			{
-				throw std::runtime_error("Sprite Frame definition references undefined imagesheet: '" + sheetId + "' " + endTag(currentRow, name()));
-			}
-			const auto& image = iterator->second;
-			if (!image.loaded())
-			{
-				throw std::runtime_error("Sprite Frame definition references imagesheet that failed to load: '" + sheetId + "' " + endTag(currentRow, name()));
-			}
-
-			// X-Coordinate
-			if (x < 0 || x > image.size().x)
-			{
-				throw std::runtime_error("Sprite frame attribute 'x' is out of bounds: " + endTag(currentRow, name()));
-			}
-
-			// Y-Coordinate
-			if (y < 0 || y > image.size().y)
-			{
-				throw std::runtime_error("Sprite frame attribute 'y' is out of bounds: " + endTag(currentRow, name()));
-			}
-
-			// Width
-			if (width <= 0 || width > image.size().x - x)
-			{
-				throw std::runtime_error("Sprite frame attribute 'width' is out of bounds: " + endTag(currentRow, name()));
-			}
-
-			// Height
-			if (height <= 0 || height > image.size().y - y)
-			{
-				throw std::runtime_error("Sprite frame attribute 'height' is out of bounds: " + endTag(currentRow, name()));
-			}
-
-			const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
-			const auto anchorOffset = Vector{anchorx, anchory};
-			frameList.push_back(SpriteFrame{sheetId, bounds, anchorOffset, static_cast<unsigned int>(delay)});
-		}
-		else
+		if (frame->value() != "frame" || !frame->toElement())
 		{
 			throw std::runtime_error("Sprite frame tag unexpected: <" + frame->value() + "> : " + endTag(currentRow, name()));
 		}
+
+		string sheetId;
+		int delay = 0;
+		int x = 0, y = 0;
+		int width = 0, height = 0;
+		int anchorx = 0, anchory = 0;
+
+		const XmlAttribute* attribute = frame->toElement()->firstAttribute();
+		while (attribute)
+		{
+			if (toLowercase(attribute->name()) == "sheetid") { sheetId = attribute->value(); }
+			else if (toLowercase(attribute->name()) == "delay") { attribute->queryIntValue(delay); }
+			else if (toLowercase(attribute->name()) == "x") { attribute->queryIntValue(x); }
+			else if (toLowercase(attribute->name()) == "y") { attribute->queryIntValue(y); }
+			else if (toLowercase(attribute->name()) == "width") { attribute->queryIntValue(width); }
+			else if (toLowercase(attribute->name()) == "height") { attribute->queryIntValue(height); }
+			else if (toLowercase(attribute->name()) == "anchorx") { attribute->queryIntValue(anchorx); }
+			else if (toLowercase(attribute->name()) == "anchory") { attribute->queryIntValue(anchory); }
+			else {
+				throw std::runtime_error("Sprite frame attribute unexpected: '" + attribute->name() + "' : " + endTag(currentRow, name()));
+			}
+
+			attribute = attribute->next();
+		}
+
+		if (sheetId.empty())
+		{
+			throw std::runtime_error("Sprite Frame definition has 'sheetid' of length zero: " + endTag(currentRow, name()));
+		}
+		const auto iterator = mImageSheets.find(sheetId);
+		if (iterator == mImageSheets.end())
+		{
+			throw std::runtime_error("Sprite Frame definition references undefined imagesheet: '" + sheetId + "' " + endTag(currentRow, name()));
+		}
+		const auto& image = iterator->second;
+		if (!image.loaded())
+		{
+			throw std::runtime_error("Sprite Frame definition references imagesheet that failed to load: '" + sheetId + "' " + endTag(currentRow, name()));
+		}
+
+		// X-Coordinate
+		if (x < 0 || x > image.size().x)
+		{
+			throw std::runtime_error("Sprite frame attribute 'x' is out of bounds: " + endTag(currentRow, name()));
+		}
+
+		// Y-Coordinate
+		if (y < 0 || y > image.size().y)
+		{
+			throw std::runtime_error("Sprite frame attribute 'y' is out of bounds: " + endTag(currentRow, name()));
+		}
+
+		// Width
+		if (width <= 0 || width > image.size().x - x)
+		{
+			throw std::runtime_error("Sprite frame attribute 'width' is out of bounds: " + endTag(currentRow, name()));
+		}
+
+		// Height
+		if (height <= 0 || height > image.size().y - y)
+		{
+			throw std::runtime_error("Sprite frame attribute 'height' is out of bounds: " + endTag(currentRow, name()));
+		}
+
+		const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
+		const auto anchorOffset = Vector{anchorx, anchory};
+		frameList.push_back(SpriteFrame{sheetId, bounds, anchorOffset, static_cast<unsigned int>(delay)});
 	}
 
-	// Add the frame list to the action container.
-	if (frameList.size() > 0)
-	{
-		mActions[toLowercase(action)] = frameList;
-	}
-	else
+	if (frameList.size() <= 0)
 	{
 		throw std::runtime_error("Sprite Action contains no valid frames: " + action + " (" + name() + ")");
 	}
+
+	mActions[toLowercase(action)] = frameList;
 }
 
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -353,15 +353,12 @@ void Sprite::processActions(const void* root)
 			{
 				throw std::runtime_error("Sprite Action definition has 'name' of length zero: " + endTag(node->row(), name()));
 			}
-
-			if (mActions.find(toLowercase(action_name)) == mActions.end())
-			{
-				processFrames(action_name, node);
-			}
-			else
+			if (mActions.find(toLowercase(action_name)) != mActions.end())
 			{
 				throw std::runtime_error("Sprite Action redefinition: '" + action_name + "' " + endTag(node->row(), name()));
 			}
+
+			processFrames(action_name, node);
 		}
 	}
 }

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -236,7 +236,7 @@ void Sprite::processXml(const std::string& filePath)
 		}
 		else if (version->value() != SPRITE_VERSION)
 		{
-			throw std::runtime_error("Sprite version mismatch. Expected: " + SPRITE_VERSION + " Actualy: " + versionString());
+			throw std::runtime_error("Sprite version mismatch. Expected: " + SPRITE_VERSION + " Actual: " + versionString());
 		}
 
 		// Note:


### PR DESCRIPTION
Since exceptions alter the flow of control, checking for and throwing exceptions first means an `else` guard is no longer necessary for later code.
