### PR TITLE
Pass Image objects by const reference in Renderer

### DIFF
--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -94,7 +94,7 @@ void Renderer::drawImageRect(Rectangle<float> rect, ImageList& images)
 }
 
 
-void Renderer::drawImageRect(Rectangle<float> rect, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight)
+void Renderer::drawImageRect(Rectangle<float> rect, const Image& topLeft, const Image& top, const Image& topRight, const Image& left, const Image& center, const Image& right, const Image& bottomLeft, const Image& bottom, const Image& bottomRight)
 {
 	const auto p1 = rect.startPoint() + topLeft.size().to<float>();
 	const auto p2 = rect.crossXPoint() + topRight.size().reflectX().to<float>();

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -54,18 +54,18 @@ public:
 
 	virtual void window_icon(const std::string& path) = 0;
 
-	virtual void drawImage(Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) = 0;
-	virtual void drawSubImage(Image& image, Point<float> raster, Rectangle<float> subImageRect, Color color = Color::Normal) = 0;
-	virtual void drawSubImageRotated(Image& image, Point<float> raster, Rectangle<float> subImageRect, float degrees, Color color = Color::Normal) = 0;
-	virtual void drawImageRotated(Image& image, Point<float> position, float degrees, Color color = Color::Normal, float scale = 1.0f) = 0;
-	virtual void drawImageStretched(Image& image, Rectangle<float> rect, Color color = Color::Normal) = 0;
-	virtual void drawImageRepeated(Image& image, Rectangle<float> rect) = 0;
-	virtual void drawSubImageRepeated(Image& image, const Rectangle<float>& destination, const Rectangle<float>& source) = 0;
+	virtual void drawImage(const Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) = 0;
+	virtual void drawSubImage(const Image& image, Point<float> raster, Rectangle<float> subImageRect, Color color = Color::Normal) = 0;
+	virtual void drawSubImageRotated(const Image& image, Point<float> raster, Rectangle<float> subImageRect, float degrees, Color color = Color::Normal) = 0;
+	virtual void drawImageRotated(const Image& image, Point<float> position, float degrees, Color color = Color::Normal, float scale = 1.0f) = 0;
+	virtual void drawImageStretched(const Image& image, Rectangle<float> rect, Color color = Color::Normal) = 0;
+	virtual void drawImageRepeated(const Image& image, Rectangle<float> rect) = 0;
+	virtual void drawSubImageRepeated(const Image& image, const Rectangle<float>& destination, const Rectangle<float>& source) = 0;
 
 	void drawImageRect(Rectangle<float> rect, ImageList& images);
-	void drawImageRect(Rectangle<float> rect, Image& topLeft, Image& top, Image& topRight, Image& left, Image& center, Image& right, Image& bottomLeft, Image& bottom, Image& bottomRight);
+	void drawImageRect(Rectangle<float> rect, const Image& topLeft, const Image& top, const Image& topRight, const Image& left, const Image& center, const Image& right, const Image& bottomLeft, const Image& bottom, const Image& bottomRight);
 
-	virtual void drawImageToImage(Image& source, Image& destination, const Point<float>& dstPoint) = 0;
+	virtual void drawImageToImage(const Image& source, const Image& destination, const Point<float>& dstPoint) = 0;
 
 	virtual void drawPoint(Point<float> position, Color color = Color::White) = 0;
 	virtual void drawLine(Point<float> startPosition, Point<float> endPosition, Color color = Color::White, int line_width = 1) = 0;

--- a/NAS2D/Renderer/RendererNull.h
+++ b/NAS2D/Renderer/RendererNull.h
@@ -24,18 +24,18 @@ public:
 	DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc&) const override { return{}; }
 	Vector<int> getWindowClientArea() const noexcept override { return {}; }
 
-	void drawImage(Image&, Point<float>, float = 1.0, Color = Color::Normal) override {}
+	void drawImage(const Image&, Point<float>, float = 1.0, Color = Color::Normal) override {}
 
-	void drawSubImage(Image&, Point<float>, Rectangle<float>, Color = Color::Normal) override {}
-	void drawSubImageRotated(Image&, Point<float>, Rectangle<float>, float, Color = Color::Normal) override {}
+	void drawSubImage(const Image&, Point<float>, Rectangle<float>, Color = Color::Normal) override {}
+	void drawSubImageRotated(const Image&, Point<float>, Rectangle<float>, float, Color = Color::Normal) override {}
 
-	void drawImageRotated(Image&, Point<float>, float, Color = Color::Normal, float = 1.0f) override {}
-	void drawImageStretched(Image&, Rectangle<float>, Color = Color::Normal) override {}
+	void drawImageRotated(const Image&, Point<float>, float, Color = Color::Normal, float = 1.0f) override {}
+	void drawImageStretched(const Image&, Rectangle<float>, Color = Color::Normal) override {}
 
-	void drawImageRepeated(Image&, Rectangle<float>) override {}
-	void drawSubImageRepeated(Image&, const Rectangle<float>&, const Rectangle<float>&) override {}
+	void drawImageRepeated(const Image&, Rectangle<float>) override {}
+	void drawSubImageRepeated(const Image&, const Rectangle<float>&, const Rectangle<float>&) override {}
 
-	void drawImageToImage(Image&, Image&, const Point<float>&) override {}
+	void drawImageToImage(const Image&, const Image&, const Point<float>&) override {}
 
 	void drawPoint(Point<float>, Color = Color::White) override {}
 	void drawLine(Point<float>, Point<float>, Color = Color::White, int = 1) override {}

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -71,7 +71,7 @@ namespace {
 	constexpr std::array<GLfloat, 12> DefaultTextureCoords = rectToQuad({0, 0, 1, 1});
 
 
-	GLuint generate_fbo(Image& image);
+	GLuint generate_fbo(const Image& image);
 	void drawTexturedQuad(GLuint textureId, const std::array<GLfloat, 12>& verticies, const std::array<GLfloat, 12>& textureCoords = DefaultTextureCoords);
 	void line(Point<float> p1, Point<float> p2, float lineWidth, Color color);
 
@@ -135,7 +135,7 @@ RendererOpenGL::~RendererOpenGL()
 }
 
 
-void RendererOpenGL::drawImage(Image& image, Point<float> position, float scale, Color color)
+void RendererOpenGL::drawImage(const Image& image, Point<float> position, float scale, Color color)
 {
 	setColor(color);
 
@@ -145,7 +145,7 @@ void RendererOpenGL::drawImage(Image& image, Point<float> position, float scale,
 }
 
 
-void RendererOpenGL::drawSubImage(Image& image, Point<float> raster, Rectangle<float> subImageRect, Color color)
+void RendererOpenGL::drawSubImage(const Image& image, Point<float> raster, Rectangle<float> subImageRect, Color color)
 {
 	setColor(color);
 
@@ -157,7 +157,7 @@ void RendererOpenGL::drawSubImage(Image& image, Point<float> raster, Rectangle<f
 }
 
 
-void RendererOpenGL::drawSubImageRotated(Image& image, Point<float> raster, Rectangle<float> subImageRect, float degrees, Color color)
+void RendererOpenGL::drawSubImageRotated(const Image& image, Point<float> raster, Rectangle<float> subImageRect, float degrees, Color color)
 {
 	glPushMatrix();
 
@@ -181,7 +181,7 @@ void RendererOpenGL::drawSubImageRotated(Image& image, Point<float> raster, Rect
 }
 
 
-void RendererOpenGL::drawImageRotated(Image& image, Point<float> position, float degrees, Color color, float scale)
+void RendererOpenGL::drawImageRotated(const Image& image, Point<float> position, float degrees, Color color, float scale)
 {
 	glPushMatrix();
 
@@ -205,7 +205,7 @@ void RendererOpenGL::drawImageRotated(Image& image, Point<float> position, float
 }
 
 
-void RendererOpenGL::drawImageStretched(Image& image, Rectangle<float> rect, Color color)
+void RendererOpenGL::drawImageStretched(const Image& image, Rectangle<float> rect, Color color)
 {
 	setColor(color);
 	glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
@@ -215,7 +215,7 @@ void RendererOpenGL::drawImageStretched(Image& image, Rectangle<float> rect, Col
 }
 
 
-void RendererOpenGL::drawImageRepeated(Image& image, Rectangle<float> rect)
+void RendererOpenGL::drawImageRepeated(const Image& image, Rectangle<float> rect)
 {
 	setColor(Color::White);
 
@@ -251,7 +251,7 @@ void RendererOpenGL::drawImageRepeated(Image& image, Rectangle<float> rect)
  * texture and reference it that way (bit of overhead to do a texture lookup and would
  * get unmanagable very quickly.
  */
-void RendererOpenGL::drawSubImageRepeated(Image& image, const Rectangle<float>& destination, const Rectangle<float>& source)
+void RendererOpenGL::drawSubImageRepeated(const Image& image, const Rectangle<float>& destination, const Rectangle<float>& source)
 {
 	glEnable(GL_SCISSOR_TEST);
 	const auto clipRect = destination.to<int>();
@@ -270,7 +270,7 @@ void RendererOpenGL::drawSubImageRepeated(Image& image, const Rectangle<float>& 
 }
 
 
-void RendererOpenGL::drawImageToImage(Image& source, Image& destination, const Point<float>& dstPoint)
+void RendererOpenGL::drawImageToImage(const Image& source, const Image& destination, const Point<float>& dstPoint)
 {
 	const auto dstPointInt = dstPoint.to<int>();
 	const auto sourceSize = source.size();
@@ -809,7 +809,7 @@ namespace {
 /**
  * Generates an OpenGL Frame Buffer Object.
  */
-GLuint generate_fbo(Image& image)
+GLuint generate_fbo(const Image& image)
 {
 	unsigned int framebuffer;
 	glGenFramebuffers(1, &framebuffer);

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -47,18 +47,18 @@ public:
 	DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const override;
 	Vector<int> getWindowClientArea() const noexcept override;
 
-	void drawImage(Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) override;
+	void drawImage(const Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) override;
 
-	void drawSubImage(Image& image, Point<float> raster, Rectangle<float> subImageRect, Color color = Color::Normal) override;
-	void drawSubImageRotated(Image& image, Point<float> raster, Rectangle<float> subImageRect, float degrees, Color color = Color::Normal) override;
+	void drawSubImage(const Image& image, Point<float> raster, Rectangle<float> subImageRect, Color color = Color::Normal) override;
+	void drawSubImageRotated(const Image& image, Point<float> raster, Rectangle<float> subImageRect, float degrees, Color color = Color::Normal) override;
 
-	void drawImageRotated(Image& image, Point<float> position, float degrees, Color color = Color::Normal, float scale = 1.0f) override;
-	void drawImageStretched(Image& image, Rectangle<float> rect, Color color = Color::Normal) override;
+	void drawImageRotated(const Image& image, Point<float> position, float degrees, Color color = Color::Normal, float scale = 1.0f) override;
+	void drawImageStretched(const Image& image, Rectangle<float> rect, Color color = Color::Normal) override;
 
-	void drawImageRepeated(Image& image, Rectangle<float> rect) override;
-	void drawSubImageRepeated(Image& image, const Rectangle<float>& destination, const Rectangle<float>& source) override;
+	void drawImageRepeated(const Image& image, Rectangle<float> rect) override;
+	void drawSubImageRepeated(const Image& image, const Rectangle<float>& destination, const Rectangle<float>& source) override;
 
-	void drawImageToImage(Image& source, Image& destination, const Point<float>& dstPoint) override;
+	void drawImageToImage(const Image& source, const Image& destination, const Point<float>& dstPoint) override;
 
 	void drawPoint(Point<float> position, Color color = Color::White) override;
 	void drawLine(Point<float> startPosition, Point<float> endPosition, Color color = Color::White, int line_width = 1) override;


### PR DESCRIPTION
Pass `Image` objects by const reference in `Renderer`.

All methods use `Image` in a read-only manner. As such, we should allow for passing of read-only objects.
