### PR TITLE
Sprite refactoring

### DIFF
--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -104,6 +104,33 @@ void Sprite::setFrame(std::size_t frameIndex)
 }
 
 
+/**
+ * Increments the frame counter.
+ */
+void Sprite::incrementFrame()
+{
+	++mCurrentFrame;
+	if (mCurrentFrame >= mActions[mCurrentAction].size())
+	{
+		mCurrentFrame = 0;
+	}
+}
+
+
+/**
+ * Decrements the frame counter.
+ */
+void Sprite::decrementFrame()
+{
+	if (mCurrentFrame == 0)
+	{
+		mCurrentFrame = mActions[mCurrentAction].size();
+	}
+
+	--mCurrentFrame;
+}
+
+
 void Sprite::update(Point<float> position)
 {
 	const auto& frame = mActions[mCurrentAction][mCurrentFrame];
@@ -175,33 +202,6 @@ Point<int> Sprite::origin(Point<int> point) const
 StringList Sprite::actions() const
 {
 	return getKeys(mActions);
-}
-
-
-/**
- * Increments the frame counter.
- */
-void Sprite::incrementFrame()
-{
-	++mCurrentFrame;
-	if (mCurrentFrame >= mActions[mCurrentAction].size())
-	{
-		mCurrentFrame = 0;
-	}
-}
-
-
-/**
- * Decrements the frame counter.
- */
-void Sprite::decrementFrame()
-{
-	if (mCurrentFrame == 0)
-	{
-		mCurrentFrame = mActions[mCurrentAction].size();
-	}
-
-	--mCurrentFrame;
 }
 
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -49,6 +49,30 @@ Sprite::Sprite(const std::string& filePath) :
 	processXml(filePath);
 }
 
+
+Vector<int> Sprite::size() const
+{
+	return mActions.at(mCurrentAction)[mCurrentFrame].bounds.size();
+}
+
+
+Point<int> Sprite::origin(Point<int> point) const
+{
+	return point - mActions.at(mCurrentAction)[mCurrentFrame].anchorOffset;
+}
+
+
+/**
+ * Gets a list of Actions available for the Sprite.
+ *
+ * \return	StringList of actions.
+ */
+StringList Sprite::actions() const
+{
+	return getKeys(mActions);
+}
+
+
 /**
  * Plays an action animation.
  *
@@ -208,29 +232,6 @@ void Sprite::color(const Color& color)
 const Color& Sprite::color() const
 {
 	return mColor;
-}
-
-
-Vector<int> Sprite::size() const
-{
-	return mActions.at(mCurrentAction)[mCurrentFrame].bounds.size();
-}
-
-
-Point<int> Sprite::origin(Point<int> point) const
-{
-	return point - mActions.at(mCurrentAction)[mCurrentFrame].anchorOffset;
-}
-
-
-/**
- * Gets a list of Actions available for the Sprite.
- *
- * \return	StringList of actions.
- */
-StringList Sprite::actions() const
-{
-	return getKeys(mActions);
 }
 
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -179,7 +179,7 @@ void Sprite::update(Point<float> position)
 
 	const auto drawPosition = position - frame.anchorOffset.to<float>();
 	const auto frameBounds = frame.bounds.to<float>();
-	Utility<Renderer>::get().drawSubImageRotated(mImageSheets.at(frame.sheetId), drawPosition, frameBounds, mRotationAngle, mColor);
+	Utility<Renderer>::get().drawSubImageRotated(frame.image, drawPosition, frameBounds, mRotationAngle, mColor);
 }
 
 
@@ -477,7 +477,7 @@ void Sprite::processFrames(const std::string& action, const void* _node)
 
 		const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
 		const auto anchorOffset = Vector{anchorx, anchory};
-		frameList.push_back(SpriteFrame{sheetId, bounds, anchorOffset, static_cast<unsigned int>(delay)});
+		frameList.push_back(SpriteFrame{mImageSheets.at(sheetId), bounds, anchorOffset, static_cast<unsigned int>(delay)});
 	}
 
 	if (frameList.size() <= 0)

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -173,6 +173,44 @@ float Sprite::rotation() const
 }
 
 
+/**
+ * Sets the alpha value for the Sprite.
+ *
+ * \param	alpha	Alpha value to set between 0 - 255.
+ */
+void Sprite::alpha(uint8_t alpha)
+{
+	mColor.alpha = alpha;
+}
+
+
+/**
+ * Gets the alpha value for the Sprite.
+ */
+uint8_t Sprite::alpha() const
+{
+	return mColor.alpha;
+}
+
+
+/**
+ * Sets the color tint of the Sprite.
+ */
+void Sprite::color(const Color& color)
+{
+	mColor = color;
+}
+
+
+/**
+ * Gets the color tint of the Sprite.
+ */
+const Color& Sprite::color() const
+{
+	return mColor;
+}
+
+
 Vector<int> Sprite::size() const
 {
 	return mActions.at(mCurrentAction)[mCurrentFrame].bounds.size();

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -339,26 +339,10 @@ void Sprite::processImageSheets(const void* root)
 				throw std::runtime_error("Sprite image sheet redefinition: id: '" + id + "' " + endTag(node->row()));
 			}
 
-			addImageSheet(id, src);
+			const string imagePath = Utility<Filesystem>::get().workingPath(mSpriteName) + src;
+			mImageSheets.try_emplace(id, imagePath);
 		}
 	}
-}
-
-
-/**
- * Adds an image sheet to the Sprite.
- *
- * \note	Imagesheet ID's are not case sensitive. "Case", "caSe",
- *			"CASE", etc. will all be viewed as identical.
- *
- * \param	id		String ID for the image sheet.
- * \param	src		Image sheet file path.
- */
-void Sprite::addImageSheet(const std::string& id, const std::string& src)
-{
-	Filesystem& fs = Utility<Filesystem>::get();
-	const string imagePath = fs.workingPath(mSpriteName) + src;
-	mImageSheets.try_emplace(id, imagePath);
 }
 
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -235,6 +235,18 @@ const Color& Sprite::color() const
 }
 
 
+Sprite::Callback& Sprite::frameCallback()
+{
+	return mAnimationCompleteCallback;
+}
+
+
+const std::string& Sprite::name() const
+{
+	return mSpriteName;
+}
+
+
 /**
  * Parses a Sprite XML Definition File.
  *

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -334,7 +334,12 @@ void Sprite::processImageSheets(const void* root)
 				throw std::runtime_error("Sprite imagesheet definition has `src` of length zero: " + endTag(node->row()));
 			}
 
-			addImageSheet(id, src, node);
+			if (mImageSheets.find(toLowercase(id)) != mImageSheets.end())
+			{
+				throw std::runtime_error("Sprite image sheet redefinition: id: '" + id + "' " + endTag(node->row()));
+			}
+
+			addImageSheet(id, src);
 		}
 	}
 }
@@ -348,16 +353,10 @@ void Sprite::processImageSheets(const void* root)
  *
  * \param	id		String ID for the image sheet.
  * \param	src		Image sheet file path.
- * \param	node	XML Node (for error information).
  */
-void Sprite::addImageSheet(const std::string& id, const std::string& src, const void* node)
+void Sprite::addImageSheet(const std::string& id, const std::string& src)
 {
 	Filesystem& fs = Utility<Filesystem>::get();
-
-	if (mImageSheets.find(toLowercase(id)) != mImageSheets.end())
-	{
-		throw std::runtime_error("Sprite image sheet redefinition: id: '" + id + "' " + endTag(static_cast<const XmlNode*>(node)->row()));
-	}
 
 	const string imagePath = fs.workingPath(mSpriteName) + src;
 	if (!fs.exists(imagePath))

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -357,12 +357,7 @@ void Sprite::processImageSheets(const void* root)
 void Sprite::addImageSheet(const std::string& id, const std::string& src)
 {
 	Filesystem& fs = Utility<Filesystem>::get();
-
 	const string imagePath = fs.workingPath(mSpriteName) + src;
-	if (!fs.exists(imagePath))
-	{
-		throw std::runtime_error("Sprite image path not found: Image: '" + imagePath + "'");
-	}
 	mImageSheets.try_emplace(id, imagePath);
 }
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -13,6 +13,7 @@
 #include "../Version.h"
 #include "../Xml/Xml.h"
 
+#include <utility>
 #include <iostream>
 #include <stdexcept>
 
@@ -484,5 +485,5 @@ void Sprite::processFrames(const std::string& action, const void* _node)
 		throw std::runtime_error("Sprite Action contains no valid frames: " + action);
 	}
 
-	mActions[toLowercase(action)] = frameList;
+	mActions[toLowercase(action)] = std::move(frameList);
 }

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -109,11 +109,7 @@ void Sprite::setFrame(std::size_t frameIndex)
  */
 void Sprite::incrementFrame()
 {
-	++mCurrentFrame;
-	if (mCurrentFrame >= mActions[mCurrentAction].size())
-	{
-		mCurrentFrame = 0;
-	}
+	setFrame(mCurrentFrame + 1);
 }
 
 
@@ -122,12 +118,7 @@ void Sprite::incrementFrame()
  */
 void Sprite::decrementFrame()
 {
-	if (mCurrentFrame == 0)
-	{
-		mCurrentFrame = mActions[mCurrentAction].size();
-	}
-
-	--mCurrentFrame;
+	setFrame(mCurrentFrame - 1);
 }
 
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -155,6 +155,18 @@ float Sprite::rotation() const
 }
 
 
+Vector<int> Sprite::size() const
+{
+	return mActions.at(mCurrentAction)[mCurrentFrame].bounds.size();
+}
+
+
+Point<int> Sprite::origin(Point<int> point) const
+{
+	return point - mActions.at(mCurrentAction)[mCurrentFrame].anchorOffset;
+}
+
+
 /**
  * Gets a list of Actions available for the Sprite.
  *
@@ -446,16 +458,4 @@ void Sprite::processFrames(const std::string& action, const void* _node)
 	}
 
 	mActions[toLowercase(action)] = frameList;
-}
-
-
-Vector<int> Sprite::size() const
-{
-	return mActions.at(mCurrentAction)[mCurrentFrame].bounds.size();
-}
-
-
-Point<int> Sprite::origin(Point<int> point) const
-{
-	return point - mActions.at(mCurrentAction)[mCurrentFrame].anchorOffset;
 }

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -134,18 +134,6 @@ void Sprite::update(Point<float> position)
 
 
 /**
- * Updates the Sprite and draws it to the screen at specified coordinaes.
- *
- * \param	x	X-Screen Coordinate to render the Sprite.
- * \param	y	X-Screen Coordinate to render the Sprite.
- */
-void Sprite::update(float x, float y)
-{
-	update(Point{x, y});
-}
-
-
-/**
  * Sets the rotation angle of the Sprite.
  *
  * \param	angle	Angle of rotation in degrees.

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -46,7 +46,14 @@ namespace {
 Sprite::Sprite(const std::string& filePath) :
 	mSpriteName(filePath)
 {
-	processXml(filePath);
+	try
+	{
+		processXml(filePath);
+	}
+	catch(const std::runtime_error& error)
+	{
+		throw std::runtime_error("Error parsing Sprite file: " + filePath + "\nError: " + error.what());
+	}
 }
 
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -75,7 +75,7 @@ protected:
 private:
 	struct SpriteFrame
 	{
-		std::string sheetId;
+		Image& image;
 		Rectangle<int> bounds;
 		Vector<int> anchorOffset;
 		unsigned int frameDelay;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -86,8 +86,6 @@ private:
 
 	void processXml(const std::string& filePath);
 	void processImageSheets(const void* root);
-	void addImageSheet(const std::string& id, const std::string& src);
-
 	void processActions(const void* root);
 	void processFrames(const std::string& action, const void* node);
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -86,7 +86,7 @@ private:
 
 	void processXml(const std::string& filePath);
 	void processImageSheets(const void* root);
-	void addImageSheet(const std::string& id, const std::string& src, const void* node);
+	void addImageSheet(const std::string& id, const std::string& src);
 
 	void processActions(const void* root);
 	void processFrames(const std::string& action, const void* node);

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -49,6 +49,8 @@ public:
 	void resume();
 
 	void setFrame(std::size_t frameIndex);
+	void incrementFrame();
+	void decrementFrame();
 
 	void update(Point<float> position);
 
@@ -83,9 +85,6 @@ public:
 	Callback& frameCallback() { return mAnimationCompleteCallback; }
 
 	StringList actions() const;
-
-	void incrementFrame();
-	void decrementFrame();
 
 protected:
 	const std::string& name() const { return mSpriteName; }

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -44,6 +44,11 @@ public:
 	Sprite& operator=(const Sprite& rhs) = default;
 	~Sprite() = default;
 
+	Vector<int> size() const;
+	Point<int> origin(Point<int> point) const;
+
+	StringList actions() const;
+
 	void play(const std::string& action);
 	void pause();
 	void resume();
@@ -62,12 +67,7 @@ public:
 	void color(const Color& color);
 	const Color& color() const;
 
-	Vector<int> size() const;
-	Point<int> origin(Point<int> point) const;
-
 	Callback& frameCallback() { return mAnimationCompleteCallback; }
-
-	StringList actions() const;
 
 protected:
 	const std::string& name() const { return mSpriteName; }

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -67,10 +67,10 @@ public:
 	void color(const Color& color);
 	const Color& color() const;
 
-	Callback& frameCallback() { return mAnimationCompleteCallback; }
+	Callback& frameCallback();
 
 protected:
-	const std::string& name() const { return mSpriteName; }
+	const std::string& name() const;
 
 private:
 	struct SpriteFrame

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -51,7 +51,6 @@ public:
 	void setFrame(std::size_t frameIndex);
 
 	void update(Point<float> position);
-	void update(float x, float y);
 
 	void rotation(float angle);
 	float rotation() const;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -57,27 +57,10 @@ public:
 	void rotation(float angle);
 	float rotation() const;
 
-	/**
-	 * Sets the alpha value for the Sprite.
-	 *
-	 * \param	alpha	Alpha value to set between 0 - 255.
-	 */
-	void alpha(uint8_t alpha) { mColor.alpha = alpha; }
-
-	/**
-	 * Gets the alpha value for the Sprite.
-	 */
-	uint8_t alpha() const { return mColor.alpha; }
-
-	/**
-	 * Sets the color tint of the Sprite.
-	 */
-	void color(const Color& color) { mColor = color; }
-
-	/**
-	 * Gets the color tint of the Sprite.
-	 */
-	const Color& color() const { return mColor; }
+	void alpha(uint8_t alpha);
+	uint8_t alpha() const;
+	void color(const Color& color);
+	const Color& color() const;
 
 	Vector<int> size() const;
 	Point<int> origin(Point<int> point) const;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -75,7 +75,7 @@ protected:
 private:
 	struct SpriteFrame
 	{
-		Image& image;
+		const Image& image;
 		Rectangle<int> bounds;
 		Vector<int> anchorOffset;
 		unsigned int frameDelay;


### PR DESCRIPTION
Reference: #401

General refactoring:
- Remove unpacked overload of `Sprite::update`.
- Re-order methods
- Reposition exception checks
- Inline and remove methods
- Pre-lookup `Image` and store in `SpriteFrame` as a `const Image&`
