### PR TITLE
Move Sprite XML methods to anonymous namespace

### DIFF
--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -293,7 +293,7 @@ void Sprite::processXml(const std::string& filePath)
 	// it, we just iterate through all nodes to find sprite sheets. This allows us to define
 	// image sheets anywhere in the sprite file.
 	mImageSheets = processImageSheets(xmlRootElement);
-	processActions(mImageSheets, xmlRootElement);
+	mActions = processActions(mImageSheets, xmlRootElement);
 }
 
 
@@ -358,9 +358,11 @@ std::map<std::string, Image> Sprite::processImageSheets(const void* root)
  * \note	Action names are not case sensitive. "Case", "caSe",
  *			"CASE", etc. will all be viewed as identical.
  */
-void Sprite::processActions(const std::map<std::string, Image>& imageSheets, const void* root)
+std::map<std::string, Sprite::FrameList> Sprite::processActions(const std::map<std::string, Image>& imageSheets, const void* root)
 {
 	const XmlElement* element = static_cast<const XmlElement*>(root);
+
+	std::map<std::string, FrameList> actions;
 
 	for (const XmlNode* node = element->iterateChildren(nullptr);
 		node != nullptr;
@@ -385,14 +387,16 @@ void Sprite::processActions(const std::map<std::string, Image>& imageSheets, con
 			{
 				throw std::runtime_error("Sprite Action definition has 'name' of length zero: " + endTag(node->row()));
 			}
-			if (mActions.find(toLowercase(action_name)) != mActions.end())
+			if (actions.find(toLowercase(action_name)) != actions.end())
 			{
 				throw std::runtime_error("Sprite Action redefinition: '" + action_name + "' " + endTag(node->row()));
 			}
 
-			mActions[toLowercase(action_name)] = processFrames(imageSheets, action_name, node);
+			actions[toLowercase(action_name)] = processFrames(imageSheets, action_name, node);
 		}
 	}
+
+	return actions;
 }
 
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -60,13 +60,13 @@ Sprite::Sprite(const std::string& filePath) :
 
 Vector<int> Sprite::size() const
 {
-	return mActions.at(mCurrentAction)[mCurrentFrame].bounds.size();
+	return mSpriteAnimations.actions.at(mCurrentAction)[mCurrentFrame].bounds.size();
 }
 
 
 Point<int> Sprite::origin(Point<int> point) const
 {
-	return point - mActions.at(mCurrentAction)[mCurrentFrame].anchorOffset;
+	return point - mSpriteAnimations.actions.at(mCurrentAction)[mCurrentFrame].anchorOffset;
 }
 
 
@@ -77,7 +77,7 @@ Point<int> Sprite::origin(Point<int> point) const
  */
 StringList Sprite::actions() const
 {
-	return getKeys(mActions);
+	return getKeys(mSpriteAnimations.actions);
 }
 
 
@@ -95,7 +95,7 @@ StringList Sprite::actions() const
 void Sprite::play(const std::string& action)
 {
 	const auto normalizedAction = toLowercase(action);
-	if (mActions.find(normalizedAction) == mActions.end())
+	if (mSpriteAnimations.actions.find(normalizedAction) == mSpriteAnimations.actions.end())
 	{
 		throw std::runtime_error("Sprite::play called on undefined action: '" + action + "' : " + name());
 	}
@@ -132,7 +132,7 @@ void Sprite::resume()
  */
 void Sprite::setFrame(std::size_t frameIndex)
 {
-	mCurrentFrame = frameIndex % mActions[mCurrentAction].size();
+	mCurrentFrame = frameIndex % mSpriteAnimations.actions[mCurrentAction].size();
 }
 
 
@@ -156,7 +156,7 @@ void Sprite::decrementFrame()
 
 void Sprite::update(Point<float> position)
 {
-	const auto& frame = mActions[mCurrentAction][mCurrentFrame];
+	const auto& frame = mSpriteAnimations.actions[mCurrentAction][mCurrentFrame];
 
 	if (!mPaused && (frame.frameDelay != FRAME_PAUSE))
 	{
@@ -166,7 +166,7 @@ void Sprite::update(Point<float> position)
 			mCurrentFrame++;
 		}
 
-		if (mCurrentFrame >= mActions[mCurrentAction].size())
+		if (mCurrentFrame >= mSpriteAnimations.actions[mCurrentAction].size())
 		{
 			mCurrentFrame = 0;
 			mAnimationCompleteCallback();
@@ -292,8 +292,8 @@ void Sprite::processXml(const std::string& filePath)
 	// Here instead of going through each element and calling a processing function to handle
 	// it, we just iterate through all nodes to find sprite sheets. This allows us to define
 	// image sheets anywhere in the sprite file.
-	mImageSheets = processImageSheets(xmlRootElement);
-	mActions = processActions(mImageSheets, xmlRootElement);
+	mSpriteAnimations.imageSheets = processImageSheets(xmlRootElement);
+	mSpriteAnimations.actions = processActions(mSpriteAnimations.imageSheets, xmlRootElement);
 }
 
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -36,6 +36,11 @@ namespace {
 	{
 		return " (Row: " + std::to_string(row) + ")";
 	}
+
+	Sprite::SpriteAnimations processXml(const std::string& filePath);
+	std::map<std::string, Image> processImageSheets(const std::string& basePath, const void* root);
+	std::map<std::string, std::vector<Sprite::SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const void* root);
+	std::vector<Sprite::SpriteFrame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const void* node);
 }
 
 
@@ -255,12 +260,14 @@ const std::string& Sprite::name() const
 }
 
 
+namespace {
+
 /**
  * Parses a Sprite XML Definition File.
  *
  * \param filePath	File path of the sprite XML definition file.
  */
-Sprite::SpriteAnimations Sprite::processXml(const std::string& filePath)
+Sprite::SpriteAnimations processXml(const std::string& filePath)
 {
 	auto& filesystem = Utility<Filesystem>::get();
 	const auto basePath = filesystem.workingPath(filePath);
@@ -310,7 +317,7 @@ Sprite::SpriteAnimations Sprite::processXml(const std::string& filePath)
  *			element in a sprite definition, these elements can appear
  *			anywhere in a Sprite XML definition.
  */
-std::map<std::string, Image> Sprite::processImageSheets(const std::string& basePath, const void* root)
+std::map<std::string, Image> processImageSheets(const std::string& basePath, const void* root)
 {
 	const XmlElement* e = static_cast<const XmlElement*>(root);
 
@@ -363,7 +370,7 @@ std::map<std::string, Image> Sprite::processImageSheets(const std::string& baseP
  * \note	Action names are not case sensitive. "Case", "caSe",
  *			"CASE", etc. will all be viewed as identical.
  */
-std::map<std::string, std::vector<Sprite::SpriteFrame>> Sprite::processActions(const std::map<std::string, Image>& imageSheets, const void* root)
+std::map<std::string, std::vector<Sprite::SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const void* root)
 {
 	const XmlElement* element = static_cast<const XmlElement*>(root);
 
@@ -408,7 +415,7 @@ std::map<std::string, std::vector<Sprite::SpriteFrame>> Sprite::processActions(c
 /**
  * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
  */
-std::vector<Sprite::SpriteFrame> Sprite::processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const void* _node)
+std::vector<Sprite::SpriteFrame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const void* _node)
 {
 	const XmlNode* node = static_cast<const XmlNode*>(_node);
 
@@ -500,3 +507,5 @@ std::vector<Sprite::SpriteFrame> Sprite::processFrames(const std::map<std::strin
 
 	return frameList;
 }
+
+} // namespace

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -49,7 +49,7 @@ Sprite::Sprite(const std::string& filePath) :
 {
 	try
 	{
-		processXml(filePath);
+		mSpriteAnimations = processXml(filePath);
 	}
 	catch(const std::runtime_error& error)
 	{
@@ -260,7 +260,7 @@ const std::string& Sprite::name() const
  *
  * \param filePath	File path of the sprite XML definition file.
  */
-void Sprite::processXml(const std::string& filePath)
+Sprite::SpriteAnimations Sprite::processXml(const std::string& filePath)
 {
 	XmlDocument xmlDoc;
 	xmlDoc.parse(Utility<Filesystem>::get().open(filePath).raw_bytes());
@@ -292,8 +292,10 @@ void Sprite::processXml(const std::string& filePath)
 	// Here instead of going through each element and calling a processing function to handle
 	// it, we just iterate through all nodes to find sprite sheets. This allows us to define
 	// image sheets anywhere in the sprite file.
-	mSpriteAnimations.imageSheets = processImageSheets(xmlRootElement);
-	mSpriteAnimations.actions = processActions(mSpriteAnimations.imageSheets, xmlRootElement);
+	SpriteAnimations spriteAnimations;
+	spriteAnimations.imageSheets = processImageSheets(xmlRootElement);
+	spriteAnimations.actions = processActions(spriteAnimations.imageSheets, xmlRootElement);
+	return spriteAnimations;
 }
 
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -360,11 +360,11 @@ std::map<std::string, Image> Sprite::processImageSheets(const void* root)
  * \note	Action names are not case sensitive. "Case", "caSe",
  *			"CASE", etc. will all be viewed as identical.
  */
-std::map<std::string, Sprite::FrameList> Sprite::processActions(const std::map<std::string, Image>& imageSheets, const void* root)
+std::map<std::string, std::vector<Sprite::SpriteFrame>> Sprite::processActions(const std::map<std::string, Image>& imageSheets, const void* root)
 {
 	const XmlElement* element = static_cast<const XmlElement*>(root);
 
-	std::map<std::string, FrameList> actions;
+	std::map<std::string, std::vector<SpriteFrame>> actions;
 
 	for (const XmlNode* node = element->iterateChildren(nullptr);
 		node != nullptr;
@@ -405,11 +405,11 @@ std::map<std::string, Sprite::FrameList> Sprite::processActions(const std::map<s
 /**
  * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
  */
-Sprite::FrameList Sprite::processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const void* _node)
+std::vector<Sprite::SpriteFrame> Sprite::processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const void* _node)
 {
 	const XmlNode* node = static_cast<const XmlNode*>(_node);
 
-	FrameList frameList;
+	std::vector<SpriteFrame> frameList;
 
 	for (const XmlNode* frame = node->iterateChildren(nullptr);
 		frame != nullptr;

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -262,8 +262,11 @@ const std::string& Sprite::name() const
  */
 Sprite::SpriteAnimations Sprite::processXml(const std::string& filePath)
 {
+	auto& filesystem = Utility<Filesystem>::get();
+	const auto basePath = filesystem.workingPath(filePath);
+
 	XmlDocument xmlDoc;
-	xmlDoc.parse(Utility<Filesystem>::get().open(filePath).raw_bytes());
+	xmlDoc.parse(filesystem.open(filePath).raw_bytes());
 
 	if (xmlDoc.error())
 	{
@@ -293,7 +296,7 @@ Sprite::SpriteAnimations Sprite::processXml(const std::string& filePath)
 	// it, we just iterate through all nodes to find sprite sheets. This allows us to define
 	// image sheets anywhere in the sprite file.
 	Sprite::SpriteAnimations spriteAnimations;
-	spriteAnimations.imageSheets = processImageSheets(xmlRootElement);
+	spriteAnimations.imageSheets = processImageSheets(basePath, xmlRootElement);
 	spriteAnimations.actions = processActions(spriteAnimations.imageSheets, xmlRootElement);
 	return spriteAnimations;
 }
@@ -307,7 +310,7 @@ Sprite::SpriteAnimations Sprite::processXml(const std::string& filePath)
  *			element in a sprite definition, these elements can appear
  *			anywhere in a Sprite XML definition.
  */
-std::map<std::string, Image> Sprite::processImageSheets(const void* root)
+std::map<std::string, Image> Sprite::processImageSheets(const std::string& basePath, const void* root)
 {
 	const XmlElement* e = static_cast<const XmlElement*>(root);
 
@@ -344,7 +347,7 @@ std::map<std::string, Image> Sprite::processImageSheets(const void* root)
 				throw std::runtime_error("Sprite image sheet redefinition: id: '" + id + "' " + endTag(node->row()));
 			}
 
-			const string imagePath = Utility<Filesystem>::get().workingPath(mSpriteName) + src;
+			const string imagePath = basePath + src;
 			imageSheets.try_emplace(id, imagePath);
 		}
 	}

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -292,7 +292,7 @@ Sprite::SpriteAnimations Sprite::processXml(const std::string& filePath)
 	// Here instead of going through each element and calling a processing function to handle
 	// it, we just iterate through all nodes to find sprite sheets. This allows us to define
 	// image sheets anywhere in the sprite file.
-	SpriteAnimations spriteAnimations;
+	Sprite::SpriteAnimations spriteAnimations;
 	spriteAnimations.imageSheets = processImageSheets(xmlRootElement);
 	spriteAnimations.actions = processActions(spriteAnimations.imageSheets, xmlRootElement);
 	return spriteAnimations;
@@ -364,7 +364,7 @@ std::map<std::string, std::vector<Sprite::SpriteFrame>> Sprite::processActions(c
 {
 	const XmlElement* element = static_cast<const XmlElement*>(root);
 
-	std::map<std::string, std::vector<SpriteFrame>> actions;
+	std::map<std::string, std::vector<Sprite::SpriteFrame>> actions;
 
 	for (const XmlNode* node = element->iterateChildren(nullptr);
 		node != nullptr;
@@ -409,7 +409,7 @@ std::vector<Sprite::SpriteFrame> Sprite::processFrames(const std::map<std::strin
 {
 	const XmlNode* node = static_cast<const XmlNode*>(_node);
 
-	std::vector<SpriteFrame> frameList;
+	std::vector<Sprite::SpriteFrame> frameList;
 
 	for (const XmlNode* frame = node->iterateChildren(nullptr);
 		frame != nullptr;
@@ -487,7 +487,7 @@ std::vector<Sprite::SpriteFrame> Sprite::processFrames(const std::map<std::strin
 
 		const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
 		const auto anchorOffset = Vector{anchorx, anchory};
-		frameList.push_back(SpriteFrame{imageSheets.at(sheetId), bounds, anchorOffset, static_cast<unsigned int>(delay)});
+		frameList.push_back(Sprite::SpriteFrame{imageSheets.at(sheetId), bounds, anchorOffset, static_cast<unsigned int>(delay)});
 	}
 
 	if (frameList.size() <= 0)

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -390,7 +390,7 @@ void Sprite::processActions(const void* root)
 				throw std::runtime_error("Sprite Action redefinition: '" + action_name + "' " + endTag(node->row()));
 			}
 
-			processFrames(action_name, node);
+			mActions[toLowercase(action_name)] = processFrames(action_name, node);
 		}
 	}
 }
@@ -399,7 +399,7 @@ void Sprite::processActions(const void* root)
 /**
  * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
  */
-void Sprite::processFrames(const std::string& action, const void* _node)
+Sprite::FrameList Sprite::processFrames(const std::string& action, const void* _node)
 {
 	const XmlNode* node = static_cast<const XmlNode*>(_node);
 
@@ -489,5 +489,5 @@ void Sprite::processFrames(const std::string& action, const void* _node)
 		throw std::runtime_error("Sprite Action contains no valid frames: " + action);
 	}
 
-	mActions[toLowercase(action)] = std::move(frameList);
+	return frameList;
 }

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -292,7 +292,7 @@ void Sprite::processXml(const std::string& filePath)
 	// Here instead of going through each element and calling a processing function to handle
 	// it, we just iterate through all nodes to find sprite sheets. This allows us to define
 	// image sheets anywhere in the sprite file.
-	processImageSheets(xmlRootElement);
+	mImageSheets = processImageSheets(xmlRootElement);
 	processActions(xmlRootElement);
 }
 
@@ -305,9 +305,11 @@ void Sprite::processXml(const std::string& filePath)
  *			element in a sprite definition, these elements can appear
  *			anywhere in a Sprite XML definition.
  */
-void Sprite::processImageSheets(const void* root)
+std::map<std::string, Image> Sprite::processImageSheets(const void* root)
 {
 	const XmlElement* e = static_cast<const XmlElement*>(root);
+
+	std::map<std::string, Image> imageSheets;
 
 	string id, src;
 	for (const XmlNode* node = e->iterateChildren(nullptr);
@@ -335,15 +337,17 @@ void Sprite::processImageSheets(const void* root)
 				throw std::runtime_error("Sprite imagesheet definition has `src` of length zero: " + endTag(node->row()));
 			}
 
-			if (mImageSheets.find(toLowercase(id)) != mImageSheets.end())
+			if (imageSheets.find(toLowercase(id)) != imageSheets.end())
 			{
 				throw std::runtime_error("Sprite image sheet redefinition: id: '" + id + "' " + endTag(node->row()));
 			}
 
 			const string imagePath = Utility<Filesystem>::get().workingPath(mSpriteName) + src;
-			mImageSheets.try_emplace(id, imagePath);
+			imageSheets.try_emplace(id, imagePath);
 		}
 	}
+
+	return imageSheets;
 }
 
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -85,7 +85,7 @@ private:
 	using FrameList = std::vector<SpriteFrame>;
 
 	void processXml(const std::string& filePath);
-	void processImageSheets(const void* root);
+	std::map<std::string, Image> processImageSheets(const void* root);
 	void processActions(const void* root);
 	void processFrames(const std::string& action, const void* node);
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -87,7 +87,7 @@ private:
 	void processXml(const std::string& filePath);
 	std::map<std::string, Image> processImageSheets(const void* root);
 	void processActions(const void* root);
-	void processFrames(const std::string& action, const void* node);
+	FrameList processFrames(const std::string& action, const void* node);
 
 
 	std::map<std::string, Image> mImageSheets;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -86,8 +86,8 @@ private:
 
 	void processXml(const std::string& filePath);
 	std::map<std::string, Image> processImageSheets(const void* root);
-	void processActions(const void* root);
-	FrameList processFrames(const std::string& action, const void* node);
+	void processActions(const std::map<std::string, Image>& imageSheets, const void* root);
+	FrameList processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const void* node);
 
 
 	std::map<std::string, Image> mImageSheets;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -90,7 +90,7 @@ private:
 
 	using FrameList = std::vector<SpriteFrame>;
 
-	void processXml(const std::string& filePath);
+	SpriteAnimations processXml(const std::string& filePath);
 	std::map<std::string, Image> processImageSheets(const void* root);
 	std::map<std::string, FrameList> processActions(const std::map<std::string, Image>& imageSheets, const void* root);
 	FrameList processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const void* node);

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -88,12 +88,10 @@ private:
 	};
 
 
-	using FrameList = std::vector<SpriteFrame>;
-
 	SpriteAnimations processXml(const std::string& filePath);
 	std::map<std::string, Image> processImageSheets(const void* root);
-	std::map<std::string, FrameList> processActions(const std::map<std::string, Image>& imageSheets, const void* root);
-	FrameList processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const void* node);
+	std::map<std::string, std::vector<SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const void* root);
+	std::vector<SpriteFrame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const void* node);
 
 
 	SpriteAnimations mSpriteAnimations;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -39,6 +39,21 @@ class Sprite
 public:
 	using Callback = Signals::Signal<>; /**< Signal used when action animations complete. */
 
+	struct SpriteFrame
+	{
+		const Image& image;
+		Rectangle<int> bounds;
+		Vector<int> anchorOffset;
+		unsigned int frameDelay;
+	};
+
+	struct SpriteAnimations
+	{
+		std::map<std::string, Image> imageSheets;
+		std::map<std::string, std::vector<SpriteFrame>> actions;
+	};
+
+
 	explicit Sprite(const std::string& filePath);
 	Sprite(const Sprite& sprite) = default;
 	Sprite& operator=(const Sprite& rhs) = default;
@@ -73,21 +88,6 @@ protected:
 	const std::string& name() const;
 
 private:
-	struct SpriteFrame
-	{
-		const Image& image;
-		Rectangle<int> bounds;
-		Vector<int> anchorOffset;
-		unsigned int frameDelay;
-	};
-
-	struct SpriteAnimations
-	{
-		std::map<std::string, Image> imageSheets;
-		std::map<std::string, std::vector<SpriteFrame>> actions;
-	};
-
-
 	SpriteAnimations processXml(const std::string& filePath);
 	std::map<std::string, Image> processImageSheets(const void* root);
 	std::map<std::string, std::vector<SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const void* root);

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -86,7 +86,7 @@ private:
 
 	void processXml(const std::string& filePath);
 	std::map<std::string, Image> processImageSheets(const void* root);
-	void processActions(const std::map<std::string, Image>& imageSheets, const void* root);
+	std::map<std::string, FrameList> processActions(const std::map<std::string, Image>& imageSheets, const void* root);
 	FrameList processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const void* node);
 
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -88,12 +88,6 @@ protected:
 	const std::string& name() const;
 
 private:
-	SpriteAnimations processXml(const std::string& filePath);
-	std::map<std::string, Image> processImageSheets(const std::string& basePath, const void* root);
-	std::map<std::string, std::vector<SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const void* root);
-	std::vector<SpriteFrame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const void* node);
-
-
 	SpriteAnimations mSpriteAnimations;
 
 	std::string mSpriteName;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -89,7 +89,7 @@ protected:
 
 private:
 	SpriteAnimations processXml(const std::string& filePath);
-	std::map<std::string, Image> processImageSheets(const void* root);
+	std::map<std::string, Image> processImageSheets(const std::string& basePath, const void* root);
 	std::map<std::string, std::vector<SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const void* root);
 	std::vector<SpriteFrame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const void* node);
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -81,6 +81,12 @@ private:
 		unsigned int frameDelay;
 	};
 
+	struct SpriteAnimations
+	{
+		std::map<std::string, Image> imageSheets;
+		std::map<std::string, std::vector<SpriteFrame>> actions;
+	};
+
 
 	using FrameList = std::vector<SpriteFrame>;
 
@@ -90,8 +96,7 @@ private:
 	FrameList processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const void* node);
 
 
-	std::map<std::string, Image> mImageSheets;
-	std::map<std::string, FrameList> mActions;
+	SpriteAnimations mSpriteAnimations;
 
 	std::string mSpriteName;
 	std::string mCurrentAction{"default"};


### PR DESCRIPTION
Move `Sprite` XML parsing methods out of the `Sprite` class and into an anonymous namespace in the implementation file.

Reference: #401
