### PR TITLE
Sprite pre-lookup action

### DIFF
--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -65,13 +65,13 @@ Sprite::Sprite(const std::string& filePath) :
 
 Vector<int> Sprite::size() const
 {
-	return mSpriteAnimations.actions.at(mCurrentAction)[mCurrentFrame].bounds.size();
+	return (*mCurrentAction)[mCurrentFrame].bounds.size();
 }
 
 
 Point<int> Sprite::origin(Point<int> point) const
 {
-	return point - mSpriteAnimations.actions.at(mCurrentAction)[mCurrentFrame].anchorOffset;
+	return point - (*mCurrentAction)[mCurrentFrame].anchorOffset;
 }
 
 
@@ -104,7 +104,7 @@ void Sprite::play(const std::string& action)
 		throw std::runtime_error("Sprite::play called on undefined action: '" + action + "' : " + mSpriteName);
 	}
 
-	mCurrentAction = action;
+	mCurrentAction = &mSpriteAnimations.actions.at(action);
 	mCurrentFrame = 0;
 	mTimer.reset();
 	resume();
@@ -136,7 +136,7 @@ void Sprite::resume()
  */
 void Sprite::setFrame(std::size_t frameIndex)
 {
-	mCurrentFrame = frameIndex % mSpriteAnimations.actions[mCurrentAction].size();
+	mCurrentFrame = frameIndex % mCurrentAction->size();
 }
 
 
@@ -160,7 +160,7 @@ void Sprite::decrementFrame()
 
 void Sprite::update(Point<float> position)
 {
-	const auto& frame = mSpriteAnimations.actions[mCurrentAction][mCurrentFrame];
+	const auto& frame = (*mCurrentAction)[mCurrentFrame];
 
 	if (!mPaused && (frame.frameDelay != FRAME_PAUSE))
 	{
@@ -170,7 +170,7 @@ void Sprite::update(Point<float> position)
 			mCurrentFrame++;
 		}
 
-		if (mCurrentFrame >= mSpriteAnimations.actions[mCurrentAction].size())
+		if (mCurrentFrame >= mCurrentAction->size())
 		{
 			mCurrentFrame = 0;
 			mAnimationCompleteCallback();

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -63,6 +63,13 @@ Sprite::Sprite(const std::string& filePath) :
 }
 
 
+Sprite::Sprite(const std::string& filePath, const std::string& initialAction) :
+	Sprite{filePath}
+{
+	mCurrentAction = &mSpriteAnimations.actions.at(initialAction);
+}
+
+
 Vector<int> Sprite::size() const
 {
 	return (*mCurrentAction)[mCurrentFrame].bounds.size();

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -88,7 +88,7 @@ private:
 	SpriteAnimations mSpriteAnimations;
 
 	std::string mSpriteName;
-	std::string mCurrentAction{"default"};
+	std::vector<SpriteFrame>* mCurrentAction{nullptr};
 
 	bool mPaused{false};
 	Timer mTimer;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -55,6 +55,7 @@ public:
 
 
 	explicit Sprite(const std::string& filePath);
+	Sprite(const std::string& filePath, const std::string& initialAction);
 	Sprite(const Sprite& sprite) = default;
 	Sprite& operator=(const Sprite& rhs) = default;
 	~Sprite() = default;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -85,14 +85,15 @@ public:
 	Callback& frameCallback();
 
 private:
+	std::string mSpriteName;
+
 	SpriteAnimations mSpriteAnimations;
 
-	std::string mSpriteName;
 	std::vector<SpriteFrame>* mCurrentAction{nullptr};
+	std::size_t mCurrentFrame{0};
 
 	bool mPaused{false};
 	Timer mTimer;
-	std::size_t mCurrentFrame{0};
 	Callback mAnimationCompleteCallback;
 
 	Color mColor{Color::Normal}; /**< Color tint to use for drawing the sprite. */


### PR DESCRIPTION
Change `mCurrentAction` field from `std::string` to pointer to the current action's frame list. This means the lookup is pre-done when the action is set, and doesn't need to be done every time the action data is accessed.

Add a constructor to set the initial action upon creation.

Most code that creates a `Sprite` will also immediately afterwards set a current action. It makes sense to combine this with the constructor. This is not just a convenience concern, but also a safety concern. Setting an initial action avoids leaving the `mCurrentAction` pointer unset, which can lead to undefined behaviour if a member function is called that uses it. Previously, a `"default"` action was used, which was either created on demand as an empty animation sequence, or an exception was thrown. The code was a bit inconsistent about this. The create on demand looks like it may have been an accidental oversight. Effectively the designed behaviour may have been undefined in that case.

Reference: #525
Reference: #401
