### PR TITLE
Remove Sprite constructor with no initial action

### DIFF
--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -49,24 +49,18 @@ namespace {
  *
  * \param filePath	File path of the Sprite definition file.
  */
-Sprite::Sprite(const std::string& filePath) :
+Sprite::Sprite(const std::string& filePath, const std::string& initialAction) :
 	mSpriteName(filePath)
 {
 	try
 	{
 		mSpriteAnimations = processXml(filePath);
+		mCurrentAction = &mSpriteAnimations.actions.at(initialAction);
 	}
 	catch(const std::runtime_error& error)
 	{
 		throw std::runtime_error("Error parsing Sprite file: " + filePath + "\nError: " + error.what());
 	}
-}
-
-
-Sprite::Sprite(const std::string& filePath, const std::string& initialAction) :
-	Sprite{filePath}
-{
-	mCurrentAction = &mSpriteAnimations.actions.at(initialAction);
 }
 
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -54,7 +54,6 @@ public:
 	};
 
 
-	explicit Sprite(const std::string& filePath);
 	Sprite(const std::string& filePath, const std::string& initialAction);
 	Sprite(const Sprite& sprite) = default;
 	Sprite& operator=(const Sprite& rhs) = default;


### PR DESCRIPTION
Remove `Sprite` constructor with no initial action.

This avoids the case where `mCurrentAction` is not set to a valid value. This means undefined behaviour can be avoiding, without having to liter the code with checks.

Closes #525
Reference: https://github.com/OutpostUniverse/OPHD/pull/554
Reference: #401
