### PR TITLE
Set Sprite as move-only

### DIFF
--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -56,8 +56,10 @@ public:
 
 	explicit Sprite(const std::string& filePath);
 	Sprite(const std::string& filePath, const std::string& initialAction);
-	Sprite(const Sprite& sprite) = default;
-	Sprite& operator=(const Sprite& rhs) = default;
+	Sprite(const Sprite& sprite) = delete;
+	Sprite(Sprite&& sprite) = default;
+	Sprite& operator=(const Sprite& rhs) = delete;
+	Sprite& operator=(Sprite&& rhs) = default;
 	~Sprite() = default;
 
 	Vector<int> size() const;


### PR DESCRIPTION
It seems the current caching of pointers can cause some invalidation issues if the `Sprite` is copied.

This should be solved shortly by splitting the common cached data from the `Sprite` class, allowing it to be referenced separately from the `Sprite`.