### PR TITLE
Support more bit depths

### DIFF
--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -28,7 +28,7 @@
 #include <stdexcept>
 
 
-extern unsigned int generateTexture(void *buffer, int bytesPerPixel, int width, int height);
+extern unsigned int generateTexture(SDL_Surface* surface);
 
 
 using namespace NAS2D;
@@ -302,7 +302,7 @@ namespace {
 		}
 		fillInTextureCoordinates(glm, glyphSize, fontSurfaceSize);
 
-		unsigned int textureId = generateTexture(fontSurface->pixels, fontSurface->format->BytesPerPixel, fontSurface->w, fontSurface->h);
+		unsigned int textureId = generateTexture(fontSurface);
 
 		// Add generated texture id to texture ID map.
 		fontInfo.textureId = textureId;
@@ -368,7 +368,7 @@ namespace {
 			SDL_FreeSurface(characterSurface);
 		}
 
-		unsigned int textureId = generateTexture(fontSurface->pixels, fontSurface->format->BytesPerPixel, fontSurface->w, fontSurface->h);
+		unsigned int textureId = generateTexture(fontSurface);
 
 		// Add generated texture id to texture ID map.
 		fontMap[name].textureId = textureId;

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -374,7 +374,16 @@ namespace {
  */
 unsigned int generateTexture(SDL_Surface* surface)
 {
-	return generateTexture(surface->pixels, surface->format->BytesPerPixel, surface->w, surface->h);
+	const auto bytesPerPixel = surface->format->BytesPerPixel;
+	if (bytesPerPixel == 3 || bytesPerPixel == 4)
+	{
+		return generateTexture(surface->pixels, bytesPerPixel, surface->w, surface->h);
+	}
+
+	auto* newSurface = SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_RGBA32, 0);
+	const auto textureId = generateTexture(newSurface->pixels, newSurface->format->BytesPerPixel, newSurface->w, newSurface->h);
+	SDL_FreeSurface(newSurface);
+	return textureId;
 }
 
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -107,7 +107,7 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) : Resource(
 
 	mSize = Vector{width, height};
 
-	unsigned int textureId = generateTexture(buffer, bytesPerPixel, width, height);
+	unsigned int textureId = generateTexture(surface);
 
 	// Update resource management.
 	auto& imageInfo = imageIdMap[name()];
@@ -205,7 +205,7 @@ void Image::load()
 
 	mSize = Vector{surface->w, surface->h};
 
-	unsigned int textureId = generateTexture(surface->pixels, surface->format->BytesPerPixel, surface->w, surface->h);
+	unsigned int textureId = generateTexture(surface);
 
 	// Add generated texture id to texture ID map.
 	auto& imageInfo = imageIdMap[name()];

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -28,6 +28,7 @@ using namespace NAS2D::Exception;
 std::map<std::string, ImageInfo> imageIdMap; /**< Lookup table for OpenGL Texture ID's. */
 
 
+unsigned int generateTexture(SDL_Surface* surface);
 unsigned int generateTexture(void *buffer, int bytesPerPixel, int width, int height);
 
 
@@ -371,6 +372,12 @@ namespace {
 /**
  * Generates a new OpenGL texture from an SDL_Surface.
  */
+unsigned int generateTexture(SDL_Surface* surface)
+{
+	return generateTexture(surface->pixels, surface->format->BytesPerPixel, surface->w, surface->h);
+}
+
+
 unsigned int generateTexture(void *buffer, int bytesPerPixel, int width, int height)
 {
 	GLenum textureFormat = 0;


### PR DESCRIPTION
Closes #208
Reference: https://github.com/lairworks/nas2d-tests/pull/57#issuecomment-665302944

Add new overload `generateTexture(SDL_Surface*)`.

Add ability to auto convert previously unsupported formats to RGBA.
