### PR TITLE
Mark Renderer::clipRectClear() as virtual

### DIFF
--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -218,15 +218,6 @@ Point<int> Renderer::center() const
 
 
 /**
- * Clears the clipping rectangle.
- */
-void Renderer::clipRectClear()
-{
-	clipRect({0, 0, 0, 0});
-}
-
-
-/**
  * Updates the screen.
  *
  * \note	All derived Renderer objects must call Renderer::update()

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -90,7 +90,7 @@ void Renderer::drawImageRect(Rectangle<float> rect, ImageList& images)
 		throw std::runtime_error("Must pass 9 images to drawImageRect, but images.size() == " + std::to_string(images.size()));
 	}
 
-	drawImageRect({rect.x, rect.y, rect.width, rect.height}, images[0], images[1], images[2], images[3], images[4], images[5], images[6], images[7], images[8]);
+	drawImageRect(rect, images[0], images[1], images[2], images[3], images[4], images[5], images[6], images[7], images[8]);
 }
 
 

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -115,7 +115,7 @@ public:
 	 * \see clipRectClear()
 	 */
 	virtual void clipRect(const Rectangle<float>& rect) = 0;
-	void clipRectClear();
+	virtual void clipRectClear() = 0;
 
 	virtual void fullscreen(bool fs, bool maintain = false) = 0;
 	virtual bool fullscreen() const = 0;

--- a/NAS2D/Renderer/RendererNull.h
+++ b/NAS2D/Renderer/RendererNull.h
@@ -64,6 +64,7 @@ public:
 	bool resizeable() const override { return false; }
 
 	void clipRect(const Rectangle<float>&) override {}
+	void clipRectClear() override {}
 
 	void window_icon(const std::string&) override {}
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -255,10 +255,10 @@ void RendererOpenGL::drawSubImageRepeated(const Image& image, const Rectangle<fl
 {
 	clipRect(destination);
 
-	const auto tileCountSize = destination.size().skewInverseBy(source.size());
-	for (std::size_t row = 0; row <= tileCountSize.y; ++row)
+	const auto tileCountSize = destination.size().skewInverseBy(source.size()).to<int>() + Vector{1, 1};
+	for (int row = 0; row < tileCountSize.y; ++row)
 	{
-		for (std::size_t col = 0; col <= tileCountSize.x; ++col)
+		for (int col = 0; col < tileCountSize.x; ++col)
 		{
 			drawSubImage(image, destination.startPoint() + Vector{col, row}.to<float>().skewBy(source.size()), source);
 		}

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -533,7 +533,7 @@ void RendererOpenGL::clipRect(const Rectangle<float>& rect)
 	}
 
 	const auto intRect = rect.to<int>();
-	glScissor(intRect.x, size().y - intRect.y - intRect.height, intRect.width, intRect.height);
+	glScissor(intRect.x, size().y - (intRect.y + intRect.height), intRect.width, intRect.height);
 
 	glEnable(GL_SCISSOR_TEST);
 }

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -10,6 +10,7 @@
 
 #include "RendererOpenGL.h"
 
+#include "VectorSizeRange.h"
 #include "../Trig.h"
 #include "../Configuration.h"
 #include "../EventHandler.h"
@@ -256,12 +257,9 @@ void RendererOpenGL::drawSubImageRepeated(const Image& image, const Rectangle<fl
 	clipRect(destination);
 
 	const auto tileCountSize = destination.size().skewInverseBy(source.size()).to<int>() + Vector{1, 1};
-	for (int row = 0; row < tileCountSize.y; ++row)
+	for (const auto tileOffset : VectorSizeRange(tileCountSize))
 	{
-		for (int col = 0; col < tileCountSize.x; ++col)
-		{
-			drawSubImage(image, destination.startPoint() + Vector{col, row}.to<float>().skewBy(source.size()), source);
-		}
+		drawSubImage(image, destination.startPoint() + tileOffset.to<float>().skewBy(source.size()), source);
 	}
 
 	glDisable(GL_SCISSOR_TEST);

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -526,16 +526,16 @@ void RendererOpenGL::setCursor(int cursorId)
 
 void RendererOpenGL::clipRect(const Rectangle<float>& rect)
 {
-	if (rect.null())
-	{
-		glDisable(GL_SCISSOR_TEST);
-		return;
-	}
-
 	const auto intRect = rect.to<int>();
 	glScissor(intRect.x, size().y - (intRect.y + intRect.height), intRect.width, intRect.height);
 
 	glEnable(GL_SCISSOR_TEST);
+}
+
+
+void RendererOpenGL::clipRectClear()
+{
+	glDisable(GL_SCISSOR_TEST);
 }
 
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -260,7 +260,7 @@ void RendererOpenGL::drawSubImageRepeated(const Image& image, const Rectangle<fl
 	{
 		for (std::size_t col = 0; col <= tileCountSize.x; ++col)
 		{
-			drawSubImage(image, {destination.x + (col * source.width), destination.y + (row * source.height)}, source);
+			drawSubImage(image, destination.startPoint() + Vector{col, row}.to<float>().skewBy(source.size()), source);
 		}
 	}
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -262,7 +262,7 @@ void RendererOpenGL::drawSubImageRepeated(const Image& image, const Rectangle<fl
 		drawSubImage(image, destination.startPoint() + tileOffset.to<float>().skewBy(source.size()), source);
 	}
 
-	glDisable(GL_SCISSOR_TEST);
+	clipRectClear();
 }
 
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -253,9 +253,7 @@ void RendererOpenGL::drawImageRepeated(const Image& image, Rectangle<float> rect
  */
 void RendererOpenGL::drawSubImageRepeated(const Image& image, const Rectangle<float>& destination, const Rectangle<float>& source)
 {
-	glEnable(GL_SCISSOR_TEST);
-	const auto clipRect = destination.to<int>();
-	glScissor(clipRect.x, size().y - (clipRect.y + clipRect.height), clipRect.width, clipRect.height);
+	clipRect(destination);
 
 	const auto tileCountSize = destination.size().skewInverseBy(source.size());
 	for (std::size_t row = 0; row <= tileCountSize.y; ++row)

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -87,6 +87,7 @@ public:
 	bool resizeable() const override;
 
 	void clipRect(const Rectangle<float>& rect) override;
+	void clipRectClear() override;
 
 	void window_icon(const std::string& path) override;
 


### PR DESCRIPTION
Make `Renderer::clipRectClear()` method `virtual`. This is probably better than re-using `clipRect` with a custom sentinel value to clear the clip rect. In the degenerate case, the destination rectangle might becomes sized zero, in which case, no output should be produced, but the previous use of the sentinel value would disable clipping instead.

Make better use of clip rect methods internally. Make better use of vectorized operations internally.
