### PR TITLE
Constexpr constants

### DIFF
--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -24,7 +24,7 @@ using namespace NAS2D::Xml;
 
 
 namespace NAS2D {
-	const string SPRITE_VERSION("0.99");
+	const string_view SPRITE_VERSION("0.99");
 }
 
 
@@ -289,7 +289,7 @@ Sprite::SpriteAnimations processXml(const std::string& filePath)
 	}
 	if (version->value() != SPRITE_VERSION)
 	{
-		throw std::runtime_error("Sprite version mismatch. Expected: " + SPRITE_VERSION + " Actual: " + versionString());
+		throw std::runtime_error("Sprite version mismatch. Expected: " + std::string{SPRITE_VERSION} + " Actual: " + versionString());
 	}
 
 	// Note:

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -23,11 +23,6 @@ using namespace NAS2D;
 using namespace NAS2D::Xml;
 
 
-namespace NAS2D {
-	const string_view SPRITE_VERSION("0.99");
-}
-
-
 namespace {
 	const auto FRAME_PAUSE = unsigned(-1);
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -20,12 +20,13 @@
 #include "../Renderer/Renderer.h"
 
 #include <map>
+#include <string_view>
 #include <string>
 #include <vector>
 
 namespace NAS2D {
 
-extern const std::string SPRITE_VERSION;
+extern const std::string_view SPRITE_VERSION;
 
 /**
  * \class Sprite

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -26,7 +26,8 @@
 
 namespace NAS2D {
 
-extern const std::string_view SPRITE_VERSION;
+constexpr std::string_view SPRITE_VERSION{"0.99"};
+
 
 /**
  * \class Sprite

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 
+
 namespace NAS2D {
 
 constexpr std::string_view SPRITE_VERSION{"0.99"};

--- a/NAS2D/Trig.cpp
+++ b/NAS2D/Trig.cpp
@@ -12,6 +12,7 @@
 
 #include <cmath>
 
+
 namespace NAS2D {
 
 /**

--- a/NAS2D/Trig.cpp
+++ b/NAS2D/Trig.cpp
@@ -14,14 +14,6 @@
 
 namespace NAS2D {
 
-// Common Trig Defines
-const float PI = 3.14159265f;
-const float PI_2 = PI * 2;
-
-const float DEG2RAD = PI / 180.0f;
-const float RAD2DEG = 180 / PI;
-
-
 /**
  * Gets an angle in radians from degrees.
  */

--- a/NAS2D/Trig.h
+++ b/NAS2D/Trig.h
@@ -17,7 +17,7 @@ namespace NAS2D {
 constexpr float PI = 3.14159265f;
 constexpr float PI_2 = PI * 2;
 
-constexpr float DEG2RAD = PI / 180.0f;
+constexpr float DEG2RAD = PI / 180;
 constexpr float RAD2DEG = 180 / PI;
 
 

--- a/NAS2D/Trig.h
+++ b/NAS2D/Trig.h
@@ -12,6 +12,7 @@
 
 #include "Renderer/Point.h"
 
+
 namespace NAS2D {
 
 constexpr float PI = 3.14159265f;

--- a/NAS2D/Trig.h
+++ b/NAS2D/Trig.h
@@ -14,10 +14,11 @@
 
 namespace NAS2D {
 
-extern const float PI;
-extern const float PI_2;
-extern const float DEG2RAD;
-extern const float RAD2DEG;
+constexpr float PI = 3.14159265f;
+constexpr float PI_2 = PI * 2;
+
+constexpr float DEG2RAD = PI / 180.0f;
+constexpr float RAD2DEG = 180 / PI;
 
 
 float degToRad(float degree);


### PR DESCRIPTION
Replace `extern const` global variables with `constexpr` declared in header files.
