### PR TITLE
Implement Sprite caching

### DIFF
--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -43,10 +43,10 @@ namespace {
  * \param filePath	File path of the Sprite definition file.
  */
 Sprite::Sprite(const std::string& filePath, const std::string& initialAction) :
-	mSpriteName(filePath)
+	mSpriteName{filePath},
+	mSpriteAnimations{processXml(filePath)},
+	mCurrentAction{&mSpriteAnimations.actions.at(initialAction)}
 {
-	mSpriteAnimations = processXml(filePath);
-	mCurrentAction = &mSpriteAnimations.actions.at(initialAction);
 }
 
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -43,8 +43,8 @@ namespace {
 		auto iter = animationCache.find(filePath);
 		if (iter == animationCache.end())
 		{
-			const auto [newIter, bInserted] = animationCache.try_emplace(filePath, processXml(filePath));
-			iter = newIter;
+			const auto result = animationCache.try_emplace(filePath, processXml(filePath));
+			iter = result.first;
 		}
 		return iter->second;
 	}

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -24,6 +24,9 @@ using namespace NAS2D;
 namespace {
 	const auto FRAME_PAUSE = unsigned(-1);
 
+	std::map<std::string, Sprite::SpriteAnimations> animationCache;
+
+
 	// Adds a row tag to the end of messages.
 	std::string endTag(int row)
 	{
@@ -34,6 +37,17 @@ namespace {
 	std::map<std::string, Image> processImageSheets(const std::string& basePath, const Xml::XmlElement* element);
 	std::map<std::string, std::vector<Sprite::SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element);
 	std::vector<Sprite::SpriteFrame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node);
+
+	const Sprite::SpriteAnimations& cachedLoad(const std::string& filePath)
+	{
+		auto iter = animationCache.find(filePath);
+		if (iter == animationCache.end())
+		{
+			const auto [newIter, bInserted] = animationCache.try_emplace(filePath, processXml(filePath));
+			iter = newIter;
+		}
+		return iter->second;
+	}
 }
 
 
@@ -44,7 +58,7 @@ namespace {
  */
 Sprite::Sprite(const std::string& filePath, const std::string& initialAction) :
 	mSpriteName{filePath},
-	mSpriteAnimations{processXml(filePath)},
+	mSpriteAnimations{cachedLoad(filePath)},
 	mCurrentAction{&mSpriteAnimations.actions.at(initialAction)}
 {
 }

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -94,7 +94,7 @@ private:
 
 	SpriteAnimations mSpriteAnimations;
 
-	std::vector<SpriteFrame>* mCurrentAction{nullptr};
+	const std::vector<SpriteFrame>* mCurrentAction{nullptr};
 	std::size_t mCurrentFrame{0};
 
 	bool mPaused{false};


### PR DESCRIPTION
Implement caching of the static `Sprite` data. This allows an XML file to be loaded and re-used multiple times, for many different independent `Sprite` objects, without having to reprocess the XML file, nor store duplicate copies of the data.

Reference: #401
