### PR TITLE
Fix SDL_Surface bit depth calculation

### DIFF
--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -103,7 +103,7 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) : Resource(
 
 	name(ARBITRARY_IMAGE_NAME + std::to_string(++IMAGE_ARBITRARY));
 
-	SDL_Surface* surface = SDL_CreateRGBSurfaceFrom(buffer, width, height, bytesPerPixel * 4, 0, 0, 0, 0, SDL_BYTEORDER == SDL_BIG_ENDIAN ? 0x000000FF : 0xFF000000);
+	SDL_Surface* surface = SDL_CreateRGBSurfaceFrom(buffer, width, height, bytesPerPixel * 8, 0, 0, 0, 0, SDL_BYTEORDER == SDL_BIG_ENDIAN ? 0x000000FF : 0xFF000000);
 
 	mSize = Vector{width, height};
 


### PR DESCRIPTION
Peviously the `bytesPerPixel` value used to generate the SDL_Surface was passed to `generateTexture`, so the actual surface bit depth was ignored. That allowed the bug to go undetected until recently when the SDL_Surface was passed directly, and values from the actual surface were used internally.

Impact of the bug was first made evident by #750.
