### PR TITLE
Remove resource default constructors

### DIFF
--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -84,15 +84,6 @@ Font::Font(const std::string& filePath, int glyphWidth, int glyphHeight, int gly
 
 
 /**
- * Default c'tor.
- *
- * Fonts instantiated with this constructor are not valid for use.
- */
-Font::Font() : Resource("Default Font")
-{}
-
-
-/**
  * Copy c'tor.
  *
  * \param	rhs	Font to copy.

--- a/NAS2D/Resources/Font.h
+++ b/NAS2D/Resources/Font.h
@@ -36,7 +36,6 @@ namespace NAS2D {
 class Font : public Resource
 {
 public:
-	Font();
 	explicit Font(const std::string& filePath, unsigned int ptSize = 12);
 	Font(const std::string& filePath, int glyphWidth, int glyphHeight, int glyphSpace);
 	Font(const Font& font);

--- a/NAS2D/Resources/Music.h
+++ b/NAS2D/Resources/Music.h
@@ -23,7 +23,6 @@ namespace NAS2D {
 class Music : public Resource
 {
 public:
-	Music() = default;
 	explicit Music(const std::string& filePath);
 
 	Music(const Music& rhs);

--- a/NAS2D/Resources/Resource.h
+++ b/NAS2D/Resources/Resource.h
@@ -24,7 +24,6 @@ namespace NAS2D {
 class Resource
 {
 public:
-	Resource() = default;
 	explicit Resource(const std::string& filePath);
 	virtual ~Resource();
 

--- a/NAS2D/Resources/Sound.h
+++ b/NAS2D/Resources/Sound.h
@@ -23,8 +23,6 @@ namespace NAS2D {
 class Sound: public Resource
 {
 public:
-
-	Sound() = default;
 	Sound(const Sound& other) = default;
 	Sound& operator=(const Sound& rhs) = default;
 	Sound(Sound&& other) = default;


### PR DESCRIPTION
Reference: #401

Remove default constructors for `Resource` derived classes:
- `Font`
- `Music`
- `Sound`
- `Resource` (base class)

Notably the `Image` class is absent from the above list. There are some breaking changes to OPHD that are not immediately fixable should the default `Image` constructor be removed. As such, removal will be deferred. Meanwhile, the default constructor on the `Image` class does not rely on the default constructor for the `Resource` class, so it is possible to remove the default constructor from the `Resource` base class.
