### PR TITLE
Resource hierarchy internal refactor

### DIFF
--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -98,7 +98,7 @@ Font::Font(const Font& rhs) : Resource(rhs.mResourceName)
 	}
 	else
 	{
-		loaded(false);
+		mIsLoaded = false;
 	}
 }
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -64,7 +64,7 @@ namespace {
 Font::Font(const std::string& filePath, unsigned int ptSize) : Resource(filePath)
 {
 	loaded(::load(filePath, ptSize));
-	name(filePath + "_" + std::to_string(ptSize) + "pt");
+	mResourceName = filePath + "_" + std::to_string(ptSize) + "pt";
 }
 
 
@@ -123,7 +123,7 @@ Font& Font::operator=(const Font& rhs)
 
 	updateFontReferenceCount(mResourceName);
 
-	name(rhs.mResourceName);
+	mResourceName = rhs.mResourceName;
 
 	auto it = fontMap.find(mResourceName);
 	if (it == fontMap.end()) { throw font_bad_data(); }

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -94,7 +94,7 @@ Font::Font(const Font& rhs) : Resource(rhs.mResourceName)
 	if (it != fontMap.end())
 	{
 		++it->second.refCount;
-		loaded(rhs.loaded());
+		mIsLoaded = rhs.mIsLoaded;
 	}
 	else
 	{
@@ -129,7 +129,7 @@ Font& Font::operator=(const Font& rhs)
 	if (it == fontMap.end()) { throw font_bad_data(); }
 
 	++it->second.refCount;
-	loaded(rhs.loaded());
+	mIsLoaded = rhs.mIsLoaded;
 
 	return *this;
 }

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -63,7 +63,7 @@ namespace {
  */
 Font::Font(const std::string& filePath, unsigned int ptSize) : Resource(filePath)
 {
-	loaded(::load(filePath, ptSize));
+	mIsLoaded = ::load(filePath, ptSize);
 	mResourceName = filePath + "_" + std::to_string(ptSize) + "pt";
 }
 
@@ -79,7 +79,7 @@ Font::Font(const std::string& filePath, unsigned int ptSize) : Resource(filePath
  */
 Font::Font(const std::string& filePath, int glyphWidth, int glyphHeight, int glyphSpace) : Resource(filePath)
 {
-	loaded(loadBitmap(filePath, glyphWidth, glyphHeight, glyphSpace));
+	mIsLoaded = loadBitmap(filePath, glyphWidth, glyphHeight, glyphSpace);
 }
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -217,22 +217,20 @@ namespace {
 		{
 			if (TTF_Init() != 0)
 			{
-				std::cout << "Font::load(): " << TTF_GetError() << std::endl;
-				return false;
+				throw std::runtime_error("Font load function failed: " + std::string{TTF_GetError()});
 			}
 		}
 
 		File fontBuffer = Utility<Filesystem>::get().open(path);
 		if (fontBuffer.empty())
 		{
-			return false;
+			throw std::runtime_error("Font file is empty: " + path);
 		}
 
 		TTF_Font *font = TTF_OpenFontRW(SDL_RWFromConstMem(fontBuffer.raw_bytes(), static_cast<int>(fontBuffer.size())), 0, static_cast<int>(ptSize));
 		if (!font)
 		{
-			std::cout << "Font::load(): " << TTF_GetError() << std::endl;
-			return false;
+			throw std::runtime_error("Font load function failed: " + std::string{TTF_GetError()});
 		}
 
 		fontMap[fontname].height = TTF_FontHeight(font);

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -63,8 +63,8 @@ namespace {
  */
 Font::Font(const std::string& filePath, unsigned int ptSize) : Resource(filePath)
 {
-	loaded(::load(name(), ptSize));
-	name(name() + "_" + std::to_string(ptSize) + "pt");
+	loaded(::load(filePath, ptSize));
+	name(filePath + "_" + std::to_string(ptSize) + "pt");
 }
 
 
@@ -88,9 +88,9 @@ Font::Font(const std::string& filePath, int glyphWidth, int glyphHeight, int gly
  *
  * \param	rhs	Font to copy.
  */
-Font::Font(const Font& rhs) : Resource(rhs.name())
+Font::Font(const Font& rhs) : Resource(rhs.mResourceName)
 {
-	auto it = fontMap.find(name());
+	auto it = fontMap.find(mResourceName);
 	if (it != fontMap.end())
 	{
 		++it->second.refCount;
@@ -108,7 +108,7 @@ Font::Font(const Font& rhs) : Resource(rhs.name())
 */
 Font::~Font()
 {
-	updateFontReferenceCount(name());
+	updateFontReferenceCount(mResourceName);
 }
 
 
@@ -121,11 +121,11 @@ Font& Font::operator=(const Font& rhs)
 {
 	if (this == &rhs) { return *this; }
 
-	updateFontReferenceCount(name());
+	updateFontReferenceCount(mResourceName);
 
-	name(rhs.name());
+	name(rhs.mResourceName);
 
-	auto it = fontMap.find(name());
+	auto it = fontMap.find(mResourceName);
 	if (it == fontMap.end()) { throw font_bad_data(); }
 
 	++it->second.refCount;
@@ -137,7 +137,7 @@ Font& Font::operator=(const Font& rhs)
 
 Vector<int> Font::glyphCellSize() const
 {
-	return fontMap[name()].glyphSize;
+	return fontMap[mResourceName].glyphSize;
 }
 
 
@@ -157,7 +157,7 @@ int Font::width(std::string_view string) const
 	if (string.empty()) { return 0; }
 
 	int width = 0;
-	GlyphMetricsList& gml = fontMap[name()].metrics;
+	GlyphMetricsList& gml = fontMap[mResourceName].metrics;
 	if (gml.empty()) { return 0; }
 
 	for (auto character : string)
@@ -175,7 +175,7 @@ int Font::width(std::string_view string) const
  */
 int Font::height() const
 {
-	return fontMap[name()].height;
+	return fontMap[mResourceName].height;
 }
 
 
@@ -184,7 +184,7 @@ int Font::height() const
  */
 int Font::ascent() const
 {
-	return fontMap[name()].ascent;
+	return fontMap[mResourceName].ascent;
 }
 
 
@@ -193,7 +193,7 @@ int Font::ascent() const
  */
 unsigned int Font::ptSize() const
 {
-	return fontMap[name()].pointSize;
+	return fontMap[mResourceName].pointSize;
 }
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -263,14 +263,13 @@ namespace {
 		File fontBuffer = Utility<Filesystem>::get().open(path);
 		if (fontBuffer.empty())
 		{
-			return false;
+			throw std::runtime_error("Font file is empty: " + path);
 		}
 
 		SDL_Surface* fontSurface = IMG_Load_RW(SDL_RWFromConstMem(fontBuffer.raw_bytes(), static_cast<int>(fontBuffer.size())), 0);
 		if (!fontSurface)
 		{
-			std::cout << "Font::loadBitmap(): " << SDL_GetError() << std::endl;
-			return false;
+			throw std::runtime_error("Font loadBitmap function failed: " + std::string{SDL_GetError()});
 		}
 
 		const auto fontSurfaceSize = Vector{fontSurface->w, fontSurface->h};

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -94,12 +94,9 @@ Font::Font(const Font& rhs) : Resource(rhs.mResourceName)
 	if (it != fontMap.end())
 	{
 		++it->second.refCount;
-		mIsLoaded = rhs.mIsLoaded;
 	}
-	else
-	{
-		mIsLoaded = false;
-	}
+
+	mIsLoaded = rhs.mIsLoaded;
 }
 
 

--- a/NAS2D/Resources/Font.h
+++ b/NAS2D/Resources/Font.h
@@ -50,9 +50,6 @@ public:
 	unsigned int ptSize() const;
 
 	Vector<int> glyphCellSize() const;
-
-private:
-	void load() override {}
 };
 
 } // namespace

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -74,7 +74,7 @@ Image::Image(int width, int height) : Resource(ARBITRARY_IMAGE_NAME)
 	mSize = Vector{width, height};
 
 	// Update resource management.
-	auto& imageInfo = imageIdMap[name()];
+	auto& imageInfo = imageIdMap[mResourceName];
 	imageInfo.textureId = 0;
 	imageInfo.size = {width, height};
 	imageInfo.refCount++;
@@ -110,7 +110,7 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) : Resource(
 	unsigned int textureId = generateTexture(surface);
 
 	// Update resource management.
-	auto& imageInfo = imageIdMap[name()];
+	auto& imageInfo = imageIdMap[mResourceName];
 	imageInfo.textureId = textureId;
 	imageInfo.size = {width, height};
 	imageInfo.refCount++;
@@ -123,7 +123,7 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) : Resource(
  *
  * \param	src		Image to copy.
  */
-Image::Image(const Image &src) : Resource(src.name()), mSize(src.mSize)
+Image::Image(const Image &src) : Resource(src.mResourceName), mSize(src.mSize)
 {
 	if (!src.loaded())
 	{
@@ -131,7 +131,7 @@ Image::Image(const Image &src) : Resource(src.name()), mSize(src.mSize)
 	}
 
 	loaded(src.loaded());
-	imageIdMap[name()].refCount++;
+	imageIdMap[mResourceName].refCount++;
 }
 
 
@@ -140,7 +140,7 @@ Image::Image(const Image &src) : Resource(src.name()), mSize(src.mSize)
  */
 Image::~Image()
 {
-	updateImageReferenceCount(name());
+	updateImageReferenceCount(mResourceName);
 }
 
 
@@ -153,12 +153,12 @@ Image& Image::operator=(const Image& rhs)
 {
 	if (this == &rhs) { return *this; }
 
-	updateImageReferenceCount(name());
+	updateImageReferenceCount(mResourceName);
 
-	name(rhs.name());
+	name(rhs.mResourceName);
 	mSize = rhs.mSize;
 
-	auto it = imageIdMap.find(name());
+	auto it = imageIdMap.find(mResourceName);
 	if (it == imageIdMap.end())
 	{
 		throw image_bad_data();
@@ -178,21 +178,21 @@ Image& Image::operator=(const Image& rhs)
  */
 void Image::load()
 {
-	if (checkTextureId(name()))
+	if (checkTextureId(mResourceName))
 	{
-		mSize = imageIdMap[name()].size;
+		mSize = imageIdMap[mResourceName].size;
 		loaded(true);
 		return;
 	}
 
 	#ifdef _DEBUG
-	//std::cout << "Loading image '" << name() << "'" << std::endl;
+	//std::cout << "Loading image '" << mResourceName << "'" << std::endl;
 	#endif
 
-	File imageFile = Utility<Filesystem>::get().open(name());
+	File imageFile = Utility<Filesystem>::get().open(mResourceName);
 	if (imageFile.size() == 0)
 	{
-		std::cout << "Image::load(): '" << name() << "' is empty." << std::endl;
+		std::cout << "Image::load(): '" << mResourceName << "' is empty." << std::endl;
 		return;
 	}
 
@@ -208,7 +208,7 @@ void Image::load()
 	unsigned int textureId = generateTexture(surface);
 
 	// Add generated texture id to texture ID map.
-	auto& imageInfo = imageIdMap[name()];
+	auto& imageInfo = imageIdMap[mResourceName];
 	imageInfo.surface = surface;
 	imageInfo.textureId = textureId;
 	imageInfo.size = mSize;
@@ -251,7 +251,7 @@ Color Image::pixelColor(int x, int y) const
 		return Color::Black;
 	}
 
-	SDL_Surface* surface = imageIdMap[name()].surface;
+	SDL_Surface* surface = imageIdMap[mResourceName].surface;
 
 	if (!surface) { throw image_null_data(); }
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -65,25 +65,6 @@ Image::Image() : Resource(DEFAULT_IMAGE_NAME)
 
 
 /**
- * Create a blank Image of X, Y dimensions.
- *
- * \param	width	Width of the Image.
- * \param	height	Height of the Image.
- */
-Image::Image(int width, int height) : Resource(ARBITRARY_IMAGE_NAME)
-{
-	mResourceName = ARBITRARY_IMAGE_NAME + std::to_string(++IMAGE_ARBITRARY);
-	mSize = Vector{width, height};
-
-	// Update resource management.
-	auto& imageInfo = imageIdMap[mResourceName];
-	imageInfo.textureId = 0;
-	imageInfo.size = {width, height};
-	imageInfo.refCount++;
-}
-
-
-/**
  * Create an Image from a raw data buffer.
  *
  * \param	buffer			Pointer to a data buffer.

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -98,6 +98,8 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) : Resource(
 	imageInfo.size = {width, height};
 	imageInfo.refCount++;
 	imageInfo.surface = surface;
+
+	mIsLoaded = true;
 }
 
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -185,10 +185,6 @@ void Image::load()
 		return;
 	}
 
-	#ifdef _DEBUG
-	//std::cout << "Loading image '" << mResourceName << "'" << std::endl;
-	#endif
-
 	File imageFile = Utility<Filesystem>::get().open(mResourceName);
 	if (imageFile.size() == 0)
 	{

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -20,6 +20,8 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <stdexcept>
+
 
 using namespace NAS2D;
 using namespace NAS2D::Exception;
@@ -188,15 +190,13 @@ void Image::load()
 	File imageFile = Utility<Filesystem>::get().open(mResourceName);
 	if (imageFile.size() == 0)
 	{
-		std::cout << "Image::load(): '" << mResourceName << "' is empty." << std::endl;
-		return;
+		throw std::runtime_error("Image::load(): File is empty: " + mResourceName);
 	}
 
 	SDL_Surface* surface = IMG_Load_RW(SDL_RWFromConstMem(imageFile.raw_bytes(), static_cast<int>(imageFile.size())), 0);
 	if (!surface)
 	{
-		std::cout << "Image::load(): " << SDL_GetError() << std::endl;
-		return;
+		throw std::runtime_error("Image::load(): " + std::string{SDL_GetError()});
 	}
 
 	mSize = Vector{surface->w, surface->h};

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -70,7 +70,7 @@ Image::Image() : Resource(DEFAULT_IMAGE_NAME)
  */
 Image::Image(int width, int height) : Resource(ARBITRARY_IMAGE_NAME)
 {
-	name(ARBITRARY_IMAGE_NAME + std::to_string(++IMAGE_ARBITRARY));
+	mResourceName = ARBITRARY_IMAGE_NAME + std::to_string(++IMAGE_ARBITRARY);
 	mSize = Vector{width, height};
 
 	// Update resource management.
@@ -101,7 +101,7 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) : Resource(
 		throw image_unsupported_bit_depth();
 	}
 
-	name(ARBITRARY_IMAGE_NAME + std::to_string(++IMAGE_ARBITRARY));
+	mResourceName = ARBITRARY_IMAGE_NAME + std::to_string(++IMAGE_ARBITRARY);
 
 	SDL_Surface* surface = SDL_CreateRGBSurfaceFrom(buffer, width, height, bytesPerPixel * 8, 0, 0, 0, 0, SDL_BYTEORDER == SDL_BIG_ENDIAN ? 0x000000FF : 0xFF000000);
 
@@ -155,7 +155,7 @@ Image& Image::operator=(const Image& rhs)
 
 	updateImageReferenceCount(mResourceName);
 
-	name(rhs.mResourceName);
+	mResourceName = rhs.mResourceName;
 	mSize = rhs.mSize;
 
 	auto it = imageIdMap.find(mResourceName);

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -58,7 +58,7 @@ Image::Image(const std::string& filePath) : Resource(filePath)
  */
 Image::Image() : Resource(DEFAULT_IMAGE_NAME)
 {
-	loaded(true);
+	mIsLoaded = true;
 }
 
 
@@ -181,7 +181,7 @@ void Image::load()
 	if (checkTextureId(mResourceName))
 	{
 		mSize = imageIdMap[mResourceName].size;
-		loaded(true);
+		mIsLoaded = true;
 		return;
 	}
 
@@ -214,7 +214,7 @@ void Image::load()
 	imageInfo.size = mSize;
 	imageInfo.refCount++;
 
-	loaded(true);
+	mIsLoaded = true;
 }
 
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -125,12 +125,12 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) : Resource(
  */
 Image::Image(const Image &src) : Resource(src.mResourceName), mSize(src.mSize)
 {
-	if (!src.loaded())
+	if (!src.mIsLoaded)
 	{
 		throw image_bad_copy();
 	}
 
-	loaded(src.loaded());
+	mIsLoaded = src.mIsLoaded;
 	imageIdMap[mResourceName].refCount++;
 }
 
@@ -164,7 +164,7 @@ Image& Image::operator=(const Image& rhs)
 		throw image_bad_data();
 	}
 
-	loaded(rhs.loaded());
+	mIsLoaded = rhs.mIsLoaded;
 	++it->second.refCount;
 
 	return *this;

--- a/NAS2D/Resources/Image.h
+++ b/NAS2D/Resources/Image.h
@@ -57,7 +57,7 @@ public:
 	Color pixelColor(int x, int y) const;
 
 private:
-	void load() override;
+	void load();
 
 private:
 	Vector<int> mSize; /**< Width/Height information about the Image. */

--- a/NAS2D/Resources/Image.h
+++ b/NAS2D/Resources/Image.h
@@ -44,7 +44,6 @@ public:
 	Image();
 	explicit Image(const std::string& filePath);
 	Image(void* buffer, int bytesPerPixel, int width, int height);
-	Image(int width, int height);
 
 	Image(const Image &rhs);
 	Image& operator=(const Image& rhs);

--- a/NAS2D/Resources/Music.cpp
+++ b/NAS2D/Resources/Music.cpp
@@ -47,7 +47,7 @@ Music::Music(const Music& rhs) : Resource(rhs.mResourceName)
 		it->second.refCount++;
 	}
 
-	loaded(rhs.loaded());
+	mIsLoaded = rhs.mIsLoaded;
 }
 
 
@@ -66,7 +66,7 @@ Music& Music::operator=(const Music& rhs)
 	if (it != MUSIC_REF_MAP.end())
 	{
 		it->second.refCount++;
-		loaded(rhs.loaded());
+		mIsLoaded = rhs.mIsLoaded;
 	}
 	else
 	{

--- a/NAS2D/Resources/Music.cpp
+++ b/NAS2D/Resources/Music.cpp
@@ -18,6 +18,8 @@
 
 #include <iostream>
 #include <string>
+#include <stdexcept>
+
 
 using namespace NAS2D;
 
@@ -104,14 +106,13 @@ void Music::load()
 	if (file->empty())
 	{
 		delete file;
-		return;
+		throw std::runtime_error("Music file is empty: " + mResourceName);
 	}
 
 	Mix_Music* music = Mix_LoadMUS_RW(SDL_RWFromConstMem(file->raw_bytes(), static_cast<int>(file->size())), 0);
 	if (!music)
 	{
-		std::cout << "Music::load(): " << Mix_GetError() << std::endl;
-		return;
+		throw std::runtime_error("Music::load() error: " + std::string{Mix_GetError()});
 	}
 
 	auto& record = MUSIC_REF_MAP[mResourceName];

--- a/NAS2D/Resources/Music.cpp
+++ b/NAS2D/Resources/Music.cpp
@@ -62,18 +62,14 @@ Music& Music::operator=(const Music& rhs)
 
 	updateMusicReferenceCount(mResourceName);
 
-	mResourceName = rhs.mResourceName;
-
 	auto it = MUSIC_REF_MAP.find(mResourceName);
 	if (it != MUSIC_REF_MAP.end())
 	{
 		it->second.refCount++;
-		mIsLoaded = rhs.mIsLoaded;
 	}
-	else
-	{
-		mIsLoaded = false;
-	}
+
+	mResourceName = rhs.mResourceName;
+	mIsLoaded = rhs.mIsLoaded;
 
 	return *this;
 }

--- a/NAS2D/Resources/Music.cpp
+++ b/NAS2D/Resources/Music.cpp
@@ -39,9 +39,9 @@ Music::Music(const std::string& filePath) : Resource(filePath)
 /**
  * Copy c'tor.
  */
-Music::Music(const Music& rhs) : Resource(rhs.name())
+Music::Music(const Music& rhs) : Resource(rhs.mResourceName)
 {
-	auto it = MUSIC_REF_MAP.find(name());
+	auto it = MUSIC_REF_MAP.find(mResourceName);
 	if (it != MUSIC_REF_MAP.end())
 	{
 		it->second.refCount++;
@@ -58,11 +58,11 @@ Music& Music::operator=(const Music& rhs)
 {
 	if (this == &rhs) { return *this; }
 
-	updateMusicReferenceCount(name());
+	updateMusicReferenceCount(mResourceName);
 
-	name(rhs.name());
+	name(rhs.mResourceName);
 
-	auto it = MUSIC_REF_MAP.find(name());
+	auto it = MUSIC_REF_MAP.find(mResourceName);
 	if (it != MUSIC_REF_MAP.end())
 	{
 		it->second.refCount++;
@@ -82,7 +82,7 @@ Music& Music::operator=(const Music& rhs)
  */
 Music::~Music()
 {
-	updateMusicReferenceCount(name());
+	updateMusicReferenceCount(mResourceName);
 }
 
 
@@ -93,14 +93,14 @@ Music::~Music()
  */
 void Music::load()
 {
-	if (MUSIC_REF_MAP.find(name()) != MUSIC_REF_MAP.end())
+	if (MUSIC_REF_MAP.find(mResourceName) != MUSIC_REF_MAP.end())
 	{
-		MUSIC_REF_MAP.find(name())->second.refCount++;
+		MUSIC_REF_MAP.find(mResourceName)->second.refCount++;
 		loaded(true);
 		return;
 	}
 
-	File* file = new File(Utility<Filesystem>::get().open(name()));
+	File* file = new File(Utility<Filesystem>::get().open(mResourceName));
 	if (file->empty())
 	{
 		delete file;
@@ -114,7 +114,7 @@ void Music::load()
 		return;
 	}
 
-	auto& record = MUSIC_REF_MAP[name()];
+	auto& record = MUSIC_REF_MAP[mResourceName];
 	record.buffer = file;
 	record.music = music;
 	record.refCount++;

--- a/NAS2D/Resources/Music.cpp
+++ b/NAS2D/Resources/Music.cpp
@@ -70,7 +70,7 @@ Music& Music::operator=(const Music& rhs)
 	}
 	else
 	{
-		loaded(false);
+		mIsLoaded = false;
 	}
 
 	return *this;
@@ -96,7 +96,7 @@ void Music::load()
 	if (MUSIC_REF_MAP.find(mResourceName) != MUSIC_REF_MAP.end())
 	{
 		MUSIC_REF_MAP.find(mResourceName)->second.refCount++;
-		loaded(true);
+		mIsLoaded = true;
 		return;
 	}
 
@@ -119,7 +119,7 @@ void Music::load()
 	record.music = music;
 	record.refCount++;
 
-	loaded(true);
+	mIsLoaded = true;
 }
 
 

--- a/NAS2D/Resources/Music.cpp
+++ b/NAS2D/Resources/Music.cpp
@@ -60,7 +60,7 @@ Music& Music::operator=(const Music& rhs)
 
 	updateMusicReferenceCount(mResourceName);
 
-	name(rhs.mResourceName);
+	mResourceName = rhs.mResourceName;
 
 	auto it = MUSIC_REF_MAP.find(mResourceName);
 	if (it != MUSIC_REF_MAP.end())

--- a/NAS2D/Resources/Music.h
+++ b/NAS2D/Resources/Music.h
@@ -31,7 +31,7 @@ public:
 	~Music() override;
 
 private:
-	void load() override;
+	void load();
 };
 
 } // namespace

--- a/NAS2D/Resources/Resource.cpp
+++ b/NAS2D/Resources/Resource.cpp
@@ -40,32 +40,9 @@ const std::string& Resource::name() const
 
 
 /**
- * Sets the name of the resource.
- */
-void Resource::name(const std::string& name)
-{
-	mResourceName = name;
-}
-
-
-/**
  * Returns true if this Resource loaded properly.
  */
 bool Resource::loaded() const
 {
 	return mIsLoaded;
-}
-
-
-/**
- * Sets whether or not the Resource is loaded.
- *
- * \note	This is an internal function only and is provided for use
- *			by derived Resource types.
- *
- * \param	loaded	Boolean value.
- */
-void Resource::loaded(bool loaded)
-{
-	mIsLoaded = loaded;
 }

--- a/NAS2D/Resources/Resource.h
+++ b/NAS2D/Resources/Resource.h
@@ -32,10 +32,6 @@ public:
 	bool loaded() const;
 
 protected:
-	void loaded(bool loaded);
-	void name(const std::string& name);
-
-
 	std::string mResourceName{"Default Resource"}; /**< File path and internal identifier. */
 	bool mIsLoaded{false}; /**< Flag indicating whether or not this Resource has loaded properly. */
 };

--- a/NAS2D/Resources/Resource.h
+++ b/NAS2D/Resources/Resource.h
@@ -35,9 +35,8 @@ protected:
 	void loaded(bool loaded);
 	void name(const std::string& name);
 
-private:
-	std::string mResourceName{"Default Resource"}; /**< File path and internal identifier. */
 
+	std::string mResourceName{"Default Resource"}; /**< File path and internal identifier. */
 	bool mIsLoaded{false}; /**< Flag indicating whether or not this Resource has loaded properly. */
 };
 

--- a/NAS2D/Resources/Resource.h
+++ b/NAS2D/Resources/Resource.h
@@ -36,17 +36,6 @@ protected:
 	void name(const std::string& name);
 
 private:
-	/**
-	 * Performs the necessary operations to load a Resource.
-	 *
-	 * \note	This is a pure virtual function and so must be
-	 *			overridden by all derived classes.
-	 *
-	 * \note	It is the responsibility of the derived class to
-	 *			call this function.
-	 */
-	virtual void load() = 0;
-
 	std::string mResourceName{"Default Resource"}; /**< File path and internal identifier. */
 
 	bool mIsLoaded{false}; /**< Flag indicating whether or not this Resource has loaded properly. */

--- a/NAS2D/Resources/Sound.cpp
+++ b/NAS2D/Resources/Sound.cpp
@@ -51,7 +51,7 @@ Sound::~Sound()
  */
 void Sound::load()
 {
-	File soundFile = Utility<Filesystem>::get().open(name());
+	File soundFile = Utility<Filesystem>::get().open(mResourceName);
 	if (soundFile.empty())
 	{
 		return;

--- a/NAS2D/Resources/Sound.cpp
+++ b/NAS2D/Resources/Sound.cpp
@@ -63,7 +63,7 @@ void Sound::load()
 		return;
 	}
 
-	loaded(true);
+	mIsLoaded = true;
 }
 
 

--- a/NAS2D/Resources/Sound.cpp
+++ b/NAS2D/Resources/Sound.cpp
@@ -16,6 +16,10 @@
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_mixer.h>
 
+#include <string>
+#include <stdexcept>
+
+
 using namespace NAS2D;
 
 /**
@@ -54,13 +58,13 @@ void Sound::load()
 	File soundFile = Utility<Filesystem>::get().open(mResourceName);
 	if (soundFile.empty())
 	{
-		return;
+		throw std::runtime_error("Sound file is empty: " + mResourceName);
 	}
 
 	_chunk = Mix_LoadWAV_RW(SDL_RWFromConstMem(soundFile.raw_bytes(), static_cast<int>(soundFile.size())), 0);
 	if (!_chunk)
 	{
-		return;
+		throw std::runtime_error("Sound file could not be loaded: " + mResourceName + " : " + std::string{Mix_GetError()});
 	}
 
 	mIsLoaded = true;

--- a/NAS2D/Resources/Sound.h
+++ b/NAS2D/Resources/Sound.h
@@ -36,7 +36,7 @@ protected:
 	void* sound() const;
 
 private:
-	void load() override;
+	void load();
 
 	void* _chunk{nullptr};
 };

--- a/test/Resources/Image.test.cpp
+++ b/test/Resources/Image.test.cpp
@@ -1,8 +1,2 @@
 #include "NAS2D/Resources/Image.h"
 #include <gtest/gtest.h>
-
-
-TEST(Image, size) {
-	EXPECT_EQ((NAS2D::Vector{1, 1}), NAS2D::Image(1, 1).size());
-	EXPECT_EQ((NAS2D::Vector{4, 2}), NAS2D::Image(4, 2).size());
-}


### PR DESCRIPTION
Reference: #401

Refactor `Resource` hierarchy without significantly changing external interface.

Derived `Resource` classes will now `throw` when an error occurs during construction, rather than setting the `loaded` property to false.

Class member variables are used directly, rather than rely on base class accessor methods.
