### PR TITLE
Add ResourceCache class

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -245,6 +245,7 @@
     <ClInclude Include="Renderer\Rectangle.h" />
     <ClInclude Include="Renderer\Renderer.h" />
     <ClInclude Include="Renderer\RendererOpenGL.h" />
+    <ClInclude Include="Resources\ResourceCache.h" />
     <ClInclude Include="Resources\Font.h" />
     <ClInclude Include="Resources\FontInfo.h" />
     <ClInclude Include="Resources\Image.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -209,6 +209,9 @@
     <ClInclude Include="Mixer\Mixer.h">
       <Filter>Header Files\Mixer</Filter>
     </ClInclude>
+    <ClInclude Include="Resources\ResourceCache.h">
+      <Filter>Header Files\Resources</Filter>
+    </ClInclude>
     <ClInclude Include="Resources\Font.h">
       <Filter>Header Files\Resources</Filter>
     </ClInclude>

--- a/NAS2D/Resources/ResourceCache.h
+++ b/NAS2D/Resources/ResourceCache.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <map>
+#include <tuple>
+
+
+template <typename Resource, typename ... Params>
+class ResourceCache
+{
+public:
+	using Key = std::tuple<Params...>;
+
+	const Resource& load(Params... params)
+	{
+		// Cache lookup key is a tuple of all Resource constructor parameters
+		const auto key = std::tuple{params...};
+
+		// Try to find resource from the cache
+		auto iter = cache.find(key);
+		if (iter == cache.end())
+		{
+			// Resource wasn't found, so create new one using constructor parameters
+			const auto pairIterBool = cache.try_emplace(key, params...);
+			iter = pairIterBool.first;
+		}
+
+		// Return reference to found or created cached object
+		return iter->second;
+	}
+
+private:
+	std::map<Key, Resource> cache;
+};

--- a/test/Resources/ResourceCache.test.cpp
+++ b/test/Resources/ResourceCache.test.cpp
@@ -1,0 +1,41 @@
+#include "NAS2D/Resources/ResourceCache.h"
+#include <gtest/gtest.h>
+
+
+TEST(ResourceCache, load) {
+	class MockResource {
+	public:
+		MockResource(const std::string& initString, int initValue) :
+			string{initString},
+			value{initValue}
+		{}
+
+		bool operator==(const MockResource& other) const {
+			return string == other.string && value == other.value;
+		}
+	private:
+		std::string string;
+		int value;
+	};
+
+	ResourceCache<MockResource, std::string, int> cache;
+
+	const auto& value1 = cache.load("abc", 123);
+	const auto& value2 = cache.load("abc", 123);
+	const auto& value3 = cache.load("abcd", 123);
+	const auto& value4 = cache.load("abc", 1234);
+
+	// Ensure expected values were returned
+	EXPECT_EQ((MockResource{"abc", 123}), value1);
+	EXPECT_EQ((MockResource{"abc", 123}), value2);
+	EXPECT_EQ((MockResource{"abcd", 123}), value3);
+	EXPECT_EQ((MockResource{"abc", 1234}), value4);
+
+	// Ensure expected identity of objects (based on their address)
+	// References to objects with the same load parameters should be the same object
+	// References to objects with different load parameters should be different
+	EXPECT_EQ(&value1, &value2);
+	EXPECT_NE(&value1, &value3);
+	EXPECT_NE(&value1, &value4);
+	EXPECT_NE(&value3, &value4);
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -52,6 +52,7 @@
     <ClCompile Include="Renderer/Vector.test.cpp" />
     <ClCompile Include="Renderer/VectorSizeRange.test.cpp" />
     <ClCompile Include="Resources/Image.test.cpp" />
+    <ClCompile Include="Resources/ResourceCache.test.cpp" />
     <ClCompile Include="ContainerUtils.test.cpp" />
     <ClCompile Include="Delegate.test.cpp" />
     <ClCompile Include="Filesystem.test.cpp" />


### PR DESCRIPTION
Add `ResourceCache` class, which will can be used for cached reference access to `const` resources.

The cache type depends on the resource type, as well as types used to construct the resource, using one of the available constructors.

Cache lookup is done using a `std::tuple` of the constructor parameters. If not found in the cache, a new object is created by passing the parameters to the constructor of that object's type, constructing the object in-place in the cache. Whether the object was found pre-existing in the cache, or was newly constructed in-place, a const reference to the object is then returned.

Example:
```cpp
// Assume there is a constructor callable with: Resource(std::string, int)
ResourceCache<Resource, std::string, int> cache;

const auto& value = cache.load("abc", 123);
```

Example:
```cpp
const auto& font = cache.load(fontName, fontSize);
```
