### PR TITLE
Pass const Sound and Music references to Mixer

### DIFF
--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -44,7 +44,7 @@ public:
 	 *
 	 * \param	sound	A reference to a Sound Resource.
 	 */
-	virtual void playSound(Sound& sound) = 0;
+	virtual void playSound(const Sound& sound) = 0;
 
 	/**
 	 * Stops playing all sounds on all channels.
@@ -93,7 +93,7 @@ public:
 	 * \param	loops	Number of times the Music should be repeated. -1 for continuous loop.
 	 * \param	time	Time, in miliseconds, for the fade to last. Default is 500.
 	 */
-	virtual void fadeInMusic(Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) = 0;
+	virtual void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) = 0;
 
 	/**
 	 * Fades out the currently playing Music track.

--- a/NAS2D/Mixer/MixerNull.cpp
+++ b/NAS2D/Mixer/MixerNull.cpp
@@ -3,7 +3,7 @@
 namespace NAS2D
 {
 
-	void MixerNull::playSound(Sound& /*sound*/)
+	void MixerNull::playSound(const Sound& /*sound*/)
 	{}
 
 	void MixerNull::stopSound()
@@ -24,7 +24,7 @@ namespace NAS2D
 	void MixerNull::resumeMusic()
 	{}
 
-	void MixerNull::fadeInMusic(Music& /*music*/, int /*loops*/ /*= Mixer::CONTINUOUS*/, int /*time*/ /*= Mixer::DEFAULT_FADE_TIME*/)
+	void MixerNull::fadeInMusic(const Music& /*music*/, int /*loops*/ /*= Mixer::CONTINUOUS*/, int /*time*/ /*= Mixer::DEFAULT_FADE_TIME*/)
 	{}
 
 	void MixerNull::fadeOutMusic(int /*time*/ /*= Mixer::DEFAULT_FADE_TIME*/)

--- a/NAS2D/Mixer/MixerNull.h
+++ b/NAS2D/Mixer/MixerNull.h
@@ -8,7 +8,7 @@ namespace NAS2D
 	class MixerNull : public Mixer
 	{
 	public:
-		void playSound(Sound& sound) override;
+		void playSound(const Sound& sound) override;
 		void stopSound() override;
 		void pauseSound() override;
 		void resumeSound() override;
@@ -17,7 +17,7 @@ namespace NAS2D
 		void pauseMusic() override;
 		void resumeMusic() override;
 
-		void fadeInMusic(Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) override;
+		void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) override;
 		void fadeOutMusic(int time = Mixer::DEFAULT_FADE_TIME) override;
 
 		bool musicPlaying() const override;

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -105,7 +105,7 @@ void MixerSDL::onMusicFinished()
 }
 
 
-void MixerSDL::playSound(Sound& sound)
+void MixerSDL::playSound(const Sound& sound)
 {
 	Mix_PlayChannel(-1, static_cast<Mix_Chunk*>(sound.sound()), 0);
 }
@@ -147,7 +147,7 @@ void MixerSDL::resumeMusic()
 }
 
 
-void MixerSDL::fadeInMusic(Music& music, int loops, int time)
+void MixerSDL::fadeInMusic(const Music& music, int loops, int time)
 {
 	Mix_FadeInMusic(static_cast<Mix_Music*>(MUSIC_REF_MAP[music.name()].music), loops, time);
 }

--- a/NAS2D/Mixer/MixerSDL.h
+++ b/NAS2D/Mixer/MixerSDL.h
@@ -44,7 +44,7 @@ public:
 	~MixerSDL() override;
 
 	// Sound Functions
-	void playSound(Sound& sound) override;
+	void playSound(const Sound& sound) override;
 	void stopSound() override;
 	void pauseSound() override;
 	void resumeSound() override;
@@ -54,7 +54,7 @@ public:
 	void pauseMusic() override;
 	void resumeMusic() override;
 
-	void fadeInMusic(Music& music, int loops, int time) override;
+	void fadeInMusic(const Music& music, int loops, int time) override;
 	void fadeOutMusic(int time) override;
 
 	bool musicPlaying() const override;


### PR DESCRIPTION
Use `const` to pass `Sound` and `Music` references to `Mixer` to improve const correctness.
