### PR TITLE
Remove internal Font caching

### DIFF
--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -34,9 +34,6 @@ using namespace NAS2D;
 using namespace NAS2D::Exception;
 
 
-std::map<std::string, Font::FontInfo> fontMap;
-
-
 namespace {
 	struct ColorMasks
 	{
@@ -237,7 +234,7 @@ namespace {
 			throw std::runtime_error("Font load function failed: " + std::string{TTF_GetError()});
 		}
 
-		auto& fontInfo = fontMap[fontname];
+		Font::FontInfo fontInfo;
 		auto& glm = fontInfo.metrics;
 		fillInCharacterDimensions(font, glm);
 		const auto charBoundsSize = maxCharacterDimensions(glm);
@@ -287,7 +284,7 @@ namespace {
 			throw font_invalid_glyph_map("Unexpected font image size. Expected: " + vectorToString(expectedSize) + " Actual: " + vectorToString(fontSurfaceSize));
 		}
 
-		auto& fontInfo = fontMap[path];
+		Font::FontInfo fontInfo;
 		auto& glm = fontInfo.metrics;
 		glm.resize(ASCII_TABLE_COUNT);
 		for (auto& metrics : glm)

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -56,7 +56,7 @@ namespace {
 
 	bool load(const std::string& path, unsigned int ptSize);
 	bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace);
-	Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name);
+	Vector<int> generateGlyphMap(TTF_Font* font, const std::string& name);
 	SDL_Surface* generateFontSurface(TTF_Font* font, Vector<int> characterSize);
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	Vector<int> roundedCharacterDimensions(Vector<int> maxSize);
@@ -307,11 +307,11 @@ namespace {
 	 *
 	 * Internal function used to generate a glyph texture map from an TTF_Font struct.
 	 */
-	Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name)
+	Vector<int> generateGlyphMap(TTF_Font* font, const std::string& name)
 	{
 		auto& glm = fontMap[name].metrics;
 
-		fillInCharacterDimensions(ft, glm);
+		fillInCharacterDimensions(font, glm);
 
 		const auto charBoundsSize = maxCharacterDimensions(glm);
 		const auto roundedCharSize = roundedCharacterDimensions(charBoundsSize);
@@ -319,7 +319,7 @@ namespace {
 
 		fillInTextureCoordinates(glm, roundedCharSize, roundedMatrixSize);
 
-		SDL_Surface* fontSurface = generateFontSurface(ft, roundedCharSize);
+		SDL_Surface* fontSurface = generateFontSurface(font, roundedCharSize);
 		unsigned int textureId = generateTexture(fontSurface);
 
 		// Add generated texture id to texture ID map.

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -58,6 +58,7 @@ namespace {
 	bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace);
 	Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name);
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
+	Vector<int> roundedCharacterDimensions(Vector<int> maxSize);
 	void fillInCharacterDimensions(TTF_Font* font, std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	void fillInTextureCoordinates(std::vector<Font::GlyphMetrics>& glyphMetricsList, Vector<int> characterSize, Vector<int> textureSize);
 }
@@ -312,9 +313,7 @@ namespace {
 		fillInCharacterDimensions(ft, glm);
 
 		const auto charBoundsSize = maxCharacterDimensions(glm);
-		const auto longestEdge = std::max(charBoundsSize.x, charBoundsSize.y);
-		const auto roundedLongestEdge = static_cast<int>(roundUpPowerOf2(static_cast<uint32_t>(longestEdge)));
-		const auto roundedCharSize = Vector{roundedLongestEdge, roundedLongestEdge};
+		const auto roundedCharSize = roundedCharacterDimensions(charBoundsSize);
 		const auto roundedMatrixSize = roundedCharSize * GLYPH_MATRIX_SIZE;
 
 		SDL_Surface* fontSurface = SDL_CreateRGBSurface(SDL_SWSURFACE, roundedMatrixSize.x, roundedMatrixSize.y, BITS_32, MasksDefault.red, MasksDefault.green, MasksDefault.blue, MasksDefault.alpha);
@@ -363,6 +362,14 @@ namespace {
 			size.y = std::max({size.y, metrics.minY + metrics.maxY});
 		}
 		return size;
+	}
+
+
+	Vector<int> roundedCharacterDimensions(Vector<int> maxSize)
+	{
+		const auto maxSizeUint32 = maxSize.to<uint32_t>();
+		const auto roundedUpSize = Vector{roundUpPowerOf2(maxSizeUint32.x), roundUpPowerOf2(maxSizeUint32.y)};
+		return roundedUpSize.to<int>();
 	}
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -56,7 +56,7 @@ namespace {
 
 	bool load(const std::string& path, unsigned int ptSize);
 	bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace);
-	unsigned int generateGlyphMap(SDL_Surface* fontSurface, Font::FontInfo& fontInfo);
+	unsigned int generateGlyphMap(SDL_Surface* fontSurface, std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	SDL_Surface* generateFontSurface(TTF_Font* font, Vector<int> characterSize);
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	Vector<int> roundedCharacterDimensions(Vector<int> maxSize);
@@ -248,7 +248,7 @@ namespace {
 		fontInfo.height = TTF_FontHeight(font);
 		fontInfo.ascent = TTF_FontAscent(font);
 		fontInfo.glyphSize = roundedCharSize;
-		fontInfo.textureId = generateGlyphMap(fontSurface, fontInfo);
+		fontInfo.textureId = generateGlyphMap(fontSurface, glm);
 		TTF_CloseFont(font);
 
 		return true;
@@ -315,10 +315,9 @@ namespace {
 	 *
 	 * Internal function used to generate a glyph texture map from an TTF_Font struct.
 	 */
-	unsigned int generateGlyphMap(SDL_Surface* fontSurface, Font::FontInfo& fontInfo)
+	unsigned int generateGlyphMap(SDL_Surface* fontSurface, std::vector<Font::GlyphMetrics>& glyphMetricsList)
 	{
-		auto& glm = fontInfo.metrics;
-		fillInTextureCoordinates(glm);
+		fillInTextureCoordinates(glyphMetricsList);
 
 		auto textureId = generateTexture(fontSurface);
 		SDL_FreeSurface(fontSurface);

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -314,12 +314,12 @@ namespace {
 		const auto charBoundsSize = maxCharacterDimensions(glm);
 		const auto longestEdge = std::max(charBoundsSize.x, charBoundsSize.y);
 		const auto roundedLongestEdge = static_cast<int>(roundUpPowerOf2(static_cast<uint32_t>(longestEdge)));
-		const auto size = Vector{roundedLongestEdge, roundedLongestEdge};
-		const auto textureSize = size.x * GLYPH_MATRIX_SIZE;
+		const auto roundedCharSize = Vector{roundedLongestEdge, roundedLongestEdge};
+		const auto textureSize = roundedCharSize.x * GLYPH_MATRIX_SIZE;
 
 		SDL_Surface* fontSurface = SDL_CreateRGBSurface(SDL_SWSURFACE, textureSize, textureSize, BITS_32, MasksDefault.red, MasksDefault.green, MasksDefault.blue, MasksDefault.alpha);
 
-		fillInTextureCoordinates(glm, size, {textureSize, textureSize});
+		fillInTextureCoordinates(glm, roundedCharSize, {textureSize, textureSize});
 
 		SDL_Color white = { 255, 255, 255, 255 };
 		for (const auto glyphPosition : PointInRectangleRange(Rectangle{0, 0, GLYPH_MATRIX_SIZE, GLYPH_MATRIX_SIZE}))
@@ -337,7 +337,7 @@ namespace {
 			}
 
 			SDL_SetSurfaceBlendMode(characterSurface, SDL_BLENDMODE_NONE);
-			const auto pixelPosition = glyphPosition.skewBy(size);
+			const auto pixelPosition = glyphPosition.skewBy(roundedCharSize);
 			SDL_Rect rect = { pixelPosition.x, pixelPosition.y, 0, 0 };
 			SDL_BlitSurface(characterSurface, nullptr, fontSurface, &rect);
 			SDL_FreeSurface(characterSurface);
@@ -349,7 +349,7 @@ namespace {
 		fontMap[name].textureId = textureId;
 		SDL_FreeSurface(fontSurface);
 
-		return size;
+		return roundedCharSize;
 	}
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -56,7 +56,7 @@ namespace {
 
 	bool load(const std::string& path, unsigned int ptSize);
 	bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace);
-	unsigned int generateGlyphMap(TTF_Font* font, Font::FontInfo& fontInfo);
+	unsigned int generateGlyphMap(SDL_Surface* fontSurface, Font::FontInfo& fontInfo);
 	SDL_Surface* generateFontSurface(TTF_Font* font, Vector<int> characterSize);
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	Vector<int> roundedCharacterDimensions(Vector<int> maxSize);
@@ -242,12 +242,13 @@ namespace {
 		fillInCharacterDimensions(font, glm);
 		const auto charBoundsSize = maxCharacterDimensions(glm);
 		const auto roundedCharSize = roundedCharacterDimensions(charBoundsSize);
+		SDL_Surface* fontSurface = generateFontSurface(font, roundedCharSize);
 
 		fontInfo.pointSize = ptSize;
 		fontInfo.height = TTF_FontHeight(font);
 		fontInfo.ascent = TTF_FontAscent(font);
 		fontInfo.glyphSize = roundedCharSize;
-		fontInfo.textureId = generateGlyphMap(font, fontInfo);
+		fontInfo.textureId = generateGlyphMap(fontSurface, fontInfo);
 		TTF_CloseFont(font);
 
 		return true;
@@ -314,12 +315,11 @@ namespace {
 	 *
 	 * Internal function used to generate a glyph texture map from an TTF_Font struct.
 	 */
-	unsigned int generateGlyphMap(TTF_Font* font, Font::FontInfo& fontInfo)
+	unsigned int generateGlyphMap(SDL_Surface* fontSurface, Font::FontInfo& fontInfo)
 	{
 		auto& glm = fontInfo.metrics;
 		fillInTextureCoordinates(glm);
 
-		SDL_Surface* fontSurface = generateFontSurface(font, fontInfo.glyphSize);
 		auto textureId = generateTexture(fontSurface);
 		SDL_FreeSurface(fontSurface);
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -295,16 +295,11 @@ namespace {
 			metrics.minX = glyphSize.x;
 			metrics.advance = glyphSpace;
 		}
-		fillInTextureCoordinates(glm);
 
-		auto textureId = generateTexture(fontSurface);
-
-		// Add generated texture id to texture ID map.
-		fontInfo.textureId = textureId;
 		fontInfo.pointSize = static_cast<unsigned int>(glyphSize.y);
 		fontInfo.height = glyphSize.y;
 		fontInfo.glyphSize = glyphSize;
-		SDL_FreeSurface(fontSurface);
+		fontInfo.textureId = generateFontTexture(fontSurface, glm);
 
 		return true;
 	}

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -237,10 +237,16 @@ namespace {
 			throw std::runtime_error("Font load function failed: " + std::string{TTF_GetError()});
 		}
 
+		auto& glm = fontMap[fontname].metrics;
+		fillInCharacterDimensions(font, glm);
+		const auto charBoundsSize = maxCharacterDimensions(glm);
+		const auto roundedCharSize = roundedCharacterDimensions(charBoundsSize);
+
 		fontMap[fontname].pointSize = ptSize;
 		fontMap[fontname].height = TTF_FontHeight(font);
 		fontMap[fontname].ascent = TTF_FontAscent(font);
-		fontMap[fontname].glyphSize = generateGlyphMap(font, fontname);
+		fontMap[fontname].glyphSize = roundedCharSize;
+		generateGlyphMap(font, fontname);
 		TTF_CloseFont(font);
 
 		return true;
@@ -310,22 +316,16 @@ namespace {
 	Vector<int> generateGlyphMap(TTF_Font* font, const std::string& name)
 	{
 		auto& glm = fontMap[name].metrics;
-
-		fillInCharacterDimensions(font, glm);
-
-		const auto charBoundsSize = maxCharacterDimensions(glm);
-		const auto roundedCharSize = roundedCharacterDimensions(charBoundsSize);
-
 		fillInTextureCoordinates(glm);
 
-		SDL_Surface* fontSurface = generateFontSurface(font, roundedCharSize);
+		SDL_Surface* fontSurface = generateFontSurface(font, fontMap[name].glyphSize);
 		auto textureId = generateTexture(fontSurface);
 
 		// Add generated texture id to texture ID map.
 		fontMap[name].textureId = textureId;
 		SDL_FreeSurface(fontSurface);
 
-		return roundedCharSize;
+		return fontMap[name].glyphSize;
 	}
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -61,7 +61,7 @@ namespace {
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	Vector<int> roundedCharacterDimensions(Vector<int> maxSize);
 	void fillInCharacterDimensions(TTF_Font* font, std::vector<Font::GlyphMetrics>& glyphMetricsList);
-	void fillInTextureCoordinates(std::vector<Font::GlyphMetrics>& glyphMetricsList, Vector<int> characterSize);
+	void fillInTextureCoordinates(std::vector<Font::GlyphMetrics>& glyphMetricsList);
 }
 
 
@@ -287,7 +287,7 @@ namespace {
 			metrics.minX = glyphSize.x;
 			metrics.advance = glyphSpace;
 		}
-		fillInTextureCoordinates(glm, glyphSize);
+		fillInTextureCoordinates(glm);
 
 		unsigned int textureId = generateTexture(fontSurface);
 
@@ -316,7 +316,7 @@ namespace {
 		const auto charBoundsSize = maxCharacterDimensions(glm);
 		const auto roundedCharSize = roundedCharacterDimensions(charBoundsSize);
 
-		fillInTextureCoordinates(glm, roundedCharSize);
+		fillInTextureCoordinates(glm);
 
 		SDL_Surface* fontSurface = generateFontSurface(font, roundedCharSize);
 		unsigned int textureId = generateTexture(fontSurface);
@@ -393,15 +393,13 @@ namespace {
 	}
 
 
-	void fillInTextureCoordinates(std::vector<Font::GlyphMetrics>& glyphMetricsList, Vector<int> characterSize)
+	void fillInTextureCoordinates(std::vector<Font::GlyphMetrics>& glyphMetricsList)
 	{
-		const auto textureSize = characterSize * GLYPH_MATRIX_SIZE;
-		const auto floatTextureSize = textureSize.to<float>();
-		const auto uvSize = characterSize.to<float>().skewInverseBy(floatTextureSize);
+		const auto uvSize = Vector<float>{1, 1} / 16.0f;
 		for (const auto glyphPosition : PointInRectangleRange(Rectangle{0, 0, GLYPH_MATRIX_SIZE, GLYPH_MATRIX_SIZE}))
 		{
 			const std::size_t glyph = static_cast<std::size_t>(glyphPosition.y) * GLYPH_MATRIX_SIZE + glyphPosition.x;
-			const auto uvStart = glyphPosition.skewBy(characterSize).to<float>().skewInverseBy(floatTextureSize);
+			const auto uvStart = glyphPosition.to<float>().skewBy(uvSize);
 			glyphMetricsList[glyph].uvRect = Rectangle<float>::Create(uvStart, uvSize);
 		}
 	}

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -58,6 +58,7 @@ namespace {
 	bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace);
 	Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name);
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
+	void fillInCharacterDimensions(TTF_Font* font, std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	void fillInTextureCoordinates(std::vector<Font::GlyphMetrics>& glyphMetricsList, Vector<int> characterSize, Vector<int> textureSize);
 }
 
@@ -308,13 +309,7 @@ namespace {
 	{
 		auto& glm = fontMap[name].metrics;
 
-		// Build table of character sizes
-		for (Uint16 i = 0; i < ASCII_TABLE_COUNT; i++)
-		{
-			Font::GlyphMetrics metrics;
-			TTF_GlyphMetrics(ft, i, &metrics.minX, &metrics.maxX, &metrics.minY, &metrics.maxY, &metrics.advance);
-			glm.push_back(metrics);
-		}
+		fillInCharacterDimensions(ft, glm);
 
 		const auto charBoundsSize = maxCharacterDimensions(glm);
 		const auto longestEdge = std::max(charBoundsSize.x, charBoundsSize.y);
@@ -368,6 +363,17 @@ namespace {
 			size.y = std::max({size.y, metrics.minY + metrics.maxY});
 		}
 		return size;
+	}
+
+
+	void fillInCharacterDimensions(TTF_Font* font, std::vector<Font::GlyphMetrics>& glyphMetricsList)
+	{
+		// Build table of character sizes
+		for (Uint16 i = 0; i < ASCII_TABLE_COUNT; i++)
+		{
+			auto& metrics = glyphMetricsList.emplace_back();
+			TTF_GlyphMetrics(font, i, &metrics.minX, &metrics.maxX, &metrics.minY, &metrics.maxY, &metrics.advance);
+		}
 	}
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -344,7 +344,7 @@ namespace {
 			if (!characterSurface)
 			{
 				SDL_FreeSurface(fontSurface);
-				throw std::runtime_error("Font::generateGlyphMap(): " + std::string(TTF_GetError()));
+				throw std::runtime_error("Font failed to generate surface for character : " + std::to_string(glyph) + " : " + std::string(TTF_GetError()));
 			}
 
 			SDL_SetSurfaceBlendMode(characterSurface, SDL_BLENDMODE_NONE);

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -270,9 +270,8 @@ namespace {
 		}
 
 		const auto fontSurfaceSize = Vector{fontSurface->w, fontSurface->h};
-		const auto glyphLayoutSize = Vector{GLYPH_MATRIX_SIZE, GLYPH_MATRIX_SIZE};
 		const auto glyphSize = Vector{glyphWidth, glyphHeight};
-		const auto expectedSize = glyphLayoutSize.skewBy(glyphSize);
+		const auto expectedSize = glyphSize * GLYPH_MATRIX_SIZE;
 		if (fontSurfaceSize != expectedSize)
 		{
 			SDL_FreeSurface(fontSurface);

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -289,7 +289,7 @@ namespace {
 		}
 		fillInTextureCoordinates(glm);
 
-		unsigned int textureId = generateTexture(fontSurface);
+		auto textureId = generateTexture(fontSurface);
 
 		// Add generated texture id to texture ID map.
 		fontInfo.textureId = textureId;
@@ -319,7 +319,7 @@ namespace {
 		fillInTextureCoordinates(glm);
 
 		SDL_Surface* fontSurface = generateFontSurface(font, roundedCharSize);
-		unsigned int textureId = generateTexture(fontSurface);
+		auto textureId = generateTexture(fontSurface);
 
 		// Add generated texture id to texture ID map.
 		fontMap[name].textureId = textureId;

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -75,7 +75,7 @@ namespace {
 Font::Font(const std::string& filePath, unsigned int ptSize) :
 	mResourceName{filePath + "_" + std::to_string(ptSize) + "pt"}
 {
-	::load(filePath, ptSize);
+	mFontInfo = ::load(filePath, ptSize);
 }
 
 
@@ -91,7 +91,7 @@ Font::Font(const std::string& filePath, unsigned int ptSize) :
 Font::Font(const std::string& filePath, int glyphWidth, int glyphHeight, int glyphSpace) :
 	mResourceName{filePath}
 {
-	loadBitmap(filePath, glyphWidth, glyphHeight, glyphSpace);
+	mFontInfo = loadBitmap(filePath, glyphWidth, glyphHeight, glyphSpace);
 }
 
 
@@ -111,7 +111,7 @@ Font::Font(const Font& rhs) :
 */
 Font::~Font()
 {
-	glDeleteTextures(1, &fontMap[mResourceName].textureId);
+	glDeleteTextures(1, &mFontInfo.textureId);
 }
 
 
@@ -124,7 +124,7 @@ Font& Font::operator=(const Font& rhs)
 {
 	if (this == &rhs) { return *this; }
 
-	glDeleteTextures(1, &fontMap[mResourceName].textureId);
+	glDeleteTextures(1, &mFontInfo.textureId);
 
 	mResourceName = rhs.mResourceName;
 
@@ -134,7 +134,7 @@ Font& Font::operator=(const Font& rhs)
 
 Vector<int> Font::glyphCellSize() const
 {
-	return fontMap[mResourceName].glyphSize;
+	return mFontInfo.glyphSize;
 }
 
 
@@ -154,7 +154,7 @@ int Font::width(std::string_view string) const
 	if (string.empty()) { return 0; }
 
 	int width = 0;
-	auto& gml = fontMap[mResourceName].metrics;
+	auto& gml = mFontInfo.metrics;
 	if (gml.empty()) { return 0; }
 
 	for (auto character : string)
@@ -172,7 +172,7 @@ int Font::width(std::string_view string) const
  */
 int Font::height() const
 {
-	return fontMap[mResourceName].height;
+	return mFontInfo.height;
 }
 
 
@@ -181,7 +181,7 @@ int Font::height() const
  */
 int Font::ascent() const
 {
-	return fontMap[mResourceName].ascent;
+	return mFontInfo.ascent;
 }
 
 
@@ -190,19 +190,19 @@ int Font::ascent() const
  */
 unsigned int Font::ptSize() const
 {
-	return fontMap[mResourceName].pointSize;
+	return mFontInfo.pointSize;
 }
 
 
 const std::vector<Font::GlyphMetrics>& Font::metrics() const
 {
-	return fontMap[mResourceName].metrics;
+	return mFontInfo.metrics;
 }
 
 
 unsigned int Font::textureId() const
 {
-	return fontMap[mResourceName].textureId;
+	return mFontInfo.textureId;
 }
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -275,6 +275,7 @@ namespace {
 		const auto expectedSize = glyphLayoutSize.skewBy(glyphSize);
 		if (fontSurfaceSize != expectedSize)
 		{
+			SDL_FreeSurface(fontSurface);
 			const auto vectorToString = [](auto vector) { return "{" + std::to_string(vector.x) + ", " + std::to_string(vector.y) + "}"; };
 			throw font_invalid_glyph_map("Unexpected font image size. Expected: " + vectorToString(expectedSize) + " Actual: " + vectorToString(fontSurfaceSize));
 		}
@@ -347,6 +348,7 @@ namespace {
 			SDL_Surface* characterSurface = TTF_RenderGlyph_Blended(font, static_cast<uint16_t>(glyph), white);
 			if (!characterSurface)
 			{
+				SDL_FreeSurface(fontSurface);
 				throw std::runtime_error("Font::generateGlyphMap(): " + std::string(TTF_GetError()));
 			}
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -315,11 +315,11 @@ namespace {
 		const auto longestEdge = std::max(charBoundsSize.x, charBoundsSize.y);
 		const auto roundedLongestEdge = static_cast<int>(roundUpPowerOf2(static_cast<uint32_t>(longestEdge)));
 		const auto roundedCharSize = Vector{roundedLongestEdge, roundedLongestEdge};
-		const auto textureSize = roundedCharSize.x * GLYPH_MATRIX_SIZE;
+		const auto roundedMatrixSize = roundedCharSize * GLYPH_MATRIX_SIZE;
 
-		SDL_Surface* fontSurface = SDL_CreateRGBSurface(SDL_SWSURFACE, textureSize, textureSize, BITS_32, MasksDefault.red, MasksDefault.green, MasksDefault.blue, MasksDefault.alpha);
+		SDL_Surface* fontSurface = SDL_CreateRGBSurface(SDL_SWSURFACE, roundedMatrixSize.x, roundedMatrixSize.y, BITS_32, MasksDefault.red, MasksDefault.green, MasksDefault.blue, MasksDefault.alpha);
 
-		fillInTextureCoordinates(glm, roundedCharSize, {textureSize, textureSize});
+		fillInTextureCoordinates(glm, roundedCharSize, roundedMatrixSize);
 
 		SDL_Color white = { 255, 255, 255, 255 };
 		for (const auto glyphPosition : PointInRectangleRange(Rectangle{0, 0, GLYPH_MATRIX_SIZE, GLYPH_MATRIX_SIZE}))

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -56,7 +56,7 @@ namespace {
 
 	bool load(const std::string& path, unsigned int ptSize);
 	bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace);
-	unsigned int generateGlyphMap(SDL_Surface* fontSurface, std::vector<Font::GlyphMetrics>& glyphMetricsList);
+	unsigned int generateFontTexture(SDL_Surface* fontSurface, std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	SDL_Surface* generateFontSurface(TTF_Font* font, Vector<int> characterSize);
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	Vector<int> roundedCharacterDimensions(Vector<int> maxSize);
@@ -248,7 +248,7 @@ namespace {
 		fontInfo.height = TTF_FontHeight(font);
 		fontInfo.ascent = TTF_FontAscent(font);
 		fontInfo.glyphSize = roundedCharSize;
-		fontInfo.textureId = generateGlyphMap(fontSurface, glm);
+		fontInfo.textureId = generateFontTexture(fontSurface, glm);
 		TTF_CloseFont(font);
 
 		return true;
@@ -315,7 +315,7 @@ namespace {
 	 *
 	 * Internal function used to generate a glyph texture map from an TTF_Font struct.
 	 */
-	unsigned int generateGlyphMap(SDL_Surface* fontSurface, std::vector<Font::GlyphMetrics>& glyphMetricsList)
+	unsigned int generateFontTexture(SDL_Surface* fontSurface, std::vector<Font::GlyphMetrics>& glyphMetricsList)
 	{
 		fillInTextureCoordinates(glyphMetricsList);
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -56,7 +56,7 @@ namespace {
 
 	bool load(const std::string& path, unsigned int ptSize);
 	bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace);
-	Vector<int> generateGlyphMap(TTF_Font* font, const std::string& name);
+	unsigned int generateGlyphMap(TTF_Font* font, const std::string& name);
 	SDL_Surface* generateFontSurface(TTF_Font* font, Vector<int> characterSize);
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	Vector<int> roundedCharacterDimensions(Vector<int> maxSize);
@@ -246,7 +246,7 @@ namespace {
 		fontMap[fontname].height = TTF_FontHeight(font);
 		fontMap[fontname].ascent = TTF_FontAscent(font);
 		fontMap[fontname].glyphSize = roundedCharSize;
-		generateGlyphMap(font, fontname);
+		fontMap[fontname].textureId = generateGlyphMap(font, fontname);
 		TTF_CloseFont(font);
 
 		return true;
@@ -313,19 +313,16 @@ namespace {
 	 *
 	 * Internal function used to generate a glyph texture map from an TTF_Font struct.
 	 */
-	Vector<int> generateGlyphMap(TTF_Font* font, const std::string& name)
+	unsigned int generateGlyphMap(TTF_Font* font, const std::string& name)
 	{
 		auto& glm = fontMap[name].metrics;
 		fillInTextureCoordinates(glm);
 
 		SDL_Surface* fontSurface = generateFontSurface(font, fontMap[name].glyphSize);
 		auto textureId = generateTexture(fontSurface);
-
-		// Add generated texture id to texture ID map.
-		fontMap[name].textureId = textureId;
 		SDL_FreeSurface(fontSurface);
 
-		return fontMap[name].glyphSize;
+		return textureId;
 	}
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -237,16 +237,17 @@ namespace {
 			throw std::runtime_error("Font load function failed: " + std::string{TTF_GetError()});
 		}
 
-		auto& glm = fontMap[fontname].metrics;
+		auto& fontInfo = fontMap[fontname];
+		auto& glm = fontInfo.metrics;
 		fillInCharacterDimensions(font, glm);
 		const auto charBoundsSize = maxCharacterDimensions(glm);
 		const auto roundedCharSize = roundedCharacterDimensions(charBoundsSize);
 
-		fontMap[fontname].pointSize = ptSize;
-		fontMap[fontname].height = TTF_FontHeight(font);
-		fontMap[fontname].ascent = TTF_FontAscent(font);
-		fontMap[fontname].glyphSize = roundedCharSize;
-		fontMap[fontname].textureId = generateGlyphMap(font, fontname);
+		fontInfo.pointSize = ptSize;
+		fontInfo.height = TTF_FontHeight(font);
+		fontInfo.ascent = TTF_FontAscent(font);
+		fontInfo.glyphSize = roundedCharSize;
+		fontInfo.textureId = generateGlyphMap(font, fontname);
 		TTF_CloseFont(font);
 
 		return true;

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -56,7 +56,7 @@ namespace {
 
 	bool load(const std::string& path, unsigned int ptSize);
 	bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace);
-	unsigned int generateGlyphMap(TTF_Font* font, const std::string& name);
+	unsigned int generateGlyphMap(TTF_Font* font, Font::FontInfo& fontInfo);
 	SDL_Surface* generateFontSurface(TTF_Font* font, Vector<int> characterSize);
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	Vector<int> roundedCharacterDimensions(Vector<int> maxSize);
@@ -247,7 +247,7 @@ namespace {
 		fontInfo.height = TTF_FontHeight(font);
 		fontInfo.ascent = TTF_FontAscent(font);
 		fontInfo.glyphSize = roundedCharSize;
-		fontInfo.textureId = generateGlyphMap(font, fontname);
+		fontInfo.textureId = generateGlyphMap(font, fontInfo);
 		TTF_CloseFont(font);
 
 		return true;
@@ -314,12 +314,12 @@ namespace {
 	 *
 	 * Internal function used to generate a glyph texture map from an TTF_Font struct.
 	 */
-	unsigned int generateGlyphMap(TTF_Font* font, const std::string& name)
+	unsigned int generateGlyphMap(TTF_Font* font, Font::FontInfo& fontInfo)
 	{
-		auto& glm = fontMap[name].metrics;
+		auto& glm = fontInfo.metrics;
 		fillInTextureCoordinates(glm);
 
-		SDL_Surface* fontSurface = generateFontSurface(font, fontMap[name].glyphSize);
+		SDL_Surface* fontSurface = generateFontSurface(font, fontInfo.glyphSize);
 		auto textureId = generateTexture(fontSurface);
 		SDL_FreeSurface(fontSurface);
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -61,7 +61,7 @@ namespace {
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	Vector<int> roundedCharacterDimensions(Vector<int> maxSize);
 	void fillInCharacterDimensions(TTF_Font* font, std::vector<Font::GlyphMetrics>& glyphMetricsList);
-	void fillInTextureCoordinates(std::vector<Font::GlyphMetrics>& glyphMetricsList, Vector<int> characterSize, Vector<int> textureSize);
+	void fillInTextureCoordinates(std::vector<Font::GlyphMetrics>& glyphMetricsList, Vector<int> characterSize);
 }
 
 
@@ -287,7 +287,7 @@ namespace {
 			metrics.minX = glyphSize.x;
 			metrics.advance = glyphSpace;
 		}
-		fillInTextureCoordinates(glm, glyphSize, fontSurfaceSize);
+		fillInTextureCoordinates(glm, glyphSize);
 
 		unsigned int textureId = generateTexture(fontSurface);
 
@@ -315,9 +315,8 @@ namespace {
 
 		const auto charBoundsSize = maxCharacterDimensions(glm);
 		const auto roundedCharSize = roundedCharacterDimensions(charBoundsSize);
-		const auto roundedMatrixSize = roundedCharSize * GLYPH_MATRIX_SIZE;
 
-		fillInTextureCoordinates(glm, roundedCharSize, roundedMatrixSize);
+		fillInTextureCoordinates(glm, roundedCharSize);
 
 		SDL_Surface* fontSurface = generateFontSurface(font, roundedCharSize);
 		unsigned int textureId = generateTexture(fontSurface);
@@ -394,8 +393,9 @@ namespace {
 	}
 
 
-	void fillInTextureCoordinates(std::vector<Font::GlyphMetrics>& glyphMetricsList, Vector<int> characterSize, Vector<int> textureSize)
+	void fillInTextureCoordinates(std::vector<Font::GlyphMetrics>& glyphMetricsList, Vector<int> characterSize)
 	{
+		const auto textureSize = characterSize * GLYPH_MATRIX_SIZE;
 		const auto floatTextureSize = textureSize.to<float>();
 		const auto uvSize = characterSize.to<float>().skewInverseBy(floatTextureSize);
 		for (const auto glyphPosition : PointInRectangleRange(Rectangle{0, 0, GLYPH_MATRIX_SIZE, GLYPH_MATRIX_SIZE}))

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -54,8 +54,8 @@ namespace {
 	const int GLYPH_MATRIX_SIZE = 16;
 	const int BITS_32 = 32;
 
-	bool load(const std::string& path, unsigned int ptSize);
-	bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace);
+	Font::FontInfo load(const std::string& path, unsigned int ptSize);
+	Font::FontInfo loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace);
 	unsigned int generateFontTexture(SDL_Surface* fontSurface, std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	SDL_Surface* generateFontSurface(TTF_Font* font, Vector<int> characterSize);
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
@@ -213,7 +213,7 @@ namespace {
 	 * \param	path	Path to the TTF or OTF font file.
 	 * \param	ptSize	Point size to use when loading the font.
 	 */
-	bool load(const std::string& path, unsigned int ptSize)
+	Font::FontInfo load(const std::string& path, unsigned int ptSize)
 	{
 		std::string fontname = path + "_" + std::to_string(ptSize) + "pt";
 
@@ -251,7 +251,7 @@ namespace {
 		fontInfo.textureId = generateFontTexture(fontSurface, glm);
 		TTF_CloseFont(font);
 
-		return true;
+		return fontInfo;
 	}
 
 
@@ -263,7 +263,7 @@ namespace {
 	 * \param	glyphHeight	Height of the glyphs in the bitmap font.
 	 * \param	glyphSpace	Spacing to use when drawing glyphs.
 	 */
-	bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace)
+	Font::FontInfo loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace)
 	{
 		File fontBuffer = Utility<Filesystem>::get().open(path);
 		if (fontBuffer.empty())
@@ -301,7 +301,7 @@ namespace {
 		fontInfo.glyphSize = glyphSize;
 		fontInfo.textureId = generateFontTexture(fontSurface, glm);
 
-		return true;
+		return fontInfo;
 	}
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -56,7 +56,7 @@ namespace {
 
 	bool load(const std::string& path, unsigned int ptSize);
 	bool loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace);
-	Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int fontSize);
+	Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name);
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	void fillInTextureCoordinates(std::vector<Font::GlyphMetrics>& glyphMetricsList, Vector<int> characterSize, Vector<int> textureSize);
 }
@@ -234,9 +234,10 @@ namespace {
 			throw std::runtime_error("Font load function failed: " + std::string{TTF_GetError()});
 		}
 
+		fontMap[fontname].pointSize = ptSize;
 		fontMap[fontname].height = TTF_FontHeight(font);
 		fontMap[fontname].ascent = TTF_FontAscent(font);
-		fontMap[fontname].glyphSize = generateGlyphMap(font, fontname, ptSize);
+		fontMap[fontname].glyphSize = generateGlyphMap(font, fontname);
 		TTF_CloseFont(font);
 
 		return true;
@@ -303,7 +304,7 @@ namespace {
 	 *
 	 * Internal function used to generate a glyph texture map from an TTF_Font struct.
 	 */
-	Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name, unsigned int fontSize)
+	Vector<int> generateGlyphMap(TTF_Font* ft, const std::string& name)
 	{
 		auto& glm = fontMap[name].metrics;
 
@@ -351,7 +352,6 @@ namespace {
 
 		// Add generated texture id to texture ID map.
 		fontMap[name].textureId = textureId;
-		fontMap[name].pointSize = fontSize;
 		SDL_FreeSurface(fontSurface);
 
 		return size;

--- a/NAS2D/Resources/Font.h
+++ b/NAS2D/Resources/Font.h
@@ -86,6 +86,7 @@ public:
 
 private:
 	std::string mResourceName{"Default Resource"}; /**< File path and internal identifier. */
+	FontInfo mFontInfo;
 };
 
 } // namespace


### PR DESCRIPTION
Reference: #763
Fix bug accidentally introduced in #764.

Removes all uses of `fontMap` for internal caching of `FontInfo` structure inside `Font`. Instead, data is stored directly inside the `Font` class. For caching, use `ResourceCache` as an external caching solution.
