### PR TITLE
Have Font bitmap constructor compute monospaced sizes

### DIFF
--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -52,7 +52,7 @@ namespace {
 	const int BITS_32 = 32;
 
 	Font::FontInfo load(const std::string& path, unsigned int ptSize);
-	Font::FontInfo loadBitmap(const std::string& path, int glyphSpace);
+	Font::FontInfo loadBitmap(const std::string& path);
 	unsigned int generateFontTexture(SDL_Surface* fontSurface, std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	SDL_Surface* generateFontSurface(TTF_Font* font, Vector<int> characterSize);
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
@@ -80,13 +80,12 @@ Font::Font(const std::string& filePath, unsigned int ptSize) :
  * Instantiate a Font as a bitmap font.
  *
  * \param	filePath	Path to a font file.
- * \param	glyphSpace	Space between glyphs when rendering a bitmap font. This value can be negative.
  *
  */
-Font::Font(const std::string& filePath, int glyphSpace) :
+Font::Font(const std::string& filePath) :
 	mResourceName{filePath}
 {
-	mFontInfo = loadBitmap(filePath, glyphSpace);
+	mFontInfo = loadBitmap(filePath);
 }
 
 
@@ -254,9 +253,8 @@ namespace {
 	 * Internal function that loads a bitmap font from an file.
 	 *
 	 * \param	path		Path to the image file.
-	 * \param	glyphSpace	Spacing to use when drawing glyphs.
 	 */
-	Font::FontInfo loadBitmap(const std::string& path, int glyphSpace)
+	Font::FontInfo loadBitmap(const std::string& path)
 	{
 		File fontBuffer = Utility<Filesystem>::get().open(path);
 		if (fontBuffer.empty())
@@ -289,7 +287,7 @@ namespace {
 			metrics.minY = 0;
 			metrics.maxX = glyphSize.x;
 			metrics.maxY = glyphSize.y;
-			metrics.advance = glyphSpace;
+			metrics.advance = glyphSize.x;
 		}
 
 		fontInfo.pointSize = static_cast<unsigned int>(glyphSize.y);

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -285,12 +285,16 @@ namespace {
 		glm.resize(ASCII_TABLE_COUNT);
 		for (auto& metrics : glm)
 		{
-			metrics.minX = glyphSize.x;
+			metrics.minX = 0;
+			metrics.minY = 0;
+			metrics.maxX = glyphSize.x;
+			metrics.maxY = glyphSize.y;
 			metrics.advance = glyphSpace;
 		}
 
 		fontInfo.pointSize = static_cast<unsigned int>(glyphSize.y);
 		fontInfo.height = glyphSize.y;
+		fontInfo.ascent = glyphSize.y;
 		fontInfo.glyphSize = glyphSize;
 		fontInfo.textureId = generateFontTexture(fontSurface, glm);
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -52,7 +52,7 @@ namespace {
 	const int BITS_32 = 32;
 
 	Font::FontInfo load(const std::string& path, unsigned int ptSize);
-	Font::FontInfo loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace);
+	Font::FontInfo loadBitmap(const std::string& path, int glyphSpace);
 	unsigned int generateFontTexture(SDL_Surface* fontSurface, std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	SDL_Surface* generateFontSurface(TTF_Font* font, Vector<int> characterSize);
 	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
@@ -80,15 +80,13 @@ Font::Font(const std::string& filePath, unsigned int ptSize) :
  * Instantiate a Font as a bitmap font.
  *
  * \param	filePath	Path to a font file.
- * \param	glyphWidth	Width of glyphs in the bitmap Font.
- * \param	glyphHeight	Height of glyphs in the bitmap Font.
  * \param	glyphSpace	Space between glyphs when rendering a bitmap font. This value can be negative.
  *
  */
-Font::Font(const std::string& filePath, int glyphWidth, int glyphHeight, int glyphSpace) :
+Font::Font(const std::string& filePath, int glyphSpace) :
 	mResourceName{filePath}
 {
-	mFontInfo = loadBitmap(filePath, glyphWidth, glyphHeight, glyphSpace);
+	mFontInfo = loadBitmap(filePath, glyphSpace);
 }
 
 
@@ -256,11 +254,9 @@ namespace {
 	 * Internal function that loads a bitmap font from an file.
 	 *
 	 * \param	path		Path to the image file.
-	 * \param	glyphWidth	Width of glyphs in the bitmap font.
-	 * \param	glyphHeight	Height of the glyphs in the bitmap font.
 	 * \param	glyphSpace	Spacing to use when drawing glyphs.
 	 */
-	Font::FontInfo loadBitmap(const std::string& path, int glyphWidth, int glyphHeight, int glyphSpace)
+	Font::FontInfo loadBitmap(const std::string& path, int glyphSpace)
 	{
 		File fontBuffer = Utility<Filesystem>::get().open(path);
 		if (fontBuffer.empty())
@@ -274,14 +270,14 @@ namespace {
 			throw std::runtime_error("Font loadBitmap function failed: " + std::string{SDL_GetError()});
 		}
 
+		// Assume image is square array of equal sized character cells
 		const auto fontSurfaceSize = Vector{fontSurface->w, fontSurface->h};
-		const auto glyphSize = Vector{glyphWidth, glyphHeight};
-		const auto expectedSize = glyphSize * GLYPH_MATRIX_SIZE;
-		if (fontSurfaceSize != expectedSize)
+		const auto glyphSize = fontSurfaceSize / GLYPH_MATRIX_SIZE;
+		if (fontSurfaceSize != glyphSize * GLYPH_MATRIX_SIZE)
 		{
 			SDL_FreeSurface(fontSurface);
 			const auto vectorToString = [](auto vector) { return "{" + std::to_string(vector.x) + ", " + std::to_string(vector.y) + "}"; };
-			throw font_invalid_glyph_map("Unexpected font image size. Expected: " + vectorToString(expectedSize) + " Actual: " + vectorToString(fontSurfaceSize));
+			throw font_invalid_glyph_map("Unexpected font image size. Image dimensions " + vectorToString(fontSurfaceSize) + " must both be evenly divisble by " + std::to_string(GLYPH_MATRIX_SIZE));
 		}
 
 		Font::FontInfo fontInfo;

--- a/NAS2D/Resources/Font.h
+++ b/NAS2D/Resources/Font.h
@@ -64,7 +64,7 @@ public:
 
 
 	explicit Font(const std::string& filePath, unsigned int ptSize = 12);
-	Font(const std::string& filePath, int glyphWidth, int glyphHeight, int glyphSpace);
+	Font(const std::string& filePath, int glyphSpace);
 	Font(const Font& font);
 	Font& operator=(const Font& font);
 	~Font();

--- a/NAS2D/Resources/Font.h
+++ b/NAS2D/Resources/Font.h
@@ -63,7 +63,7 @@ public:
 	};
 
 
-	explicit Font(const std::string& filePath, unsigned int ptSize = 12);
+	Font(const std::string& filePath, unsigned int ptSize);
 	Font(const std::string& filePath, int glyphSpace);
 	Font(const Font& font);
 	Font& operator=(const Font& font);

--- a/NAS2D/Resources/Font.h
+++ b/NAS2D/Resources/Font.h
@@ -64,7 +64,7 @@ public:
 
 
 	Font(const std::string& filePath, unsigned int ptSize);
-	Font(const std::string& filePath, int glyphSpace);
+	explicit Font(const std::string& filePath);
 	Font(const Font& font);
 	Font& operator=(const Font& font);
 	~Font();


### PR DESCRIPTION
Have `Font` bitmap loading constructor compute glyph dimensions for an assumed monospaced font. Previously, there was an inbuilt assumption of monospaced, and error checking to ensure the bitmap size was a proper multiple of the provided glyph size. This instead computes what the glyph size and spacing should be, based on the bitmap size and the monospaced assumption.

Reference: #401
