### PR TITLE
Fix Font spacing

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -464,11 +464,11 @@ void RendererOpenGL::drawText(const Font& font, std::string_view text, Point<flo
 		const auto& gm = gml[std::clamp<std::size_t>(static_cast<uint8_t>(character), 0, 255)];
 
 		const auto glyphCellSize = font.glyphCellSize().to<float>();
-		const auto vertexArray = rectToQuad({position.x + offset, position.y, glyphCellSize.x, glyphCellSize.y});
+		const auto vertexArray = rectToQuad({position.x + offset + gm.minX, position.y, glyphCellSize.x, glyphCellSize.y});
 		const auto textureCoordArray = rectToQuad(gm.uvRect);
 
 		drawTexturedQuad(font.textureId(), vertexArray, textureCoordArray);
-		offset += gm.advance + gm.minX;
+		offset += gm.advance;
 	}
 }
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -55,7 +55,7 @@ namespace {
 	Font::FontInfo loadBitmap(const std::string& path);
 	unsigned int generateFontTexture(SDL_Surface* fontSurface, std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	SDL_Surface* generateFontSurface(TTF_Font* font, Vector<int> characterSize);
-	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList);
+	Vector<int> maxCharacterDimensions(TTF_Font* font);
 	Vector<int> roundedCharacterDimensions(Vector<int> maxSize);
 	void fillInCharacterDimensions(TTF_Font* font, std::vector<Font::GlyphMetrics>& glyphMetricsList);
 	void fillInTextureCoordinates(std::vector<Font::GlyphMetrics>& glyphMetricsList);
@@ -234,7 +234,7 @@ namespace {
 		Font::FontInfo fontInfo;
 		auto& glm = fontInfo.metrics;
 		fillInCharacterDimensions(font, glm);
-		const auto charBoundsSize = maxCharacterDimensions(glm);
+		const auto charBoundsSize = maxCharacterDimensions(font);
 		const auto roundedCharSize = roundedCharacterDimensions(charBoundsSize);
 		SDL_Surface* fontSurface = generateFontSurface(font, roundedCharSize);
 
@@ -348,14 +348,16 @@ namespace {
 	}
 
 
-	Vector<int> maxCharacterDimensions(const std::vector<Font::GlyphMetrics>& glyphMetricsList)
+	Vector<int> maxCharacterDimensions(TTF_Font* font)
 	{
 		Vector<int> size{0, 0};
 
-		for (const auto metrics : glyphMetricsList)
+		for (int i = 0; i < 256; ++i)
 		{
-			size.x = std::max({size.x, metrics.minX + metrics.maxX, metrics.advance});
-			size.y = std::max({size.y, metrics.minY + metrics.maxY});
+			Vector<int> sizeChar;
+			char text[2] = {static_cast<char>(i), 0};
+			TTF_SizeText(font, text, &sizeChar.x, &sizeChar.y);
+			size = {std::max({size.x, sizeChar.x}), std::max({size.y, sizeChar.y})};
 		}
 		return size;
 	}


### PR DESCRIPTION
Closes #767

Fixes some visual oddities with `Font` rendering that caused odd spacing. It was particularly notable when "J" or "j" was displayed, which both had negative `minX` values.

Rendering might still be a bit imperfect, particularly with regards to the `minX` offset used when drawing glyphs. I suspect it might need to be one sided clipped, so it is only used when it's negative. Visually it looks fine, so I'm going to call this close enough.

We also don't do proper kerning, but again, close enough. If we want to look into it someday, the SDL_ttf.c file does it using [`FT_Get_Kerning`](https://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html#ft_get_kerning) from the FreeType library. It's a fairly simple method call, which gets an adjustment value to be added in to the current position along with the `advance`.
