### PR TITLE
Implement one sided adjustments for negative minX font spacing

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -464,7 +464,8 @@ void RendererOpenGL::drawText(const Font& font, std::string_view text, Point<flo
 		const auto& gm = gml[std::clamp<std::size_t>(static_cast<uint8_t>(character), 0, 255)];
 
 		const auto glyphCellSize = font.glyphCellSize().to<float>();
-		const auto vertexArray = rectToQuad({position.x + offset + gm.minX, position.y, glyphCellSize.x, glyphCellSize.y});
+		const auto adjustX = (gm.minX < 0) ? gm.minX : 0;
+		const auto vertexArray = rectToQuad({position.x + offset + adjustX, position.y, glyphCellSize.x, glyphCellSize.y});
 		const auto textureCoordArray = rectToQuad(gm.uvRect);
 
 		drawTexturedQuad(font.textureId(), vertexArray, textureCoordArray);


### PR DESCRIPTION
Reference: #767

I figured since it's fresh on my mind still, maybe I'd try out that one sided spacing adjustment for glyphs with a negative `minX` value. It does make the font rendering look ever so slightly better. The adjustment makes the spacing between characters appear more even.
