### PR TITLE
Fix possible bug in Image cleanup code

### DIFF
--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -323,11 +323,10 @@ namespace {
 
 		if (imageInfo.refCount <= 0)
 		{
-			if (imageInfo.textureId == 0)
+			if (imageInfo.textureId != 0)
 			{
-				return;
+				glDeleteTextures(1, &imageInfo.textureId);
 			}
-			glDeleteTextures(1, &imageInfo.textureId);
 
 			if (imageInfo.frameBufferObjectId != 0)
 			{


### PR DESCRIPTION
Previously, if `textureId` was ever empty, the remainder of the cleanup code was skipped.

Reference: #763
