### PR TITLE
Remove default Image constructor

### DIFF
--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -42,7 +42,6 @@ namespace {
 
 	std::map<std::string, ImageInfo> imageIdMap; /**< Lookup table for OpenGL Texture ID's. */
 
-	const std::string DEFAULT_IMAGE_NAME = "Default Image";
 	const std::string ARBITRARY_IMAGE_NAME = "arbitrary_image_";
 	int IMAGE_ARBITRARY = 0; /**< Counter for arbitrary image ID's. */
 
@@ -62,15 +61,6 @@ Image::Image(const std::string& filePath) :
 	mResourceName{filePath}
 {
 	load();
-}
-
-
-/**
- * Default C'tor.
- */
-Image::Image() :
-	mResourceName{DEFAULT_IMAGE_NAME}
-{
 }
 
 

--- a/NAS2D/Resources/Image.h
+++ b/NAS2D/Resources/Image.h
@@ -37,7 +37,6 @@ namespace NAS2D {
 class Image
 {
 public:
-	Image();
 	explicit Image(const std::string& filePath);
 	Image(void* buffer, int bytesPerPixel, int width, int height);
 


### PR DESCRIPTION
Remove default `Image` constructor.

This makes reworking and removing the internal `Image` caching code easier. Last downstream use of the default `Image` constructor is removed by: https://github.com/OutpostUniverse/OPHD/pull/576

Reference: #763
