### PR TITLE
Image internal refactor

### DIFF
--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -216,7 +216,7 @@ Image& Image::operator=(const Image& rhs)
  */
 Vector<int> Image::size() const
 {
-	return mSize;
+	return imageIdMap[mResourceName].size;
 }
 
 
@@ -227,12 +227,13 @@ Vector<int> Image::size() const
  */
 Color Image::pixelColor(Point<int> point) const
 {
-	if (!Rectangle<int>::Create({0, 0}, mSize).contains(point))
+	const auto& imageInfo = imageIdMap[mResourceName];
+	if (!Rectangle<int>::Create({0, 0}, imageInfo.size).contains(point))
 	{
 		throw std::runtime_error("Pixel coordinates out of bounds: {" + std::to_string(point.x) + ", " + std::to_string(point.y) + "}");
 	}
 
-	SDL_Surface* surface = imageIdMap[mResourceName].surface;
+	SDL_Surface* surface = imageInfo.surface;
 	if (!surface) { throw image_null_data(); }
 
 	uint8_t bytesPerPixel = surface->format->BytesPerPixel;

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -159,6 +159,7 @@ void Image::load()
 {
 	if (checkTextureId(mResourceName))
 	{
+		++imageIdMap[mResourceName].refCount;
 		mSize = imageIdMap[mResourceName].size;
 		return;
 	}
@@ -346,7 +347,6 @@ namespace {
 
 		if (it != imageIdMap.end())
 		{
-			++imageIdMap[name].refCount;
 			return true;
 		}
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -45,7 +45,6 @@ namespace {
 	const std::string ARBITRARY_IMAGE_NAME = "arbitrary_image_";
 	int IMAGE_ARBITRARY = 0; /**< Counter for arbitrary image ID's. */
 
-	bool checkTextureId(const std::string& name);
 	void updateImageReferenceCount(const std::string& name);
 
 	GLuint generateFbo(const Image& image);
@@ -157,7 +156,7 @@ Image& Image::operator=(const Image& rhs)
  */
 void Image::load()
 {
-	if (checkTextureId(mResourceName))
+	if (imageIdMap.find(mResourceName) != imageIdMap.end())
 	{
 		++imageIdMap[mResourceName].refCount;
 		mSize = imageIdMap[mResourceName].size;
@@ -332,18 +331,6 @@ namespace {
 
 			imageIdMap.erase(it);
 		}
-	}
-
-
-	/**
-	* Checks to see if a texture has already been generated
-	* and if it has, increases the reference count.
-	*
-	* \return	True if texture already exists. False otherwise.
-	*/
-	bool checkTextureId(const std::string& name)
-	{
-		return imageIdMap.find(name) != imageIdMap.end();
 	}
 
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -343,12 +343,7 @@ namespace {
 	*/
 	bool checkTextureId(const std::string& name)
 	{
-		if (imageIdMap.find(name) != imageIdMap.end())
-		{
-			return true;
-		}
-
-		return false;
+		return imageIdMap.find(name) != imageIdMap.end();
 	}
 
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -166,13 +166,13 @@ void Image::load()
 	File imageFile = Utility<Filesystem>::get().open(mResourceName);
 	if (imageFile.size() == 0)
 	{
-		throw std::runtime_error("Image::load(): File is empty: " + mResourceName);
+		throw std::runtime_error("Image file is empty: " + mResourceName);
 	}
 
 	SDL_Surface* surface = IMG_Load_RW(SDL_RWFromConstMem(imageFile.raw_bytes(), static_cast<int>(imageFile.size())), 0);
 	if (!surface)
 	{
-		throw std::runtime_error("Image::load(): " + std::string{SDL_GetError()});
+		throw std::runtime_error("Image failed to load: " + std::string{SDL_GetError()});
 	}
 
 	mSize = Vector{surface->w, surface->h};

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -343,9 +343,7 @@ namespace {
 	*/
 	bool checkTextureId(const std::string& name)
 	{
-		auto it = imageIdMap.find(name);
-
-		if (it != imageIdMap.end())
+		if (imageIdMap.find(name) != imageIdMap.end())
 		{
 			return true;
 		}

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -252,18 +252,6 @@ Color Image::pixelColor(Point<int> point) const
 }
 
 
-/**
- * Gets the color of a pixel at a given coordinate.
- *
- * \param	x	X-Coordinate of the pixel to check.
- * \param	y	Y-Coordinate of the pixel to check.
- */
-Color Image::pixelColor(int x, int y) const
-{
-	return pixelColor({x, y});
-}
-
-
 unsigned int Image::textureId() const
 {
 	return imageIdMap[mResourceName].textureId;

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -131,10 +131,9 @@ Image::Image(const std::string& filePath) :
  *
  * \param	buffer			Pointer to a data buffer.
  * \param	bytesPerPixel	Number of bytes per pixel. Valid values are 3 and 4 (images < 24-bit are not supported).
- * \param	width			Width of the Image.
- * \param	height			Height of the Image.
+ * \param	size			Size of the Image in pixels.
  */
-Image::Image(void* buffer, int bytesPerPixel, int width, int height) :
+Image::Image(void* buffer, int bytesPerPixel, Vector<int> size) :
 	mResourceName{ARBITRARY_IMAGE_NAME + std::to_string(IMAGE_ARBITRARY)}
 {
 	if (buffer == nullptr)
@@ -149,16 +148,16 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) :
 
 	++IMAGE_ARBITRARY;
 
-	SDL_Surface* surface = SDL_CreateRGBSurfaceFrom(buffer, width, height, bytesPerPixel * 8, 0, 0, 0, 0, SDL_BYTEORDER == SDL_BIG_ENDIAN ? 0x000000FF : 0xFF000000);
+	SDL_Surface* surface = SDL_CreateRGBSurfaceFrom(buffer, size.x, size.y, bytesPerPixel * 8, 0, 0, 0, 0, SDL_BYTEORDER == SDL_BIG_ENDIAN ? 0x000000FF : 0xFF000000);
 
-	mSize = Vector{width, height};
+	mSize = size;
 
 	unsigned int textureId = generateTexture(surface);
 
 	// Update resource management.
 	auto& imageInfo = imageIdMap[mResourceName];
 	imageInfo.textureId = textureId;
-	imageInfo.size = {width, height};
+	imageInfo.size = size;
 	imageInfo.refCount++;
 	imageInfo.surface = surface;
 }

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -208,7 +208,7 @@ Color Image::pixelColor(int x, int y) const
 {
 	if (!Rectangle<int>::Create({0, 0}, mSize).contains({x, y}))
 	{
-		return Color::Black;
+		throw std::runtime_error("Pixel coordinates out of bounds: {" + std::to_string(x) + ", " + std::to_string(y) + "}");
 	}
 
 	SDL_Surface* surface = imageIdMap[mResourceName].surface;

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -194,21 +194,9 @@ Vector<int> Image::size() const
  */
 Color Image::pixelColor(Point<int> point) const
 {
-	return pixelColor(point.x, point.y);
-}
-
-
-/**
- * Gets the color of a pixel at a given coordinate.
- *
- * \param	x	X-Coordinate of the pixel to check.
- * \param	y	Y-Coordinate of the pixel to check.
- */
-Color Image::pixelColor(int x, int y) const
-{
-	if (!Rectangle<int>::Create({0, 0}, mSize).contains({x, y}))
+	if (!Rectangle<int>::Create({0, 0}, mSize).contains(point))
 	{
-		throw std::runtime_error("Pixel coordinates out of bounds: {" + std::to_string(x) + ", " + std::to_string(y) + "}");
+		throw std::runtime_error("Pixel coordinates out of bounds: {" + std::to_string(point.x) + ", " + std::to_string(point.y) + "}");
 	}
 
 	SDL_Surface* surface = imageIdMap[mResourceName].surface;
@@ -217,7 +205,7 @@ Color Image::pixelColor(int x, int y) const
 
 	SDL_LockSurface(surface);
 	uint8_t bytesPerPixel = surface->format->BytesPerPixel;
-	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + static_cast<std::size_t>(y) * static_cast<std::size_t>(surface->pitch) + static_cast<std::size_t>(x) * bytesPerPixel;
+	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + static_cast<std::size_t>(point.y) * static_cast<std::size_t>(surface->pitch) + static_cast<std::size_t>(point.x) * bytesPerPixel;
 
 	unsigned int pixelBytes = 0;
 
@@ -263,6 +251,18 @@ Color Image::pixelColor(int x, int y) const
 	SDL_UnlockSurface(surface);
 
 	return Color{r, g, b, a};
+}
+
+
+/**
+ * Gets the color of a pixel at a given coordinate.
+ *
+ * \param	x	X-Coordinate of the pixel to check.
+ * \param	y	Y-Coordinate of the pixel to check.
+ */
+Color Image::pixelColor(int x, int y) const
+{
+	return pixelColor({x, y});
 }
 
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -215,19 +215,19 @@ Color Image::pixelColor(Point<int> point) const
 	{
 		case 1:
 		{
-			auto p = reinterpret_cast<uint8_t*>(pixelPtr);
+			auto p = reinterpret_cast<const uint8_t*>(pixelPtr);
 			pixelBytes = *p;
 			break;
 		}
 		case 2:
 		{
-			auto p = reinterpret_cast<uint16_t*>(pixelPtr);
+			auto p = reinterpret_cast<const uint16_t*>(pixelPtr);
 			pixelBytes = *p;
 			break;
 		}
 		case 3:
 		{
-			auto p = reinterpret_cast<uint8_t*>(pixelPtr);
+			auto p = reinterpret_cast<const uint8_t*>(pixelPtr);
 			if constexpr (SDL_BYTEORDER == SDL_BIG_ENDIAN)
 			{
 				pixelBytes = p[0] << 16 | p[1] << 8 | p[2];
@@ -240,7 +240,7 @@ Color Image::pixelColor(Point<int> point) const
 		}
 		case 4:
 		{
-			auto p = reinterpret_cast<uint32_t*>(pixelPtr);
+			auto p = reinterpret_cast<const uint32_t*>(pixelPtr);
 			pixelBytes = *p;
 			break;
 		}

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -247,11 +247,11 @@ Color Image::pixelColor(Point<int> point) const
 		throw image_bad_data();
 	}
 
-	uint8_t r, g, b, a;
-	SDL_GetRGBA(pixelBytes, surface->format, &r, &g, &b, &a);
+	Color color;
+	SDL_GetRGBA(pixelBytes, surface->format, &color.red, &color.green, &color.blue, &color.alpha);
 	SDL_UnlockSurface(surface);
 
-	return Color{r, g, b, a};
+	return color;
 }
 
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -237,17 +237,17 @@ Color Image::pixelColor(Point<int> point) const
 
 	if (!surface) { throw image_null_data(); }
 
-	SDL_LockSurface(surface);
 	uint8_t bytesPerPixel = surface->format->BytesPerPixel;
 	const auto unsignedPoint = point.to<std::size_t>();
 	const auto pixelOffset = unsignedPoint.y * static_cast<std::size_t>(surface->pitch) + unsignedPoint.x * bytesPerPixel;
-	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + pixelOffset;
 
+	SDL_LockSurface(surface);
+	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + pixelOffset;
 	unsigned int pixelBytes = readPixelValue(pixelPtr, bytesPerPixel);
+	SDL_UnlockSurface(surface);
 
 	Color color;
 	SDL_GetRGBA(pixelBytes, surface->format, &color.red, &color.green, &color.blue, &color.alpha);
-	SDL_UnlockSurface(surface);
 
 	return color;
 }

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -100,7 +100,7 @@ Image::Image(const std::string& filePath) :
  * \param	height			Height of the Image.
  */
 Image::Image(void* buffer, int bytesPerPixel, int width, int height) :
-	mResourceName{ARBITRARY_IMAGE_NAME}
+	mResourceName{ARBITRARY_IMAGE_NAME + std::to_string(IMAGE_ARBITRARY)}
 {
 	if (buffer == nullptr)
 	{
@@ -112,7 +112,7 @@ Image::Image(void* buffer, int bytesPerPixel, int width, int height) :
 		throw image_unsupported_bit_depth();
 	}
 
-	mResourceName = ARBITRARY_IMAGE_NAME + std::to_string(++IMAGE_ARBITRARY);
+	++IMAGE_ARBITRARY;
 
 	SDL_Surface* surface = SDL_CreateRGBSurfaceFrom(buffer, width, height, bytesPerPixel * 8, 0, 0, 0, 0, SDL_BYTEORDER == SDL_BIG_ENDIAN ? 0x000000FF : 0xFF000000);
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -245,7 +245,9 @@ Color Image::pixelColor(Point<int> point) const
 		break;
 	}
 	default: // Should never be possible.
+	{
 		throw image_bad_data();
+	}
 	}
 
 	Color color;

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -112,12 +112,9 @@ Image::Image(const std::string& filePath) :
 		throw std::runtime_error("Image failed to load: " + std::string{SDL_GetError()});
 	}
 
-	unsigned int textureId = generateTexture(surface);
-
-	// Add generated texture id to texture ID map.
 	auto& imageInfo = imageIdMap[mResourceName];
 	imageInfo.surface = surface;
-	imageInfo.textureId = textureId;
+	imageInfo.textureId = generateTexture(surface);
 	imageInfo.size = Vector{surface->w, surface->h};
 	imageInfo.refCount++;
 }
@@ -147,14 +144,11 @@ Image::Image(void* buffer, int bytesPerPixel, Vector<int> size) :
 
 	SDL_Surface* surface = SDL_CreateRGBSurfaceFrom(buffer, size.x, size.y, bytesPerPixel * 8, 0, 0, 0, 0, SDL_BYTEORDER == SDL_BIG_ENDIAN ? 0x000000FF : 0xFF000000);
 
-	unsigned int textureId = generateTexture(surface);
-
-	// Update resource management.
 	auto& imageInfo = imageIdMap[mResourceName];
-	imageInfo.textureId = textureId;
+	imageInfo.surface = surface;
+	imageInfo.textureId = generateTexture(surface);
 	imageInfo.size = size;
 	imageInfo.refCount++;
-	imageInfo.surface = surface;
 }
 
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -9,6 +9,7 @@
 // ==================================================================================
 #include "Image.h"
 
+#include "../Renderer/Rectangle.h"
 #include "../Exception.h"
 #include "../Filesystem.h"
 #include "../Utility.h"
@@ -205,7 +206,7 @@ Color Image::pixelColor(Point<int> point) const
  */
 Color Image::pixelColor(int x, int y) const
 {
-	if (x < 0 || x >= mSize.x || y < 0 || y >= mSize.y)
+	if (!Rectangle<int>::Create({0, 0}, mSize).contains({x, y}))
 	{
 		return Color::Black;
 	}

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -242,8 +242,8 @@ Color Image::pixelColor(Point<int> point) const
 	const auto pixelOffset = unsignedPoint.y * static_cast<std::size_t>(surface->pitch) + unsignedPoint.x * bytesPerPixel;
 
 	SDL_LockSurface(surface);
-	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + pixelOffset;
-	unsigned int pixelBytes = readPixelValue(pixelPtr, bytesPerPixel);
+	const auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + pixelOffset;
+	const auto pixelBytes = readPixelValue(pixelPtr, bytesPerPixel);
 	SDL_UnlockSurface(surface);
 
 	Color color;

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -213,41 +213,41 @@ Color Image::pixelColor(Point<int> point) const
 
 	switch (bytesPerPixel)
 	{
-	case 1:
-	{
-		auto p = reinterpret_cast<uint8_t*>(pixelPtr);
-		pixelBytes = *p;
-		break;
-	}
-	case 2:
-	{
-		auto p = reinterpret_cast<uint16_t*>(pixelPtr);
-		pixelBytes = *p;
-		break;
-	}
-	case 3:
-	{
-		auto p = reinterpret_cast<uint8_t*>(pixelPtr);
-		if constexpr (SDL_BYTEORDER == SDL_BIG_ENDIAN)
+		case 1:
 		{
-			pixelBytes = p[0] << 16 | p[1] << 8 | p[2];
+			auto p = reinterpret_cast<uint8_t*>(pixelPtr);
+			pixelBytes = *p;
+			break;
 		}
-		else
+		case 2:
 		{
-			pixelBytes = p[0] | p[1] << 8 | p[2] << 16;
+			auto p = reinterpret_cast<uint16_t*>(pixelPtr);
+			pixelBytes = *p;
+			break;
 		}
-		break;
-	}
-	case 4:
-	{
-		auto p = reinterpret_cast<uint32_t*>(pixelPtr);
-		pixelBytes = *p;
-		break;
-	}
-	default: // Should never be possible.
-	{
-		throw image_bad_data();
-	}
+		case 3:
+		{
+			auto p = reinterpret_cast<uint8_t*>(pixelPtr);
+			if constexpr (SDL_BYTEORDER == SDL_BIG_ENDIAN)
+			{
+				pixelBytes = p[0] << 16 | p[1] << 8 | p[2];
+			}
+			else
+			{
+				pixelBytes = p[0] | p[1] << 8 | p[2] << 16;
+			}
+			break;
+		}
+		case 4:
+		{
+			auto p = reinterpret_cast<uint32_t*>(pixelPtr);
+			pixelBytes = *p;
+			break;
+		}
+		default: // Should never be possible.
+		{
+			throw image_bad_data();
+		}
 	}
 
 	Color color;

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -206,7 +206,8 @@ Color Image::pixelColor(Point<int> point) const
 	SDL_LockSurface(surface);
 	uint8_t bytesPerPixel = surface->format->BytesPerPixel;
 	const auto unsignedPoint = point.to<std::size_t>();
-	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + unsignedPoint.y * static_cast<std::size_t>(surface->pitch) + unsignedPoint.x * bytesPerPixel;
+	const auto pixelOffset = unsignedPoint.y * static_cast<std::size_t>(surface->pitch) + unsignedPoint.x * bytesPerPixel;
+	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + pixelOffset;
 
 	unsigned int pixelBytes = 0;
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -234,7 +234,6 @@ Color Image::pixelColor(Point<int> point) const
 	}
 
 	SDL_Surface* surface = imageIdMap[mResourceName].surface;
-
 	if (!surface) { throw image_null_data(); }
 
 	uint8_t bytesPerPixel = surface->format->BytesPerPixel;

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -205,7 +205,8 @@ Color Image::pixelColor(Point<int> point) const
 
 	SDL_LockSurface(surface);
 	uint8_t bytesPerPixel = surface->format->BytesPerPixel;
-	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + static_cast<std::size_t>(point.y) * static_cast<std::size_t>(surface->pitch) + static_cast<std::size_t>(point.x) * bytesPerPixel;
+	const auto unsignedPoint = point.to<std::size_t>();
+	auto pixelPtr = reinterpret_cast<std::uintptr_t>(surface->pixels) + unsignedPoint.y * static_cast<std::size_t>(surface->pitch) + unsignedPoint.x * bytesPerPixel;
 
 	unsigned int pixelBytes = 0;
 

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -97,7 +97,6 @@ Image::Image(const std::string& filePath) :
 	if (imageIdMap.find(mResourceName) != imageIdMap.end())
 	{
 		++imageIdMap[mResourceName].refCount;
-		mSize = imageIdMap[mResourceName].size;
 		return;
 	}
 
@@ -113,15 +112,13 @@ Image::Image(const std::string& filePath) :
 		throw std::runtime_error("Image failed to load: " + std::string{SDL_GetError()});
 	}
 
-	mSize = Vector{surface->w, surface->h};
-
 	unsigned int textureId = generateTexture(surface);
 
 	// Add generated texture id to texture ID map.
 	auto& imageInfo = imageIdMap[mResourceName];
 	imageInfo.surface = surface;
 	imageInfo.textureId = textureId;
-	imageInfo.size = mSize;
+	imageInfo.size = Vector{surface->w, surface->h};
 	imageInfo.refCount++;
 }
 
@@ -150,8 +147,6 @@ Image::Image(void* buffer, int bytesPerPixel, Vector<int> size) :
 
 	SDL_Surface* surface = SDL_CreateRGBSurfaceFrom(buffer, size.x, size.y, bytesPerPixel * 8, 0, 0, 0, 0, SDL_BYTEORDER == SDL_BIG_ENDIAN ? 0x000000FF : 0xFF000000);
 
-	mSize = size;
-
 	unsigned int textureId = generateTexture(surface);
 
 	// Update resource management.
@@ -169,8 +164,7 @@ Image::Image(void* buffer, int bytesPerPixel, Vector<int> size) :
  * \param	src		Image to copy.
  */
 Image::Image(const Image &src) :
-	mResourceName{src.mResourceName},
-	mSize{src.mSize}
+	mResourceName{src.mResourceName}
 {
 	imageIdMap[mResourceName].refCount++;
 }
@@ -197,7 +191,6 @@ Image& Image::operator=(const Image& rhs)
 	updateImageReferenceCount(mResourceName);
 
 	mResourceName = rhs.mResourceName;
-	mSize = rhs.mSize;
 
 	auto it = imageIdMap.find(mResourceName);
 	if (it == imageIdMap.end())

--- a/NAS2D/Resources/Image.h
+++ b/NAS2D/Resources/Image.h
@@ -50,7 +50,6 @@ public:
 	Vector<int> size() const;
 
 	Color pixelColor(Point<int> point) const;
-	Color pixelColor(int x, int y) const;
 
 	// Temporary methods, that will be removed in a future refactor
 	// Intended only to be used by RendererOpenGL

--- a/NAS2D/Resources/Image.h
+++ b/NAS2D/Resources/Image.h
@@ -59,9 +59,6 @@ public:
 	unsigned int frameBufferObjectId() const;
 
 private:
-	void load();
-
-private:
 	std::string mResourceName{"Default Resource"}; /**< File path and internal identifier. */
 	Vector<int> mSize; /**< Width/Height information about the Image. */
 };

--- a/NAS2D/Resources/Image.h
+++ b/NAS2D/Resources/Image.h
@@ -59,7 +59,6 @@ public:
 
 private:
 	std::string mResourceName{"Default Resource"}; /**< File path and internal identifier. */
-	Vector<int> mSize; /**< Width/Height information about the Image. */
 };
 
 

--- a/NAS2D/Resources/Image.h
+++ b/NAS2D/Resources/Image.h
@@ -38,7 +38,7 @@ class Image
 {
 public:
 	explicit Image(const std::string& filePath);
-	Image(void* buffer, int bytesPerPixel, int width, int height);
+	Image(void* buffer, int bytesPerPixel, Vector<int> size);
 
 	Image(const Image &rhs);
 	Image& operator=(const Image& rhs);


### PR DESCRIPTION
Reference: #763

Prep-work to for `Image` internal caching removal. Refactor `Image` implementation to make it easier to remove the internal caching.
