### PR TITLE
Add ResourceCache::clear() method

### DIFF
--- a/NAS2D/Resources/ResourceCache.h
+++ b/NAS2D/Resources/ResourceCache.h
@@ -30,6 +30,12 @@ public:
 	}
 
 
+	void unload(Params... params)
+	{
+		cache.erase(Key{params...});
+	}
+
+
 	void clear()
 	{
 		cache.clear();

--- a/NAS2D/Resources/ResourceCache.h
+++ b/NAS2D/Resources/ResourceCache.h
@@ -42,6 +42,11 @@ public:
 	}
 
 
+	auto size() const
+	{
+		return cache.size();
+	}
+
 private:
 	std::map<Key, Resource> cache;
 };

--- a/NAS2D/Resources/ResourceCache.h
+++ b/NAS2D/Resources/ResourceCache.h
@@ -28,6 +28,11 @@ public:
 		return iter->second;
 	}
 
+	void clear()
+	{
+		cache.clear();
+	}
+
 private:
 	std::map<Key, Resource> cache;
 };

--- a/NAS2D/Resources/ResourceCache.h
+++ b/NAS2D/Resources/ResourceCache.h
@@ -10,6 +10,7 @@ class ResourceCache
 public:
 	using Key = std::tuple<Params...>;
 
+
 	const Resource& load(Params... params)
 	{
 		// Cache lookup key is a tuple of all Resource constructor parameters
@@ -28,10 +29,12 @@ public:
 		return iter->second;
 	}
 
+
 	void clear()
 	{
 		cache.clear();
 	}
+
 
 private:
 	std::map<Key, Resource> cache;

--- a/NAS2D/Resources/ResourceCache.h
+++ b/NAS2D/Resources/ResourceCache.h
@@ -13,7 +13,7 @@ public:
 	const Resource& load(Params... params)
 	{
 		// Cache lookup key is a tuple of all Resource constructor parameters
-		const auto key = std::tuple{params...};
+		const auto key = Key{params...};
 
 		// Try to find resource from the cache
 		auto iter = cache.find(key);

--- a/test/Resources/ResourceCache.test.cpp
+++ b/test/Resources/ResourceCache.test.cpp
@@ -38,4 +38,12 @@ TEST(ResourceCache, load) {
 	EXPECT_NE(&value1, &value3);
 	EXPECT_NE(&value1, &value4);
 	EXPECT_NE(&value3, &value4);
+
+	EXPECT_EQ(3u, cache.size());
+	EXPECT_NO_THROW(cache.unload("not found", 0));
+	EXPECT_EQ(3u, cache.size());
+	EXPECT_NO_THROW(cache.unload("abc", 123));
+	EXPECT_EQ(2u, cache.size());
+	EXPECT_NO_THROW(cache.clear());
+	EXPECT_EQ(0u, cache.size());
 }


### PR DESCRIPTION
Add methods to `ResourceCache`:
- `unload(Key)`
- `clear()`
- `size()`

Being able to clear the cache is important when destruction of global objects must be sequenced due to references to other global objects by the cached items. In particular, if the cached items reference other global objects in their destructors, you'll want to destruct the cached items before the referenced items are destructed. That can be done by clearing the cache, which will destruct all contained objects.
