### PR TITLE
Extract Fade control from Renderer

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -191,6 +191,7 @@
     <ClCompile Include="Mixer\MixerNull.cpp" />
     <ClCompile Include="Renderer\Color.cpp" />
     <ClCompile Include="Renderer\DisplayDesc.cpp" />
+    <ClCompile Include="Renderer\Fade.cpp" />
     <ClCompile Include="Renderer\Point.cpp" />
     <ClCompile Include="Renderer\Rectangle.cpp" />
     <ClCompile Include="Renderer\RectangleSkin.cpp" />
@@ -239,6 +240,7 @@
     <ClInclude Include="Renderer\DisplayDesc.h" />
     <ClInclude Include="Renderer\RendererNull.h" />
     <ClInclude Include="Renderer\Color.h" />
+    <ClInclude Include="Renderer\Fade.h" />
     <ClInclude Include="Renderer\Point.h" />
     <ClInclude Include="Renderer\PointInRectangleRange.h" />
     <ClInclude Include="Renderer\Vector.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -81,6 +81,9 @@
     <ClCompile Include="Renderer\Color.cpp">
       <Filter>Source Files\Renderer</Filter>
     </ClCompile>
+    <ClCompile Include="Renderer\Fade.cpp">
+      <Filter>Source Files\Renderer</Filter>
+    </ClCompile>
     <ClCompile Include="Renderer\Point.cpp">
       <Filter>Source Files\Renderer</Filter>
     </ClCompile>
@@ -234,6 +237,9 @@
       <Filter>Header Files\Renderer</Filter>
     </ClInclude>
     <ClInclude Include="Renderer\Color.h">
+      <Filter>Header Files\Renderer</Filter>
+    </ClInclude>
+    <ClInclude Include="Renderer\Fade.h">
       <Filter>Header Files\Renderer</Filter>
     </ClInclude>
     <ClInclude Include="Renderer\Point.h">

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -76,7 +76,7 @@ void Fade::draw(Renderer& renderer) const
 
 void Fade::setDuration(unsigned int durationInMilliseconds)
 {
-	if (durationInMilliseconds <= 0)
+	if (durationInMilliseconds == 0)
 	{
 		throw std::runtime_error("Fade duration must be positive");
 	}

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -1,0 +1,86 @@
+
+#include "Fade.h"
+
+#include <algorithm>
+
+
+using namespace NAS2D;
+
+
+Fade::Fade(Color fadeColor) :
+	mFadeColor{fadeColor.alphaFade(255)}
+{}
+
+
+Signals::Signal<>& Fade::fadeComplete()
+{
+	return mFadeComplete;
+}
+
+
+// Fade in from fadeColor
+void Fade::fadeIn(unsigned int durationInMilliseconds)
+{
+	setDuration(durationInMilliseconds);
+	mDirection = FadeDirection::In;
+}
+
+
+// Fade out to fadeColor
+void Fade::fadeOut(unsigned int durationInMilliseconds)
+{
+	setDuration(durationInMilliseconds);
+	mDirection = FadeDirection::Out;
+}
+
+
+bool Fade::isFading() const
+{
+	return (mDirection != FadeDirection::None);
+}
+
+
+bool Fade::isFaded() const
+{
+	return (mFadeColor.alpha == 255);
+}
+
+
+void Fade::update()
+{
+	if (mDirection == FadeDirection::None)
+	{
+		return;
+	}
+
+	const auto step = static_cast<uint8_t>(std::clamp(mFadeTimer.accumulator() * 255u / mDuration, 0u, 255u));
+	mFadeColor.alpha = (mDirection == FadeDirection::In) ? 255 - step : step;
+
+	if (step == 255)
+	{
+		mDirection = FadeDirection::None;
+		mFadeComplete();
+	}
+}
+
+
+void Fade::draw(Renderer& renderer) const
+{
+	if (mFadeColor.alpha > 0)
+	{
+		const auto displayRect = Rectangle<int>::Create({0, 0}, renderer.size());
+		renderer.drawBoxFilled(displayRect, mFadeColor);
+	}
+}
+
+
+void Fade::setDuration(unsigned int durationInMilliseconds)
+{
+	if (durationInMilliseconds <= 0)
+	{
+		throw std::runtime_error("Fade duration must be positive");
+	}
+
+	mDuration = durationInMilliseconds;
+	mFadeTimer.reset();
+}

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "Color.h"
+#include "Renderer.h"
+#include "../Timer.h"
+#include "../Signal.h"
+
+
+namespace NAS2D {
+
+class Fade
+{
+public:
+	Fade(Color fadeColor = Color::Black);
+
+	Signals::Signal<>& fadeComplete();
+
+	void fadeIn(unsigned int durationInMilliseconds);
+	void fadeOut(unsigned int durationInMilliseconds);
+
+	bool isFading() const;
+	bool isFaded() const;
+
+	void update();
+	void draw(Renderer& renderer) const;
+
+private:
+	void setDuration(unsigned int durationInMilliseconds);
+
+	enum class FadeDirection
+	{
+		None,
+		In,
+		Out
+	};
+
+	Color mFadeColor{Color::Black};
+	FadeDirection mDirection{FadeDirection::None};
+	unsigned int mDuration{0};
+	Timer mFadeTimer;
+	Signals::Signal<> mFadeComplete;
+};
+
+}


### PR DESCRIPTION
Reference: #702

Extract the fade code from `Renderer` to a new `Fade` class.

This should allow downstream projects to update, so the `Renderer` fade methods are no longer used. At that point, the corresponding fade methods can be removed from `Renderer`.
