### PR TITLE
Simplify Image cleanup

### DIFF
--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -276,21 +276,10 @@ namespace {
 
 		if (imageInfo.refCount <= 0)
 		{
-			if (imageInfo.textureId != 0)
-			{
-				glDeleteTextures(1, &imageInfo.textureId);
-			}
-
-			if (imageInfo.frameBufferObjectId != 0)
-			{
-				glDeleteFramebuffers(1, &imageInfo.frameBufferObjectId);
-			}
-
-			if (imageInfo.surface != nullptr)
-			{
-				SDL_FreeSurface(imageInfo.surface);
-				imageInfo.surface = nullptr;
-			}
+			glDeleteTextures(1, &imageInfo.textureId);
+			glDeleteFramebuffers(1, &imageInfo.frameBufferObjectId);
+			SDL_FreeSurface(imageInfo.surface);
+			imageInfo.surface = nullptr;
 
 			imageIdMap.erase(it);
 		}

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -279,7 +279,6 @@ namespace {
 			glDeleteTextures(1, &imageInfo.textureId);
 			glDeleteFramebuffers(1, &imageInfo.frameBufferObjectId);
 			SDL_FreeSurface(imageInfo.surface);
-			imageInfo.surface = nullptr;
 
 			imageIdMap.erase(it);
 		}


### PR DESCRIPTION
Simplify `Image` cleanup, by using documented behaviour for null handles.

Documentation references:
- [`glDeleteFramebuffers`](https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glDeleteFramebuffers.xml)
  - > glDeleteFramebuffers silently ignores 0's and names that do not correspond to existing framebuffer objects.

- [`glDeleteTextures`](https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glDeleteTextures.xml)
  - > glDeleteTextures silently ignores 0's and names that do not correspond to existing textures.

- [`SDL_FreeSurface`](https://wiki.libsdl.org/SDL_FreeSurface)
  - > It is safe to pass NULL to this function.

Reference: #763
