### PR TITLE
Resource copy operations

### DIFF
--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -146,7 +146,7 @@ void MixerSDL::resumeMusic()
 
 void MixerSDL::fadeInMusic(const Music& music, int loops, int time)
 {
-	Mix_FadeInMusic(static_cast<Mix_Music*>(music.music()), loops, time);
+	Mix_FadeInMusic(music.music(), loops, time);
 }
 
 

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -104,7 +104,7 @@ void MixerSDL::onMusicFinished()
 
 void MixerSDL::playSound(const Sound& sound)
 {
-	Mix_PlayChannel(-1, static_cast<Mix_Chunk*>(sound.sound()), 0);
+	Mix_PlayChannel(-1, sound.sound(), 0);
 }
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -89,9 +89,6 @@ Font::Font(const std::string& filePath) :
 }
 
 
-/**
-* D'tor
-*/
 Font::~Font()
 {
 	glDeleteTextures(1, &mFontInfo.textureId);

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -90,39 +90,11 @@ Font::Font(const std::string& filePath) :
 
 
 /**
- * Copy c'tor.
- *
- * \param	rhs	Font to copy.
- */
-Font::Font(const Font& rhs) :
-	mResourceName{rhs.mResourceName}
-{
-}
-
-
-/**
 * D'tor
 */
 Font::~Font()
 {
 	glDeleteTextures(1, &mFontInfo.textureId);
-}
-
-
-/**
- * Copy assignment operator.
- *
- * \param rhs Font to copy.
- */
-Font& Font::operator=(const Font& rhs)
-{
-	if (this == &rhs) { return *this; }
-
-	glDeleteTextures(1, &mFontInfo.textureId);
-
-	mResourceName = rhs.mResourceName;
-
-	return *this;
 }
 
 

--- a/NAS2D/Resources/Font.h
+++ b/NAS2D/Resources/Font.h
@@ -85,7 +85,7 @@ public:
 	unsigned int textureId() const;
 
 private:
-	std::string mResourceName{"Default Resource"}; /**< File path and internal identifier. */
+	std::string mResourceName; /**< File path */
 	FontInfo mFontInfo;
 };
 

--- a/NAS2D/Resources/Font.h
+++ b/NAS2D/Resources/Font.h
@@ -65,8 +65,8 @@ public:
 
 	Font(const std::string& filePath, unsigned int ptSize);
 	explicit Font(const std::string& filePath);
-	Font(const Font& font);
-	Font& operator=(const Font& font);
+	Font(const Font& font) = delete;
+	Font& operator=(const Font& font) = delete;
 	~Font();
 
 	const std::string& name() const { return mResourceName; }

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -35,7 +35,7 @@ namespace {
 	const std::string ARBITRARY_IMAGE_NAME = "arbitrary_image_";
 	int IMAGE_ARBITRARY = 0; /**< Counter for arbitrary image ID's. */
 
-	GLuint generateFbo(const Image& image);
+	unsigned int generateFbo(const Image& image);
 	unsigned int readPixelValue(std::uintptr_t pixelAddress, unsigned int bytesPerPixel);
 }
 
@@ -195,7 +195,7 @@ namespace {
 	/**
 	 * Generates an OpenGL Frame Buffer Object.
 	 */
-	GLuint generateFbo(const Image& image)
+	unsigned int generateFbo(const Image& image)
 	{
 		unsigned int framebuffer;
 		glGenFramebuffers(1, &framebuffer);

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -35,7 +35,7 @@ namespace {
 	const std::string ARBITRARY_IMAGE_NAME = "arbitrary_image_";
 	int IMAGE_ARBITRARY = 0; /**< Counter for arbitrary image ID's. */
 
-	unsigned int generateFbo(const Image& image);
+	unsigned int generateFbo(unsigned int textureId, Vector<int> imageSize);
 	unsigned int readPixelValue(std::uintptr_t pixelAddress, unsigned int bytesPerPixel);
 }
 
@@ -149,7 +149,7 @@ unsigned int Image::frameBufferObjectId() const
 {
 	if (mFrameBufferObjectId == 0)
 	{
-		mFrameBufferObjectId = generateFbo(*this);
+		mFrameBufferObjectId = generateFbo(mTextureId, mSize);
 	}
 	return mFrameBufferObjectId;
 }
@@ -195,26 +195,25 @@ namespace {
 	/**
 	 * Generates an OpenGL Frame Buffer Object.
 	 */
-	unsigned int generateFbo(const Image& image)
+	unsigned int generateFbo(unsigned int textureId, Vector<int> imageSize)
 	{
 		unsigned int framebuffer;
 		glGenFramebuffers(1, &framebuffer);
 		glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
 
-		if (image.textureId() == 0)
+		if (textureId == 0)
 		{
 			unsigned int textureColorbuffer;
 			glGenTextures(1, &textureColorbuffer);
 			glBindTexture(GL_TEXTURE_2D, textureColorbuffer);
 			const auto textureFormat = (SDL_BYTEORDER == SDL_BIG_ENDIAN) ? GL_BGRA : GL_RGBA;
 
-			const auto imageSize = image.size();
 			glTexImage2D(GL_TEXTURE_2D, 0, textureFormat, imageSize.x, imageSize.y, 0, textureFormat, GL_UNSIGNED_BYTE, nullptr);
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		}
 
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, image.textureId(), 0);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureId, 0);
 		glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
 		return framebuffer;

--- a/NAS2D/Resources/Image.h
+++ b/NAS2D/Resources/Image.h
@@ -53,9 +53,8 @@ public:
 
 	Color pixelColor(Point<int> point) const;
 
-	// Temporary methods, that will be removed in a future refactor
-	// Intended only to be used by RendererOpenGL
-	// As they are so specific, they should not be part of the Image class, nor ImageInfo
+protected:
+	friend class RendererOpenGL;
 	unsigned int textureId() const;
 	unsigned int frameBufferObjectId() const;
 

--- a/NAS2D/Resources/Music.cpp
+++ b/NAS2D/Resources/Music.cpp
@@ -46,7 +46,7 @@ Music::~Music()
 }
 
 
-void* Music::music() const
+Mix_Music* Music::music() const
 {
 	return mMusic;
 }

--- a/NAS2D/Resources/Music.h
+++ b/NAS2D/Resources/Music.h
@@ -39,7 +39,7 @@ public:
 
 protected:
 	friend class MixerSDL;
-	void* music() const;
+	Mix_Music* music() const;
 
 private:
 	std::string mResourceName; /**< File path */

--- a/NAS2D/Resources/Music.h
+++ b/NAS2D/Resources/Music.h
@@ -37,8 +37,8 @@ public:
 
 	const std::string& name() const { return mResourceName; }
 
-	// Temporary method that may be removed in the future
-	// Intended only to be used by MixerSDL
+protected:
+	friend class MixerSDL;
 	void* music() const;
 
 private:

--- a/NAS2D/Resources/Sound.cpp
+++ b/NAS2D/Resources/Sound.cpp
@@ -30,7 +30,17 @@ using namespace NAS2D;
 Sound::Sound(const std::string& filePath) :
 	mResourceName{filePath}
 {
-	load();
+	File soundFile = Utility<Filesystem>::get().open(mResourceName);
+	if (soundFile.empty())
+	{
+		throw std::runtime_error("Sound file is empty: " + mResourceName);
+	}
+
+	_chunk = Mix_LoadWAV_RW(SDL_RWFromConstMem(soundFile.raw_bytes(), static_cast<int>(soundFile.size())), 0);
+	if (!_chunk)
+	{
+		throw std::runtime_error("Sound file could not be loaded: " + mResourceName + " : " + std::string{Mix_GetError()});
+	}
 }
 
 
@@ -43,28 +53,6 @@ Sound::~Sound()
 	{
 		Mix_FreeChunk(static_cast<Mix_Chunk*>(_chunk));
 		_chunk = nullptr;
-	}
-}
-
-
-/**
- * Attempts to load a specified sound file.
- *
- * \note	This function is called internally during
- *			instantiation.
- */
-void Sound::load()
-{
-	File soundFile = Utility<Filesystem>::get().open(mResourceName);
-	if (soundFile.empty())
-	{
-		throw std::runtime_error("Sound file is empty: " + mResourceName);
-	}
-
-	_chunk = Mix_LoadWAV_RW(SDL_RWFromConstMem(soundFile.raw_bytes(), static_cast<int>(soundFile.size())), 0);
-	if (!_chunk)
-	{
-		throw std::runtime_error("Sound file could not be loaded: " + mResourceName + " : " + std::string{Mix_GetError()});
 	}
 }
 

--- a/NAS2D/Resources/Sound.cpp
+++ b/NAS2D/Resources/Sound.cpp
@@ -49,7 +49,7 @@ Sound::Sound(const std::string& filePath) :
  */
 Sound::~Sound()
 {
-	Mix_FreeChunk(static_cast<Mix_Chunk*>(_chunk));
+	Mix_FreeChunk(_chunk);
 }
 
 

--- a/NAS2D/Resources/Sound.cpp
+++ b/NAS2D/Resources/Sound.cpp
@@ -56,7 +56,7 @@ Sound::~Sound()
 /**
  * Gets a pointer to sound buffer.
  */
-void* Sound::sound() const
+Mix_Chunk* Sound::sound() const
 {
 	return _chunk;
 }

--- a/NAS2D/Resources/Sound.cpp
+++ b/NAS2D/Resources/Sound.cpp
@@ -23,8 +23,6 @@
 using namespace NAS2D;
 
 /**
- * C'tor.
- *
  * \param	filePath	File path of the sound file to load.
  */
 Sound::Sound(const std::string& filePath) :
@@ -44,9 +42,6 @@ Sound::Sound(const std::string& filePath) :
 }
 
 
-/**
- * D'tor.
- */
 Sound::~Sound()
 {
 	Mix_FreeChunk(mMixChunk);

--- a/NAS2D/Resources/Sound.cpp
+++ b/NAS2D/Resources/Sound.cpp
@@ -49,11 +49,7 @@ Sound::Sound(const std::string& filePath) :
  */
 Sound::~Sound()
 {
-	if (_chunk)
-	{
-		Mix_FreeChunk(static_cast<Mix_Chunk*>(_chunk));
-		_chunk = nullptr;
-	}
+	Mix_FreeChunk(static_cast<Mix_Chunk*>(_chunk));
 }
 
 

--- a/NAS2D/Resources/Sound.cpp
+++ b/NAS2D/Resources/Sound.cpp
@@ -36,8 +36,8 @@ Sound::Sound(const std::string& filePath) :
 		throw std::runtime_error("Sound file is empty: " + mResourceName);
 	}
 
-	_chunk = Mix_LoadWAV_RW(SDL_RWFromConstMem(soundFile.raw_bytes(), static_cast<int>(soundFile.size())), 0);
-	if (!_chunk)
+	mMixChunk = Mix_LoadWAV_RW(SDL_RWFromConstMem(soundFile.raw_bytes(), static_cast<int>(soundFile.size())), 0);
+	if (!mMixChunk)
 	{
 		throw std::runtime_error("Sound file could not be loaded: " + mResourceName + " : " + std::string{Mix_GetError()});
 	}
@@ -49,7 +49,7 @@ Sound::Sound(const std::string& filePath) :
  */
 Sound::~Sound()
 {
-	Mix_FreeChunk(_chunk);
+	Mix_FreeChunk(mMixChunk);
 }
 
 
@@ -58,5 +58,5 @@ Sound::~Sound()
  */
 Mix_Chunk* Sound::sound() const
 {
-	return _chunk;
+	return mMixChunk;
 }

--- a/NAS2D/Resources/Sound.h
+++ b/NAS2D/Resources/Sound.h
@@ -39,8 +39,6 @@ protected:
 	void* sound() const;
 
 private:
-	void load();
-
 	std::string mResourceName{"Default Resource"}; /**< File path and internal identifier. */
 	void* _chunk{nullptr};
 };

--- a/NAS2D/Resources/Sound.h
+++ b/NAS2D/Resources/Sound.h
@@ -44,7 +44,7 @@ protected:
 	Mix_Chunk* sound() const;
 
 private:
-	std::string mResourceName{"Default Resource"}; /**< File path and internal identifier. */
+	std::string mResourceName; /**< File path */
 	Mix_Chunk* mMixChunk{nullptr};
 };
 

--- a/NAS2D/Resources/Sound.h
+++ b/NAS2D/Resources/Sound.h
@@ -23,7 +23,6 @@ namespace NAS2D {
  *
  *  Represents a Sound.
  */
-
 class Sound
 {
 public:
@@ -40,7 +39,6 @@ public:
 
 protected:
 	friend class MixerSDL;
-
 	Mix_Chunk* sound() const;
 
 private:

--- a/NAS2D/Resources/Sound.h
+++ b/NAS2D/Resources/Sound.h
@@ -12,6 +12,9 @@
 #include <string>
 
 
+struct Mix_Chunk;
+
+
 namespace NAS2D {
 
 /**
@@ -40,7 +43,7 @@ protected:
 
 private:
 	std::string mResourceName{"Default Resource"}; /**< File path and internal identifier. */
-	void* _chunk{nullptr};
+	Mix_Chunk* _chunk{nullptr};
 };
 
 } // namespace

--- a/NAS2D/Resources/Sound.h
+++ b/NAS2D/Resources/Sound.h
@@ -28,10 +28,12 @@ class Sound
 {
 public:
 	explicit Sound(const std::string& filePath);
-	Sound(const Sound& other) = default;
-	Sound& operator=(const Sound& rhs) = default;
-	Sound(Sound&& other) = default;
-	Sound& operator=(Sound&& other) = default;
+
+	Sound(const Sound& other) = delete;
+	Sound(Sound&& other) = delete;
+	Sound& operator=(const Sound& rhs) = delete;
+	Sound& operator=(Sound&& other) = delete;
+
 	~Sound();
 
 	const std::string& name() const { return mResourceName; }

--- a/NAS2D/Resources/Sound.h
+++ b/NAS2D/Resources/Sound.h
@@ -39,7 +39,7 @@ public:
 protected:
 	friend class MixerSDL;
 
-	void* sound() const;
+	Mix_Chunk* sound() const;
 
 private:
 	std::string mResourceName{"Default Resource"}; /**< File path and internal identifier. */

--- a/NAS2D/Resources/Sound.h
+++ b/NAS2D/Resources/Sound.h
@@ -43,7 +43,7 @@ protected:
 
 private:
 	std::string mResourceName{"Default Resource"}; /**< File path and internal identifier. */
-	Mix_Chunk* _chunk{nullptr};
+	Mix_Chunk* mMixChunk{nullptr};
 };
 
 } // namespace

--- a/NAS2D/Resources/Sound.h
+++ b/NAS2D/Resources/Sound.h
@@ -27,11 +27,11 @@ namespace NAS2D {
 class Sound
 {
 public:
+	explicit Sound(const std::string& filePath);
 	Sound(const Sound& other) = default;
 	Sound& operator=(const Sound& rhs) = default;
 	Sound(Sound&& other) = default;
 	Sound& operator=(Sound&& other) = default;
-	explicit Sound(const std::string& filePath);
 	~Sound();
 
 	const std::string& name() const { return mResourceName; }


### PR DESCRIPTION
Reference: #763

Removed some resource copy operations impacted by the removal of internal caching. As default implemented they were unsafe, and so were marked as `deleted`.

Marked some special methods as protected and gave friend access where needed. Use proper types and removed uses of `static_cast`. Did some final cleanup to make the classes more consistent with each other.
