### PR TITLE
Make MixerSDL::Options methods public

### DIFF
--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -12,10 +12,12 @@
 #include "../Configuration.h"
 #include "../Exception.h"
 #include "../Utility.h"
+#include "../ContainerUtils.h"
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_mixer.h>
 
+#include <array>
 #include <iostream>
 #include <functional>
 #include <algorithm>
@@ -32,6 +34,32 @@ namespace {
 	Signals::Signal<> musicFinished;
 	// ==================================================================================
 
+
+	constexpr int AudioVolumeMin = 0;
+	constexpr int AudioVolumeMax = 128;
+
+	constexpr int AudioNumChannelsMin = 1;
+	constexpr int AudioNumChannelsMax = 2;
+
+	constexpr int AudioQualityLow = 11025;
+	constexpr int AudioQualityMedium = 22050;
+	constexpr int AudioQualityHigh = 44100;
+
+	constexpr auto AllowedMixRate = std::array{AudioQualityLow, AudioQualityMedium, AudioQualityHigh};
+
+	constexpr int AudioBufferSizeMin = 256;
+	constexpr int AudioBufferSizeMax = 4096;
+
+	MixerSDL::Options InvalidToDefault(const MixerSDL::Options& options)
+	{
+		return {
+			has(AllowedMixRate, options.mixRate) ? options.mixRate : AudioQualityMedium,
+			std::clamp(options.numChannels, AudioNumChannelsMin, AudioNumChannelsMax),
+			std::clamp(options.sfxVolume, AudioVolumeMin, AudioVolumeMax),
+			std::clamp(options.musicVolume, AudioVolumeMin, AudioVolumeMax),
+			std::clamp(options.bufferSize, AudioBufferSizeMin, AudioBufferSizeMax)
+		};
+	}
 
 	MixerSDL::Options ReadConfigurationOptions()
 	{
@@ -50,7 +78,7 @@ namespace {
 /*
  * C'tor.
  */
-MixerSDL::MixerSDL() : MixerSDL(ReadConfigurationOptions())
+MixerSDL::MixerSDL() : MixerSDL(InvalidToDefault(ReadConfigurationOptions()))
 {
 }
 

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -76,6 +76,17 @@ MixerSDL::Options MixerSDL::ReadConfigurationOptions()
 	};
 }
 
+void MixerSDL::WriteConfigurationOptions(const MixerSDL::Options& options)
+{
+	auto& configuration = Utility<Configuration>::get();
+	auto& audio = configuration["audio"];
+	audio.set("mixrate", options.mixRate);
+	audio.set("channels", options.numChannels);
+	audio.set("sfxvolume", options.sfxVolume);
+	audio.set("musicvolume", options.musicVolume);
+	audio.set("bufferlength", options.bufferSize);
+}
+
 
 /*
  * C'tor.

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -64,12 +64,13 @@ namespace {
 	MixerSDL::Options ReadConfigurationOptions()
 	{
 		const auto& configuration = Utility<Configuration>::get();
+		const auto& audio = configuration["audio"];
 		return {
-			configuration.audioMixRate(),
-			configuration.audioStereoChannels(),
-			configuration.audioSfxVolume(),
-			configuration.audioMusicVolume(),
-			configuration.audioBufferSize()
+			audio.get<int>("mixrate"),
+			audio.get<int>("channels"),
+			audio.get<int>("sfxvolume"),
+			audio.get<int>("musicvolume"),
+			audio.get<int>("bufferlength")
 		};
 	}
 }

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -49,30 +49,31 @@ namespace {
 
 	constexpr int AudioBufferSizeMin = 256;
 	constexpr int AudioBufferSizeMax = 4096;
+}
 
-	MixerSDL::Options InvalidToDefault(const MixerSDL::Options& options)
-	{
-		return {
-			has(AllowedMixRate, options.mixRate) ? options.mixRate : AudioQualityMedium,
-			std::clamp(options.numChannels, AudioNumChannelsMin, AudioNumChannelsMax),
-			std::clamp(options.sfxVolume, AudioVolumeMin, AudioVolumeMax),
-			std::clamp(options.musicVolume, AudioVolumeMin, AudioVolumeMax),
-			std::clamp(options.bufferSize, AudioBufferSizeMin, AudioBufferSizeMax)
-		};
-	}
 
-	MixerSDL::Options ReadConfigurationOptions()
-	{
-		const auto& configuration = Utility<Configuration>::get();
-		const auto& audio = configuration["audio"];
-		return {
-			audio.get<int>("mixrate"),
-			audio.get<int>("channels"),
-			audio.get<int>("sfxvolume"),
-			audio.get<int>("musicvolume"),
-			audio.get<int>("bufferlength")
-		};
-	}
+MixerSDL::Options MixerSDL::InvalidToDefault(const MixerSDL::Options& options)
+{
+	return {
+		has(AllowedMixRate, options.mixRate) ? options.mixRate : AudioQualityMedium,
+		std::clamp(options.numChannels, AudioNumChannelsMin, AudioNumChannelsMax),
+		std::clamp(options.sfxVolume, AudioVolumeMin, AudioVolumeMax),
+		std::clamp(options.musicVolume, AudioVolumeMin, AudioVolumeMax),
+		std::clamp(options.bufferSize, AudioBufferSizeMin, AudioBufferSizeMax)
+	};
+}
+
+MixerSDL::Options MixerSDL::ReadConfigurationOptions()
+{
+	const auto& configuration = Utility<Configuration>::get();
+	const auto& audio = configuration["audio"];
+	return {
+		audio.get<int>("mixrate"),
+		audio.get<int>("channels"),
+		audio.get<int>("sfxvolume"),
+		audio.get<int>("musicvolume"),
+		audio.get<int>("bufferlength")
+	};
 }
 
 

--- a/NAS2D/Mixer/MixerSDL.h
+++ b/NAS2D/Mixer/MixerSDL.h
@@ -35,6 +35,9 @@ public:
 		int bufferSize;
 	};
 
+	static MixerSDL::Options InvalidToDefault(const MixerSDL::Options& options);
+	static MixerSDL::Options ReadConfigurationOptions();
+
 	MixerSDL();
 	MixerSDL(const Options& options);
 	MixerSDL(const MixerSDL&) = delete;

--- a/NAS2D/Mixer/MixerSDL.h
+++ b/NAS2D/Mixer/MixerSDL.h
@@ -37,6 +37,7 @@ public:
 
 	static MixerSDL::Options InvalidToDefault(const MixerSDL::Options& options);
 	static MixerSDL::Options ReadConfigurationOptions();
+	static void WriteConfigurationOptions(const MixerSDL::Options& options);
 
 	MixerSDL();
 	MixerSDL(const Options& options);

--- a/test/Mixer/MixerSDL.test.cpp
+++ b/test/Mixer/MixerSDL.test.cpp
@@ -1,0 +1,22 @@
+#include "NAS2D/Mixer/MixerSDL.h"
+#include <gtest/gtest.h>
+
+
+TEST(MixerSDL, InvalidToDefault) {
+	{
+		const auto options = NAS2D::MixerSDL::InvalidToDefault({});
+		EXPECT_EQ(22050, options.mixRate);
+		EXPECT_EQ(1, options.numChannels);
+		EXPECT_EQ(0, options.sfxVolume);
+		EXPECT_EQ(0, options.musicVolume);
+		EXPECT_EQ(256, options.bufferSize);
+	}
+
+	const NAS2D::MixerSDL::Options highEndOptions{44100, 2, 128, 128, 4096};
+	const auto options = NAS2D::MixerSDL::InvalidToDefault(highEndOptions);
+	EXPECT_EQ(highEndOptions.mixRate, options.mixRate);
+	EXPECT_EQ(highEndOptions.numChannels, options.numChannels);
+	EXPECT_EQ(highEndOptions.sfxVolume, options.sfxVolume);
+	EXPECT_EQ(highEndOptions.musicVolume, options.musicVolume);
+	EXPECT_EQ(highEndOptions.bufferSize, options.bufferSize);
+}


### PR DESCRIPTION
Reference: #739

Expand on methods to handle `MixerSDL::Options` structs, and make them public.
