### PR TITLE
Make RendererOpenGL::Options methods public

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -92,6 +92,16 @@ RendererOpenGL::Options RendererOpenGL::ReadConfigurationOptions()
 	};
 }
 
+void RendererOpenGL::WriteConfigurationOptions(const Options& options)
+{
+	auto& configuration = Utility<Configuration>::get();
+	auto& graphics = configuration["graphics"];
+	graphics.set("screenwidth", options.resolution.x);
+	graphics.set("screenheight", options.resolution.y);
+	graphics.set("fullscreen", options.fullscreen);
+	graphics.set("vsync", options.vsync);
+}
+
 
 /**
  * C'tor

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -78,18 +78,18 @@ namespace {
 		const auto apiResult = glGetString(name);
 		return apiResult ? reinterpret_cast<const char*>(apiResult) : "";
 	}
+}
 
 
-	RendererOpenGL::Options ReadConfigurationOptions()
-	{
-		const auto& configuration = Utility<Configuration>::get();
-		const auto& graphics = configuration["graphics"];
-		return {
-			{graphics.get<int>("screenwidth"), graphics.get<int>("screenheight")},
-			graphics.get<bool>("fullscreen"),
-			graphics.get<bool>("vsync")
-		};
-	}
+RendererOpenGL::Options RendererOpenGL::ReadConfigurationOptions()
+{
+	const auto& configuration = Utility<Configuration>::get();
+	const auto& graphics = configuration["graphics"];
+	return {
+		{graphics.get<int>("screenwidth"), graphics.get<int>("screenheight")},
+		graphics.get<bool>("fullscreen"),
+		graphics.get<bool>("vsync")
+	};
 }
 
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -83,10 +83,11 @@ namespace {
 	RendererOpenGL::Options ReadConfigurationOptions()
 	{
 		const auto& configuration = Utility<Configuration>::get();
+		const auto& graphics = configuration["graphics"];
 		return {
-			{configuration.graphicsWidth(), configuration.graphicsHeight()},
-			configuration.fullscreen(),
-			configuration.vsync()
+			{graphics.get<int>("screenwidth"), graphics.get<int>("screenheight")},
+			graphics.get<bool>("fullscreen"),
+			graphics.get<bool>("vsync")
 		};
 	}
 }

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -34,6 +34,8 @@ public:
 		bool vsync;
 	};
 
+	static Options ReadConfigurationOptions();
+
 	RendererOpenGL() = delete;
 	explicit RendererOpenGL(const std::string& title);
 	RendererOpenGL(const std::string& title, const Options& options);

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -35,6 +35,7 @@ public:
 	};
 
 	static Options ReadConfigurationOptions();
+	static void WriteConfigurationOptions(const Options& options);
 
 	RendererOpenGL() = delete;
 	explicit RendererOpenGL(const std::string& title);


### PR DESCRIPTION
Reference: #739

Expand on methods to handle `RendererOpenGL::Options` structs, and make them public.

----

See #787 for corresponding changes to `MixerSDL`.
