### PR TITLE
Remove std::cout logging in MixerSDL

### DIFF
--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -18,7 +18,6 @@
 #include <SDL2/SDL_mixer.h>
 
 #include <array>
-#include <functional>
 #include <algorithm>
 
 using namespace NAS2D;

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -18,7 +18,6 @@
 #include <SDL2/SDL_mixer.h>
 
 #include <array>
-#include <iostream>
 #include <functional>
 #include <algorithm>
 
@@ -98,8 +97,6 @@ MixerSDL::MixerSDL() : MixerSDL(InvalidToDefault(ReadConfigurationOptions()))
 
 MixerSDL::MixerSDL(const Options& options)
 {
-	std::cout << "Initializing Mixer... ";
-
 	if (SDL_Init(SDL_INIT_AUDIO) < 0)
 	{
 		throw mixer_backend_init_failure(SDL_GetError());
@@ -115,8 +112,6 @@ MixerSDL::MixerSDL(const Options& options)
 
 	musicFinished.connect(this, &MixerSDL::onMusicFinished);
 	Mix_HookMusicFinished([](){ musicFinished(); });
-
-	std::cout << "done." << std::endl;
 }
 
 
@@ -133,8 +128,6 @@ MixerSDL::~MixerSDL()
 	musicFinished.disconnect(this, &MixerSDL::onMusicFinished);
 
 	SDL_QuitSubSystem(SDL_INIT_AUDIO);
-
-	std::cout << "Mixer Terminated." << std::endl;
 }
 
 void MixerSDL::onMusicFinished()

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -20,6 +20,7 @@
 #include <array>
 #include <algorithm>
 
+
 using namespace NAS2D;
 using namespace NAS2D::Exception;
 

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -52,7 +52,7 @@ namespace {
 }
 
 
-MixerSDL::Options MixerSDL::InvalidToDefault(const MixerSDL::Options& options)
+MixerSDL::Options MixerSDL::InvalidToDefault(const Options& options)
 {
 	return {
 		has(AllowedMixRate, options.mixRate) ? options.mixRate : AudioQualityMedium,
@@ -76,7 +76,7 @@ MixerSDL::Options MixerSDL::ReadConfigurationOptions()
 	};
 }
 
-void MixerSDL::WriteConfigurationOptions(const MixerSDL::Options& options)
+void MixerSDL::WriteConfigurationOptions(const Options& options)
 {
 	auto& configuration = Utility<Configuration>::get();
 	auto& audio = configuration["audio"];

--- a/NAS2D/Mixer/MixerSDL.h
+++ b/NAS2D/Mixer/MixerSDL.h
@@ -35,9 +35,9 @@ public:
 		int bufferSize;
 	};
 
-	static MixerSDL::Options InvalidToDefault(const MixerSDL::Options& options);
-	static MixerSDL::Options ReadConfigurationOptions();
-	static void WriteConfigurationOptions(const MixerSDL::Options& options);
+	static Options InvalidToDefault(const Options& options);
+	static Options ReadConfigurationOptions();
+	static void WriteConfigurationOptions(const Options& options);
 
 	MixerSDL();
 	MixerSDL(const Options& options);


### PR DESCRIPTION
Noticed while working on #739.
