### PR TITLE
Add method findMissingAndUnexpected

### DIFF
--- a/NAS2D/ContainerUtils.h
+++ b/NAS2D/ContainerUtils.h
@@ -62,4 +62,30 @@ namespace NAS2D {
 		}
 		return result;
 	}
+
+
+	template <typename T>
+	struct MissingAndUnexpected {
+		std::vector<T> missing;
+		std::vector<T> unexpected;
+
+		bool operator==(const MissingAndUnexpected& other) const {
+			return missing == other.missing && unexpected == other.unexpected;
+		}
+		bool operator!=(const MissingAndUnexpected& other) const {
+			return !(*this == other);
+		}
+	};
+
+	template <typename T>
+	MissingAndUnexpected<T> findMissingAndUnexpected(
+		const std::vector<T>& names,
+		const std::vector<T>& required,
+		const std::vector<T>& optional = {}
+	) {
+		using namespace ContainerOperators;
+
+		const auto expected = required + optional;
+		return {required - names, names - expected};
+	}
 }

--- a/test/ContainerUtils.test.cpp
+++ b/test/ContainerUtils.test.cpp
@@ -3,6 +3,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <string>
 #include <array>
 #include <vector>
 #include <list>
@@ -116,4 +117,15 @@ TEST(Container, getKeys) {
 		std::sort(std::begin(result), std::end(result));
 		EXPECT_EQ((std::vector<int>{1, 2}), result);
 	}
+}
+
+TEST(Container, findMissingAndUnexpected) {
+	using ResultType = NAS2D::MissingAndUnexpected<std::string>;
+
+	EXPECT_EQ((ResultType{{}, {}}), NAS2D::findMissingAndUnexpected<std::string>({}, {}, {}));
+	EXPECT_EQ((ResultType{{}, {}}), NAS2D::findMissingAndUnexpected<std::string>({}, {}, {"a"}));
+	EXPECT_EQ((ResultType{{}, {}}), NAS2D::findMissingAndUnexpected<std::string>({"a"}, {}, {"a"}));
+	EXPECT_EQ((ResultType{{}, {}}), NAS2D::findMissingAndUnexpected<std::string>({"a"}, {"a"}, {}));
+	EXPECT_EQ((ResultType{{}, {"a"}}), NAS2D::findMissingAndUnexpected<std::string>({"a"}, {}, {}));
+	EXPECT_EQ((ResultType{{"a"}, {}}), NAS2D::findMissingAndUnexpected<std::string>({}, {"a"}, {}));
 }


### PR DESCRIPTION
Reference: #739

Add method `findMissingAndUnexpected` to help with error reporting. Given a set of `keys`/`names`/`values`, and a set of `required` and `optional` values, find the sets of `missing` and `unexpected` values. This can be used to combine a bunch of individual value name checks into a single comprehensive error report.

The `findMissingAndUnexpected` method is effectively implemented through set minus.

----

Is this method a good idea? It contains 3 parameters of the same type, which could potentially be confused with each other. Unless named values are passed in, this design might not be very self documenting. The unit test code kind of shows the lack of self documentation. Similarly the method returns two collections of the same type.

Is this method needed? Using the custom `operator-` for `std::vector` allows this code to be written inline quite easily. Doing so may be more self documenting due to variable names. That may be less standard though, and so leave room for bugs, such as getting the order of sets swapped. That is the case with the current code on `master`, which contains such a bug.

This method is meant to replace `ReportProblemNames`, which is private to `Configuration`. It is only used 2 times, and one of those uses is scheduled to be removed.

This method may be more useful if combined with an exception throwing wrapper, that throws when either result set is non-empty, and formats a list of the missing and unexpected sets.

Where's the best place to put this new method? It's generic enough that it shouldn't be tied to `Configuration`. Maybe not so generic that it belongs in `ContainerUtils.h`? What about an exception throwing wrapper method?

I kind of feel like this method is a good idea, but I'm not quite certain how to get the most value out of it.
