### PR TITLE
Use freesrc parameter to fix SDL_RWops leaks

### DIFF
--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -194,7 +194,7 @@ namespace {
 			throw std::runtime_error("Font file is empty: " + path);
 		}
 
-		TTF_Font *font = TTF_OpenFontRW(SDL_RWFromConstMem(fontBuffer.raw_bytes(), static_cast<int>(fontBuffer.size())), 0, static_cast<int>(ptSize));
+		TTF_Font *font = TTF_OpenFontRW(SDL_RWFromConstMem(fontBuffer.raw_bytes(), static_cast<int>(fontBuffer.size())), 1, static_cast<int>(ptSize));
 		if (!font)
 		{
 			throw std::runtime_error("Font load function failed: " + std::string{TTF_GetError()});
@@ -231,7 +231,7 @@ namespace {
 			throw std::runtime_error("Font file is empty: " + path);
 		}
 
-		SDL_Surface* fontSurface = IMG_Load_RW(SDL_RWFromConstMem(fontBuffer.raw_bytes(), static_cast<int>(fontBuffer.size())), 0);
+		SDL_Surface* fontSurface = IMG_Load_RW(SDL_RWFromConstMem(fontBuffer.raw_bytes(), static_cast<int>(fontBuffer.size())), 1);
 		if (!fontSurface)
 		{
 			throw std::runtime_error("Font loadBitmap function failed: " + std::string{SDL_GetError()});

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -54,7 +54,7 @@ Image::Image(const std::string& filePath) :
 		throw std::runtime_error("Image file is empty: " + mResourceName);
 	}
 
-	mSurface = IMG_Load_RW(SDL_RWFromConstMem(imageFile.raw_bytes(), static_cast<int>(imageFile.size())), 0);
+	mSurface = IMG_Load_RW(SDL_RWFromConstMem(imageFile.raw_bytes(), static_cast<int>(imageFile.size())), 1);
 	if (!mSurface)
 	{
 		throw std::runtime_error("Image failed to load: " + std::string{SDL_GetError()});

--- a/NAS2D/Resources/Music.cpp
+++ b/NAS2D/Resources/Music.cpp
@@ -32,7 +32,7 @@ Music::Music(const std::string& filePath) :
 		throw std::runtime_error("Music file is empty: " + mResourceName);
 	}
 
-	mMusic = Mix_LoadMUS_RW(SDL_RWFromConstMem(mBuffer.raw_bytes(), static_cast<int>(mBuffer.size())), 0);
+	mMusic = Mix_LoadMUS_RW(SDL_RWFromConstMem(mBuffer.raw_bytes(), static_cast<int>(mBuffer.size())), 1);
 	if (!mMusic)
 	{
 		throw std::runtime_error("Music::load() error: " + std::string{Mix_GetError()});

--- a/NAS2D/Resources/Sound.cpp
+++ b/NAS2D/Resources/Sound.cpp
@@ -34,7 +34,7 @@ Sound::Sound(const std::string& filePath) :
 		throw std::runtime_error("Sound file is empty: " + mResourceName);
 	}
 
-	mMixChunk = Mix_LoadWAV_RW(SDL_RWFromConstMem(soundFile.raw_bytes(), static_cast<int>(soundFile.size())), 0);
+	mMixChunk = Mix_LoadWAV_RW(SDL_RWFromConstMem(soundFile.raw_bytes(), static_cast<int>(soundFile.size())), 1);
 	if (!mMixChunk)
 	{
 		throw std::runtime_error("Sound file could not be loaded: " + mResourceName + " : " + std::string{Mix_GetError()});


### PR DESCRIPTION
Closes #786

Using `valgrind`, I was able to determine this change significantly reduced the number of definitely lost blocks of memory.

Test 1:
Loading game and closing the main window as soon as it displays, before the intro is started.
- Without patch: 14 definitely lost blocks
- With path: 8 definitely lost blocks

Test 2:
Loading game to the main menu, and then exiting.
- Without patch: 114 definitely lost blocks
- With path: 8 definitely lost blocks

Looks like a number of resources are loaded by the time the main menu is displayed, which results in leaked `SDL_RWops`. (I would like to quickly verify this before merging).
