### PR TITLE
Fix order bug in ReportProblemNames

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -43,7 +43,7 @@ namespace {
 
 		const auto expected = required + optional;
 
-		const auto missing = names - required;
+		const auto missing = required - names;
 		const auto unexpected = names - expected;
 
 		if (!missing.empty() || !unexpected.empty())


### PR DESCRIPTION
Fix order bug in `ReportProblemNames`, mentioned in #739 and #792.
