### PR TITLE
Add split unit test for empty string

### DIFF
--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -125,6 +125,9 @@ TEST(String, dataStringData) {
 
 
 TEST(String, split) {
+	EXPECT_EQ((NAS2D::StringList{}), NAS2D::split(""));
+	EXPECT_EQ((NAS2D::StringList{"a"}), NAS2D::split("a"));
+
 	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::split("a,b,c"));
 	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split("abc"));
 	EXPECT_EQ((NAS2D::StringList{"", "abc"}), NAS2D::split(",abc"));


### PR DESCRIPTION
Add unit test to specify behaviour of `split` function when passed an empty string, which is to return an empty list:
```cpp
EXPECT_EQ((NAS2D::StringList{}), NAS2D::split(""));
```

----

The other contender was to return a list with a single empty string: `NAS2D::StringList{""}`

Both options offer a logical inverse to the specified behaviour of `NAS2D::join`:
```cpp
EXPECT_EQ("", NAS2D::join(NAS2D::StringList{}));
```

Options:
- `join({})` -> `""`, `split("")` -> `{}`  (chosen)
- `join({""})` -> `""`, `split("")` -> `{""}`  (contender)

The reverse round trip will be the same either way:
- `split("")` -> `{}`, `join({})` -> `""`  (chosen)
- `split("")` -> `{""}`, `join({""})` -> `""`  (contender)

----

In terms of typical use, I find empty strings usually tend to mean no data. Since `split` is often used to build an array from textual data, if makes sense to allow for a textual representation of the empty array. This is only possible if the empty string maps to an empty array.

This behaviour corresponds well with source code array representations:
- `{}` (empty initializer list)
- `{1}` (single element initializer list)
- `{1, 2}` (two element initializer list)
