### PR TITLE
Refactor XML helper code and move some to ContainerUtils

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -23,18 +23,6 @@ using namespace NAS2D;
 
 
 namespace {
-	/// Key-wise merge of values from two key/value containers
-	template <typename KeyValueContainer>
-	KeyValueContainer mergeByKey(const KeyValueContainer& defaults, const KeyValueContainer& priorityValues)
-	{
-		KeyValueContainer results = defaults;
-		for (const auto& [key, value] : priorityValues)
-		{
-			results[key] += value;
-		}
-		return results;
-	}
-
 	void reportMissingOrUnexpected(const std::vector<std::string>& missing, const std::vector<std::string>& unexpected)
 	{
 		if (!missing.empty() || !unexpected.empty())

--- a/NAS2D/ContainerUtils.h
+++ b/NAS2D/ContainerUtils.h
@@ -77,4 +77,16 @@ namespace NAS2D {
 		}
 		return result;
 	}
+
+	/// Key-wise merge of values from two key/value containers
+	template <typename KeyValueContainer>
+	KeyValueContainer mergeByKey(const KeyValueContainer& defaults, const KeyValueContainer& priorityValues)
+	{
+		KeyValueContainer results = defaults;
+		for (const auto& [key, value] : priorityValues)
+		{
+			results[key] += value;
+		}
+		return results;
+	}
 }


### PR DESCRIPTION
Reference: #797

Prep-work for updating the `Sprite` XML loading code. This cleans up some of the `Configuration` XML loading code, preparing it for re-use by the `Sprite` class. Added is the ability to version check the root element. Some helper code needed for common error reporting tasks was split and partially moved to `ContainerUtils.h`. Ability to merge key/value containers, where the values themselves may be containers was moved to `ContainerUtils.h`.

Some more prep-work is needed, as the XML processing code is still contained in an unnamed namespace in the `Configuration` code, which makes it impossible to use from the `Sprite` code.
