### PR TITLE
Update docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,15 +82,15 @@ jobs:
     steps:
       - checkout
       - build-and-test
-  build-linux-gcc8:
+  build-linux-gcc:
     docker:
-      - image: outpostuniverse/nas2d-gcc8:1.1
+      - image: outpostuniverse/nas2d-gcc:1.2
     steps:
       - checkout
       - build-and-test
   build-linux-clang:
     docker:
-      - image: outpostuniverse/nas2d-clang:1.0
+      - image: outpostuniverse/nas2d-clang:1.1
     environment:
       - WARN_EXTRA: "-Wdocumentation -Wdocumentation-unknown-command -Wcomma -Winconsistent-missing-destructor-override -Wmissing-prototypes"
     steps:
@@ -98,7 +98,7 @@ jobs:
       - build-and-test
   build-linux-mingw:
     docker:
-      - image: outpostuniverse/nas2d-mingw:1.4
+      - image: outpostuniverse/nas2d-mingw:1.5
     environment:
       - WARN_EXTRA: "-Wno-redundant-decls"
     steps:
@@ -110,6 +110,6 @@ workflows:
     jobs:
       - build-macos
       - build-linux
-      - build-linux-gcc8
+      - build-linux-gcc
       - build-linux-clang
       - build-linux-mingw

--- a/docker/nas2d-clang.Dockerfile
+++ b/docker/nas2d-clang.Dockerfile
@@ -1,19 +1,20 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages
 # Includes tools needed for primary CircleCI containers
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential=12.4* \
-    clang=1:6.0-* \
-    cmake=3.10.2-* \
-    curl=7.58.0-* \
-    git=1:2.17.1-* \
-    ssh=1:7.6p1-* \
-    tar=1.29b-* \
-    gzip=1.6-* \
+# Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential=12.8* \
+    clang=1:10.0-* \
+    cmake=3.16.3-* \
+    curl=7.68.0-* \
+    git=1:2.25.1-* \
+    ssh=1:8.2p1-* \
+    tar=1.30* \
+    gzip=1.10-* \
     ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
 
@@ -45,12 +46,12 @@ RUN curl --location https://github.com/google/googletest/archive/release-1.10.0.
 
 # Install NAS2D specific dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libglew-dev=2.0.0-* \
-    libphysfs-dev=3.0.1-* \
-    libsdl2-dev=2.0.8+* \
-    libsdl2-image-dev=2.0.3+* \
-    libsdl2-mixer-dev=2.0.2+* \
-    libsdl2-ttf-dev=2.0.14+* \
+    libglew-dev=2.1.0-* \
+    libphysfs-dev=3.0.2-* \
+    libsdl2-dev=2.0.10+* \
+    libsdl2-image-dev=2.0.5+* \
+    libsdl2-mixer-dev=2.0.4+* \
+    libsdl2-ttf-dev=2.0.15+* \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash user

--- a/docker/nas2d-gcc.Dockerfile
+++ b/docker/nas2d-gcc.Dockerfile
@@ -1,25 +1,27 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages
 # Includes tools needed for primary CircleCI containers
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    g++-8=8.4.0-* \
-    dpkg-dev=1.19.0.* \
-    make=4.1-* \
-    cmake=3.10.2-* \
-    curl=7.58.0-* \
-    git=1:2.17.1-* \
-    ssh=1:7.6p1-* \
-    tar=1.29b-* \
-    gzip=1.6-* \
+# Install latest available GCC compiler (which may not be the default)
+# Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    g++-10=10-20200411-* \
+    dpkg-dev=1.19.* \
+    make=4.2.1-* \
+    cmake=3.16.3-* \
+    curl=7.68.0-* \
+    git=1:2.25.1-* \
+    ssh=1:8.2p1-* \
+    tar=1.30+* \
+    gzip=1.10-* \
     ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
 
-ENV CXX=g++-8
-ENV  CC=gcc-8
+ENV CXX=g++-10
+ENV  CC=gcc-10
 
 # Download, compile, and install Google Test source package
 WORKDIR /tmp/gtest/
@@ -47,12 +49,12 @@ RUN curl --location https://github.com/google/googletest/archive/release-1.10.0.
 
 # Install NAS2D specific dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libglew-dev=2.0.0-* \
-    libphysfs-dev=3.0.1-* \
-    libsdl2-dev=2.0.8+* \
-    libsdl2-image-dev=2.0.3+* \
-    libsdl2-mixer-dev=2.0.2+* \
-    libsdl2-ttf-dev=2.0.14+* \
+    libglew-dev=2.1.0-* \
+    libphysfs-dev=3.0.2-* \
+    libsdl2-dev=2.0.10+* \
+    libsdl2-image-dev=2.0.5+* \
+    libsdl2-mixer-dev=2.0.4+* \
+    libsdl2-ttf-dev=2.0.15+* \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash user

--- a/makefile
+++ b/makefile
@@ -236,7 +236,7 @@ ImageName_clang := nas2d-clang
 ImageVersion_clang := 1.1
 
 ImageName_mingw := nas2d-mingw
-ImageVersion_mingw := 1.4
+ImageVersion_mingw := 1.5
 
 .PHONY: build-image
 build-image:

--- a/makefile
+++ b/makefile
@@ -233,7 +233,7 @@ ImageName_gcc8 := nas2d-gcc8
 ImageVersion_gcc8 := 1.1
 
 ImageName_clang := nas2d-clang
-ImageVersion_clang := 1.0
+ImageVersion_clang := 1.1
 
 ImageName_mingw := nas2d-mingw
 ImageVersion_mingw := 1.4

--- a/makefile
+++ b/makefile
@@ -229,8 +229,8 @@ DockerRepository := outpostuniverse
 ImageName := nas2d
 ImageVersion := 1.4
 
-ImageName_gcc8 := nas2d-gcc8
-ImageVersion_gcc8 := 1.1
+ImageName_gcc := nas2d-gcc
+ImageVersion_gcc := 1.2
 
 ImageName_clang := nas2d-clang
 ImageVersion_clang := 1.1
@@ -258,22 +258,22 @@ root-debug-image:
 push-image:
 	docker push ${DockerRepository}/${ImageName}
 
-.PHONY: build-image-gcc8
-build-image-gcc8: ImageName := ${ImageName_gcc8}
-build-image-gcc8: ImageVersion := ${ImageVersion_gcc8}
-build-image-gcc8: | build-image
-.PHONY: run-image-gcc8
-run-image-gcc8: ImageName := ${ImageName_gcc8}
-run-image-gcc8: | run-image
-.PHONY: debug-image-gcc8
-debug-image-gcc8: ImageName := ${ImageName_gcc8}
-debug-image-gcc8: | debug-image
-.PHONY: root-debug-image-gcc8
-root-debug-image-gcc8: ImageName := ${ImageName_gcc8}
-root-debug-image-gcc8: | root-debug-image
-.PHONY: push-image-gcc8
-push-image-gcc8: ImageName := ${ImageName_gcc8}
-push-image-gcc8: | push-image
+.PHONY: build-image-gcc
+build-image-gcc: ImageName := ${ImageName_gcc}
+build-image-gcc: ImageVersion := ${ImageVersion_gcc}
+build-image-gcc: | build-image
+.PHONY: run-image-gcc
+run-image-gcc: ImageName := ${ImageName_gcc}
+run-image-gcc: | run-image
+.PHONY: debug-image-gcc
+debug-image-gcc: ImageName := ${ImageName_gcc}
+debug-image-gcc: | debug-image
+.PHONY: root-debug-image-gcc
+root-debug-image-gcc: ImageName := ${ImageName_gcc}
+root-debug-image-gcc: | root-debug-image
+.PHONY: push-image-gcc
+push-image-gcc: ImageName := ${ImageName_gcc}
+push-image-gcc: | push-image
 
 .PHONY: build-image-clang
 build-image-clang: ImageName := ${ImageName_clang}


### PR DESCRIPTION
Reference: #528 (as some warning flags require having newer compilers)

Update Docker images to be based on Ubuntu 20.04, which provides updated Apt packages, with newer compilers and newer compiler features.

The upgrade impacts Linux builds with Clang, Mingw-w64, and GCC (latest).

The main (unmarked) NAS2D Docker image is still using Ubuntu 18.04 as the base, with a stock install of GCC. This helps ensure we don't break anything for slightly older LTS (Long Term Support) releases that are likely to still be in use.
