### PR TITLE
Update vcpkg options

### DIFF
--- a/InstallVcpkgDeps.bat
+++ b/InstallVcpkgDeps.bat
@@ -16,4 +16,4 @@ if not defined PLATFORM (
 )
 
 :Install
-vcpkg install --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[dynamic-load,libflac,libmodplug,libvorbis,mpg123,nativemidi,opusfile] gtest
+vcpkg install --recurse --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[dynamic-load,libflac,libmodplug,libvorbis,mpg123,nativemidi,opusfile] gtest

--- a/InstallVcpkgDeps.bat
+++ b/InstallVcpkgDeps.bat
@@ -16,4 +16,4 @@ if not defined PLATFORM (
 )
 
 :Install
-vcpkg install --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[dynamic-load,libflac,mpg123,libmodplug,libvorbis,opusfile] gtest
+vcpkg install --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[dynamic-load,libflac,libmodplug,libvorbis,mpg123,nativemidi,opusfile] gtest


### PR DESCRIPTION
It seems there have been some AppVeyor updates, which have brought in an updated version of `vcpkg`, which has updated install options for the `SDL2-mixer` package. Since a package check is done before building, the sdl2-mixer option discrepancy was causing failures during package installation, which prevented builds from starting.
