### PR TITLE
Font restructure surface cleanup

### DIFF
--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -67,7 +67,6 @@ namespace {
  *
  * \param	filePath	Path to a font file.
  * \param	ptSize		Point size of the font. Defaults to 12pt.
- *
  */
 Font::Font(const std::string& filePath, unsigned int ptSize) :
 	mResourceName{filePath + "_" + std::to_string(ptSize) + "pt"},
@@ -80,7 +79,6 @@ Font::Font(const std::string& filePath, unsigned int ptSize) :
  * Instantiate a Font as a bitmap font.
  *
  * \param	filePath	Path to a font file.
- *
  */
 Font::Font(const std::string& filePath) :
 	mResourceName{filePath},

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -70,9 +70,9 @@ namespace {
  *
  */
 Font::Font(const std::string& filePath, unsigned int ptSize) :
-	mResourceName{filePath + "_" + std::to_string(ptSize) + "pt"}
+	mResourceName{filePath + "_" + std::to_string(ptSize) + "pt"},
+	mFontInfo{load(filePath, ptSize)}
 {
-	mFontInfo = load(filePath, ptSize);
 }
 
 
@@ -83,9 +83,9 @@ Font::Font(const std::string& filePath, unsigned int ptSize) :
  *
  */
 Font::Font(const std::string& filePath) :
-	mResourceName{filePath}
+	mResourceName{filePath},
+	mFontInfo{loadBitmap(filePath)}
 {
-	mFontInfo = loadBitmap(filePath);
 }
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -279,10 +279,7 @@ namespace {
 	unsigned int generateFontTexture(SDL_Surface* fontSurface, std::vector<Font::GlyphMetrics>& glyphMetricsList)
 	{
 		fillInTextureCoordinates(glyphMetricsList);
-
-		auto textureId = generateTexture(fontSurface);
-
-		return textureId;
+		return generateTexture(fontSurface);
 	}
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -72,7 +72,7 @@ namespace {
 Font::Font(const std::string& filePath, unsigned int ptSize) :
 	mResourceName{filePath + "_" + std::to_string(ptSize) + "pt"}
 {
-	mFontInfo = ::load(filePath, ptSize);
+	mFontInfo = load(filePath, ptSize);
 }
 
 

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -212,6 +212,7 @@ namespace {
 		fontInfo.ascent = TTF_FontAscent(font);
 		fontInfo.glyphSize = roundedCharSize;
 		fontInfo.textureId = generateFontTexture(fontSurface, glm);
+		SDL_FreeSurface(fontSurface);
 		TTF_CloseFont(font);
 
 		return fontInfo;
@@ -264,6 +265,7 @@ namespace {
 		fontInfo.ascent = glyphSize.y;
 		fontInfo.glyphSize = glyphSize;
 		fontInfo.textureId = generateFontTexture(fontSurface, glm);
+		SDL_FreeSurface(fontSurface);
 
 		return fontInfo;
 	}
@@ -279,7 +281,6 @@ namespace {
 		fillInTextureCoordinates(glyphMetricsList);
 
 		auto textureId = generateTexture(fontSurface);
-		SDL_FreeSurface(fontSurface);
 
 		return textureId;
 	}


### PR DESCRIPTION
Bit of code cleanup left over from the earlier `Font` refactoring that still hadn't been cleaned up and merged.

Relates somewhat to the exploration done for #786.
