### PR TITLE
Wrap ResourceCache template class in NAS2D namespace

### DIFF
--- a/NAS2D/Resources/ResourceCache.h
+++ b/NAS2D/Resources/ResourceCache.h
@@ -4,6 +4,8 @@
 #include <tuple>
 
 
+namespace NAS2D {
+
 template <typename Resource, typename ... Params>
 class ResourceCache
 {
@@ -50,3 +52,5 @@ public:
 private:
 	std::map<Key, Resource> cache;
 };
+
+} // namespace

--- a/test/Resources/ResourceCache.test.cpp
+++ b/test/Resources/ResourceCache.test.cpp
@@ -18,7 +18,7 @@ TEST(ResourceCache, load) {
 		int value;
 	};
 
-	ResourceCache<MockResource, std::string, int> cache;
+	NAS2D::ResourceCache<MockResource, std::string, int> cache;
 
 	const auto& value1 = cache.load("abc", 123);
 	const auto& value2 = cache.load("abc", 123);


### PR DESCRIPTION
Noticed the `ResourceCache` template class was accidentally left out of the NAS2D namespace, and fixed it.
