### PR TITLE
Add AnimationSet split off from Sprite

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -197,6 +197,7 @@
     <ClCompile Include="Renderer\RectangleSkin.cpp" />
     <ClCompile Include="Renderer\Renderer.cpp" />
     <ClCompile Include="Renderer\RendererOpenGL.cpp" />
+    <ClCompile Include="Resources\AnimationSet.cpp" />
     <ClCompile Include="Resources\Font.cpp" />
     <ClCompile Include="Resources\Image.cpp" />
     <ClCompile Include="Resources\Music.cpp" />
@@ -250,6 +251,7 @@
     <ClInclude Include="Renderer\Renderer.h" />
     <ClInclude Include="Renderer\RendererOpenGL.h" />
     <ClInclude Include="Resources\ResourceCache.h" />
+    <ClInclude Include="Resources\AnimationSet.h" />
     <ClInclude Include="Resources\Font.h" />
     <ClInclude Include="Resources\Image.h" />
     <ClInclude Include="Resources\Music.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -63,6 +63,9 @@
     <ClCompile Include="Trig.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Resources\AnimationSet.cpp">
+      <Filter>Source Files\Resources</Filter>
+    </ClCompile>
     <ClCompile Include="Resources\Font.cpp">
       <Filter>Source Files\Resources</Filter>
     </ClCompile>
@@ -216,6 +219,9 @@
       <Filter>Header Files\Mixer</Filter>
     </ClInclude>
     <ClInclude Include="Resources\ResourceCache.h">
+      <Filter>Header Files\Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="Resources\AnimationSet.h">
       <Filter>Header Files\Resources</Filter>
     </ClInclude>
     <ClInclude Include="Resources\Font.h">

--- a/NAS2D/Resources/AnimationSet.cpp
+++ b/NAS2D/Resources/AnimationSet.cpp
@@ -7,9 +7,9 @@
 using namespace NAS2D;
 
 
-AnimationSet::AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<AnimationSet::Frame>> actions) :
+AnimationSet::AnimationSet(std::string fileName, std::map<std::string, std::string> imageSheetMap, std::map<std::string, std::vector<AnimationSet::Frame>> actions) :
 	mFileName{std::move(fileName)},
-	mImageSheets{std::move(imageSheets)},
+	mImageSheetMap{std::move(imageSheetMap)},
 	mActions{std::move(actions)}
 {
 }

--- a/NAS2D/Resources/AnimationSet.cpp
+++ b/NAS2D/Resources/AnimationSet.cpp
@@ -1,0 +1,32 @@
+
+#include "AnimationSet.h"
+
+#include "../ContainerUtils.h"
+
+
+using namespace NAS2D;
+
+
+AnimationSet::AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<AnimationSet::Frame>> actions) :
+	mFileName{std::move(fileName)},
+	mImageSheets{std::move(imageSheets)},
+	mActions{std::move(actions)}
+{
+}
+
+
+std::vector<std::string> AnimationSet::actionNames() const
+{
+	return getKeys(mActions);
+}
+
+
+const std::vector<AnimationSet::Frame>& AnimationSet::frames(const std::string& actionName) const
+{
+	if (mActions.find(actionName) == mActions.end())
+	{
+		throw std::runtime_error("Sprite::play called on undefined action: " + actionName + "  (" + mFileName + ")");
+	}
+
+	return mActions.at(actionName);
+}

--- a/NAS2D/Resources/AnimationSet.cpp
+++ b/NAS2D/Resources/AnimationSet.cpp
@@ -1,10 +1,41 @@
 
 #include "AnimationSet.h"
 
+#include "ResourceCache.h"
+#include "../Utility.h"
+#include "../Filesystem.h"
 #include "../ContainerUtils.h"
+#include "../StringUtils.h"
+#include "../Version.h"
+#include "../Xml/Xml.h"
 
 
 using namespace NAS2D;
+
+
+namespace {
+	constexpr std::string_view SPRITE_VERSION{"0.99"};
+
+	using ImageCache = ResourceCache<Image, std::string>;
+	ImageCache animationImageCache;
+
+
+	// Adds a row tag to the end of messages.
+	std::string endTag(int row)
+	{
+		return " (Row: " + std::to_string(row) + ")";
+	}
+
+	AnimationSet processXml(const std::string& filePath, ImageCache& imageCache);
+	std::map<std::string, std::string> processImageSheets(const std::string& basePath, const Xml::XmlElement* element, ImageCache& imageCache);
+	std::map<std::string, std::vector<AnimationSet::Frame>> processActions(const std::map<std::string, std::string>& imageSheetMap, const Xml::XmlElement* element, ImageCache& imageCache);
+	std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, std::string>& imageSheetMap, const std::string& action, const Xml::XmlNode* node, ImageCache& imageCache);
+}
+
+
+AnimationSet::AnimationSet(std::string fileName) : AnimationSet{processXml(fileName, animationImageCache)}
+{
+}
 
 
 AnimationSet::AnimationSet(std::string fileName, std::map<std::string, std::string> imageSheetMap, std::map<std::string, std::vector<AnimationSet::Frame>> actions) :
@@ -29,4 +60,249 @@ const std::vector<AnimationSet::Frame>& AnimationSet::frames(const std::string& 
 	}
 
 	return mActions.at(actionName);
+}
+
+
+namespace {
+
+/**
+ * Parses a Sprite XML Definition File.
+ *
+ * \param filePath	File path of the sprite XML definition file.
+ */
+AnimationSet processXml(const std::string& filePath, ImageCache& imageCache)
+{
+	try
+	{
+		auto& filesystem = Utility<Filesystem>::get();
+		const auto basePath = filesystem.workingPath(filePath);
+
+		Xml::XmlDocument xmlDoc;
+		xmlDoc.parse(filesystem.open(filePath).raw_bytes());
+
+		if (xmlDoc.error())
+		{
+			throw std::runtime_error("Sprite file has malformed XML: Row: " + std::to_string(xmlDoc.errorRow()) + " Column: " + std::to_string(xmlDoc.errorCol()) + " : " + xmlDoc.errorDesc());
+		}
+
+		// Find the Sprite node.
+		const auto* xmlRootElement = xmlDoc.firstChildElement("sprite");
+		if (!xmlRootElement)
+		{
+			throw std::runtime_error("Sprite file does not contain required <sprite> tag");
+		}
+
+		// Get the Sprite version.
+		const auto* version = xmlRootElement->firstAttribute();
+		if (!version || version->value().empty())
+		{
+			throw std::runtime_error("Sprite file's root element does not specify a version");
+		}
+		if (version->value() != SPRITE_VERSION)
+		{
+			throw std::runtime_error("Sprite version mismatch. Expected: " + std::string{SPRITE_VERSION} + " Actual: " + versionString());
+		}
+
+		// Note:
+		// Here instead of going through each element and calling a processing function to handle
+		// it, we just iterate through all nodes to find sprite sheets. This allows us to define
+		// image sheets anywhere in the sprite file.
+		auto imageSheetMap = processImageSheets(basePath, xmlRootElement, imageCache);
+		auto actions = processActions(imageSheetMap, xmlRootElement, imageCache);
+		return {filePath, std::move(imageSheetMap), std::move(actions)};
+	}
+	catch(const std::runtime_error& error)
+	{
+		throw std::runtime_error("Error parsing Sprite file: " + filePath + "\nError: " + error.what());
+	}
+}
+
+
+/**
+ * Iterates through all elements of a Sprite XML definition looking
+ * for 'imagesheet' elements and processes them.
+ *
+ * \note	Since 'imagesheet' elements are processed before any other
+ *			element in a sprite definition, these elements can appear
+ *			anywhere in a Sprite XML definition.
+ */
+std::map<std::string, std::string> processImageSheets(const std::string& basePath, const Xml::XmlElement* element, ImageCache& imageCache)
+{
+	std::map<std::string, std::string> imageSheetMap;
+
+	for (const auto* node = element->iterateChildren(nullptr);
+		node != nullptr;
+		node = element->iterateChildren(node))
+	{
+		if (node->value() == "imagesheet" && node->toElement())
+		{
+			std::string id, src;
+			const auto* attribute = node->toElement()->firstAttribute();
+			while (attribute)
+			{
+				if (toLowercase(attribute->name()) == "id") { id = attribute->value(); }
+				else if (toLowercase(attribute->name()) == "src") { src = attribute->value(); }
+
+				attribute = attribute->next();
+			}
+
+			if (id.empty())
+			{
+				throw std::runtime_error("Sprite imagesheet definition has `id` of length zero: " + endTag(node->row()));
+			}
+
+			if (src.empty())
+			{
+				throw std::runtime_error("Sprite imagesheet definition has `src` of length zero: " + endTag(node->row()));
+			}
+
+			if (imageSheetMap.find(id) != imageSheetMap.end())
+			{
+				throw std::runtime_error("Sprite image sheet redefinition: id: '" + id + "' " + endTag(node->row()));
+			}
+
+			const auto imagePath = basePath + src;
+			imageSheetMap.try_emplace(id, imagePath);
+			imageCache.load(imagePath);
+		}
+	}
+
+	return imageSheetMap;
+}
+
+
+/**
+ * Iterates through all elements of a Sprite XML definition looking
+ * for 'action' elements and processes them.
+ *
+ * \note	Action names are not case sensitive. "Case", "caSe",
+ *			"CASE", etc. will all be viewed as identical.
+ */
+std::map<std::string, std::vector<AnimationSet::Frame>> processActions(const std::map<std::string, std::string>& imageSheetMap, const Xml::XmlElement* element, ImageCache& imageCache)
+{
+	std::map<std::string, std::vector<AnimationSet::Frame>> actions;
+
+	for (const auto* node = element->iterateChildren(nullptr);
+		node != nullptr;
+		node = element->iterateChildren(node))
+	{
+		if (toLowercase(node->value()) == "action" && node->toElement())
+		{
+
+			std::string actionName;
+			const auto* attribute = node->toElement()->firstAttribute();
+			while (attribute)
+			{
+				if (toLowercase(attribute->name()) == "name")
+				{
+					actionName = attribute->value();
+				}
+
+				attribute = attribute->next();
+			}
+
+			if (actionName.empty())
+			{
+				throw std::runtime_error("Sprite Action definition has 'name' of length zero: " + endTag(node->row()));
+			}
+			if (actions.find(actionName) != actions.end())
+			{
+				throw std::runtime_error("Sprite Action redefinition: '" + actionName + "' " + endTag(node->row()));
+			}
+
+			actions[actionName] = processFrames(imageSheetMap, actionName, node, imageCache);
+		}
+	}
+
+	return actions;
+}
+
+
+/**
+ * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
+ */
+std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, std::string>& imageSheetMap, const std::string& action, const Xml::XmlNode* node, ImageCache& imageCache)
+{
+	std::vector<AnimationSet::Frame> frameList;
+
+	for (const auto* frame = node->iterateChildren(nullptr);
+		frame != nullptr;
+		frame = node->iterateChildren(frame))
+	{
+		int currentRow = frame->row();
+
+		if (frame->value() != "frame" || !frame->toElement())
+		{
+			throw std::runtime_error("Sprite frame tag unexpected: <" + frame->value() + "> : " + endTag(currentRow));
+		}
+
+		std::string sheetId;
+		int delay = 0;
+		int x = 0, y = 0;
+		int width = 0, height = 0;
+		int anchorx = 0, anchory = 0;
+
+		const auto* attribute = frame->toElement()->firstAttribute();
+		while (attribute)
+		{
+			if (toLowercase(attribute->name()) == "sheetid") { sheetId = attribute->value(); }
+			else if (toLowercase(attribute->name()) == "delay") { attribute->queryIntValue(delay); }
+			else if (toLowercase(attribute->name()) == "x") { attribute->queryIntValue(x); }
+			else if (toLowercase(attribute->name()) == "y") { attribute->queryIntValue(y); }
+			else if (toLowercase(attribute->name()) == "width") { attribute->queryIntValue(width); }
+			else if (toLowercase(attribute->name()) == "height") { attribute->queryIntValue(height); }
+			else if (toLowercase(attribute->name()) == "anchorx") { attribute->queryIntValue(anchorx); }
+			else if (toLowercase(attribute->name()) == "anchory") { attribute->queryIntValue(anchory); }
+			else {
+				throw std::runtime_error("Sprite frame attribute unexpected: '" + attribute->name() + "' : " + endTag(currentRow));
+			}
+
+			attribute = attribute->next();
+		}
+
+		if (sheetId.empty())
+		{
+			throw std::runtime_error("Sprite Frame definition has 'sheetid' of length zero: " + endTag(currentRow));
+		}
+		const auto iterator = imageSheetMap.find(sheetId);
+		if (iterator == imageSheetMap.end())
+		{
+			throw std::runtime_error("Sprite Frame definition references undefined imagesheet: '" + sheetId + "' " + endTag(currentRow));
+		}
+
+		const auto& image = imageCache.load(iterator->second);
+		// X-Coordinate
+		if (x < 0 || x > image.size().x)
+		{
+			throw std::runtime_error("Sprite frame attribute 'x' is out of bounds: " + endTag(currentRow));
+		}
+		// Y-Coordinate
+		if (y < 0 || y > image.size().y)
+		{
+			throw std::runtime_error("Sprite frame attribute 'y' is out of bounds: " + endTag(currentRow));
+		}
+		// Width
+		if (width <= 0 || width > image.size().x - x)
+		{
+			throw std::runtime_error("Sprite frame attribute 'width' is out of bounds: " + endTag(currentRow));
+		}
+		// Height
+		if (height <= 0 || height > image.size().y - y)
+		{
+			throw std::runtime_error("Sprite frame attribute 'height' is out of bounds: " + endTag(currentRow));
+		}
+
+		const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
+		const auto anchorOffset = Vector{anchorx, anchory};
+		frameList.push_back(AnimationSet::Frame{image, bounds, anchorOffset, static_cast<unsigned int>(delay)});
+	}
+
+	if (frameList.size() <= 0)
+	{
+		throw std::runtime_error("Sprite Action contains no valid frames: " + action);
+	}
+
+	return frameList;
+}
+
 }

--- a/NAS2D/Resources/AnimationSet.cpp
+++ b/NAS2D/Resources/AnimationSet.cpp
@@ -26,14 +26,14 @@ namespace {
 		return " (Row: " + std::to_string(row) + ")";
 	}
 
-	AnimationSet processXml(const std::string& filePath, ImageCache& imageCache);
+	AnimationSet processXml(std::string filePath, ImageCache& imageCache);
 	std::map<std::string, std::string> processImageSheets(const std::string& basePath, const Xml::XmlElement* element, ImageCache& imageCache);
 	std::map<std::string, std::vector<AnimationSet::Frame>> processActions(const std::map<std::string, std::string>& imageSheetMap, const Xml::XmlElement* element, ImageCache& imageCache);
 	std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, std::string>& imageSheetMap, const std::string& action, const Xml::XmlNode* node, ImageCache& imageCache);
 }
 
 
-AnimationSet::AnimationSet(std::string fileName) : AnimationSet{processXml(fileName, animationImageCache)}
+AnimationSet::AnimationSet(std::string fileName) : AnimationSet{processXml(std::move(fileName), animationImageCache)}
 {
 }
 
@@ -70,7 +70,7 @@ namespace {
  *
  * \param filePath	File path of the sprite XML definition file.
  */
-AnimationSet processXml(const std::string& filePath, ImageCache& imageCache)
+AnimationSet processXml(std::string filePath, ImageCache& imageCache)
 {
 	try
 	{
@@ -109,7 +109,7 @@ AnimationSet processXml(const std::string& filePath, ImageCache& imageCache)
 		// image sheets anywhere in the sprite file.
 		auto imageSheetMap = processImageSheets(basePath, xmlRootElement, imageCache);
 		auto actions = processActions(imageSheetMap, xmlRootElement, imageCache);
-		return {filePath, std::move(imageSheetMap), std::move(actions)};
+		return {std::move(filePath), std::move(imageSheetMap), std::move(actions)};
 	}
 	catch(const std::runtime_error& error)
 	{

--- a/NAS2D/Resources/AnimationSet.h
+++ b/NAS2D/Resources/AnimationSet.h
@@ -22,6 +22,7 @@ public:
 		unsigned int frameDelay;
 	};
 
+	AnimationSet(std::string fileName);
 	AnimationSet(std::string fileName, std::map<std::string, std::string> imageSheetMap, std::map<std::string, std::vector<Frame>> actions);
 
 	std::vector<std::string> actionNames() const;

--- a/NAS2D/Resources/AnimationSet.h
+++ b/NAS2D/Resources/AnimationSet.h
@@ -22,14 +22,14 @@ public:
 		unsigned int frameDelay;
 	};
 
-	AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<Frame>> actions);
+	AnimationSet(std::string fileName, std::map<std::string, std::string> imageSheetMap, std::map<std::string, std::vector<Frame>> actions);
 
 	std::vector<std::string> actionNames() const;
 	const std::vector<Frame>& frames(const std::string& actionName) const;
 
 private:
 	std::string mFileName;
-	std::map<std::string, Image> mImageSheets;
+	std::map<std::string, std::string> mImageSheetMap;
 	std::map<std::string, std::vector<Frame>> mActions;
 };
 

--- a/NAS2D/Resources/AnimationSet.h
+++ b/NAS2D/Resources/AnimationSet.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Image.h"
+#include "../Renderer/Vector.h"
+#include "../Renderer/Rectangle.h"
+
+#include <map>
+#include <vector>
+#include <string>
+
+
+namespace NAS2D {
+
+class AnimationSet
+{
+public:
+	struct Frame
+	{
+		const Image& image;
+		Rectangle<int> bounds;
+		Vector<int> anchorOffset;
+		unsigned int frameDelay;
+	};
+
+	AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<Frame>> actions);
+
+	std::vector<std::string> actionNames() const;
+	const std::vector<Frame>& frames(const std::string& actionName) const;
+
+private:
+	std::string mFileName;
+	std::map<std::string, Image> mImageSheets;
+	std::map<std::string, std::vector<Frame>> mActions;
+};
+
+} // namespace

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -483,7 +483,7 @@ std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, Image
 
 		const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
 		const auto anchorOffset = Vector{anchorx, anchory};
-		frameList.push_back(AnimationSet::Frame{imageSheets.at(sheetId), bounds, anchorOffset, static_cast<unsigned int>(delay)});
+		frameList.push_back(AnimationSet::Frame{image, bounds, anchorOffset, static_cast<unsigned int>(delay)});
 	}
 
 	if (frameList.size() <= 0)

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -28,7 +28,7 @@ using namespace NAS2D;
 namespace {
 	const auto FRAME_PAUSE = unsigned(-1);
 
-	std::map<std::string, Sprite::SpriteAnimations> animationCache;
+	std::map<std::string, Sprite::AnimationSet> animationCache;
 
 
 	// Adds a row tag to the end of messages.
@@ -37,7 +37,7 @@ namespace {
 		return " (Row: " + std::to_string(row) + ")";
 	}
 
-	Sprite::SpriteAnimations processXml(const std::string& filePath);
+	Sprite::AnimationSet processXml(const std::string& filePath);
 	std::map<std::string, Image> processImageSheets(const std::string& basePath, const Xml::XmlElement* element);
 	std::map<std::string, std::vector<Sprite::SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element);
 	std::vector<Sprite::SpriteFrame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node);
@@ -265,7 +265,7 @@ namespace {
  *
  * \param filePath	File path of the sprite XML definition file.
  */
-Sprite::SpriteAnimations processXml(const std::string& filePath)
+Sprite::AnimationSet processXml(const std::string& filePath)
 {
 	try
 	{

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -65,7 +65,7 @@ const std::vector<Sprite::SpriteFrame>& Sprite::AnimationSet::frames(const std::
 {
 	if (actions.find(actionName) == actions.end())
 	{
-		throw std::runtime_error("Sprite::play called on undefined action: " + actionName);
+		throw std::runtime_error("Sprite::play called on undefined action: " + actionName + "  (" + fileName + ")");
 	}
 
 	return actions.at(actionName);

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -28,7 +28,7 @@ using namespace NAS2D;
 namespace {
 	const auto FRAME_PAUSE = unsigned(-1);
 
-	std::map<std::string, Sprite::AnimationSet> animationCache;
+	std::map<std::string, AnimationSet> animationCache;
 
 
 	// Adds a row tag to the end of messages.
@@ -37,12 +37,12 @@ namespace {
 		return " (Row: " + std::to_string(row) + ")";
 	}
 
-	Sprite::AnimationSet processXml(const std::string& filePath);
+	AnimationSet processXml(const std::string& filePath);
 	std::map<std::string, Image> processImageSheets(const std::string& basePath, const Xml::XmlElement* element);
-	std::map<std::string, std::vector<Sprite::AnimationSet::Frame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element);
-	std::vector<Sprite::AnimationSet::Frame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node);
+	std::map<std::string, std::vector<AnimationSet::Frame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element);
+	std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node);
 
-	const Sprite::AnimationSet& cachedLoad(const std::string& filePath)
+	const AnimationSet& cachedLoad(const std::string& filePath)
 	{
 		auto iter = animationCache.find(filePath);
 		if (iter == animationCache.end())
@@ -55,7 +55,7 @@ namespace {
 }
 
 
-Sprite::AnimationSet::AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<Sprite::AnimationSet::Frame>> actions) :
+AnimationSet::AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<AnimationSet::Frame>> actions) :
 	mFileName{std::move(fileName)},
 	mImageSheets{std::move(imageSheets)},
 	mActions{std::move(actions)}
@@ -63,13 +63,13 @@ Sprite::AnimationSet::AnimationSet(std::string fileName, std::map<std::string, I
 }
 
 
-std::vector<std::string> Sprite::AnimationSet::actionNames() const
+std::vector<std::string> AnimationSet::actionNames() const
 {
 	return getKeys(mActions);
 }
 
 
-const std::vector<Sprite::AnimationSet::Frame>& Sprite::AnimationSet::frames(const std::string& actionName) const
+const std::vector<AnimationSet::Frame>& AnimationSet::frames(const std::string& actionName) const
 {
 	if (mActions.find(actionName) == mActions.end())
 	{
@@ -285,7 +285,7 @@ namespace {
  *
  * \param filePath	File path of the sprite XML definition file.
  */
-Sprite::AnimationSet processXml(const std::string& filePath)
+AnimationSet processXml(const std::string& filePath)
 {
 	try
 	{
@@ -392,9 +392,9 @@ std::map<std::string, Image> processImageSheets(const std::string& basePath, con
  * \note	Action names are not case sensitive. "Case", "caSe",
  *			"CASE", etc. will all be viewed as identical.
  */
-std::map<std::string, std::vector<Sprite::AnimationSet::Frame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element)
+std::map<std::string, std::vector<AnimationSet::Frame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element)
 {
-	std::map<std::string, std::vector<Sprite::AnimationSet::Frame>> actions;
+	std::map<std::string, std::vector<AnimationSet::Frame>> actions;
 
 	for (const auto* node = element->iterateChildren(nullptr);
 		node != nullptr;
@@ -435,9 +435,9 @@ std::map<std::string, std::vector<Sprite::AnimationSet::Frame>> processActions(c
 /**
  * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
  */
-std::vector<Sprite::AnimationSet::Frame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node)
+std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node)
 {
-	std::vector<Sprite::AnimationSet::Frame> frameList;
+	std::vector<AnimationSet::Frame> frameList;
 
 	for (const auto* frame = node->iterateChildren(nullptr);
 		frame != nullptr;
@@ -508,7 +508,7 @@ std::vector<Sprite::AnimationSet::Frame> processFrames(const std::map<std::strin
 
 		const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
 		const auto anchorOffset = Vector{anchorx, anchory};
-		frameList.push_back(Sprite::AnimationSet::Frame{imageSheets.at(sheetId), bounds, anchorOffset, static_cast<unsigned int>(delay)});
+		frameList.push_back(AnimationSet::Frame{imageSheets.at(sheetId), bounds, anchorOffset, static_cast<unsigned int>(delay)});
 	}
 
 	if (frameList.size() <= 0)

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -39,8 +39,8 @@ namespace {
 
 	Sprite::AnimationSet processXml(const std::string& filePath);
 	std::map<std::string, Image> processImageSheets(const std::string& basePath, const Xml::XmlElement* element);
-	std::map<std::string, std::vector<Sprite::SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element);
-	std::vector<Sprite::SpriteFrame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node);
+	std::map<std::string, std::vector<Sprite::AnimationSet::SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element);
+	std::vector<Sprite::AnimationSet::SpriteFrame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node);
 
 	const Sprite::AnimationSet& cachedLoad(const std::string& filePath)
 	{
@@ -55,7 +55,7 @@ namespace {
 }
 
 
-Sprite::AnimationSet::AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<Sprite::SpriteFrame>> actions) :
+Sprite::AnimationSet::AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<Sprite::AnimationSet::SpriteFrame>> actions) :
 	mFileName{std::move(fileName)},
 	mImageSheets{std::move(imageSheets)},
 	mActions{std::move(actions)}
@@ -69,7 +69,7 @@ std::vector<std::string> Sprite::AnimationSet::actionNames() const
 }
 
 
-const std::vector<Sprite::SpriteFrame>& Sprite::AnimationSet::frames(const std::string& actionName) const
+const std::vector<Sprite::AnimationSet::SpriteFrame>& Sprite::AnimationSet::frames(const std::string& actionName) const
 {
 	if (mActions.find(actionName) == mActions.end())
 	{
@@ -392,9 +392,9 @@ std::map<std::string, Image> processImageSheets(const std::string& basePath, con
  * \note	Action names are not case sensitive. "Case", "caSe",
  *			"CASE", etc. will all be viewed as identical.
  */
-std::map<std::string, std::vector<Sprite::SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element)
+std::map<std::string, std::vector<Sprite::AnimationSet::SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element)
 {
-	std::map<std::string, std::vector<Sprite::SpriteFrame>> actions;
+	std::map<std::string, std::vector<Sprite::AnimationSet::SpriteFrame>> actions;
 
 	for (const auto* node = element->iterateChildren(nullptr);
 		node != nullptr;
@@ -435,9 +435,9 @@ std::map<std::string, std::vector<Sprite::SpriteFrame>> processActions(const std
 /**
  * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
  */
-std::vector<Sprite::SpriteFrame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node)
+std::vector<Sprite::AnimationSet::SpriteFrame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node)
 {
-	std::vector<Sprite::SpriteFrame> frameList;
+	std::vector<Sprite::AnimationSet::SpriteFrame> frameList;
 
 	for (const auto* frame = node->iterateChildren(nullptr);
 		frame != nullptr;
@@ -508,7 +508,7 @@ std::vector<Sprite::SpriteFrame> processFrames(const std::map<std::string, Image
 
 		const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
 		const auto anchorOffset = Vector{anchorx, anchory};
-		frameList.push_back(Sprite::SpriteFrame{imageSheets.at(sheetId), bounds, anchorOffset, static_cast<unsigned int>(delay)});
+		frameList.push_back(Sprite::AnimationSet::SpriteFrame{imageSheets.at(sheetId), bounds, anchorOffset, static_cast<unsigned int>(delay)});
 	}
 
 	if (frameList.size() <= 0)

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -10,12 +10,8 @@
 
 #include "Sprite.h"
 #include "ResourceCache.h"
-#include "../Utility.h"
-#include "../Filesystem.h"
-#include "../StringUtils.h"
-#include "../Version.h"
-#include "../Xml/Xml.h"
 #include "../Renderer/Renderer.h"
+#include "../Utility.h"
 
 #include <utility>
 #include <iostream>
@@ -26,35 +22,10 @@ using namespace NAS2D;
 
 
 namespace {
-	constexpr std::string_view SPRITE_VERSION{"0.99"};
 	const auto FRAME_PAUSE = unsigned(-1);
 
-	using ImageCache = ResourceCache<Image, std::string>;
-	ImageCache animationImageCache;
-	std::map<std::string, AnimationSet> animationCache;
-
-
-	// Adds a row tag to the end of messages.
-	std::string endTag(int row)
-	{
-		return " (Row: " + std::to_string(row) + ")";
-	}
-
-	AnimationSet processXml(const std::string& filePath, ImageCache& imageCache);
-	std::map<std::string, std::string> processImageSheets(const std::string& basePath, const Xml::XmlElement* element, ImageCache& imageCache);
-	std::map<std::string, std::vector<AnimationSet::Frame>> processActions(const std::map<std::string, std::string>& imageSheetMap, const Xml::XmlElement* element, ImageCache& imageCache);
-	std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, std::string>& imageSheetMap, const std::string& action, const Xml::XmlNode* node, ImageCache& imageCache);
-
-	const AnimationSet& cachedLoad(const std::string& filePath)
-	{
-		auto iter = animationCache.find(filePath);
-		if (iter == animationCache.end())
-		{
-			const auto result = animationCache.try_emplace(filePath, processXml(filePath, animationImageCache));
-			iter = result.first;
-		}
-		return iter->second;
-	}
+	using AnimationCache = ResourceCache<AnimationSet, std::string>;
+	AnimationCache animationCache;
 }
 
 
@@ -65,7 +36,7 @@ namespace {
  */
 Sprite::Sprite(const std::string& filePath, const std::string& initialAction) :
 	mSpriteName{filePath},
-	mAnimationSet{&cachedLoad(filePath)},
+	mAnimationSet{&animationCache.load(filePath)},
 	mCurrentAction{&mAnimationSet->frames(initialAction)}
 {
 }
@@ -254,248 +225,3 @@ Sprite::Callback& Sprite::frameCallback()
 {
 	return mAnimationCompleteCallback;
 }
-
-
-namespace {
-
-/**
- * Parses a Sprite XML Definition File.
- *
- * \param filePath	File path of the sprite XML definition file.
- */
-AnimationSet processXml(const std::string& filePath, ImageCache& imageCache)
-{
-	try
-	{
-		auto& filesystem = Utility<Filesystem>::get();
-		const auto basePath = filesystem.workingPath(filePath);
-
-		Xml::XmlDocument xmlDoc;
-		xmlDoc.parse(filesystem.open(filePath).raw_bytes());
-
-		if (xmlDoc.error())
-		{
-			throw std::runtime_error("Sprite file has malformed XML: Row: " + std::to_string(xmlDoc.errorRow()) + " Column: " + std::to_string(xmlDoc.errorCol()) + " : " + xmlDoc.errorDesc());
-		}
-
-		// Find the Sprite node.
-		const auto* xmlRootElement = xmlDoc.firstChildElement("sprite");
-		if (!xmlRootElement)
-		{
-			throw std::runtime_error("Sprite file does not contain required <sprite> tag");
-		}
-
-		// Get the Sprite version.
-		const auto* version = xmlRootElement->firstAttribute();
-		if (!version || version->value().empty())
-		{
-			throw std::runtime_error("Sprite file's root element does not specify a version");
-		}
-		if (version->value() != SPRITE_VERSION)
-		{
-			throw std::runtime_error("Sprite version mismatch. Expected: " + std::string{SPRITE_VERSION} + " Actual: " + versionString());
-		}
-
-		// Note:
-		// Here instead of going through each element and calling a processing function to handle
-		// it, we just iterate through all nodes to find sprite sheets. This allows us to define
-		// image sheets anywhere in the sprite file.
-		auto imageSheetMap = processImageSheets(basePath, xmlRootElement, imageCache);
-		auto actions = processActions(imageSheetMap, xmlRootElement, imageCache);
-		return {filePath, std::move(imageSheetMap), std::move(actions)};
-	}
-	catch(const std::runtime_error& error)
-	{
-		throw std::runtime_error("Error parsing Sprite file: " + filePath + "\nError: " + error.what());
-	}
-}
-
-
-/**
- * Iterates through all elements of a Sprite XML definition looking
- * for 'imagesheet' elements and processes them.
- *
- * \note	Since 'imagesheet' elements are processed before any other
- *			element in a sprite definition, these elements can appear
- *			anywhere in a Sprite XML definition.
- */
-std::map<std::string, std::string> processImageSheets(const std::string& basePath, const Xml::XmlElement* element, ImageCache& imageCache)
-{
-	std::map<std::string, std::string> imageSheetMap;
-
-	for (const auto* node = element->iterateChildren(nullptr);
-		node != nullptr;
-		node = element->iterateChildren(node))
-	{
-		if (node->value() == "imagesheet" && node->toElement())
-		{
-			std::string id, src;
-			const auto* attribute = node->toElement()->firstAttribute();
-			while (attribute)
-			{
-				if (toLowercase(attribute->name()) == "id") { id = attribute->value(); }
-				else if (toLowercase(attribute->name()) == "src") { src = attribute->value(); }
-
-				attribute = attribute->next();
-			}
-
-			if (id.empty())
-			{
-				throw std::runtime_error("Sprite imagesheet definition has `id` of length zero: " + endTag(node->row()));
-			}
-
-			if (src.empty())
-			{
-				throw std::runtime_error("Sprite imagesheet definition has `src` of length zero: " + endTag(node->row()));
-			}
-
-			if (imageSheetMap.find(id) != imageSheetMap.end())
-			{
-				throw std::runtime_error("Sprite image sheet redefinition: id: '" + id + "' " + endTag(node->row()));
-			}
-
-			const auto imagePath = basePath + src;
-			imageSheetMap.try_emplace(id, imagePath);
-			imageCache.load(imagePath);
-		}
-	}
-
-	return imageSheetMap;
-}
-
-
-/**
- * Iterates through all elements of a Sprite XML definition looking
- * for 'action' elements and processes them.
- *
- * \note	Action names are not case sensitive. "Case", "caSe",
- *			"CASE", etc. will all be viewed as identical.
- */
-std::map<std::string, std::vector<AnimationSet::Frame>> processActions(const std::map<std::string, std::string>& imageSheetMap, const Xml::XmlElement* element, ImageCache& imageCache)
-{
-	std::map<std::string, std::vector<AnimationSet::Frame>> actions;
-
-	for (const auto* node = element->iterateChildren(nullptr);
-		node != nullptr;
-		node = element->iterateChildren(node))
-	{
-		if (toLowercase(node->value()) == "action" && node->toElement())
-		{
-
-			std::string actionName;
-			const auto* attribute = node->toElement()->firstAttribute();
-			while (attribute)
-			{
-				if (toLowercase(attribute->name()) == "name")
-				{
-					actionName = attribute->value();
-				}
-
-				attribute = attribute->next();
-			}
-
-			if (actionName.empty())
-			{
-				throw std::runtime_error("Sprite Action definition has 'name' of length zero: " + endTag(node->row()));
-			}
-			if (actions.find(actionName) != actions.end())
-			{
-				throw std::runtime_error("Sprite Action redefinition: '" + actionName + "' " + endTag(node->row()));
-			}
-
-			actions[actionName] = processFrames(imageSheetMap, actionName, node, imageCache);
-		}
-	}
-
-	return actions;
-}
-
-
-/**
- * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
- */
-std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, std::string>& imageSheetMap, const std::string& action, const Xml::XmlNode* node, ImageCache& imageCache)
-{
-	std::vector<AnimationSet::Frame> frameList;
-
-	for (const auto* frame = node->iterateChildren(nullptr);
-		frame != nullptr;
-		frame = node->iterateChildren(frame))
-	{
-		int currentRow = frame->row();
-
-		if (frame->value() != "frame" || !frame->toElement())
-		{
-			throw std::runtime_error("Sprite frame tag unexpected: <" + frame->value() + "> : " + endTag(currentRow));
-		}
-
-		std::string sheetId;
-		int delay = 0;
-		int x = 0, y = 0;
-		int width = 0, height = 0;
-		int anchorx = 0, anchory = 0;
-
-		const auto* attribute = frame->toElement()->firstAttribute();
-		while (attribute)
-		{
-			if (toLowercase(attribute->name()) == "sheetid") { sheetId = attribute->value(); }
-			else if (toLowercase(attribute->name()) == "delay") { attribute->queryIntValue(delay); }
-			else if (toLowercase(attribute->name()) == "x") { attribute->queryIntValue(x); }
-			else if (toLowercase(attribute->name()) == "y") { attribute->queryIntValue(y); }
-			else if (toLowercase(attribute->name()) == "width") { attribute->queryIntValue(width); }
-			else if (toLowercase(attribute->name()) == "height") { attribute->queryIntValue(height); }
-			else if (toLowercase(attribute->name()) == "anchorx") { attribute->queryIntValue(anchorx); }
-			else if (toLowercase(attribute->name()) == "anchory") { attribute->queryIntValue(anchory); }
-			else {
-				throw std::runtime_error("Sprite frame attribute unexpected: '" + attribute->name() + "' : " + endTag(currentRow));
-			}
-
-			attribute = attribute->next();
-		}
-
-		if (sheetId.empty())
-		{
-			throw std::runtime_error("Sprite Frame definition has 'sheetid' of length zero: " + endTag(currentRow));
-		}
-		const auto iterator = imageSheetMap.find(sheetId);
-		if (iterator == imageSheetMap.end())
-		{
-			throw std::runtime_error("Sprite Frame definition references undefined imagesheet: '" + sheetId + "' " + endTag(currentRow));
-		}
-
-		const auto& image = imageCache.load(iterator->second);
-		// X-Coordinate
-		if (x < 0 || x > image.size().x)
-		{
-			throw std::runtime_error("Sprite frame attribute 'x' is out of bounds: " + endTag(currentRow));
-		}
-		// Y-Coordinate
-		if (y < 0 || y > image.size().y)
-		{
-			throw std::runtime_error("Sprite frame attribute 'y' is out of bounds: " + endTag(currentRow));
-		}
-		// Width
-		if (width <= 0 || width > image.size().x - x)
-		{
-			throw std::runtime_error("Sprite frame attribute 'width' is out of bounds: " + endTag(currentRow));
-		}
-		// Height
-		if (height <= 0 || height > image.size().y - y)
-		{
-			throw std::runtime_error("Sprite frame attribute 'height' is out of bounds: " + endTag(currentRow));
-		}
-
-		const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
-		const auto anchorOffset = Vector{anchorx, anchory};
-		frameList.push_back(AnimationSet::Frame{image, bounds, anchorOffset, static_cast<unsigned int>(delay)});
-	}
-
-	if (frameList.size() <= 0)
-	{
-		throw std::runtime_error("Sprite Action contains no valid frames: " + action);
-	}
-
-	return frameList;
-}
-
-} // namespace

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -55,6 +55,12 @@ namespace {
 }
 
 
+std::vector<std::string> Sprite::AnimationSet::actionNames() const
+{
+	return getKeys(actions);
+}
+
+
 /**
  * C'tor.
  *

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -61,6 +61,17 @@ std::vector<std::string> Sprite::AnimationSet::actionNames() const
 }
 
 
+const std::vector<Sprite::SpriteFrame>& Sprite::AnimationSet::frames(const std::string& actionName) const
+{
+	if (actions.find(actionName) == actions.end())
+	{
+		throw std::runtime_error("Sprite::play called on undefined action: " + actionName);
+	}
+
+	return actions.at(actionName);
+}
+
+
 /**
  * C'tor.
  *

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -39,8 +39,8 @@ namespace {
 
 	Sprite::AnimationSet processXml(const std::string& filePath);
 	std::map<std::string, Image> processImageSheets(const std::string& basePath, const Xml::XmlElement* element);
-	std::map<std::string, std::vector<Sprite::AnimationSet::SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element);
-	std::vector<Sprite::AnimationSet::SpriteFrame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node);
+	std::map<std::string, std::vector<Sprite::AnimationSet::Frame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element);
+	std::vector<Sprite::AnimationSet::Frame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node);
 
 	const Sprite::AnimationSet& cachedLoad(const std::string& filePath)
 	{
@@ -55,7 +55,7 @@ namespace {
 }
 
 
-Sprite::AnimationSet::AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<Sprite::AnimationSet::SpriteFrame>> actions) :
+Sprite::AnimationSet::AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<Sprite::AnimationSet::Frame>> actions) :
 	mFileName{std::move(fileName)},
 	mImageSheets{std::move(imageSheets)},
 	mActions{std::move(actions)}
@@ -69,7 +69,7 @@ std::vector<std::string> Sprite::AnimationSet::actionNames() const
 }
 
 
-const std::vector<Sprite::AnimationSet::SpriteFrame>& Sprite::AnimationSet::frames(const std::string& actionName) const
+const std::vector<Sprite::AnimationSet::Frame>& Sprite::AnimationSet::frames(const std::string& actionName) const
 {
 	if (mActions.find(actionName) == mActions.end())
 	{
@@ -392,9 +392,9 @@ std::map<std::string, Image> processImageSheets(const std::string& basePath, con
  * \note	Action names are not case sensitive. "Case", "caSe",
  *			"CASE", etc. will all be viewed as identical.
  */
-std::map<std::string, std::vector<Sprite::AnimationSet::SpriteFrame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element)
+std::map<std::string, std::vector<Sprite::AnimationSet::Frame>> processActions(const std::map<std::string, Image>& imageSheets, const Xml::XmlElement* element)
 {
-	std::map<std::string, std::vector<Sprite::AnimationSet::SpriteFrame>> actions;
+	std::map<std::string, std::vector<Sprite::AnimationSet::Frame>> actions;
 
 	for (const auto* node = element->iterateChildren(nullptr);
 		node != nullptr;
@@ -435,9 +435,9 @@ std::map<std::string, std::vector<Sprite::AnimationSet::SpriteFrame>> processAct
 /**
  * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
  */
-std::vector<Sprite::AnimationSet::SpriteFrame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node)
+std::vector<Sprite::AnimationSet::Frame> processFrames(const std::map<std::string, Image>& imageSheets, const std::string& action, const Xml::XmlNode* node)
 {
-	std::vector<Sprite::AnimationSet::SpriteFrame> frameList;
+	std::vector<Sprite::AnimationSet::Frame> frameList;
 
 	for (const auto* frame = node->iterateChildren(nullptr);
 		frame != nullptr;
@@ -508,7 +508,7 @@ std::vector<Sprite::AnimationSet::SpriteFrame> processFrames(const std::map<std:
 
 		const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
 		const auto anchorOffset = Vector{anchorx, anchory};
-		frameList.push_back(Sprite::AnimationSet::SpriteFrame{imageSheets.at(sheetId), bounds, anchorOffset, static_cast<unsigned int>(delay)});
+		frameList.push_back(Sprite::AnimationSet::Frame{imageSheets.at(sheetId), bounds, anchorOffset, static_cast<unsigned int>(delay)});
 	}
 
 	if (frameList.size() <= 0)

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -55,20 +55,28 @@ namespace {
 }
 
 
+Sprite::AnimationSet::AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<Sprite::SpriteFrame>> actions) :
+	mFileName{std::move(fileName)},
+	mImageSheets{std::move(imageSheets)},
+	mActions{std::move(actions)}
+{
+}
+
+
 std::vector<std::string> Sprite::AnimationSet::actionNames() const
 {
-	return getKeys(actions);
+	return getKeys(mActions);
 }
 
 
 const std::vector<Sprite::SpriteFrame>& Sprite::AnimationSet::frames(const std::string& actionName) const
 {
-	if (actions.find(actionName) == actions.end())
+	if (mActions.find(actionName) == mActions.end())
 	{
-		throw std::runtime_error("Sprite::play called on undefined action: " + actionName + "  (" + fileName + ")");
+		throw std::runtime_error("Sprite::play called on undefined action: " + actionName + "  (" + mFileName + ")");
 	}
 
-	return actions.at(actionName);
+	return mActions.at(actionName);
 }
 
 

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -321,7 +321,7 @@ Sprite::AnimationSet processXml(const std::string& filePath)
 		// image sheets anywhere in the sprite file.
 		auto imageSheets = processImageSheets(basePath, xmlRootElement);
 		auto actions = processActions(imageSheets, xmlRootElement);
-		return {std::move(imageSheets), std::move(actions)};
+		return {filePath, std::move(imageSheets), std::move(actions)};
 	}
 	catch(const std::runtime_error& error)
 	{

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -25,6 +25,7 @@ using namespace NAS2D;
 
 
 namespace {
+	constexpr std::string_view SPRITE_VERSION{"0.99"};
 	const auto FRAME_PAUSE = unsigned(-1);
 
 	std::map<std::string, AnimationSet> animationCache;

--- a/NAS2D/Resources/Sprite.cpp
+++ b/NAS2D/Resources/Sprite.cpp
@@ -12,7 +12,6 @@
 #include "../Utility.h"
 #include "../Filesystem.h"
 #include "../StringUtils.h"
-#include "../ContainerUtils.h"
 #include "../Version.h"
 #include "../Xml/Xml.h"
 #include "../Renderer/Renderer.h"
@@ -52,31 +51,6 @@ namespace {
 		}
 		return iter->second;
 	}
-}
-
-
-AnimationSet::AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<AnimationSet::Frame>> actions) :
-	mFileName{std::move(fileName)},
-	mImageSheets{std::move(imageSheets)},
-	mActions{std::move(actions)}
-{
-}
-
-
-std::vector<std::string> AnimationSet::actionNames() const
-{
-	return getKeys(mActions);
-}
-
-
-const std::vector<AnimationSet::Frame>& AnimationSet::frames(const std::string& actionName) const
-{
-	if (mActions.find(actionName) == mActions.end())
-	{
-		throw std::runtime_error("Sprite::play called on undefined action: " + actionName + "  (" + mFileName + ")");
-	}
-
-	return mActions.at(actionName);
 }
 
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -27,6 +27,29 @@ namespace NAS2D {
 constexpr std::string_view SPRITE_VERSION{"0.99"};
 
 
+class AnimationSet
+{
+public:
+	struct Frame
+	{
+		const Image& image;
+		Rectangle<int> bounds;
+		Vector<int> anchorOffset;
+		unsigned int frameDelay;
+	};
+
+	AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<Frame>> actions);
+
+	std::vector<std::string> actionNames() const;
+	const std::vector<Frame>& frames(const std::string& actionName) const;
+
+private:
+	std::string mFileName;
+	std::map<std::string, Image> mImageSheets;
+	std::map<std::string, std::vector<Frame>> mActions;
+};
+
+
 /**
  * \class Sprite
  * \brief Sprite Resource.
@@ -38,29 +61,6 @@ class Sprite
 {
 public:
 	using Callback = Signals::Signal<>; /**< Signal used when action animations complete. */
-
-	class AnimationSet
-	{
-	public:
-		struct Frame
-		{
-			const Image& image;
-			Rectangle<int> bounds;
-			Vector<int> anchorOffset;
-			unsigned int frameDelay;
-		};
-
-		AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<Frame>> actions);
-
-		std::vector<std::string> actionNames() const;
-		const std::vector<Frame>& frames(const std::string& actionName) const;
-
-	private:
-		std::string mFileName;
-		std::map<std::string, Image> mImageSheets;
-		std::map<std::string, std::vector<Frame>> mActions;
-	};
-
 
 	Sprite(const std::string& filePath, const std::string& initialAction);
 	Sprite(const Sprite& sprite) = delete;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -21,9 +21,6 @@
 
 namespace NAS2D {
 
-constexpr std::string_view SPRITE_VERSION{"0.99"};
-
-
 /**
  * \class Sprite
  * \brief Sprite Resource.

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -50,12 +50,7 @@ public:
 	class AnimationSet
 	{
 	public:
-		AnimationSet() = default;
 		AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<SpriteFrame>> actions);
-		AnimationSet(const AnimationSet& other) = delete;
-		AnimationSet(AnimationSet&& other) = default;
-		AnimationSet& operator=(const AnimationSet& other) = delete;
-		AnimationSet& operator=(AnimationSet&& other) = default;
 
 		std::vector<std::string> actionNames() const;
 		const std::vector<SpriteFrame>& frames(const std::string& actionName) const;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -42,7 +42,7 @@ public:
 	class AnimationSet
 	{
 	public:
-		struct SpriteFrame
+		struct Frame
 		{
 			const Image& image;
 			Rectangle<int> bounds;
@@ -50,15 +50,15 @@ public:
 			unsigned int frameDelay;
 		};
 
-		AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<SpriteFrame>> actions);
+		AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<Frame>> actions);
 
 		std::vector<std::string> actionNames() const;
-		const std::vector<SpriteFrame>& frames(const std::string& actionName) const;
+		const std::vector<Frame>& frames(const std::string& actionName) const;
 
 	private:
 		std::string mFileName;
 		std::map<std::string, Image> mImageSheets;
-		std::map<std::string, std::vector<SpriteFrame>> mActions;
+		std::map<std::string, std::vector<Frame>> mActions;
 	};
 
 
@@ -98,7 +98,7 @@ private:
 	std::string mSpriteName;
 
 	const AnimationSet* mAnimationSet;
-	const std::vector<AnimationSet::SpriteFrame>* mCurrentAction{nullptr};
+	const std::vector<AnimationSet::Frame>* mCurrentAction{nullptr};
 	std::size_t mCurrentFrame{0};
 
 	bool mPaused{false};

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -47,16 +47,16 @@ public:
 		unsigned int frameDelay;
 	};
 
-	struct SpriteAnimations
+	struct AnimationSet
 	{
 		std::map<std::string, Image> imageSheets;
 		std::map<std::string, std::vector<SpriteFrame>> actions;
 
-		SpriteAnimations() = default;
-		SpriteAnimations(const SpriteAnimations& other) = delete;
-		SpriteAnimations(SpriteAnimations&& other) = default;
-		SpriteAnimations& operator=(const SpriteAnimations& other) = delete;
-		SpriteAnimations& operator=(SpriteAnimations&& other) = default;
+		AnimationSet() = default;
+		AnimationSet(const AnimationSet& other) = delete;
+		AnimationSet(AnimationSet&& other) = default;
+		AnimationSet& operator=(const AnimationSet& other) = delete;
+		AnimationSet& operator=(AnimationSet&& other) = default;
 	};
 
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -49,6 +49,7 @@ public:
 
 	struct AnimationSet
 	{
+		std::string fileName;
 		std::map<std::string, Image> imageSheets;
 		std::map<std::string, std::vector<SpriteFrame>> actions;
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -99,7 +99,7 @@ public:
 private:
 	std::string mSpriteName;
 
-	const std::map<std::string, std::vector<SpriteFrame>>* mActions;
+	const AnimationSet* mAnimationSet;
 	const std::vector<SpriteFrame>* mCurrentAction{nullptr};
 	std::size_t mCurrentFrame{0};
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -39,17 +39,17 @@ class Sprite
 public:
 	using Callback = Signals::Signal<>; /**< Signal used when action animations complete. */
 
-	struct SpriteFrame
-	{
-		const Image& image;
-		Rectangle<int> bounds;
-		Vector<int> anchorOffset;
-		unsigned int frameDelay;
-	};
-
 	class AnimationSet
 	{
 	public:
+		struct SpriteFrame
+		{
+			const Image& image;
+			Rectangle<int> bounds;
+			Vector<int> anchorOffset;
+			unsigned int frameDelay;
+		};
+
 		AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<SpriteFrame>> actions);
 
 		std::vector<std::string> actionNames() const;
@@ -98,7 +98,7 @@ private:
 	std::string mSpriteName;
 
 	const AnimationSet* mAnimationSet;
-	const std::vector<SpriteFrame>* mCurrentAction{nullptr};
+	const std::vector<AnimationSet::SpriteFrame>* mCurrentAction{nullptr};
 	std::size_t mCurrentFrame{0};
 
 	bool mPaused{false};

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -57,6 +57,8 @@ public:
 		AnimationSet(AnimationSet&& other) = default;
 		AnimationSet& operator=(const AnimationSet& other) = delete;
 		AnimationSet& operator=(AnimationSet&& other) = default;
+
+		std::vector<std::string> actionNames() const;
 	};
 
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -47,13 +47,11 @@ public:
 		unsigned int frameDelay;
 	};
 
-	struct AnimationSet
+	class AnimationSet
 	{
-		std::string fileName;
-		std::map<std::string, Image> imageSheets;
-		std::map<std::string, std::vector<SpriteFrame>> actions;
-
+	public:
 		AnimationSet() = default;
+		AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<SpriteFrame>> actions);
 		AnimationSet(const AnimationSet& other) = delete;
 		AnimationSet(AnimationSet&& other) = default;
 		AnimationSet& operator=(const AnimationSet& other) = delete;
@@ -61,6 +59,11 @@ public:
 
 		std::vector<std::string> actionNames() const;
 		const std::vector<SpriteFrame>& frames(const std::string& actionName) const;
+
+	private:
+		std::string mFileName;
+		std::map<std::string, Image> mImageSheets;
+		std::map<std::string, std::vector<SpriteFrame>> mActions;
 	};
 
 

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -34,11 +34,6 @@ public:
 	using Callback = Signals::Signal<>; /**< Signal used when action animations complete. */
 
 	Sprite(const std::string& filePath, const std::string& initialAction);
-	Sprite(const Sprite& sprite) = delete;
-	Sprite(Sprite&& sprite) = default;
-	Sprite& operator=(const Sprite& rhs) = delete;
-	Sprite& operator=(Sprite&& rhs) = default;
-	~Sprite() = default;
 
 	Vector<int> size() const;
 	Point<int> origin(Point<int> point) const;

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -10,44 +10,18 @@
 
 #pragma once
 
-#include "Image.h"
+#include "AnimationSet.h"
 #include "../Signal.h"
 #include "../Timer.h"
 #include "../Renderer/Color.h"
-#include "../Renderer/Rectangle.h"
 
-#include <map>
-#include <string_view>
-#include <string>
 #include <vector>
+#include <string>
 
 
 namespace NAS2D {
 
 constexpr std::string_view SPRITE_VERSION{"0.99"};
-
-
-class AnimationSet
-{
-public:
-	struct Frame
-	{
-		const Image& image;
-		Rectangle<int> bounds;
-		Vector<int> anchorOffset;
-		unsigned int frameDelay;
-	};
-
-	AnimationSet(std::string fileName, std::map<std::string, Image> imageSheets, std::map<std::string, std::vector<Frame>> actions);
-
-	std::vector<std::string> actionNames() const;
-	const std::vector<Frame>& frames(const std::string& actionName) const;
-
-private:
-	std::string mFileName;
-	std::map<std::string, Image> mImageSheets;
-	std::map<std::string, std::vector<Frame>> mActions;
-};
 
 
 /**

--- a/NAS2D/Resources/Sprite.h
+++ b/NAS2D/Resources/Sprite.h
@@ -59,6 +59,7 @@ public:
 		AnimationSet& operator=(AnimationSet&& other) = default;
 
 		std::vector<std::string> actionNames() const;
+		const std::vector<SpriteFrame>& frames(const std::string& actionName) const;
 	};
 
 


### PR DESCRIPTION
Add new `AnimationSet` resource class by splitting off code from `Sprite`.

MSVC Code Analysis seems to produce a false warning about an uninitialized member variable. Seems this trades one warning for another. This can probably be cleaned up in the near future.

Closes #785
Reference: https://github.com/OutpostUniverse/OPHD/issues/637  for discussion on splitting `Sprite`
