### PR TITLE
Fix SDL memory leak for cursor and window icons

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -498,6 +498,7 @@ void RendererOpenGL::addCursor(const std::string& filePath, int cursorId, int of
 	}
 
 	SDL_Cursor* cur = SDL_CreateColorCursor(surface, offx, offy);
+	SDL_FreeSurface(surface);
 	if (!cur)
 	{
 		std::cout << "RendererOpenGL::addCursor(): " << SDL_GetError() << std::endl;

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -490,7 +490,7 @@ void RendererOpenGL::addCursor(const std::string& filePath, int cursorId, int of
 		return;
 	}
 
-	SDL_Surface* surface = IMG_Load_RW(SDL_RWFromConstMem(imageFile.raw_bytes(), static_cast<int>(imageFile.size())), 0);
+	SDL_Surface* surface = IMG_Load_RW(SDL_RWFromConstMem(imageFile.raw_bytes(), static_cast<int>(imageFile.size())), 1);
 	if (!surface)
 	{
 		std::cout << "RendererOpenGL::addCursor(): " << SDL_GetError() << std::endl;
@@ -652,7 +652,7 @@ void RendererOpenGL::window_icon(const std::string& path)
 	if (!Utility<Filesystem>::get().exists(path)) { return; }
 
 	File f = Utility<Filesystem>::get().open(path);
-	SDL_Surface* icon = IMG_Load_RW(SDL_RWFromConstMem(f.raw_bytes(), static_cast<int>(f.size())), 0);
+	SDL_Surface* icon = IMG_Load_RW(SDL_RWFromConstMem(f.raw_bytes(), static_cast<int>(f.size())), 1);
 	if (!icon)
 	{
 		std::cout << "RendererOpenGL::window_icon(): " << SDL_GetError() << std::endl;


### PR DESCRIPTION
Fixed a couple of SDL memory leaks using the `freesrc` parameter, as was done earlier in #794. It seems a few calls were missing for loading mouse cursor and window icons.

Leaks were found using `valgrind`, with the help of the `--show-possibly-lost=no` flag to cut down on the output noise. This change drops the number of definitely lost blocks from 8 to 5.

----

The mouse cursor icon code was leaking `SDL_Surface` objects. The `surface` variable went out of scope without ever freeing the assigned surface.

In `RendererOpenGL::addCursor`, line 493:
```cpp
SDL_Surface* surface = IMG_Load_RW(SDL_RWFromConstMem(imageFile.raw_bytes(), static_cast<int>(imageFile.size())), 1);
```

Fixing this drops the definitely lost blocks from 5 to 2.
