### PR TITLE
Call SDL_Init in Game constructor

### DIFF
--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -108,10 +108,10 @@ Game::~Game()
 	Utility<Configuration>::clear();
 	Utility<Filesystem>::clear();
 
-	std::cout << "\nGame object has been terminated." << std::endl;
-
 	// Shut down all SDL subsystems.
 	SDL_Quit();
+
+	std::cout << "\nGame object has been terminated." << std::endl;
 }
 
 

--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -47,6 +47,8 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 	std::cout << "Initializing subsystems...\n\n";
 	std::cout.flush();
 
+	SDL_Init(0);
+
 	auto& fs = Utility<Filesystem>::init<Filesystem>(argv_0, appName, organizationName);
 	fs.mountSoftFail(dataPath);
 	fs.mountSoftFail(fs.basePath() + dataPath);

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -101,7 +101,7 @@ MixerSDL::MixerSDL() : MixerSDL(InvalidToDefault(ReadConfigurationOptions()))
 
 MixerSDL::MixerSDL(const Options& options)
 {
-	if (SDL_Init(SDL_INIT_AUDIO) < 0)
+	if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0)
 	{
 		throw mixer_backend_init_failure(SDL_GetError());
 	}

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -707,7 +707,7 @@ void RendererOpenGL::initGL()
 
 void RendererOpenGL::initVideo(Vector<int> resolution, bool fullscreen, bool vsync)
 {
-	if (SDL_Init(SDL_INIT_VIDEO) < 0)
+	if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
 	{
 		throw renderer_backend_init_failure(SDL_GetError());
 	}


### PR DESCRIPTION
Closes #446
Related: #810

Verified that SDL initialization and shutdown code appears to be correct. The memory leak from #810 doesn't appear to be caused by NAS2D code, but rather by either the SDL2 library, or the X11 library called by SDL2.
