### PR TITLE
Add ParserHelper

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -10,6 +10,7 @@
 
 #include "Configuration.h"
 #include "ContainerUtils.h"
+#include "ParserHelper.h"
 #include "Filesystem.h"
 #include "Utility.h"
 #include "Xml/Xml.h"
@@ -22,25 +23,6 @@ using namespace NAS2D;
 
 
 namespace {
-	void reportMissingOrUnexpected(const std::vector<std::string>& missing, const std::vector<std::string>& unexpected)
-	{
-		if (!missing.empty() || !unexpected.empty())
-		{
-			const auto missingString = !missing.empty() ? "Missing names: {" + join(missing, ", ") +"}" : "";
-			const auto unexpectedString = !unexpected.empty() ? "Unexpected names: {" + join(unexpected, ", ") + "}" : "";
-			const auto joinString = (!missingString.empty() && !unexpectedString.empty()) ? "\n" : "";
-			throw std::runtime_error(missingString + joinString + unexpectedString);
-		}
-	}
-
-	void reportMissingOrUnexpected(const std::vector<std::string>& names, const std::vector<std::string>& required, const std::vector<std::string>& optional)
-	{
-		const auto missing = missingValues(names, required);
-		const auto unexpected = unexpectedValues(names, required, optional);
-		reportMissingOrUnexpected(missing, unexpected);
-	}
-
-
 	Dictionary attributesToDictionary(const Xml::XmlElement& element)
 	{
 		Dictionary dictionary;

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="FpsCounter.cpp" />
     <ClCompile Include="Game.cpp" />
     <ClCompile Include="MathUtils.cpp" />
+    <ClCompile Include="ParserHelper.cpp" />
     <ClCompile Include="Mixer\Mixer.cpp" />
     <ClCompile Include="Mixer\MixerSDL.cpp" />
     <ClCompile Include="Mixer\MixerNull.cpp" />
@@ -238,6 +239,7 @@
     <ClInclude Include="Mixer\MixerSDL.h" />
     <ClInclude Include="Mixer\MixerNull.h" />
     <ClInclude Include="NAS2D.h" />
+    <ClInclude Include="ParserHelper.h" />
     <ClInclude Include="Renderer\DisplayDesc.h" />
     <ClInclude Include="Renderer\RendererNull.h" />
     <ClInclude Include="Renderer\Color.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -156,6 +156,9 @@
     <ClCompile Include="MathUtils.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ParserHelper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Version.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -324,6 +327,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="MathUtils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ParserHelper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Version.h">

--- a/NAS2D/ParserHelper.cpp
+++ b/NAS2D/ParserHelper.cpp
@@ -1,0 +1,25 @@
+
+#include "ParserHelper.h"
+#include "StringUtils.h"
+#include "ContainerUtils.h"
+
+
+namespace NAS2D {
+	void reportMissingOrUnexpected(const std::vector<std::string>& missing, const std::vector<std::string>& unexpected)
+	{
+		if (!missing.empty() || !unexpected.empty())
+		{
+			const auto missingString = !missing.empty() ? "Missing names: {" + join(missing, ", ") +"}" : "";
+			const auto unexpectedString = !unexpected.empty() ? "Unexpected names: {" + join(unexpected, ", ") + "}" : "";
+			const auto joinString = (!missingString.empty() && !unexpectedString.empty()) ? "\n" : "";
+			throw std::runtime_error(missingString + joinString + unexpectedString);
+		}
+	}
+
+	void reportMissingOrUnexpected(const std::vector<std::string>& names, const std::vector<std::string>& required, const std::vector<std::string>& optional)
+	{
+		const auto missing = missingValues(names, required);
+		const auto unexpected = unexpectedValues(names, required, optional);
+		reportMissingOrUnexpected(missing, unexpected);
+	}
+}

--- a/NAS2D/ParserHelper.h
+++ b/NAS2D/ParserHelper.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+
+namespace NAS2D {
+	void reportMissingOrUnexpected(const std::vector<std::string>& missing, const std::vector<std::string>& unexpected);
+	void reportMissingOrUnexpected(const std::vector<std::string>& names, const std::vector<std::string>& required, const std::vector<std::string>& optional);
+}

--- a/test/ParserHelper.test.cpp
+++ b/test/ParserHelper.test.cpp
@@ -1,0 +1,24 @@
+#include "NAS2D/ParserHelper.h"
+
+#include <gtest/gtest.h>
+
+
+TEST(ParserHelper, reportMissingOrUnexpected) {
+	// Nothing missing or unexpected
+	EXPECT_NO_THROW(NAS2D::reportMissingOrUnexpected({}, {}));
+	// Unexpected result
+	EXPECT_THROW(NAS2D::reportMissingOrUnexpected({"a"}, {}), std::runtime_error);
+	EXPECT_THROW(NAS2D::reportMissingOrUnexpected({}, {"b"}), std::runtime_error);
+	EXPECT_THROW(NAS2D::reportMissingOrUnexpected({"a"}, {"b"}), std::runtime_error);
+
+	// Nothing missing or unexpected
+	EXPECT_NO_THROW(NAS2D::reportMissingOrUnexpected({}, {}, {}));
+	EXPECT_NO_THROW(NAS2D::reportMissingOrUnexpected({}, {}, {"a"}));
+	EXPECT_NO_THROW(NAS2D::reportMissingOrUnexpected({"a"}, {}, {"a"}));
+	// Missing required value
+	EXPECT_THROW(NAS2D::reportMissingOrUnexpected({}, {"a"}, {}), std::runtime_error);
+	// Unexpected value
+	EXPECT_THROW(NAS2D::reportMissingOrUnexpected({"a"}, {}, {}), std::runtime_error);
+	// Both missing and unexpected
+	EXPECT_THROW(NAS2D::reportMissingOrUnexpected({"b"}, {"a"}, {}), std::runtime_error);
+}


### PR DESCRIPTION
Move `reportMissingOrUnexpected` methods to ParserHelper.

Related: #792, #796

Edit:
Since an error reporting function can only throw a single exception at a time, I want both missing and unexpected values to be reported by a single exception.
