### PR TITLE
Brew install google test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
       - restore_cache:
           name: Restoring brew dependencies
           key: deps-v4-NAS2D-{{ arch }}
-      - run: brew install << parameters.packages >>
+      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install << parameters.packages >>
       - save_cache:
           name: Caching brew dependencies
           key: deps-v4-NAS2D-{{ arch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
 jobs:
   build-macos:
     macos:
-      xcode: "11.3.0"
+      xcode: "11.7.0"
     environment:
       - WARN_EXTRA: "-Wno-double-promotion"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,11 +9,11 @@ commands:
     steps:
       - restore_cache:
           name: Restoring brew dependencies
-          key: deps-v3-NAS2D-{{ arch }}
+          key: deps-v4-NAS2D-{{ arch }}
       - run: brew install << parameters.packages >>
       - save_cache:
           name: Caching brew dependencies
-          key: deps-v3-NAS2D-{{ arch }}
+          key: deps-v4-NAS2D-{{ arch }}
           paths:
             - /usr/local/Cellar
       - run: brew link << parameters.packages >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
 jobs:
   build-macos:
     macos:
-      xcode: "11.7.0"
+      xcode: "12.2.0"
     environment:
       - WARN_EXTRA: "-Wno-double-promotion"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
       - restore_cache:
           name: Restoring brew dependencies
           key: deps-v3-NAS2D-{{ arch }}
-      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install << parameters.packages >>
+      - run: brew install << parameters.packages >>
       - save_cache:
           name: Caching brew dependencies
           key: deps-v3-NAS2D-{{ arch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,44 +17,6 @@ commands:
           paths:
             - /usr/local/Cellar
       - run: brew link << parameters.packages >>
-  build-googletest:
-    description: "Install Google Test from source package"
-    parameters:
-      buildPrefix:
-        type: string
-        default: ~/googletest/
-      installPrefix:
-        type: string
-        default: /usr/local/
-    steps:
-      - restore_cache:
-          name: Restoring Google Test
-          key: v3-gtest-{{ arch }}
-      - run:
-          name: "Download and build Google Test"
-          command: |
-            set -x
-            if [[ ! -d << parameters.buildPrefix >> ]]; then
-              pushd /tmp
-              curl --silent --location https://github.com/google/googletest/archive/release-1.10.0.tar.gz | tar xz -
-              cd googletest-release-1.10.0/
-              cmake -DCMAKE_CXX_FLAGS="-std=c++17"
-              make
-              mkdir -p << parameters.buildPrefix >>
-              cp -r googletest/include << parameters.buildPrefix >>
-              cp -r googlemock/include << parameters.buildPrefix >>
-              mkdir -p << parameters.buildPrefix >>lib/
-              find . -name 'lib*.a' -exec cp {} << parameters.buildPrefix >>lib/ \;
-              popd
-            fi
-      - save_cache:
-          name: Caching Google Test
-          key: v3-gtest-{{ arch }}
-          paths:
-            - << parameters.buildPrefix >>
-      - run:
-          name: "Install Google Test system wide"
-          command: cp -r << parameters.buildPrefix >> << parameters.installPrefix >>
   build-and-test:
     steps:
       - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror"
@@ -72,8 +34,7 @@ jobs:
       - WARN_EXTRA: "-Wno-double-promotion"
     steps:
       - brew-install:
-          packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew cmake
-      - build-googletest
+          packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew googletest
       - checkout
       - build-and-test
   build-linux:


### PR DESCRIPTION
Use `brew install googletest` instead of a manual download and source install.

Updates to a newer base MacOS image to get an updated version of `brew` that supports the `googletest` package.

Closes #816
