### PR TITLE
Simplify stringFrom by collapsing cases

### DIFF
--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -24,9 +24,7 @@ namespace NAS2D
 	template<typename T>
 	std::string stringFrom(T value)
 	{
-		if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, const char*>) {
-			return value;
-		} else if constexpr (std::is_convertible<T, std::string>::value) {
+		if constexpr (std::is_convertible<T, std::string>::value) {
 			return value;
 		} else if constexpr (std::is_same_v<T, bool>) {
 			return value ? "true" : "false";


### PR DESCRIPTION
The `std::is_convertible` check should handle all of `std::string`, `const char*`, and objects with an `operator std::string() const` method.
