### PR TITLE
Update C++ standard target

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS_EXTRA)
 CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Wswitch-enum -Wswitch-default -Winvalid-pch -Wmissing-format-attribute -Wredundant-decls $(WARN_EXTRA)
-CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++17 $(CXXFLAGS_WARN) $(shell sdl2-config --cflags)
+CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++20 $(CXXFLAGS_WARN) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA)
 LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
 

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 CPPFLAGS := $(CPPFLAGS_EXTRA)
 CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Wswitch-enum -Wswitch-default -Winvalid-pch -Wmissing-format-attribute -Wredundant-decls $(WARN_EXTRA)
-CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++20 $(CXXFLAGS_WARN) $(shell sdl2-config --cflags)
+CXXFLAGS := $(CXXFLAGS_EXTRA) -std=c++2a $(CXXFLAGS_WARN) $(shell sdl2-config --cflags)
 LDFLAGS := $(LDFLAGS_EXTRA)
 LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(shell sdl2-config --static-libs) $(OpenGL_LIBS)
 


### PR DESCRIPTION
Reference: #826

This PR gives a snapshot of support for C++20 using the currently configured CI compilers. Currently `c++20` fails for MacOS, Mingw-w64, and GCC on Ubuntu 18.04. If we use the earlier `c++2a` target, from before the C++20 standard became official, than some of the older compilers can manage to build successfully. We'll need to drop support for Ubuntu 18.04 though.

Perhaps someone would like to add the corresponding update for Windows.
