### PR TITLE
Fix undefined behaviour in `split`

### DIFF
--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -56,7 +56,7 @@ std::vector<std::string> split(const std::string& str, char delim /*= ','*/)
 	{
 		result.push_back(curString);
 	}
-	if (ss.eof() && str.back() == delim)
+	if (ss.eof() && !str.empty() && str.back() == delim)
 	{
 		result.push_back(std::string{});
 	}


### PR DESCRIPTION
We should not be calling `std::string::back` on an empty string.

Closes #825
