### PR TITLE
Enable move semantics when constructing File

### DIFF
--- a/NAS2D/File.h
+++ b/NAS2D/File.h
@@ -11,6 +11,8 @@
 #pragma once
 
 #include <string>
+#include <utility>
+
 
 namespace NAS2D {
 
@@ -40,9 +42,9 @@ public:
 	 * \param	stream	A ByteStream representing the file.
 	 * \param	name	The full name of the file including path.
 	 */
-	File(const ByteStream& stream, const std::string& name) :
-		mByteStream(stream),
-		mFileName(name)
+	File(ByteStream stream, std::string name) :
+		mByteStream(std::move(stream)),
+		mFileName(std::move(name))
 	{}
 
 	~File()


### PR DESCRIPTION
The previous code was unconditionally copying the buffer and filename parameters into local fields. Instead, we should use move semantics when possible. By passing the parameter by-value, rvalue buffers can be moved into the parameter, which are then moved into the local field, all without having to copy the buffer. For lvalue buffer parameters, a copy must be made, in which case the by-value semantics forces the copy early during parameter passing, and then that copy is moved into the local field.

Now that we have move semantics, if you want speed, pass by value.

This of course is for the case when we are making a local copy of the passed data. If you're only reading a parameter, without copying it, then yes, continue passing by const reference.

----

If passing lvalues, using `std::move` at the call site can now improve performance. If passing rvalues, the performance improvement is automatic.
