### PR TITLE
Refactor Filesystem::open

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -18,6 +18,8 @@
 #include <string>
 #include <iostream>
 #include <sstream>
+#include <utility>
+
 
 using namespace NAS2D;
 using namespace NAS2D::Exception;
@@ -258,7 +260,7 @@ File Filesystem::open(const std::string& filename) const
 		throw std::runtime_error(std::string("Unable to load '") + filename + "': " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}
 
-	return File{fileBuffer, filename};
+	return File{std::move(fileBuffer), filename};
 }
 
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -244,7 +244,7 @@ File Filesystem::open(const std::string& filename) const
 	}
 
 	// Create a char* buffer large enough to hold the entire file.
-	PHYSFS_uint32 fileLength = static_cast<PHYSFS_uint32>(len);
+	auto fileLength = static_cast<PHYSFS_uint32>(len);
 	char* fileBuffer = new char[std::size_t{fileLength} + std::size_t{1}];
 
 	// If we read less then the file length, return an empty File object, log a message and free any used memory.

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -248,15 +248,17 @@ File Filesystem::open(const std::string& filename) const
 	std::string fileBuffer;
 	fileBuffer.resize(std::size_t{fileLength});
 
-	// If we read less then the file length, return an empty File object, log a message and free any used memory.
-	if (PHYSFS_readBytes(myFile, fileBuffer.data(), fileLength) < fileLength)
+	// Read file data into buffer and close file
+	const auto actualReadLength = PHYSFS_readBytes(myFile, fileBuffer.data(), fileLength);
+	closeFile(myFile);
+
+	// Ensure we read the expected length
+	if (actualReadLength < fileLength)
 	{
-		closeFile(myFile);
 		throw std::runtime_error(std::string("Unable to load '") + filename + "': " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}
 
 	File file(fileBuffer, filename);
-	closeFile(myFile);
 
 	return file;
 }

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -246,7 +246,7 @@ File Filesystem::open(const std::string& filename) const
 	}
 
 	// Create buffer large enough to hold entire file
-	auto bufferSize = static_cast<PHYSFS_uint32>(fileLength);
+	const auto bufferSize = static_cast<PHYSFS_uint32>(fileLength);
 	std::string fileBuffer;
 	fileBuffer.resize(std::size_t{bufferSize});
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -246,12 +246,12 @@ File Filesystem::open(const std::string& filename) const
 	}
 
 	// Create buffer large enough to hold entire file
-	auto fileLength = static_cast<PHYSFS_uint32>(len);
+	auto bufferSize = static_cast<PHYSFS_uint32>(len);
 	std::string fileBuffer;
-	fileBuffer.resize(std::size_t{fileLength});
+	fileBuffer.resize(std::size_t{bufferSize});
 
 	// Read file data into buffer and close file
-	const auto actualReadLength = PHYSFS_readBytes(myFile, fileBuffer.data(), fileLength);
+	const auto actualReadLength = PHYSFS_readBytes(myFile, fileBuffer.data(), bufferSize);
 	closeFile(myFile);
 
 	// Ensure we read the expected length

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -238,7 +238,7 @@ File Filesystem::open(const std::string& filename) const
 	}
 
 	// Ensure that the file size is greater than zero and can fit in a 32-bit integer.
-	PHYSFS_sint64 fileLength = PHYSFS_fileLength(myFile);
+	auto fileLength = PHYSFS_fileLength(myFile);
 	if (fileLength < 0 || fileLength > UINT_MAX)
 	{
 		closeFile(myFile);

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -245,7 +245,7 @@ File Filesystem::open(const std::string& filename) const
 
 	// Create a char* buffer large enough to hold the entire file.
 	auto fileLength = static_cast<PHYSFS_uint32>(len);
-	char* fileBuffer = new char[std::size_t{fileLength} + std::size_t{1}];
+	char* fileBuffer = new char[std::size_t{fileLength} + 1];
 
 	// If we read less then the file length, return an empty File object, log a message and free any used memory.
 	if (PHYSFS_readBytes(myFile, fileBuffer, fileLength) < fileLength)

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -238,15 +238,15 @@ File Filesystem::open(const std::string& filename) const
 	}
 
 	// Ensure that the file size is greater than zero and can fit in a 32-bit integer.
-	PHYSFS_sint64 len = PHYSFS_fileLength(myFile);
-	if (len < 0 || len > UINT_MAX)
+	PHYSFS_sint64 fileLength = PHYSFS_fileLength(myFile);
+	if (fileLength < 0 || fileLength > UINT_MAX)
 	{
 		closeFile(myFile);
 		throw std::runtime_error(std::string("File '") + filename + "' is too large or size could not be determined");
 	}
 
 	// Create buffer large enough to hold entire file
-	auto bufferSize = static_cast<PHYSFS_uint32>(len);
+	auto bufferSize = static_cast<PHYSFS_uint32>(fileLength);
 	std::string fileBuffer;
 	fileBuffer.resize(std::size_t{bufferSize});
 
@@ -255,7 +255,7 @@ File Filesystem::open(const std::string& filename) const
 	closeFile(myFile);
 
 	// Ensure we read the expected length
-	if (actualReadLength < len)
+	if (actualReadLength < fileLength)
 	{
 		throw std::runtime_error(std::string("Unable to load '") + filename + "': " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -246,9 +246,9 @@ File Filesystem::open(const std::string& filename) const
 	}
 
 	// Create buffer large enough to hold entire file
-	const auto bufferSize = static_cast<PHYSFS_uint32>(fileLength);
+	const auto bufferSize = static_cast<std::size_t>(fileLength);
 	std::string fileBuffer;
-	fileBuffer.resize(std::size_t{bufferSize});
+	fileBuffer.resize(bufferSize);
 
 	// Read file data into buffer and close file
 	const auto actualReadLength = PHYSFS_readBytes(myFile, fileBuffer.data(), bufferSize);

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <sstream>
 #include <utility>
+#include <limits>
 
 
 using namespace NAS2D;
@@ -237,9 +238,9 @@ File Filesystem::open(const std::string& filename) const
 		throw std::runtime_error(std::string("Unable to load '") + filename + "': " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}
 
-	// Ensure that the file size is greater than zero and can fit in a 32-bit integer.
+	// Ensure that the file size is greater than zero and can fit in a std::size_t
 	auto fileLength = PHYSFS_fileLength(myFile);
-	if (fileLength < 0 || fileLength > UINT_MAX)
+	if (fileLength < 0 || static_cast<PHYSFS_uint64>(fileLength) > std::numeric_limits<std::size_t>::max())
 	{
 		closeFile(myFile);
 		throw std::runtime_error(std::string("File '") + filename + "' is too large or size could not be determined");

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -255,7 +255,7 @@ File Filesystem::open(const std::string& filename) const
 	closeFile(myFile);
 
 	// Ensure we read the expected length
-	if (actualReadLength < fileLength)
+	if (actualReadLength < len)
 	{
 		throw std::runtime_error(std::string("Unable to load '") + filename + "': " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -243,21 +243,20 @@ File Filesystem::open(const std::string& filename) const
 		throw std::runtime_error(std::string("File '") + filename + "' is too large or size could not be determined");
 	}
 
-	// Create a char* buffer large enough to hold the entire file.
+	// Create buffer large enough to hold entire file
 	auto fileLength = static_cast<PHYSFS_uint32>(len);
-	char* fileBuffer = new char[std::size_t{fileLength} + 1];
+	std::string fileBuffer;
+	fileBuffer.resize(std::size_t{fileLength});
 
 	// If we read less then the file length, return an empty File object, log a message and free any used memory.
-	if (PHYSFS_readBytes(myFile, fileBuffer, fileLength) < fileLength)
+	if (PHYSFS_readBytes(myFile, fileBuffer.data(), fileLength) < fileLength)
 	{
-		delete[] fileBuffer;
 		closeFile(myFile);
 		throw std::runtime_error(std::string("Unable to load '") + filename + "': " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}
 
-	File file(std::string(fileBuffer, fileLength), filename);
+	File file(fileBuffer, filename);
 	closeFile(myFile);
-	delete[] fileBuffer;
 
 	return file;
 }

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -258,9 +258,7 @@ File Filesystem::open(const std::string& filename) const
 		throw std::runtime_error(std::string("Unable to load '") + filename + "': " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}
 
-	File file(fileBuffer, filename);
-
-	return file;
+	return File{fileBuffer, filename};
 }
 
 


### PR DESCRIPTION
Refactor `Filesystem::open` to remove use of naked `new`/`delete`, enable move construction of returned `File` objects, and to enable loading of files larger than 4GB when `size_t` allows it (such as 64-bit builds).
