### PR TITLE
Use auto for returned File objects

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -137,7 +137,7 @@ void Configuration::load(const std::string& filePath)
 	{
 		try {
 			// Read in the Config File.
-			File xmlFile = Utility<Filesystem>::get().open(filePath);
+			auto xmlFile = Utility<Filesystem>::get().open(filePath);
 			loadData(xmlFile.raw_bytes());
 			std::cout << "done." << std::endl;
 		}

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -478,7 +478,7 @@ void RendererOpenGL::showSystemPointer(bool _b)
 
 void RendererOpenGL::addCursor(const std::string& filePath, int cursorId, int offx, int offy)
 {
-	File imageFile = Utility<Filesystem>::get().open(filePath);
+	auto imageFile = Utility<Filesystem>::get().open(filePath);
 	if (imageFile.size() == 0)
 	{
 		std::cout << "RendererOpenGL::addCursor(): '" << filePath << "' is empty." << std::endl;
@@ -647,7 +647,7 @@ void RendererOpenGL::window_icon(const std::string& path)
 {
 	if (!Utility<Filesystem>::get().exists(path)) { return; }
 
-	File f = Utility<Filesystem>::get().open(path);
+	auto f = Utility<Filesystem>::get().open(path);
 	SDL_Surface* icon = IMG_Load_RW(SDL_RWFromConstMem(f.raw_bytes(), static_cast<int>(f.size())), 1);
 	if (!icon)
 	{

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -647,8 +647,8 @@ void RendererOpenGL::window_icon(const std::string& path)
 {
 	if (!Utility<Filesystem>::get().exists(path)) { return; }
 
-	auto f = Utility<Filesystem>::get().open(path);
-	SDL_Surface* icon = IMG_Load_RW(SDL_RWFromConstMem(f.raw_bytes(), static_cast<int>(f.size())), 1);
+	auto iconFile = Utility<Filesystem>::get().open(path);
+	SDL_Surface* icon = IMG_Load_RW(SDL_RWFromConstMem(iconFile.raw_bytes(), static_cast<int>(iconFile.size())), 1);
 	if (!icon)
 	{
 		std::cout << "RendererOpenGL::window_icon(): " << SDL_GetError() << std::endl;

--- a/NAS2D/Resources/Font.cpp
+++ b/NAS2D/Resources/Font.cpp
@@ -186,7 +186,7 @@ namespace {
 			}
 		}
 
-		File fontBuffer = Utility<Filesystem>::get().open(path);
+		auto fontBuffer = Utility<Filesystem>::get().open(path);
 		if (fontBuffer.empty())
 		{
 			throw std::runtime_error("Font file is empty: " + path);
@@ -224,7 +224,7 @@ namespace {
 	 */
 	Font::FontInfo loadBitmap(const std::string& path)
 	{
-		File fontBuffer = Utility<Filesystem>::get().open(path);
+		auto fontBuffer = Utility<Filesystem>::get().open(path);
 		if (fontBuffer.empty())
 		{
 			throw std::runtime_error("Font file is empty: " + path);

--- a/NAS2D/Resources/Image.cpp
+++ b/NAS2D/Resources/Image.cpp
@@ -48,7 +48,7 @@ namespace {
 Image::Image(const std::string& filePath) :
 	mResourceName{filePath}
 {
-	File imageFile = Utility<Filesystem>::get().open(mResourceName);
+	auto imageFile = Utility<Filesystem>::get().open(mResourceName);
 	if (imageFile.size() == 0)
 	{
 		throw std::runtime_error("Image file is empty: " + mResourceName);

--- a/NAS2D/Resources/Sound.cpp
+++ b/NAS2D/Resources/Sound.cpp
@@ -28,7 +28,7 @@ using namespace NAS2D;
 Sound::Sound(const std::string& filePath) :
 	mResourceName{filePath}
 {
-	File soundFile = Utility<Filesystem>::get().open(mResourceName);
+	auto soundFile = Utility<Filesystem>::get().open(mResourceName);
 	if (soundFile.empty())
 	{
 		throw std::runtime_error("Sound file is empty: " + mResourceName);


### PR DESCRIPTION
Minor stylistic update. Sometimes `auto` has benefits, though not so much here. Mostly this adds to the trend of using `auto` which sometimes does have benefits.
