### PR TITLE
Protect Signal::emit() in Renderer

### DIFF
--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -14,7 +14,7 @@ Fade::Fade(Color fadeColor) :
 {}
 
 
-Signals::Signal<>& Fade::fadeComplete()
+Signals::SignalSource<>& Fade::fadeComplete()
 {
 	return mFadeComplete;
 }

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -15,7 +15,7 @@ class Fade
 public:
 	Fade(Color fadeColor = Color::Black);
 
-	Signals::Signal<>& fadeComplete();
+	Signals::SignalSource<>& fadeComplete();
 
 	void fadeIn(unsigned int durationInMilliseconds);
 	void fadeOut(unsigned int durationInMilliseconds);

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -145,7 +145,7 @@ bool Renderer::isFaded() const
 /**
  * Gets a refernece to the callback signal for fade transitions.
  */
-Signals::Signal<>& Renderer::fadeComplete()
+Signals::SignalSource<>& Renderer::fadeComplete()
 {
 	return fadeCompleteSignal;
 }

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -94,7 +94,7 @@ public:
 	void fadeOut(float delayTime);
 	bool isFading() const;
 	bool isFaded() const;
-	Signals::Signal<>& fadeComplete();
+	Signals::SignalSource<>& fadeComplete();
 
 	virtual void showSystemPointer(bool) = 0;
 	virtual void addCursor(const std::string& filePath, int cursorId, int offx, int offy) = 0;


### PR DESCRIPTION
Relies on #835. Cleanup associated with #830.

There's similar work to do for `EventHandler`, though that might take a bit longer. I didn't want to sit on these changes meanwhile. Especially since they serve as an example for updating other parts of the code, including in OPHD.
