### PR TITLE
Split EventHandler signals

### DIFF
--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -84,7 +84,7 @@ EventHandler::~EventHandler()
  *
  * \arg \c gained Bool value indicating whether or not the app lost focus.
  */
-EventHandler::ActivateEventCallback& EventHandler::activate()
+EventHandler::ActivateEventSource& EventHandler::activate()
 {
 	return mActivateEvent;
 }
@@ -106,7 +106,7 @@ EventHandler::ActivateEventCallback& EventHandler::activate()
  *
  * \arg \c gained Bool value indicating whether or not the window was hidden.
  */
-EventHandler::WindowHiddenEventCallback& EventHandler::windowHidden()
+EventHandler::WindowHiddenEventSource& EventHandler::windowHidden()
 {
 	return mWindowHiddenEventCallback;
 }
@@ -126,7 +126,7 @@ EventHandler::WindowHiddenEventCallback& EventHandler::windowHidden()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowExposedEventCallback& EventHandler::windowExposed()
+EventHandler::WindowExposedEventSource& EventHandler::windowExposed()
 {
 	return mWindowExposedEventCallback;
 }
@@ -146,7 +146,7 @@ EventHandler::WindowExposedEventCallback& EventHandler::windowExposed()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowMinimizedEventCallback& EventHandler::windowMinimized()
+EventHandler::WindowMinimizedEventSource& EventHandler::windowMinimized()
 {
 	return mWindowMinimizedEventCallback;
 }
@@ -166,7 +166,7 @@ EventHandler::WindowMinimizedEventCallback& EventHandler::windowMinimized()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowMaximizedEventCallback& EventHandler::windowMaximized()
+EventHandler::WindowMaximizedEventSource& EventHandler::windowMaximized()
 {
 	return mWindowMaximizedEventCallback;
 }
@@ -186,7 +186,7 @@ EventHandler::WindowMaximizedEventCallback& EventHandler::windowMaximized()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowRestoredEventCallback& EventHandler::windowRestored()
+EventHandler::WindowRestoredEventSource& EventHandler::windowRestored()
 {
 	return mWindowRestoredEventCallback;
 }
@@ -206,7 +206,7 @@ EventHandler::WindowRestoredEventCallback& EventHandler::windowRestored()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowResizedEventCallback& EventHandler::windowResized()
+EventHandler::WindowResizedEventSource& EventHandler::windowResized()
 {
 	return mWindowResizedEventCallback;
 }
@@ -226,7 +226,7 @@ EventHandler::WindowResizedEventCallback& EventHandler::windowResized()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowMouseEnterEventCallback& EventHandler::windowMouseEnter()
+EventHandler::WindowMouseEnterEventSource& EventHandler::windowMouseEnter()
 {
 	return mWindowMouseEnterEventCallback;
 }
@@ -246,7 +246,7 @@ EventHandler::WindowMouseEnterEventCallback& EventHandler::windowMouseEnter()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowMouseLeaveEventCallback& EventHandler::windowMouseLeave()
+EventHandler::WindowMouseLeaveEventSource& EventHandler::windowMouseLeave()
 {
 	return mWindowMouseLeaveEventCallback;
 }
@@ -272,7 +272,7 @@ EventHandler::WindowMouseLeaveEventCallback& EventHandler::windowMouseLeave()
  * Some joysticks use additional axis as buttons.
  * \arg \c pos Current position of the axis.
  */
-EventHandler::JoystickAxisMotionEventCallback& EventHandler::joystickAxisMotion()
+EventHandler::JoystickAxisMotionEventSource& EventHandler::joystickAxisMotion()
 {
 	return mJoystickAxisMotionEvent;
 }
@@ -298,7 +298,7 @@ EventHandler::JoystickAxisMotionEventCallback& EventHandler::joystickAxisMotion(
  * \arg \c xChange Change in relative position of the X position.
  * \arg \c yChange Change in relative position of the Y position.
  */
-EventHandler::JoystickBallMotionEventCallback& EventHandler::joystickBallMotion()
+EventHandler::JoystickBallMotionEventSource& EventHandler::joystickBallMotion()
 {
 	return mJoystickBallMotionEvent;
 }
@@ -323,7 +323,7 @@ EventHandler::JoystickBallMotionEventCallback& EventHandler::joystickBallMotion(
  * \arg \c deviceId	Joystick ID which this event was generated from.
  * \arg \c buttonId	Button ID which the event was generated from.
  */
-EventHandler::JoystickButtonEventCallback& EventHandler::joystickButtonUp()
+EventHandler::JoystickButtonEventSource& EventHandler::joystickButtonUp()
 {
 	return mJoystickButtonUpEvent;
 }
@@ -348,7 +348,7 @@ EventHandler::JoystickButtonEventCallback& EventHandler::joystickButtonUp()
  * \arg \c deviceId	Joystick ID which this event was generated from.
  * \arg \c buttonId	Button ID which the event was generated from.
  */
-EventHandler::JoystickButtonEventCallback& EventHandler::joystickButtonDown()
+EventHandler::JoystickButtonEventSource& EventHandler::joystickButtonDown()
 {
 	return mJoystickButtonDownEvent;
 }
@@ -373,7 +373,7 @@ EventHandler::JoystickButtonEventCallback& EventHandler::joystickButtonDown()
  * \arg \c hatId	Hat ID.
  * \arg \c pos		Current position of the hat.
  */
-EventHandler::JoystickHatMotionEventCallback& EventHandler::joystickHatMotion()
+EventHandler::JoystickHatMotionEventSource& EventHandler::joystickHatMotion()
 {
 	return mJoystickHatMotionEvent;
 }
@@ -398,7 +398,7 @@ EventHandler::JoystickHatMotionEventCallback& EventHandler::joystickHatMotion()
  * \arg \c mod		Keyboard modifier.
  * \arg \c repeat	Indicates that this event is a repeat and not an initial key event.
  */
-EventHandler::KeyDownEventCallback& EventHandler::keyDown()
+EventHandler::KeyDownEventSource& EventHandler::keyDown()
 {
 	return mKeyDownEvent;
 }
@@ -422,7 +422,7 @@ EventHandler::KeyDownEventCallback& EventHandler::keyDown()
  * \arg \c key		KeyCode representing a key on the keyboard.
  * \arg \c mod		Keyboard modifier.
  */
-EventHandler::KeyUpEventCallback& EventHandler::keyUp()
+EventHandler::KeyUpEventSource& EventHandler::keyUp()
 {
 	return mKeyUpEvent;
 }
@@ -442,7 +442,7 @@ EventHandler::KeyUpEventCallback& EventHandler::keyUp()
 * void function(const std::string&);
 * \endcode
 */
-EventHandler::TextInputEventCallback& EventHandler::textInput()
+EventHandler::TextInputEventSource& EventHandler::textInput()
 {
 	return mTextInput;
 }
@@ -467,7 +467,7 @@ EventHandler::TextInputEventCallback& EventHandler::textInput()
  * \arg \c x: X position of the mouse button event.
  * \arg \c y: Y position of the mouse button event.
  */
-EventHandler::MouseButtonEventCallback& EventHandler::mouseButtonDown()
+EventHandler::MouseButtonEventSource& EventHandler::mouseButtonDown()
 {
 	return mMouseButtonDownEvent;
 }
@@ -492,7 +492,7 @@ EventHandler::MouseButtonEventCallback& EventHandler::mouseButtonDown()
  * \arg \c x: X position of the mouse button event.
  * \arg \c y: Y position of the mouse button event.
  */
-EventHandler::MouseButtonEventCallback& EventHandler::mouseButtonUp()
+EventHandler::MouseButtonEventSource& EventHandler::mouseButtonUp()
 {
 	return mMouseButtonUpEvent;
 }
@@ -517,7 +517,7 @@ EventHandler::MouseButtonEventCallback& EventHandler::mouseButtonUp()
  * \arg \c x: X position of the mouse button event.
  * \arg \c y: Y position of the mouse button event.
  */
-EventHandler::MouseButtonEventCallback& EventHandler::mouseDoubleClick()
+EventHandler::MouseButtonEventSource& EventHandler::mouseDoubleClick()
 {
 	return mMouseDoubleClick;
 }
@@ -543,7 +543,7 @@ EventHandler::MouseButtonEventCallback& EventHandler::mouseDoubleClick()
  * \arg \c relX: X position of the mouse relative to its last position.
  * \arg \c relY: Y position of the mouse relative to its last position.
  */
-EventHandler::MouseMotionEventCallback& EventHandler::mouseMotion()
+EventHandler::MouseMotionEventSource& EventHandler::mouseMotion()
 {
 	return mMouseMotionEvent;
 }
@@ -572,7 +572,7 @@ EventHandler::MouseMotionEventCallback& EventHandler::mouseMotion()
  * more than one (on Windows this value is typical 120,
  * not 1).
  */
-EventHandler::MouseWheelEventCallback& EventHandler::mouseWheel()
+EventHandler::MouseWheelEventSource& EventHandler::mouseWheel()
 {
 	return mMouseWheelEvent;
 }
@@ -592,7 +592,7 @@ EventHandler::MouseWheelEventCallback& EventHandler::mouseWheel()
  * void function(void);
  * \endcode
  */
-EventHandler::QuitEventCallback& EventHandler::quit()
+EventHandler::QuitEventSource& EventHandler::quit()
 {
 	return mQuitEvent;
 }

--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -108,7 +108,7 @@ EventHandler::ActivateEventSource& EventHandler::activate()
  */
 EventHandler::WindowHiddenEventSource& EventHandler::windowHidden()
 {
-	return mWindowHiddenEventCallback;
+	return mWindowHiddenEvent;
 }
 
 
@@ -128,7 +128,7 @@ EventHandler::WindowHiddenEventSource& EventHandler::windowHidden()
  */
 EventHandler::WindowExposedEventSource& EventHandler::windowExposed()
 {
-	return mWindowExposedEventCallback;
+	return mWindowExposedEvent;
 }
 
 
@@ -148,7 +148,7 @@ EventHandler::WindowExposedEventSource& EventHandler::windowExposed()
  */
 EventHandler::WindowMinimizedEventSource& EventHandler::windowMinimized()
 {
-	return mWindowMinimizedEventCallback;
+	return mWindowMinimizedEvent;
 }
 
 
@@ -168,7 +168,7 @@ EventHandler::WindowMinimizedEventSource& EventHandler::windowMinimized()
  */
 EventHandler::WindowMaximizedEventSource& EventHandler::windowMaximized()
 {
-	return mWindowMaximizedEventCallback;
+	return mWindowMaximizedEvent;
 }
 
 
@@ -188,7 +188,7 @@ EventHandler::WindowMaximizedEventSource& EventHandler::windowMaximized()
  */
 EventHandler::WindowRestoredEventSource& EventHandler::windowRestored()
 {
-	return mWindowRestoredEventCallback;
+	return mWindowRestoredEvent;
 }
 
 
@@ -208,7 +208,7 @@ EventHandler::WindowRestoredEventSource& EventHandler::windowRestored()
  */
 EventHandler::WindowResizedEventSource& EventHandler::windowResized()
 {
-	return mWindowResizedEventCallback;
+	return mWindowResizedEvent;
 }
 
 
@@ -228,7 +228,7 @@ EventHandler::WindowResizedEventSource& EventHandler::windowResized()
  */
 EventHandler::WindowMouseEnterEventSource& EventHandler::windowMouseEnter()
 {
-	return mWindowMouseEnterEventCallback;
+	return mWindowMouseEnterEvent;
 }
 
 
@@ -248,7 +248,7 @@ EventHandler::WindowMouseEnterEventSource& EventHandler::windowMouseEnter()
  */
 EventHandler::WindowMouseLeaveEventSource& EventHandler::windowMouseLeave()
 {
-	return mWindowMouseLeaveEventCallback;
+	return mWindowMouseLeaveEvent;
 }
 
 
@@ -715,15 +715,15 @@ void EventHandler::pump()
 			// Not completely happy with this but meh, it works.
 			if (event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED) { mActivateEvent(true); }
 			else if (event.window.event == SDL_WINDOWEVENT_FOCUS_LOST) { mActivateEvent(false); }
-			else if (event.window.event == SDL_WINDOWEVENT_SHOWN) { mWindowHiddenEventCallback(false); }
-			else if (event.window.event == SDL_WINDOWEVENT_HIDDEN) { mWindowHiddenEventCallback(true); }
-			else if (event.window.event == SDL_WINDOWEVENT_EXPOSED) { mWindowExposedEventCallback(); }
-			else if (event.window.event == SDL_WINDOWEVENT_MINIMIZED) { mWindowMinimizedEventCallback(); }
-			else if (event.window.event == SDL_WINDOWEVENT_MAXIMIZED) { mWindowMaximizedEventCallback(); }
-			else if (event.window.event == SDL_WINDOWEVENT_RESTORED) { mWindowRestoredEventCallback(); }
-			else if (event.window.event == SDL_WINDOWEVENT_ENTER) { mWindowMouseEnterEventCallback(); }
-			else if (event.window.event == SDL_WINDOWEVENT_LEAVE) { mWindowMouseLeaveEventCallback(); }
-			else if (event.window.event == SDL_WINDOWEVENT_RESIZED) { mWindowResizedEventCallback(event.window.data1, event.window.data2); }
+			else if (event.window.event == SDL_WINDOWEVENT_SHOWN) { mWindowHiddenEvent(false); }
+			else if (event.window.event == SDL_WINDOWEVENT_HIDDEN) { mWindowHiddenEvent(true); }
+			else if (event.window.event == SDL_WINDOWEVENT_EXPOSED) { mWindowExposedEvent(); }
+			else if (event.window.event == SDL_WINDOWEVENT_MINIMIZED) { mWindowMinimizedEvent(); }
+			else if (event.window.event == SDL_WINDOWEVENT_MAXIMIZED) { mWindowMaximizedEvent(); }
+			else if (event.window.event == SDL_WINDOWEVENT_RESTORED) { mWindowRestoredEvent(); }
+			else if (event.window.event == SDL_WINDOWEVENT_ENTER) { mWindowMouseEnterEvent(); }
+			else if (event.window.event == SDL_WINDOWEVENT_LEAVE) { mWindowMouseLeaveEvent(); }
+			else if (event.window.event == SDL_WINDOWEVENT_RESIZED) { mWindowResizedEvent(event.window.data1, event.window.data2); }
 			break;
 
 		case SDL_QUIT:

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -246,66 +246,66 @@ public:
 	};
 
 
-	using ActivateEventCallback = Signals::SignalSource<bool>;
-	using WindowHiddenEventCallback = Signals::SignalSource<bool>;
-	using WindowExposedEventCallback = Signals::SignalSource<>;
-	using WindowMinimizedEventCallback = Signals::SignalSource<>;
-	using WindowMaximizedEventCallback = Signals::SignalSource<>;
-	using WindowRestoredEventCallback = Signals::SignalSource<>;
-	using WindowResizedEventCallback = Signals::SignalSource<int, int>;
-	using WindowMouseEnterEventCallback = Signals::SignalSource<>;
-	using WindowMouseLeaveEventCallback = Signals::SignalSource<>;
+	using ActivateEventSource = Signals::SignalSource<bool>;
+	using WindowHiddenEventSource = Signals::SignalSource<bool>;
+	using WindowExposedEventSource = Signals::SignalSource<>;
+	using WindowMinimizedEventSource = Signals::SignalSource<>;
+	using WindowMaximizedEventSource = Signals::SignalSource<>;
+	using WindowRestoredEventSource = Signals::SignalSource<>;
+	using WindowResizedEventSource = Signals::SignalSource<int, int>;
+	using WindowMouseEnterEventSource = Signals::SignalSource<>;
+	using WindowMouseLeaveEventSource = Signals::SignalSource<>;
 
-	using JoystickAxisMotionEventCallback = Signals::SignalSource<int, int, int>;
-	using JoystickBallMotionEventCallback = Signals::SignalSource<int, int, int, int>;
-	using JoystickButtonEventCallback = Signals::SignalSource<int, int>;
-	using JoystickHatMotionEventCallback = Signals::SignalSource<int, int, int>;
+	using JoystickAxisMotionEventSource = Signals::SignalSource<int, int, int>;
+	using JoystickBallMotionEventSource = Signals::SignalSource<int, int, int, int>;
+	using JoystickButtonEventSource = Signals::SignalSource<int, int>;
+	using JoystickHatMotionEventSource = Signals::SignalSource<int, int, int>;
 
-	using KeyDownEventCallback = Signals::SignalSource<KeyCode, KeyModifier, bool>;
-	using KeyUpEventCallback = Signals::SignalSource<KeyCode, KeyModifier>;
-	using TextInputEventCallback = Signals::SignalSource<const std::string&>;
+	using KeyDownEventSource = Signals::SignalSource<KeyCode, KeyModifier, bool>;
+	using KeyUpEventSource = Signals::SignalSource<KeyCode, KeyModifier>;
+	using TextInputEventSource = Signals::SignalSource<const std::string&>;
 
-	using MouseButtonEventCallback = Signals::SignalSource<MouseButton, int, int>;
-	using MouseMotionEventCallback = Signals::SignalSource<int, int, int, int>;
-	using MouseWheelEventCallback = Signals::SignalSource<int, int>;
+	using MouseButtonEventSource = Signals::SignalSource<MouseButton, int, int>;
+	using MouseMotionEventSource = Signals::SignalSource<int, int, int, int>;
+	using MouseWheelEventSource = Signals::SignalSource<int, int>;
 
-	using QuitEventCallback = Signals::SignalSource<>;
+	using QuitEventSource = Signals::SignalSource<>;
 
 public:
 	EventHandler();
 	~EventHandler();
 
-	ActivateEventCallback& activate();
+	ActivateEventSource& activate();
 
-	WindowHiddenEventCallback& windowHidden();
-	WindowExposedEventCallback& windowExposed();
+	WindowHiddenEventSource& windowHidden();
+	WindowExposedEventSource& windowExposed();
 
-	WindowMinimizedEventCallback& windowMinimized();
-	WindowMaximizedEventCallback& windowMaximized();
-	WindowRestoredEventCallback& windowRestored();
-	WindowResizedEventCallback& windowResized();
+	WindowMinimizedEventSource& windowMinimized();
+	WindowMaximizedEventSource& windowMaximized();
+	WindowRestoredEventSource& windowRestored();
+	WindowResizedEventSource& windowResized();
 
-	WindowMouseEnterEventCallback& windowMouseEnter();
-	WindowMouseLeaveEventCallback& windowMouseLeave();
+	WindowMouseEnterEventSource& windowMouseEnter();
+	WindowMouseLeaveEventSource& windowMouseLeave();
 
-	JoystickAxisMotionEventCallback& joystickAxisMotion();
-	JoystickBallMotionEventCallback& joystickBallMotion();
-	JoystickButtonEventCallback& joystickButtonUp();
-	JoystickButtonEventCallback& joystickButtonDown();
-	JoystickHatMotionEventCallback& joystickHatMotion();
+	JoystickAxisMotionEventSource& joystickAxisMotion();
+	JoystickBallMotionEventSource& joystickBallMotion();
+	JoystickButtonEventSource& joystickButtonUp();
+	JoystickButtonEventSource& joystickButtonDown();
+	JoystickHatMotionEventSource& joystickHatMotion();
 
-	KeyUpEventCallback& keyUp();
-	KeyDownEventCallback& keyDown();
+	KeyUpEventSource& keyUp();
+	KeyDownEventSource& keyDown();
 
-	TextInputEventCallback& textInput();
+	TextInputEventSource& textInput();
 
-	MouseButtonEventCallback& mouseButtonUp();
-	MouseButtonEventCallback& mouseButtonDown();
-	MouseButtonEventCallback& mouseDoubleClick();
-	MouseMotionEventCallback& mouseMotion();
-	MouseWheelEventCallback& mouseWheel();
+	MouseButtonEventSource& mouseButtonUp();
+	MouseButtonEventSource& mouseButtonDown();
+	MouseButtonEventSource& mouseDoubleClick();
+	MouseMotionEventSource& mouseMotion();
+	MouseWheelEventSource& mouseWheel();
 
-	QuitEventCallback& quit();
+	QuitEventSource& quit();
 
 	void grabMouse();
 	void releaseMouse();

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -346,13 +346,13 @@ private:
 	Signals::Signal<int, int> mJoystickButtonDownEvent;
 	Signals::Signal<int, int, int> mJoystickHatMotionEvent;
 
-	Signals::Signal<KeyCode, KeyModifier> mKeyUpEvent;
 	Signals::Signal<KeyCode, KeyModifier, bool> mKeyDownEvent;
+	Signals::Signal<KeyCode, KeyModifier> mKeyUpEvent;
 
 	Signals::Signal<const std::string&> mTextInput;
 
-	Signals::Signal<MouseButton, int, int> mMouseButtonUpEvent;
 	Signals::Signal<MouseButton, int, int> mMouseButtonDownEvent;
+	Signals::Signal<MouseButton, int, int> mMouseButtonUpEvent;
 	Signals::Signal<MouseButton, int, int> mMouseDoubleClick;
 	Signals::Signal<int, int, int, int> mMouseMotionEvent;
 	Signals::Signal<int, int> mMouseWheelEvent;

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -331,14 +331,14 @@ public:
 private:
 	Signals::Signal<bool> mActivateEvent;
 
-	Signals::Signal<bool> mWindowHiddenEventCallback;
-	Signals::Signal<> mWindowExposedEventCallback;
-	Signals::Signal<> mWindowMinimizedEventCallback;
-	Signals::Signal<> mWindowMaximizedEventCallback;
-	Signals::Signal<> mWindowRestoredEventCallback;
-	Signals::Signal<int, int> mWindowResizedEventCallback;
-	Signals::Signal<> mWindowMouseEnterEventCallback;
-	Signals::Signal<> mWindowMouseLeaveEventCallback;
+	Signals::Signal<bool> mWindowHiddenEvent;
+	Signals::Signal<> mWindowExposedEvent;
+	Signals::Signal<> mWindowMinimizedEvent;
+	Signals::Signal<> mWindowMaximizedEvent;
+	Signals::Signal<> mWindowRestoredEvent;
+	Signals::Signal<int, int> mWindowResizedEvent;
+	Signals::Signal<> mWindowMouseEnterEvent;
+	Signals::Signal<> mWindowMouseLeaveEvent;
 
 	Signals::Signal<int, int, int> mJoystickAxisMotionEvent;
 	Signals::Signal<int, int, int, int> mJoystickBallMotionEvent;

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -246,30 +246,30 @@ public:
 	};
 
 
-	using ActivateEventCallback = Signals::Signal<bool>;
-	using WindowHiddenEventCallback = Signals::Signal<bool>;
-	using WindowExposedEventCallback = Signals::Signal<>;
-	using WindowMinimizedEventCallback = Signals::Signal<>;
-	using WindowMaximizedEventCallback = Signals::Signal<>;
-	using WindowRestoredEventCallback = Signals::Signal<>;
-	using WindowResizedEventCallback = Signals::Signal<int, int>;
-	using WindowMouseEnterEventCallback = Signals::Signal<>;
-	using WindowMouseLeaveEventCallback = Signals::Signal<>;
+	using ActivateEventCallback = Signals::SignalSource<bool>;
+	using WindowHiddenEventCallback = Signals::SignalSource<bool>;
+	using WindowExposedEventCallback = Signals::SignalSource<>;
+	using WindowMinimizedEventCallback = Signals::SignalSource<>;
+	using WindowMaximizedEventCallback = Signals::SignalSource<>;
+	using WindowRestoredEventCallback = Signals::SignalSource<>;
+	using WindowResizedEventCallback = Signals::SignalSource<int, int>;
+	using WindowMouseEnterEventCallback = Signals::SignalSource<>;
+	using WindowMouseLeaveEventCallback = Signals::SignalSource<>;
 
-	using JoystickAxisMotionEventCallback = Signals::Signal<int, int, int>;
-	using JoystickBallMotionEventCallback = Signals::Signal<int, int, int, int>;
-	using JoystickButtonEventCallback = Signals::Signal<int, int>;
-	using JoystickHatMotionEventCallback = Signals::Signal<int, int, int>;
+	using JoystickAxisMotionEventCallback = Signals::SignalSource<int, int, int>;
+	using JoystickBallMotionEventCallback = Signals::SignalSource<int, int, int, int>;
+	using JoystickButtonEventCallback = Signals::SignalSource<int, int>;
+	using JoystickHatMotionEventCallback = Signals::SignalSource<int, int, int>;
 
-	using KeyDownEventCallback = Signals::Signal<KeyCode, KeyModifier, bool>;
-	using KeyUpEventCallback = Signals::Signal<KeyCode, KeyModifier>;
-	using TextInputEventCallback = Signals::Signal<const std::string&>;
+	using KeyDownEventCallback = Signals::SignalSource<KeyCode, KeyModifier, bool>;
+	using KeyUpEventCallback = Signals::SignalSource<KeyCode, KeyModifier>;
+	using TextInputEventCallback = Signals::SignalSource<const std::string&>;
 
-	using MouseButtonEventCallback = Signals::Signal<MouseButton, int, int>;
-	using MouseMotionEventCallback = Signals::Signal<int, int, int, int>;
-	using MouseWheelEventCallback = Signals::Signal<int, int>;
+	using MouseButtonEventCallback = Signals::SignalSource<MouseButton, int, int>;
+	using MouseMotionEventCallback = Signals::SignalSource<int, int, int, int>;
+	using MouseWheelEventCallback = Signals::SignalSource<int, int>;
 
-	using QuitEventCallback = Signals::Signal<>;
+	using QuitEventCallback = Signals::SignalSource<>;
 
 public:
 	EventHandler();

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -329,35 +329,35 @@ public:
 	void disconnectAll();
 
 private:
-	ActivateEventCallback mActivateEvent;
+	Signals::Signal<bool> mActivateEvent;
 
-	WindowHiddenEventCallback mWindowHiddenEventCallback;
-	WindowExposedEventCallback mWindowExposedEventCallback;
-	WindowMinimizedEventCallback mWindowMinimizedEventCallback;
-	WindowMaximizedEventCallback mWindowMaximizedEventCallback;
-	WindowRestoredEventCallback mWindowRestoredEventCallback;
-	WindowResizedEventCallback mWindowResizedEventCallback;
-	WindowMouseEnterEventCallback mWindowMouseEnterEventCallback;
-	WindowMouseLeaveEventCallback mWindowMouseLeaveEventCallback;
+	Signals::Signal<bool> mWindowHiddenEventCallback;
+	Signals::Signal<> mWindowExposedEventCallback;
+	Signals::Signal<> mWindowMinimizedEventCallback;
+	Signals::Signal<> mWindowMaximizedEventCallback;
+	Signals::Signal<> mWindowRestoredEventCallback;
+	Signals::Signal<int, int> mWindowResizedEventCallback;
+	Signals::Signal<> mWindowMouseEnterEventCallback;
+	Signals::Signal<> mWindowMouseLeaveEventCallback;
 
-	JoystickAxisMotionEventCallback mJoystickAxisMotionEvent;
-	JoystickBallMotionEventCallback mJoystickBallMotionEvent;
-	JoystickButtonEventCallback mJoystickButtonUpEvent;
-	JoystickButtonEventCallback mJoystickButtonDownEvent;
-	JoystickHatMotionEventCallback mJoystickHatMotionEvent;
+	Signals::Signal<int, int, int> mJoystickAxisMotionEvent;
+	Signals::Signal<int, int, int, int> mJoystickBallMotionEvent;
+	Signals::Signal<int, int> mJoystickButtonUpEvent;
+	Signals::Signal<int, int> mJoystickButtonDownEvent;
+	Signals::Signal<int, int, int> mJoystickHatMotionEvent;
 
-	KeyUpEventCallback mKeyUpEvent;
-	KeyDownEventCallback mKeyDownEvent;
+	Signals::Signal<KeyCode, KeyModifier> mKeyUpEvent;
+	Signals::Signal<KeyCode, KeyModifier, bool> mKeyDownEvent;
 
-	TextInputEventCallback mTextInput;
+	Signals::Signal<const std::string&> mTextInput;
 
-	MouseButtonEventCallback mMouseButtonUpEvent;
-	MouseButtonEventCallback mMouseButtonDownEvent;
-	MouseButtonEventCallback mMouseDoubleClick;
-	MouseMotionEventCallback mMouseMotionEvent;
-	MouseWheelEventCallback mMouseWheelEvent;
+	Signals::Signal<MouseButton, int, int> mMouseButtonUpEvent;
+	Signals::Signal<MouseButton, int, int> mMouseButtonDownEvent;
+	Signals::Signal<MouseButton, int, int> mMouseDoubleClick;
+	Signals::Signal<int, int, int, int> mMouseMotionEvent;
+	Signals::Signal<int, int> mMouseWheelEvent;
 
-	QuitEventCallback mQuitEvent;
+	Signals::Signal<> mQuitEvent;
 };
 
 void postQuitEvent();


### PR DESCRIPTION
Addresses part of #830.

Split off access to `SignalSource` interface from `Signal` in `EventHandler`.

Rename types and variables for added clarity. The restricted type is an "EventSource", while `Signal` variables are an "Event". Neither of them is a "Callback", which is a different related type.
