### PR TITLE
Rename enum class values

### DIFF
--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -767,7 +767,7 @@ bool EventHandler::textInputMode()
  */
 bool EventHandler::shift(KeyModifier mod) const
 {
-	return KeyModifier::KEY_MOD_NONE != (mod & (KeyModifier::KEY_MOD_SHIFT | KeyModifier::KEY_MOD_CAPS));
+	return KeyModifier::None != (mod & (KeyModifier::Shift | KeyModifier::Caps));
 }
 
 
@@ -778,7 +778,7 @@ bool EventHandler::shift(KeyModifier mod) const
  */
 bool EventHandler::alt(KeyModifier mod) const
 {
-	return KeyModifier::KEY_MOD_NONE != (mod & KeyModifier::KEY_MOD_ALT);
+	return KeyModifier::None != (mod & KeyModifier::Alt);
 }
 
 
@@ -789,7 +789,7 @@ bool EventHandler::alt(KeyModifier mod) const
  */
 bool EventHandler::numlock(KeyModifier mod) const
 {
-	return KeyModifier::KEY_MOD_NONE != (mod & KeyModifier::KEY_MOD_NUM);
+	return KeyModifier::None != (mod & KeyModifier::Num);
 }
 
 
@@ -800,7 +800,7 @@ bool EventHandler::numlock(KeyModifier mod) const
  */
 bool EventHandler::control(KeyModifier mod) const
 {
-	return KeyModifier::KEY_MOD_NONE != (mod & KeyModifier::KEY_MOD_CTRL);
+	return KeyModifier::None != (mod & KeyModifier::Ctrl);
 }
 
 
@@ -810,7 +810,7 @@ bool EventHandler::control(KeyModifier mod) const
 bool EventHandler::query_shift() const
 {
 	using underlying = std::underlying_type_t<KeyModifier>;
-	return KeyModifier::KEY_MOD_NONE != static_cast<KeyModifier>(SDL_GetModState() & static_cast<underlying>(KeyModifier::KEY_MOD_SHIFT));
+	return KeyModifier::None != static_cast<KeyModifier>(SDL_GetModState() & static_cast<underlying>(KeyModifier::Shift));
 }
 
 
@@ -820,7 +820,7 @@ bool EventHandler::query_shift() const
 bool EventHandler::query_numlock() const
 {
 	using underlying = std::underlying_type_t<KeyModifier>;
-	return KeyModifier::KEY_MOD_NONE != static_cast<KeyModifier>(SDL_GetModState() & static_cast<underlying>(KeyModifier::KEY_MOD_NUM));
+	return KeyModifier::None != static_cast<KeyModifier>(SDL_GetModState() & static_cast<underlying>(KeyModifier::Num));
 }
 
 
@@ -830,7 +830,7 @@ bool EventHandler::query_numlock() const
 bool EventHandler::query_control() const
 {
 	using underlying = std::underlying_type_t<KeyModifier>;
-	return KeyModifier::KEY_MOD_NONE != static_cast<KeyModifier>(SDL_GetModState() & static_cast<underlying>(KeyModifier::KEY_MOD_CTRL));
+	return KeyModifier::None != static_cast<KeyModifier>(SDL_GetModState() & static_cast<underlying>(KeyModifier::Ctrl));
 }
 
 

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -239,10 +239,10 @@ public:
 	*/
 	enum class MouseButton
 	{
-		BUTTON_NONE,
-		BUTTON_LEFT,
-		BUTTON_MIDDLE,
-		BUTTON_RIGHT
+		None,
+		Left,
+		Middle,
+		Right
 	};
 
 

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -34,23 +34,23 @@ public:
 	*/
 	enum class KeyModifier : uint16_t
 	{
-		KEY_MOD_NONE = 0x0000,
-		KEY_MOD_LSHIFT = 0x0001,
-		KEY_MOD_RSHIFT = 0x0002,
-		KEY_MOD_SHIFT = KEY_MOD_LSHIFT | KEY_MOD_RSHIFT,
-		KEY_MOD_LCTRL = 0x0040,
-		KEY_MOD_RCTRL = 0x0080,
-		KEY_MOD_CTRL = KEY_MOD_LCTRL | KEY_MOD_RCTRL,
-		KEY_MOD_LALT = 0x0100,
-		KEY_MOD_RALT = 0x0200,
-		KEY_MOD_ALT = KEY_MOD_LALT | KEY_MOD_RALT,
-		KEY_MOD_LMETA = 0x0400,
-		KEY_MOD_RMETA = 0x0800,
-		KEY_MOD_META = KEY_MOD_LMETA | KEY_MOD_RMETA,
-		KEY_MOD_NUM = 0x1000,
-		KEY_MOD_CAPS = 0x2000,
-		KEY_MOD_MODE = 0x4000,
-		KEY_MOD_RESERVED = 0x8000
+		None = 0x0000,
+		ShiftLeft = 0x0001,
+		ShiftRight = 0x0002,
+		Shift = ShiftLeft | ShiftRight,
+		CtrlLeft = 0x0040,
+		CtrlRight = 0x0080,
+		Ctrl = CtrlLeft | CtrlRight,
+		AltLeft = 0x0100,
+		AltRight = 0x0200,
+		Alt = AltLeft | AltRight,
+		MetaLeft = 0x0400,
+		MetaRight = 0x0800,
+		Meta = MetaLeft | MetaRight,
+		Num = 0x1000,
+		Caps = 0x2000,
+		Mode = 0x4000,
+		Reserved = 0x8000
 	};
 
 


### PR DESCRIPTION
Noticed this while working on #830.

Renames some of the enum class value names in `EventHandler`.

----

For now I've left the rather large `KeyCode` enum alone. If we rename the value names, we'd need a new convention for the `KEY_0` .. `KEY_9` names. If we shortened the names to `0` .. `9`, they would no longer be valid variable names. Perhaps they could be named `_0` .. `_9`. Additionally we are a bit inconsistent currently about the capitalization of `KEY_a` .. `KEY_z`. To be more consistent, these could be shortened to `A` .. `Z`.

We use a couple of `#define` macros in this file to implement `SCANCODE_TO_KEYCODE`. These should be switched to a `constexpr` style function `scancodeToKeycode`.

Of course another question is if we really want or need such a large enum? Maybe probably yes. Though do we need to include the printable characters? Maybe just the special keys is sufficient. I can't imagine anyone using a constant name instead of a literal for numbers or letters.
