### PR TITLE
Add Signal Connection

### DIFF
--- a/NAS2D/Connection.h
+++ b/NAS2D/Connection.h
@@ -14,6 +14,16 @@ public:
 	using SignalType = SignalSource<Params...>;
 	using DelegateType = DelegateX<void, Params...>;
 
+	// No copy/move construction/assignment
+	// This class is designed to handle a parent object's connection to a signal
+	// The delegate parameter is likely tied to the address of the parent object
+	// When parent object is copied/moved, a new updated connection must be formed
+	// Disable copy/move to remove default copy/move from parent objects
+	Connection(const Connection&) = delete;
+	Connection(Connection&&) = delete;
+	Connection& operator=(const Connection&) = delete;
+	Connection& operator=(Connection&&) = delete;
+
 	Connection(SignalType& signalSource, DelegateType delegate) :
 		mSignalSource{signalSource},
 		mDelegate{delegate}

--- a/NAS2D/Connection.h
+++ b/NAS2D/Connection.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Delegate.h"
+#include "SignalSource.h"
+
+
+namespace NAS2D::Signals {
+
+
+template<typename ... Params>
+class Connection
+{
+public:
+	using SignalType = SignalSource<Params...>;
+	using DelegateType = DelegateX<void, Params...>;
+
+	Connection(SignalType& signalSource, DelegateType delegate) :
+		mSignalSource{signalSource},
+		mDelegate{delegate}
+	{
+		mSignalSource.connect(mDelegate);
+	}
+
+	~Connection()
+	{
+		mSignalSource.disconnect(mDelegate);
+	}
+
+private:
+	SignalType& mSignalSource;
+	DelegateType mDelegate;
+};
+
+}

--- a/NAS2D/SignalSource.h
+++ b/NAS2D/SignalSource.h
@@ -13,26 +13,6 @@ class SignalSource
 public:
 	using DelegateType = DelegateX<void, Params...>;
 
-	class Connection
-	{
-	public:
-		Connection(SignalSource& signalSource, DelegateType delegate) :
-			mSignalSource{signalSource},
-			mDelegate{delegate}
-		{
-			mSignalSource.connect(mDelegate);
-		}
-
-		~Connection()
-		{
-			mSignalSource.disconnect(mDelegate);
-		}
-
-	private:
-		SignalSource& mSignalSource;
-		DelegateType mDelegate;
-	};
-
 public:
 	bool empty() const { return delegateList.empty(); }
 

--- a/NAS2D/SignalSource.h
+++ b/NAS2D/SignalSource.h
@@ -13,6 +13,26 @@ class SignalSource
 public:
 	using DelegateType = DelegateX<void, Params...>;
 
+	class Connection
+	{
+	public:
+		Connection(SignalSource& signalSource, DelegateType delegate) :
+			mSignalSource{signalSource},
+			mDelegate{delegate}
+		{
+			mSignalSource.connect(mDelegate);
+		}
+
+		~Connection()
+		{
+			mSignalSource.disconnect(mDelegate);
+		}
+
+	private:
+		SignalSource& mSignalSource;
+		DelegateType mDelegate;
+	};
+
 public:
 	bool empty() const { return delegateList.empty(); }
 

--- a/test/Connection.test.cpp
+++ b/test/Connection.test.cpp
@@ -1,0 +1,32 @@
+#include "NAS2D/Connection.h"
+#include "NAS2D/Signal.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+
+namespace {
+	class MockHandler {
+	public:
+		MOCK_CONST_METHOD0(MockMethod, void());
+	};
+}
+
+
+TEST(Signal, Connection) {
+	MockHandler handler;
+	auto delegate = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
+	NAS2D::Signals::Signal<> signal;
+
+	// Expect a single call to MockMethod
+	EXPECT_CALL(handler, MockMethod()).Times(1);
+
+	{
+		// Connection is only valid in this code block
+		auto connection = NAS2D::Signals::Connection{signal, delegate};
+		signal.emit();
+	}
+
+	// Disconnected - No additional calls to MockMethod
+	signal.emit();
+}

--- a/test/Delegate.test.cpp
+++ b/test/Delegate.test.cpp
@@ -1,4 +1,5 @@
 #include "NAS2D/Delegate.h"
+
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -1,4 +1,5 @@
 #include "NAS2D/Filesystem.h"
+
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 

--- a/test/Signal.test.cpp
+++ b/test/Signal.test.cpp
@@ -1,4 +1,5 @@
 #include "NAS2D/Signal.h"
+#include "NAS2D/Connection.h"
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -41,7 +42,7 @@ TEST(Signal, Connection) {
 
 	{
 		// Connection is only valid in this code block
-		auto connection = decltype(signal)::Connection{signal, delegate};
+		auto connection = NAS2D::Signals::Connection{signal, delegate};
 		signal.emit();
 	}
 

--- a/test/Signal.test.cpp
+++ b/test/Signal.test.cpp
@@ -30,3 +30,21 @@ TEST(Signal, ConnectEmitDisconnect) {
 	EXPECT_CALL(handler, MockMethod()).Times(0);
 	signal.emit();
 }
+
+TEST(Signal, Connection) {
+	MockHandler handler;
+	auto delegate = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
+	NAS2D::Signals::Signal<> signal;
+
+	// Expect a single call to MockMethod
+	EXPECT_CALL(handler, MockMethod()).Times(1);
+
+	{
+		// Connection is only valid in this code block
+		auto connection = decltype(signal)::Connection{signal, delegate};
+		signal.emit();
+	}
+
+	// Disconnected - No additional calls to MockMethod
+	signal.emit();
+}

--- a/test/Signal.test.cpp
+++ b/test/Signal.test.cpp
@@ -1,5 +1,5 @@
 #include "NAS2D/Signal.h"
-#include "NAS2D/Connection.h"
+
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -29,23 +29,5 @@ TEST(Signal, ConnectEmitDisconnect) {
 	EXPECT_TRUE(signal.empty());
 
 	EXPECT_CALL(handler, MockMethod()).Times(0);
-	signal.emit();
-}
-
-TEST(Signal, Connection) {
-	MockHandler handler;
-	auto delegate = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
-	NAS2D::Signals::Signal<> signal;
-
-	// Expect a single call to MockMethod
-	EXPECT_CALL(handler, MockMethod()).Times(1);
-
-	{
-		// Connection is only valid in this code block
-		auto connection = NAS2D::Signals::Connection{signal, delegate};
-		signal.emit();
-	}
-
-	// Disconnected - No additional calls to MockMethod
 	signal.emit();
 }

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -2,7 +2,9 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include <string>
+
 
 class ImplicitStringConversionTestFixture
 {

--- a/test/Utility.test.cpp
+++ b/test/Utility.test.cpp
@@ -1,4 +1,5 @@
 #include "NAS2D/Utility.h"
+
 #include <gtest/gtest.h>
 
 


### PR DESCRIPTION
Implements `Signal` `Connection` object for #830.

Copy/move operations are disabled to avoid accidental unsafe usage by parent objects when the connection is to a member function of the parent object, which is pretty much the major motivating use case for this object.
