### PR TITLE
Doxygen ignore detail namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ Debug/
 x64/
 .vs/
 *.user
+
+# Doxygen documentation
+/doc/

--- a/Doxyfile
+++ b/Doxyfile
@@ -134,7 +134,7 @@ EXCLUDE                = ./src/Xml\XmlAttributeSet.cpp \
 
 EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       = 
-EXCLUDE_SYMBOLS        = 
+EXCLUDE_SYMBOLS        = detail
 EXAMPLE_PATH           = 
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = NO


### PR DESCRIPTION
Ignore the `detail` namespace when generating Doxygen documentation.
