### PR TITLE
Doxygen source folder update

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -104,7 +104,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = .
+INPUT                  = NAS2D/
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \
                          *.cc \

--- a/Doxyfile
+++ b/Doxyfile
@@ -118,19 +118,7 @@ FILE_PATTERNS          = *.c \
                          *.h++
 
 RECURSIVE              = YES
-EXCLUDE                = ./src/Xml\XmlAttributeSet.cpp \
-						 ./src/Xml\XmlParser.cpp \
-                         ./include/NAS2D/Xml\XmlAttributeSet.h \
-                         ./include/NAS2D/Xml\XmlVisitor.h \
-						 ./include/NAS2D/Delegate.h \
-						 ./include/NAS2D/Renderer/ShaderManager.h \
-						 ./include/NAS2D/Renderer/OGL_Renderer.h \
-						 ./src/Renderer/OGL_Renderer.cpp \
-						 ./src/Resources/Shader.cpp \
-						 ./src/Renderer/ShaderManager.cpp \
-						 ./include/NAS2D/Mixer/Mixer_SDL.h \
-						 ./src/Mixer/Mixer_SDL.cpp \
-                         ./proj
+EXCLUDE                =
 
 EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       = 


### PR DESCRIPTION
Noticed after working on #845.

Fix Doxygen source include/exclude paths. The Doxygen file had been neglected for an exceedingly long time, and still had paths configured for the previous project structure from long ago.
