### PR TITLE
Add AppVeyor Yasm fix

### DIFF
--- a/InstallVcpkgDeps.bat
+++ b/InstallVcpkgDeps.bat
@@ -16,5 +16,7 @@ if not defined PLATFORM (
 )
 
 :Install
+REM Work around problem where yasm tool (recursive dependency) needs x86 version installed before x64 version
+if "%PLATFORM%" == "x64" vcpkg install --recurse  yasm-tool:x86-windows
 REM Install dependencies (recursively)
 vcpkg install --recurse --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[dynamic-load,libflac,libmodplug,libvorbis,mpg123,nativemidi,opusfile] gtest

--- a/InstallVcpkgDeps.bat
+++ b/InstallVcpkgDeps.bat
@@ -16,4 +16,5 @@ if not defined PLATFORM (
 )
 
 :Install
+REM Install dependencies (recursively)
 vcpkg install --recurse --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[dynamic-load,libflac,libmodplug,libvorbis,mpg123,nativemidi,opusfile] gtest


### PR DESCRIPTION
While trying to update dependent projects, I encountered an error with the `vcpkg` install scripts used by AppVeyor. It's an external problem, though the issue did mention a workaround, which I've incorporated into the batch file.

As `vcpkg` is updated, we may be able to eventually remove the workaround. Consider it as a temporary fix until they get things sorted out on their end. Sounds like it will take a long while though.
