### PR TITLE
Add Source alias to SignalSource

### DIFF
--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -11,6 +11,7 @@ template<typename ... Params>
 class SignalSource
 {
 public:
+	using Source = SignalSource; // Restricted base interface for use in derived
 	using DelegateType = DelegateX<void, Params...>;
 
 public:


### PR DESCRIPTION
Add an important usability helper that was absent from #830. This makes it easy to refer to the restricted base class `SignalSource` interface when using a derived class type, such as `Signal`.

For example:
```cpp
using SomeTypeAlias = NAS2D::Signal<>;

SomeTypeAlias::Source& getEventSource() { return mSignal; }
```
