### PR TITLE
Remove redundant uses of `\class` in Doxygen comments

### DIFF
--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -18,7 +18,6 @@ namespace NAS2D {
 
 
 /**
- * \class Configuration
  * \brief Configuration Parser.
  *
  * Parses and interprets Configuration data stored in XML files (e.g., config.xml).

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -21,9 +21,7 @@ namespace NAS2D {
 
 
 /**
- * \class	EventHandler
  * \brief	Handles and dispatches low-level events.
- *
  */
 class EventHandler
 {

--- a/NAS2D/Exception.h
+++ b/NAS2D/Exception.h
@@ -23,72 +23,54 @@ namespace Exception {
  */
 
 /**
- * \class filesystem_backend_init_failure
- *
  * Thrown when the Filesystem is unable to initialize itself.
  */
 class filesystem_backend_init_failure : public std::runtime_error { public: filesystem_backend_init_failure(const std::string& description); filesystem_backend_init_failure(); };
 
 
 /**
- * \class filesystem_already_initialized
- *
  * Thrown when Filesystem::init() is called but the Filesystem is already initialized.
  */
 class filesystem_already_initialized : public std::runtime_error { public: filesystem_already_initialized(); };
 
 
 /**
- * \class filesystem_file_handle_still_open
- *
  * Thrown when the Filesystem is unable to close a file handle.
  */
 class filesystem_file_handle_still_open : public std::runtime_error { public: filesystem_file_handle_still_open(const std::string& description); filesystem_file_handle_still_open();};
 
 
 /**
- * \class font_bad_data
- *
  * Thrown when Font::operator=() is called but the font hasn't been loaded yet.
  */
 class font_bad_data : public std::runtime_error { public: font_bad_data(); };
 
 
 /**
-* \class font_invalid_glyph_map
-*
 * Thrown when a bitmap font is loaded but the texture does not conform to expected paramters.
 */
 class font_invalid_glyph_map : public std::runtime_error { public: font_invalid_glyph_map(); font_invalid_glyph_map(const std::string& description); };
 
 
 /**
-* \class image_bad_copy
-*
 * Thrown when an Image resource contains an invalid pixel buffer.
 */
 class image_bad_copy : public std::runtime_error { public: image_bad_copy(); };
 
 
 /**
- * \class image_bad_data
- *
  * Thrown when an Image resource contains an invalid pixel buffer.
  */
 class image_bad_data : public std::runtime_error { public: image_bad_data(); };
 
 
 /**
- * \class image_null_data
- *
  * Thrown when an Image resource contains no data in its pixel buffer.
  */
 class image_null_data : public std::runtime_error { public: image_null_data(); };
 
 
 /**
- * \class image_unsupported_bit_depth
- *
  * Thrown when attempting to load or perform operations on an image file in
  * an 8-bit or 16-bit format. See Image for further details.
  */
@@ -96,40 +78,30 @@ class image_unsupported_bit_depth : public std::runtime_error { public: image_un
 
 
 /**
- * \class mixer_backend_init_failure
- *
  * Thrown when a derived Mixer type is unable to initialize itself.
  */
 class mixer_backend_init_failure : public std::runtime_error { public: mixer_backend_init_failure(const std::string& description); mixer_backend_init_failure(); };
 
 
 /**
-* \class renderer_no_glsl
-*
 * Thrown when the RendererOpenGL determines that no GLSL shading language is available.
 */
 class renderer_no_glsl : public std::runtime_error { public: renderer_no_glsl(); };
 
 
 /**
-* \class renderer_backend_init_failure
-*
 * Thrown when a derived Renderer type is unable to initialize itself.
 */
 class renderer_backend_init_failure : public std::runtime_error { public: renderer_backend_init_failure(const std::string& description); renderer_backend_init_failure();};
 
 
 /**
-* \class renderer_window_creation_failure
-*
 * Thrown when a window context can't be created.
 */
 class renderer_window_creation_failure : public std::runtime_error { public: renderer_window_creation_failure(); };
 
 
 /**
-* \class renderer_opengl_context_failure
-*
 * Thrown when the RendererOpenGL can't create an OpenGL context.
 */
 class renderer_opengl_context_failure : public std::runtime_error { public: renderer_opengl_context_failure(); };

--- a/NAS2D/File.h
+++ b/NAS2D/File.h
@@ -17,7 +17,6 @@
 namespace NAS2D {
 
 /**
- * \class File
  * \brief Represent a File object.
  *
  * The File object represents a file as a stream of bytes.

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -19,7 +19,6 @@
 namespace NAS2D {
 
 /**
- * \class Filesystem
  * \brief Implements a virtual file system.
  *
  * Provides cross-platform and transparent archive Filesystem functions.

--- a/NAS2D/FpsCounter.h
+++ b/NAS2D/FpsCounter.h
@@ -12,7 +12,6 @@
 namespace NAS2D {
 
 /**
- * \class FpsCounter
  * \brief Implements a basic FPS Counter.
  *
  * FPS values are only approximates. As the FPS count gets higher, the returned value

--- a/NAS2D/Game.h
+++ b/NAS2D/Game.h
@@ -19,7 +19,6 @@ class State;
 
 
 /**
- * \class Game
  * \brief	A simple way to start a NAS2D application.
  *
  * The Game class is a simple way to quickly delve right into developing a NAS2D

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -20,7 +20,6 @@ class Music;
 
 
 /**
- * \class Mixer
  * \brief Mixer base class.
  *
  * Provides a standard Mixer interface. The base Mixer can be used

--- a/NAS2D/Mixer/MixerSDL.h
+++ b/NAS2D/Mixer/MixerSDL.h
@@ -15,7 +15,6 @@
 namespace NAS2D {
 
 /**
- * \class MixerSDL
  * \brief SDL Mixer.
  *
  * Implements all Mixer functions with the SDL API.

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -30,7 +30,6 @@ template <typename BaseType> struct Rectangle;
 
 
 /**
- * \class Renderer
  * \brief Renderer base class.
  *
  * Provides a standard Renderer interface. The base Renderer can be used

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -21,12 +21,11 @@ struct SDL_Cursor;
 namespace NAS2D {
 
 /**
- * \class RendererOpenGL
  * \brief OpenGL Renderer.
  *
  * Implements an OpenGL based Renderer.
  */
-class RendererOpenGL: public Renderer
+class RendererOpenGL : public Renderer
 {
 public:
 	struct Options

--- a/NAS2D/Resource/Font.h
+++ b/NAS2D/Resource/Font.h
@@ -20,7 +20,6 @@
 namespace NAS2D {
 
 /**
- * \class Font
  * \brief Font resource.
  *
  * The Font class can be used to render TrueType, OpenType and Bitmap fonts. Two

--- a/NAS2D/Resource/Image.h
+++ b/NAS2D/Resource/Image.h
@@ -24,7 +24,6 @@ struct SDL_Surface;
 namespace NAS2D {
 
 /**
- * \class Image
  * \brief Image Class
  *
  * Provides a high level interface for image files. Can load the following formats:

--- a/NAS2D/Resource/Music.h
+++ b/NAS2D/Resource/Music.h
@@ -22,7 +22,6 @@ typedef struct _Mix_Music Mix_Music;
 namespace NAS2D {
 
 /**
- *  \class Music
  *  \brief Music resource.
  */
 class Music

--- a/NAS2D/Resource/Sound.h
+++ b/NAS2D/Resource/Sound.h
@@ -18,7 +18,6 @@ struct Mix_Chunk;
 namespace NAS2D {
 
 /**
- *  \class Sound
  *  \brief Sound resource.
  *
  *  Represents a Sound.

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -22,7 +22,6 @@
 namespace NAS2D {
 
 /**
- * \class Sprite
  * \brief Sprite resource.
  *
  * The Sprite Class is a self-contained group of Image resources that displays

--- a/NAS2D/Signal/Signal.h
+++ b/NAS2D/Signal/Signal.h
@@ -32,7 +32,6 @@ namespace NAS2D {
 
 
 /**
- * \class Signal
  * \brief Signal with preset number of parameters
  *
  * See https://github.com/lairworks/nas2d-core/wiki/Signal-&-Slots for usage documentation.

--- a/NAS2D/State.h
+++ b/NAS2D/State.h
@@ -14,7 +14,6 @@
 namespace NAS2D {
 
 /**
- * \class	State
  * \brief	The State class operates within a StateManager as a separate unit of
  *			logic.
  *

--- a/NAS2D/StateManager.h
+++ b/NAS2D/StateManager.h
@@ -19,7 +19,6 @@ class State;
 
 
 /**
- * \class	StateManager
  * \brief	Implements a Finite State Machine model that switches between
  *			State objects.
  *

--- a/NAS2D/Timer.h
+++ b/NAS2D/Timer.h
@@ -13,7 +13,6 @@
 namespace NAS2D {
 
 /**
- * \class Timer
  * \brief A timing class that provides high-resolution, millisecond-precision timing services.
  *
  * The Timer class provides three different method for getting and managing timing.

--- a/NAS2D/Utility.h
+++ b/NAS2D/Utility.h
@@ -17,7 +17,6 @@
 namespace NAS2D {
 
 /**
- * \class	Utility
  * \brief	Provides a simple interface to classes that should only be instantiated
  *			once globally for a NAS2D application.
  *

--- a/NAS2D/Xml/XmlAttributeSet.h
+++ b/NAS2D/Xml/XmlAttributeSet.h
@@ -17,7 +17,6 @@ namespace NAS2D {
 namespace Xml {
 
 /**
- * \class XmlAttributeSet
  * \brief Used to manage a group of attributes.
  *
  * It is only used internally, both by the ELEMENT and the DECLARATION.


### PR DESCRIPTION
Reference: #850

Remove redundant uses of `\class` in Doxygen comments.

The class name is auto inferred when the Doxygen comment comes immediately before a class declaration.
