### PR TITLE
Fix bug in RendererOpenGL::minimumSize

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -571,6 +571,10 @@ void RendererOpenGL::size(Vector<int> newSize)
 void RendererOpenGL::minimumSize(Vector<int> newSize)
 {
 	SDL_SetWindowMinimumSize(underlyingWindow, newSize.x, newSize.y);
+
+	// Read back the window size, in case it was changed
+	// Window may need to have been enlarged to the minimum size
+	SDL_GetWindowSize(underlyingWindow, &newSize.x, &newSize.y);
 	onResize(newSize.x, newSize.y);
 }
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -629,7 +629,6 @@ void RendererOpenGL::onResize(int w, int h)
 	setViewport(Rectangle{0, 0, w, h});
 	setOrthoProjection(Rectangle<float>::Create(Point{0.0f, 0.0f}, dimensions.to<float>()));
 	setResolution(dimensions);
-
 }
 
 void RendererOpenGL::setViewport(const Rectangle<int>& viewport)


### PR DESCRIPTION
Noticed in downstream project: https://github.com/OutpostUniverse/OPHD/issues/873

It seems a new viewport was being set using the minimum size, rather than the actual size of the window. This has been fixed by reading back the window size after setting a new minimum size. That will catch cases where the window size was updated by enlarging it to the new minimum size, while also respecting the original dimensions of windows that were already larger than the minimum size.
