### PR TITLE
Mac local install support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,11 @@ commands:
     steps:
       - restore_cache:
           name: Restoring brew dependencies
-          key: deps-v5-NAS2D-{{ arch }}
+          key: deps-NAS2D-{{ arch }}-{{ checksum "BrewDeps.txt" }}
       - run: HOMEBREW_NO_AUTO_UPDATE=1 make install-dependencies-darwin
       - save_cache:
           name: Caching brew dependencies
-          key: deps-v5-NAS2D-{{ arch }}
+          key: deps-NAS2D-{{ arch }}-{{ checksum "BrewDeps.txt" }}
           paths:
             - /usr/local/Cellar
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ commands:
           key: deps-v5-NAS2D-{{ arch }}
           paths:
             - /usr/local/Cellar
-      - run: make brew-link
   build-and-test:
     steps:
       - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,20 +3,17 @@ version: 2.1
 commands:
   brew-install:
     description: "Brew install MacOS dependencies (or restore from cache)"
-    parameters:
-      packages:
-        type: string
     steps:
       - restore_cache:
           name: Restoring brew dependencies
           key: deps-v5-NAS2D-{{ arch }}
-      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install << parameters.packages >>
+      - run: HOMEBREW_NO_AUTO_UPDATE=1 make install-dependencies-darwin
       - save_cache:
           name: Caching brew dependencies
           key: deps-v5-NAS2D-{{ arch }}
           paths:
             - /usr/local/Cellar
-      - run: brew link << parameters.packages >>
+      - run: make brew-link
   build-and-test:
     steps:
       - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror"
@@ -34,8 +31,7 @@ jobs:
       - WARN_EXTRA: "-Wno-double-promotion"
     steps:
       - checkout
-      - brew-install:
-          packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew googletest
+      - brew-install
       - build-and-test
   build-linux:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,9 @@ jobs:
     environment:
       - WARN_EXTRA: "-Wno-double-promotion"
     steps:
+      - checkout
       - brew-install:
           packages: physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew googletest
-      - checkout
       - build-and-test
   build-linux:
     docker:

--- a/BrewDeps.txt
+++ b/BrewDeps.txt
@@ -1,0 +1,16 @@
+physfs
+sdl2
+sdl2_image
+sdl2_mixer
+sdl2_ttf
+libpng
+libjpeg
+libtiff
+webp
+libmodplug
+libvorbis
+libogg
+freetype
+glew
+
+googletest

--- a/makefile
+++ b/makefile
@@ -215,7 +215,7 @@ install-dependencies-arch:
 ## MacOS ##
 .PHONY: install-dependencies-darwin
 install-dependencies-darwin:
-	brew install physfs sdl2 sdl2_image sdl2_mixer sdl2_ttf libpng libjpeg libtiff webp libmodplug libvorbis libogg freetype glew
+	xargs --verbose --arg-file=BrewDeps.txt brew install
 
 
 #### Docker related build rules ####

--- a/makefile
+++ b/makefile
@@ -216,6 +216,9 @@ install-dependencies-arch:
 .PHONY: install-dependencies-darwin
 install-dependencies-darwin:
 	xargs --verbose --arg-file=BrewDeps.txt brew install
+.PHONY: brew-link
+brew-link:
+	xargs --verbose --arg-file=BrewDeps.txt brew link
 
 
 #### Docker related build rules ####

--- a/makefile
+++ b/makefile
@@ -215,10 +215,10 @@ install-dependencies-arch:
 ## MacOS ##
 .PHONY: install-dependencies-darwin
 install-dependencies-darwin:
-	xargs --verbose --arg-file=BrewDeps.txt brew install
+	xargs brew install < BrewDeps.txt
 .PHONY: brew-link
 brew-link:
-	xargs --verbose --arg-file=BrewDeps.txt brew link
+	xargs brew link < BrewDeps.txt
 
 
 #### Docker related build rules ####

--- a/makefile
+++ b/makefile
@@ -216,8 +216,6 @@ install-dependencies-arch:
 .PHONY: install-dependencies-darwin
 install-dependencies-darwin:
 	xargs brew install < BrewDeps.txt
-.PHONY: brew-link
-brew-link:
 	xargs brew link < BrewDeps.txt
 
 


### PR DESCRIPTION
Closes #822

It is now possible to install dependencies on MacOS using the `makefile`:
```sh
make install-dependencies-darwin
```

No need to copy long complicated looking commands from the CircleCI config file in order to install dependencies locally on MacOS.
