### PR TITLE
Fix CircleCI MacOS dependency problem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ commands:
       - restore_cache:
           name: Restoring brew dependencies
           key: deps-NAS2D-{{ arch }}-{{ checksum "BrewDeps.txt" }}
-      - run: HOMEBREW_NO_AUTO_UPDATE=1 make install-dependencies-darwin
+      - run: make install-dependencies-darwin
       - save_cache:
           name: Caching brew dependencies
           key: deps-NAS2D-{{ arch }}-{{ checksum "BrewDeps.txt" }}
@@ -27,6 +27,7 @@ jobs:
     macos:
       xcode: "12.4.0"
     environment:
+      - HOMEBREW_NO_AUTO_UPDATE: 1
       - WARN_EXTRA: "-Wno-double-promotion"
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,11 @@ commands:
     steps:
       - restore_cache:
           name: Restoring brew dependencies
-          key: deps-NAS2D-{{ arch }}-{{ checksum "BrewDeps.txt" }}
+          key: deps-NAS2D-{{ arch }}-v1-{{ checksum "BrewDeps.txt" }}
       - run: make install-dependencies-darwin
       - save_cache:
           name: Caching brew dependencies
-          key: deps-NAS2D-{{ arch }}-{{ checksum "BrewDeps.txt" }}
+          key: deps-NAS2D-{{ arch }}-v1-{{ checksum "BrewDeps.txt" }}
           paths:
             - /usr/local/Cellar
   build-and-test:

--- a/BrewDeps.txt
+++ b/BrewDeps.txt
@@ -10,6 +10,7 @@ webp
 libmodplug
 libvorbis
 libogg
+flac
 freetype
 glew
 


### PR DESCRIPTION
Recently MacOS builds have been unstable. Newer versions of dependent packages were being installed. In some cases those new packages were not building properly, possibly due to conflicts with older installed packages. In other cases, some transitive dependencies were not being linked after a dependency cache restore, and so were not being found at runtime. These updates address those problems.
