### PR TITLE
Add file exists guard for /etc/os-release

### DIFF
--- a/makefile
+++ b/makefile
@@ -183,7 +183,7 @@ cppclean:
 
 RELEASE_FILES = $(wildcard /etc/*-release)
 RELEASE_FILE_TAGS = $(filter-out os lsb,$(patsubst /etc/%-release,%,$(RELEASE_FILES)))
-RELEASE_SETTING_NAME = $(shell '$(SHELL)' -c '. /etc/os-release && echo $${ID}')
+RELEASE_SETTING_NAME = $(shell '$(SHELL)' -c '[ -f /etc/os-release ] && . /etc/os-release && echo $${ID}')
 LINUX_DISTRIBUTION = $(or $(RELEASE_SETTING_NAME),$(RELEASE_FILE_TAGS),Unknown)
 DISTRIBUTION = $(subst Darwin,darwin,$(subst Linux,$(LINUX_DISTRIBUTION),$(CURRENT_OS)))
 


### PR DESCRIPTION
Closes #864

This prevents confusing warnings on MacOS when running `make install-dependencies`.
