### PR TITLE
Fix Delegate::BaseType definition bug

### DIFF
--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -458,7 +458,7 @@ template <typename RetType, typename ... Params>
 class Delegate<RetType(Params...)> : public DelegateX<RetType, Params...>
 {
 public:
-	using BaseType = Delegate<RetType(Params...)>;
+	using BaseType = DelegateX<RetType, Params...>;
 	using SelfType = Delegate;
 
 	Delegate() : BaseType() {}


### PR DESCRIPTION
This should really be pointing to DelegateX, rather than Delegate. This bug appears to have been introduced by my refactoring to use parameter packs.
