### PR TITLE
Update package tag

### DIFF
--- a/makefile
+++ b/makefile
@@ -66,8 +66,8 @@ include $(wildcard $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.d,$(SRCS)))
 
 
 VERSION = $(shell git describe --tags --dirty)
-CONFIG = $(TARGET_OS).x64
-PACKAGE_NAME = $(PACKAGEDIR)/nas2d-$(VERSION)-$(CONFIG).tar.gz
+PLATFORM = $(TARGET_OS).x64
+PACKAGE_NAME = $(PACKAGEDIR)/nas2d-$(VERSION)-$(PLATFORM).tar.gz
 Darwin_TAR_RENAME_FLAG := -s '!^$(SRCDIR)/!include/\0!'
 Linux_TAR_RENAME_FLAG := --transform='s/^$(SRCDIR)/include\/\0/'
 TAR_RENAME_FLAG := $($(CURRENT_OS)_TAR_RENAME_FLAG)

--- a/makefile
+++ b/makefile
@@ -67,7 +67,7 @@ include $(wildcard $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.d,$(SRCS)))
 
 VERSION = $(shell git describe --tags --dirty)
 PLATFORM = $(TARGET_OS).x64
-PACKAGE_NAME = $(PACKAGEDIR)/nas2d-$(VERSION)-$(PLATFORM).tar.gz
+PACKAGE_NAME = $(PACKAGEDIR)/nas2d-$(VERSION)-$(PLATFORM)-$(CONFIG).tar.gz
 Darwin_TAR_RENAME_FLAG := -s '!^$(SRCDIR)/!include/\0!'
 Linux_TAR_RENAME_FLAG := --transform='s/^$(SRCDIR)/include\/\0/'
 TAR_RENAME_FLAG := $($(CURRENT_OS)_TAR_RENAME_FLAG)


### PR DESCRIPTION
Reference: #867

Fixes a new issue with package naming, relating to #870 which added build configs. It seems the name `CONFIG` was used in two separate contexts. One of which was really intended to be `PLATFORM`.

Add both `PLATFORM` and `CONFIG` as tags to package name.
