### PR TITLE
Limit parallelism to 16 concurrent jobs on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,9 @@ commands:
             - /usr/local/Cellar
   build-and-test:
     steps:
-      - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror"
-      - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror" test
-      - run: make --keep-going --jobs CXXFLAGS_EXTRA="-Werror" check
+      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
+      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" test
+      - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" check
       - run: make package
       - store_artifacts:
           path: .build/package/


### PR DESCRIPTION
This reduces the memory pressure, and lowers the chance of a compile failing due to out of memory conditions.

There was a recent failure due to memory exhaustion:
https://app.circleci.com/pipelines/github/lairworks/nas2d-core/1609/workflows/af661f7c-8937-4bc7-8e8a-49c3839e61d7/jobs/6402
> Cannot allocate memory
