### PR TITLE
Delegate to SignalType::DelegateType for type of Delegate

### DIFF
--- a/NAS2D/Signal/SignalConnection.h
+++ b/NAS2D/Signal/SignalConnection.h
@@ -12,7 +12,7 @@ class SignalConnection
 {
 public:
 	using SignalType = SignalSource<Params...>;
-	using DelegateType = DelegateX<void, Params...>;
+	using DelegateType = typename SignalType::DelegateType;
 
 	// No copy/move construction/assignment
 	// This class is designed to handle a parent object's connection to a signal


### PR DESCRIPTION
This ensures the `SignalConnection` object will be automatically updated to match if the `Signal`'s `DelegateType` is ever changed.
