### PR TITLE
Fix test-graphics

### DIFF
--- a/makefile
+++ b/makefile
@@ -135,7 +135,7 @@ $(BUILDDIR)/testGraphics: $(OUTPUT)
 
 .PHONY: run-test-graphics
 run-test-graphics: | test-graphics
-	cd test-graphics/ && ../.build/testGraphics ; cd ..
+	cd test-graphics/ && ../$(BUILDDIR)/testGraphics ; cd ..
 
 
 .PHONY: lint

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ SDL_CONFIG_CFLAGS := $(shell type sdl2-config >/dev/null 2>&1 && sdl2-config --c
 SDL_CONFIG_LIBS := $(shell type sdl2-config >/dev/null 2>&1 && sdl2-config --static-libs)
 
 CPPFLAGS := $(CPPFLAGS_EXTRA)
-CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Wswitch-enum -Wswitch-default -Winvalid-pch -Wmissing-format-attribute -Wredundant-decls $(WARN_EXTRA)
+CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute -Wredundant-decls $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) $(CONFIG_CXX_FLAGS) -std=c++17 $(CXXFLAGS_WARN) $(SDL_CONFIG_CFLAGS)
 LDFLAGS := $(LDFLAGS_EXTRA)
 LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(SDL_CONFIG_LIBS) $(OpenGL_LIBS)


### PR DESCRIPTION
Remove warning flags that are maybe a little beyond what we want to check for.
- `-Wswitch-enum`
- `-Wswitch-default`

In particular, we don't want `KeyCode` based enums to produce warnings if they don't specify every single key code. We also want the developer to have control over `default` labels, so they can control where they explicitly handle default cases, and where they would like to get warnings if they haven't specified every enum value.

Reference:
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

----

Fix running of the `test-graphics` project using `make run-test-graphics`.

This was likely broken by #871. (Issue reference: #867)
