### PR TITLE
Add nas2d make target

### DIFF
--- a/makefile
+++ b/makefile
@@ -51,7 +51,7 @@ OBJS := $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.o,$(SRCS))
 nas2d: $(OUTPUT)
 
 .PHONY: all
-all: nas2d
+all: nas2d test test-graphics
 
 $(OUTPUT): $(OBJS)
 	@mkdir -p "${@D}"

--- a/makefile
+++ b/makefile
@@ -47,8 +47,11 @@ POSTCOMPILE = @mv -f $(INTDIR)/$*.Td $(INTDIR)/$*.d && touch $@
 SRCS := $(shell find $(SRCDIR) -name '*.cpp')
 OBJS := $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.o,$(SRCS))
 
+.PHONY: nas2d
+nas2d: $(OUTPUT)
+
 .PHONY: all
-all: $(OUTPUT)
+all: nas2d
 
 $(OUTPUT): $(OBJS)
 	@mkdir -p "${@D}"


### PR DESCRIPTION
Add `make` target specific to `nas2d` project, and set as default target.

Allow `make all` to be used to build NAS2D, and test projects (`test`, `test-graphics`).

Inspired by work for #867.
