### PR TITLE
Refactor test-graphics

### DIFF
--- a/makefile
+++ b/makefile
@@ -133,7 +133,7 @@ include $(wildcard $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.d,$(TESTSRCS)))
 .PHONY: test-graphics
 test-graphics: $(BUILDDIR)/testGraphics
 $(BUILDDIR)/testGraphics: $(OUTPUT)
-	@mkdir -p $(BUILDDIR)
+	@mkdir -p "${@D}"
 	$(CXX) -o $(BUILDDIR)/testGraphics test-graphics/*.cpp $(TESTCPPFLAGS) $(CXXFLAGS) $(TESTLDFLAGS) -lnas2d $(LDLIBS)
 
 .PHONY: run-test-graphics

--- a/makefile
+++ b/makefile
@@ -134,7 +134,7 @@ include $(wildcard $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.d,$(TESTSRCS)))
 test-graphics: $(BUILDDIR)/testGraphics
 $(BUILDDIR)/testGraphics: $(OUTPUT)
 	@mkdir -p "${@D}"
-	$(CXX) -o $(BUILDDIR)/testGraphics test-graphics/*.cpp $(TESTCPPFLAGS) $(CXXFLAGS) $(TESTLDFLAGS) -lnas2d $(LDLIBS)
+	$(CXX) -o $@ test-graphics/*.cpp $(TESTCPPFLAGS) $(CXXFLAGS) $(TESTLDFLAGS) -lnas2d $(LDLIBS)
 
 .PHONY: run-test-graphics
 run-test-graphics: | test-graphics

--- a/makefile
+++ b/makefile
@@ -132,7 +132,7 @@ include $(wildcard $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.d,$(TESTSRCS)))
 
 .PHONY: test-graphics
 test-graphics: $(BUILDDIR)/testGraphics
-$(BUILDDIR)/testGraphics: $(OUTPUT)
+$(BUILDDIR)/testGraphics: test-graphics/*.cpp test-graphics/*.h $(OUTPUT)
 	@mkdir -p "${@D}"
 	$(CXX) -o $@ test-graphics/*.cpp $(TESTCPPFLAGS) $(CXXFLAGS) $(TESTLDFLAGS) -lnas2d $(LDLIBS)
 

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -1,5 +1,9 @@
 #include "TestGraphics.h"
 
+#include <NAS2D/Utility.h>
+#include <NAS2D/Renderer/Renderer.h>
+#include <NAS2D/Renderer/Rectangle.h>
+
 #include <functional>
 #include <random>
 

--- a/test-graphics/TestGraphics.h
+++ b/test-graphics/TestGraphics.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "NAS2D/NAS2D.h"
+#include "NAS2D/State.h"
+#include "NAS2D/EventHandler.h"
+#include "NAS2D/Timer.h"
+#include "NAS2D/Resource/Image.h"
 
 
 class TestGraphics : public NAS2D::State

--- a/test-graphics/main.cpp
+++ b/test-graphics/main.cpp
@@ -10,7 +10,7 @@
 
 #include "TestGraphics.h"
 
-#include <NAS2D/NAS2D.h>
+#include <NAS2D/Game.h>
 
 #include <iostream>
 #include <string>


### PR DESCRIPTION
Use more specific includes than `NAS2D/NAS2D.h`.

Update `makefile` rules to be a bit more generic, and to ensure rebuilds for source file changes.
