### PR TITLE
Add mapToVector

### DIFF
--- a/NAS2D/ContainerUtils.h
+++ b/NAS2D/ContainerUtils.h
@@ -89,8 +89,9 @@ namespace NAS2D {
 	auto mapToVector(const Container& container, UnaryOperation mapFunction)
 	{
 		using ResultType = decltype(mapFunction(*std::begin(container)));
+		using ElementType = std::remove_cv_t<std::remove_reference_t<ResultType>>;
 
-		std::vector<ResultType> results;
+		std::vector<ElementType> results;
 		results.reserve(std::size(container));
 
 		std::transform(std::begin(container), std::end(container), std::back_inserter(results), mapFunction);

--- a/NAS2D/ContainerUtils.h
+++ b/NAS2D/ContainerUtils.h
@@ -46,6 +46,19 @@ namespace NAS2D {
 	}
 
 
+	template <typename Container, typename UnaryOperation>
+	auto mapToVector(const Container& container, UnaryOperation mapFunction)
+	{
+		using ResultType = decltype(mapFunction(*std::begin(container)));
+		using ElementType = std::remove_cv_t<std::remove_reference_t<ResultType>>;
+
+		std::vector<ElementType> results;
+		results.reserve(std::size(container));
+
+		std::transform(std::begin(container), std::end(container), std::back_inserter(results), mapFunction);
+		return results;
+	}
+
 	template <typename T>
 	auto missingValues(const std::vector<T>& values, const std::vector<T>& required)
 	{
@@ -82,19 +95,6 @@ namespace NAS2D {
 		{
 			results[key] += value;
 		}
-		return results;
-	}
-
-	template <typename Container, typename UnaryOperation>
-	auto mapToVector(const Container& container, UnaryOperation mapFunction)
-	{
-		using ResultType = decltype(mapFunction(*std::begin(container)));
-		using ElementType = std::remove_cv_t<std::remove_reference_t<ResultType>>;
-
-		std::vector<ElementType> results;
-		results.reserve(std::size(container));
-
-		std::transform(std::begin(container), std::end(container), std::back_inserter(results), mapFunction);
 		return results;
 	}
 }

--- a/NAS2D/ContainerUtils.h
+++ b/NAS2D/ContainerUtils.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <algorithm>
+#include <iterator>
 
 
 namespace NAS2D {
@@ -87,6 +88,18 @@ namespace NAS2D {
 		{
 			results[key] += value;
 		}
+		return results;
+	}
+
+	template <typename Container, typename UnaryOperation>
+	auto mapToVector(const Container& container, UnaryOperation mapFunction)
+	{
+		using ResultType = decltype(mapFunction(*std::begin(container)));
+
+		std::vector<ResultType> results;
+		results.reserve(std::size(container));
+
+		std::transform(std::begin(container), std::end(container), std::back_inserter(results), mapFunction);
 		return results;
 	}
 }

--- a/NAS2D/ContainerUtils.h
+++ b/NAS2D/ContainerUtils.h
@@ -70,13 +70,7 @@ namespace NAS2D {
 	template <typename KeyValueContainer>
 	std::vector<typename KeyValueContainer::key_type> getKeys(const KeyValueContainer& map)
 	{
-		std::vector<typename KeyValueContainer::key_type> result;
-		result.reserve(map.size());
-		for (const auto& pair : map)
-		{
-			result.push_back(pair.first);
-		}
-		return result;
+		return mapToVector(map, [](auto keyValuePair){return keyValuePair.first;});
 	}
 
 	/// Key-wise merge of values from two key/value containers

--- a/test/ContainerUtils.test.cpp
+++ b/test/ContainerUtils.test.cpp
@@ -117,3 +117,22 @@ TEST(Container, getKeys) {
 		EXPECT_EQ((std::vector<int>{1, 2}), result);
 	}
 }
+
+TEST(Container, mapToVector) {
+	{
+		int data[]{1, 2, 3};
+		EXPECT_EQ((std::vector{1, 2, 3}), (NAS2D::mapToVector(data, [](auto x){return x;})));
+	}
+
+	{
+		const std::vector data{1, 2, 3};
+		EXPECT_EQ((std::vector{1, 2, 3}), (NAS2D::mapToVector(data, [](auto x){return x;})));
+		EXPECT_EQ((std::vector{2, 3, 4}), (NAS2D::mapToVector(data, [](auto x){return x + 1;})));
+	}
+
+	{
+		const std::vector<std::string> data{"a", "bb", "ccc"};
+		EXPECT_EQ((std::vector<std::size_t>{1, 2, 3}), (NAS2D::mapToVector(data, [](const auto& x){return x.length();})));
+		EXPECT_EQ((std::vector<std::size_t>{1, 2, 3}), (NAS2D::mapToVector(data, std::mem_fn(&std::string::length))));
+	}
+}

--- a/test/ContainerUtils.test.cpp
+++ b/test/ContainerUtils.test.cpp
@@ -135,4 +135,12 @@ TEST(Container, mapToVector) {
 		EXPECT_EQ((std::vector<std::size_t>{1, 2, 3}), (NAS2D::mapToVector(data, [](const auto& x){return x.length();})));
 		EXPECT_EQ((std::vector<std::size_t>{1, 2, 3}), (NAS2D::mapToVector(data, std::mem_fn(&std::string::length))));
 	}
+
+	{
+		struct Struct {
+			const int field;
+		};
+		const std::array<Struct, 3> data{{{1}, {2}, {3}}};
+		EXPECT_EQ((std::vector{1, 2, 3}), (NAS2D::mapToVector(data, std::mem_fn(&Struct::field))));
+	}
 }

--- a/test/ContainerUtils.test.cpp
+++ b/test/ContainerUtils.test.cpp
@@ -68,6 +68,34 @@ TEST(Container, VectorSubtract) {
 	}
 }
 
+
+TEST(Container, mapToVector) {
+	{
+		int data[]{1, 2, 3};
+		EXPECT_EQ((std::vector{1, 2, 3}), (NAS2D::mapToVector(data, [](auto x){return x;})));
+	}
+
+	{
+		const std::vector data{1, 2, 3};
+		EXPECT_EQ((std::vector{1, 2, 3}), (NAS2D::mapToVector(data, [](auto x){return x;})));
+		EXPECT_EQ((std::vector{2, 3, 4}), (NAS2D::mapToVector(data, [](auto x){return x + 1;})));
+	}
+
+	{
+		const std::vector<std::string> data{"a", "bb", "ccc"};
+		EXPECT_EQ((std::vector<std::size_t>{1, 2, 3}), (NAS2D::mapToVector(data, [](const auto& x){return x.length();})));
+		EXPECT_EQ((std::vector<std::size_t>{1, 2, 3}), (NAS2D::mapToVector(data, std::mem_fn(&std::string::length))));
+	}
+
+	{
+		struct Struct {
+			const int field;
+		};
+		const std::array<Struct, 3> data{{{1}, {2}, {3}}};
+		EXPECT_EQ((std::vector{1, 2, 3}), (NAS2D::mapToVector(data, std::mem_fn(&Struct::field))));
+	}
+}
+
 TEST(Container, has) {
 	EXPECT_FALSE(NAS2D::has(std::array<int, 0>{}, 1));
 	EXPECT_FALSE(NAS2D::has(std::array{2}, 1));
@@ -115,32 +143,5 @@ TEST(Container, getKeys) {
 		auto result = NAS2D::getKeys(std::unordered_multimap<int, int>{{1, 10}, {2, 20}});
 		std::sort(std::begin(result), std::end(result));
 		EXPECT_EQ((std::vector<int>{1, 2}), result);
-	}
-}
-
-TEST(Container, mapToVector) {
-	{
-		int data[]{1, 2, 3};
-		EXPECT_EQ((std::vector{1, 2, 3}), (NAS2D::mapToVector(data, [](auto x){return x;})));
-	}
-
-	{
-		const std::vector data{1, 2, 3};
-		EXPECT_EQ((std::vector{1, 2, 3}), (NAS2D::mapToVector(data, [](auto x){return x;})));
-		EXPECT_EQ((std::vector{2, 3, 4}), (NAS2D::mapToVector(data, [](auto x){return x + 1;})));
-	}
-
-	{
-		const std::vector<std::string> data{"a", "bb", "ccc"};
-		EXPECT_EQ((std::vector<std::size_t>{1, 2, 3}), (NAS2D::mapToVector(data, [](const auto& x){return x.length();})));
-		EXPECT_EQ((std::vector<std::size_t>{1, 2, 3}), (NAS2D::mapToVector(data, std::mem_fn(&std::string::length))));
-	}
-
-	{
-		struct Struct {
-			const int field;
-		};
-		const std::array<Struct, 3> data{{{1}, {2}, {3}}};
-		EXPECT_EQ((std::vector{1, 2, 3}), (NAS2D::mapToVector(data, std::mem_fn(&Struct::field))));
 	}
 }


### PR DESCRIPTION
I've been sorely missing the equivalent of `map` style function often found in functional programming languages. Basically, give it a collection of elements, and a `mapFunction` which operates on those elements, and you'll get back a `std::vector` of the result of applying that function to every element in the collection.

The closest function available in the standard library is perhaps [`std::ranges::transform`](https://en.cppreference.com/w/cpp/algorithm/ranges/transform) coming in C++20, or the older and more awkward to use [`std::transform`](https://en.cppreference.com/w/cpp/algorithm/transform) available since C++17.

Example usage:
```cpp
// Find lengths of all strings
const std::vector<std::string> data{"a", "bb", "ccc"};
const std::vector<std::size_t> result{1, 2, 3};
// Using a lambda
EXPECT_EQ(result, (NAS2D::mapToVector(data, [](const auto& x){return x.length();})));
// Using a reference to a member function
EXPECT_EQ(result, (NAS2D::mapToVector(data, std::mem_fn(&std::string::length))));
```
