### PR TITLE
Add flattenSize template function

### DIFF
--- a/NAS2D/ContainerUtils.h
+++ b/NAS2D/ContainerUtils.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <algorithm>
 #include <iterator>
+#include <numeric>
 
 
 namespace NAS2D {
@@ -57,6 +58,29 @@ namespace NAS2D {
 
 		std::transform(std::begin(container), std::end(container), std::back_inserter(results), mapFunction);
 		return results;
+	}
+
+	/**
+	 * Determine the number of elements in a collection of collection of elements
+	 *
+	 * Example:
+	 * A std::string is a collection of chars, so a std::vector<std::string> would
+	 * be a collection of collection of chars. The result of flattenSize would be
+	 * the char length if all those strings were joined into on. That is, the size
+	 * of flatten the collection of collection of chars into a collection of
+	 * chars.
+	 **/
+	template <typename Container>
+	auto flattenSize(const Container& collectionOfCollection)
+	{
+		return std::accumulate(
+			std::begin(collectionOfCollection),
+			std::end(collectionOfCollection),
+			std::size_t{0},
+			[](std::size_t sum, const typename Container::value_type& innerCollection) noexcept {
+				return sum + innerCollection.size();
+			}
+		);
 	}
 
 	template <typename T>

--- a/NAS2D/ContainerUtils.h
+++ b/NAS2D/ContainerUtils.h
@@ -83,6 +83,21 @@ namespace NAS2D {
 		);
 	}
 
+	template <typename Container>
+	auto flatten(const Container& collectionOfCollection)
+	{
+		using InnerCollectionType = typename Container::value_type;
+
+		InnerCollectionType result;
+		result.reserve(flattenSize(collectionOfCollection));
+
+		for (const auto& innerCollection : collectionOfCollection)
+		{
+			result.insert(result.end(), innerCollection.begin(), innerCollection.end());
+		}
+		return result;
+	}
+
 	template <typename T>
 	auto missingValues(const std::vector<T>& values, const std::vector<T>& required)
 	{

--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -9,6 +9,8 @@
 // ==================================================================================
 #include "StringUtils.h"
 
+#include "ContainerUtils.h"
+
 #include <algorithm>
 #include <cctype>
 #include <numeric>
@@ -96,12 +98,7 @@ std::string join(const std::vector<std::string>& strs, std::string_view delimite
 
 	if (!strs.empty())
 	{
-		const auto totalStringSize = std::accumulate(
-			std::begin(strs),
-			std::end(strs),
-			std::size_t{},
-			[](std::size_t a, const std::string& b) noexcept { return a + b.size(); }
-		);
+		const auto totalStringSize = flattenSize(strs);
 		const auto delimiterSize = (strs.size() - 1) * delimiter.size();
 		result.reserve(totalStringSize + delimiterSize);
 

--- a/test/ContainerUtils.test.cpp
+++ b/test/ContainerUtils.test.cpp
@@ -101,6 +101,11 @@ TEST(Container, flattenSize) {
 	EXPECT_EQ(std::size_t{5}, NAS2D::flattenSize(std::vector<std::vector<int>>{{1, 2}, {3, 4, 5}}));
 }
 
+TEST(Container, flatten) {
+	EXPECT_EQ(std::string{"123456"}, NAS2D::flatten(std::vector<std::string>{"1", "23", "456"}));
+	EXPECT_EQ((std::vector{1, 2, 3, 4, 5}), NAS2D::flatten(std::vector<std::vector<int>>{{1, 2}, {3, 4, 5}}));
+}
+
 TEST(Container, has) {
 	EXPECT_FALSE(NAS2D::has(std::array<int, 0>{}, 1));
 	EXPECT_FALSE(NAS2D::has(std::array{2}, 1));

--- a/test/ContainerUtils.test.cpp
+++ b/test/ContainerUtils.test.cpp
@@ -96,6 +96,11 @@ TEST(Container, mapToVector) {
 	}
 }
 
+TEST(Container, flattenSize) {
+	EXPECT_EQ(std::size_t{6}, NAS2D::flattenSize(std::vector<std::string>{"1", "23", "456"}));
+	EXPECT_EQ(std::size_t{5}, NAS2D::flattenSize(std::vector<std::vector<int>>{{1, 2}, {3, 4, 5}}));
+}
+
 TEST(Container, has) {
 	EXPECT_FALSE(NAS2D::has(std::array<int, 0>{}, 1));
 	EXPECT_FALSE(NAS2D::has(std::array{2}, 1));

--- a/test/ContainerUtils.test.cpp
+++ b/test/ContainerUtils.test.cpp
@@ -72,19 +72,19 @@ TEST(Container, VectorSubtract) {
 TEST(Container, mapToVector) {
 	{
 		int data[]{1, 2, 3};
-		EXPECT_EQ((std::vector{1, 2, 3}), (NAS2D::mapToVector(data, [](auto x){return x;})));
+		EXPECT_EQ((std::vector{1, 2, 3}), NAS2D::mapToVector(data, [](auto x){return x;}));
 	}
 
 	{
 		const std::vector data{1, 2, 3};
-		EXPECT_EQ((std::vector{1, 2, 3}), (NAS2D::mapToVector(data, [](auto x){return x;})));
-		EXPECT_EQ((std::vector{2, 3, 4}), (NAS2D::mapToVector(data, [](auto x){return x + 1;})));
+		EXPECT_EQ((std::vector{1, 2, 3}), NAS2D::mapToVector(data, [](auto x){return x;}));
+		EXPECT_EQ((std::vector{2, 3, 4}), NAS2D::mapToVector(data, [](auto x){return x + 1;}));
 	}
 
 	{
 		const std::vector<std::string> data{"a", "bb", "ccc"};
-		EXPECT_EQ((std::vector<std::size_t>{1, 2, 3}), (NAS2D::mapToVector(data, [](const auto& x){return x.length();})));
-		EXPECT_EQ((std::vector<std::size_t>{1, 2, 3}), (NAS2D::mapToVector(data, std::mem_fn(&std::string::length))));
+		EXPECT_EQ((std::vector<std::size_t>{1, 2, 3}), NAS2D::mapToVector(data, [](const auto& x){return x.length();}));
+		EXPECT_EQ((std::vector<std::size_t>{1, 2, 3}), NAS2D::mapToVector(data, std::mem_fn(&std::string::length)));
 	}
 
 	{
@@ -92,7 +92,7 @@ TEST(Container, mapToVector) {
 			const int field;
 		};
 		const std::array<Struct, 3> data{{{1}, {2}, {3}}};
-		EXPECT_EQ((std::vector{1, 2, 3}), (NAS2D::mapToVector(data, std::mem_fn(&Struct::field))));
+		EXPECT_EQ((std::vector{1, 2, 3}), NAS2D::mapToVector(data, std::mem_fn(&Struct::field)));
 	}
 }
 


### PR DESCRIPTION
Add `flattenSize` template function to calculation the flattened size of a collection of collections. That is, calculate the number of elements in a collection of collection of elements.

Use `flattenSize` to implement the `reserve` size calculation in the `join` function.

Closes #217
