### PR TITLE
Adds Dictionary class files to appropriate MSVC project filters

### DIFF
--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -165,6 +165,9 @@
     <ClCompile Include="Renderer\DisplayDesc.cpp">
       <Filter>Source Files\Renderer</Filter>
     </ClCompile>
+    <ClCompile Include="Dictionary.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Configuration.h">
@@ -343,6 +346,9 @@
     </ClInclude>
     <ClInclude Include="Renderer\DisplayDesc.h">
       <Filter>Header Files\Renderer</Filter>
+    </ClInclude>
+    <ClInclude Include="Dictionary.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The dictionary class files had its files applied to the base project filter tree instead of Source and Header. This happens when you try and edit the .vcxproj file directly to add files to a project instead of using the IDE.