### PR TITLE
Fix startup error by setting default config values

### DIFF
--- a/test-graphics/main.cpp
+++ b/test-graphics/main.cpp
@@ -11,6 +11,9 @@
 #include "TestGraphics.h"
 
 #include <NAS2D/Game.h>
+#include <NAS2D/Utility.h>
+#include <NAS2D/Configuration.h>
+#include <NAS2D/Dictionary.h>
 
 #include <iostream>
 #include <string>
@@ -20,6 +23,32 @@ int main(int /*argc*/, char *argv[])
 {
 	try
 	{
+		NAS2D::Utility<NAS2D::Configuration>::init(
+			std::map<std::string, NAS2D::Dictionary>{
+				{
+					"graphics",
+					{{
+						{"screenwidth", 1000},
+						{"screenheight", 700},
+						{"bitdepth", 32},
+						{"fullscreen", false},
+						{"vsync", true}
+					}}
+				},
+				{
+					"audio",
+					{{
+						{"mixer", "SDL"},
+						{"musicvolume", 100},
+						{"sfxvolume", 128},
+						{"channels", 2},
+						{"mixrate", 22050},
+						{"bufferlength", 1024}
+					}}
+				}
+			}
+		);
+
 		NAS2D::Game game("NAS2D Graphics Test", "NAS2D_GraphicsTest", "LairWorks", argv[0]);
 		game.go(new TestGraphics());
 	}


### PR DESCRIPTION
This prevents load errors when the config file is not pre-existing.

Closes #885

More long term we might want to consider updating how error handling works in the config option parsing.
- `RendererOpenGL::ReadConfigurationOptions()`
- `MixerSDL::ReadConfigurationOptions()`

Tagging #797 as related.
