### PR TITLE
Update MacOS image to Xcode 12.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
 jobs:
   build-macos:
     macos:
-      xcode: "12.4.0"
+      xcode: "12.5.0"
     environment:
       - HOMEBREW_NO_AUTO_UPDATE: 1
       - WARN_EXTRA: "-Wno-double-promotion"


### PR DESCRIPTION
Bumping Xcode version from 12.4.0 to 12.5.0. This means an updated macOS version being bumped from 10.15.5 to 11.4.0.

Tagging #826 as possibly related.
