### PR TITLE
Add Dictionary::get with defaultValue

### DIFF
--- a/NAS2D/Dictionary.h
+++ b/NAS2D/Dictionary.h
@@ -30,7 +30,12 @@ namespace NAS2D {
 		template <typename T = std::string>
 		T get(const std::string& key) const
 		{
-			return mDictionary.at(key).to<T>();
+			const auto iterator = mDictionary.find(key);
+			if (iterator == mDictionary.end())
+			{
+				throw std::out_of_range("Dictionary lookup failed for key : " + key);
+			}
+			return iterator->second.to<T>();
 		}
 
 		template <typename T = std::string>

--- a/NAS2D/Dictionary.h
+++ b/NAS2D/Dictionary.h
@@ -20,7 +20,7 @@ namespace NAS2D {
 		Dictionary& operator+=(const Dictionary& other);
 
 
-		template <typename T = std::string>
+		template <typename T>
 		T get(const std::string& key, T defaultValue) const
 		{
 			const auto iterator = mDictionary.find(key);

--- a/NAS2D/Dictionary.h
+++ b/NAS2D/Dictionary.h
@@ -21,6 +21,13 @@ namespace NAS2D {
 
 
 		template <typename T = std::string>
+		T get(const std::string& key, T defaultValue) const
+		{
+			const auto iterator = mDictionary.find(key);
+			return (iterator != mDictionary.end()) ? iterator->second.to<T>() : defaultValue;
+		}
+
+		template <typename T = std::string>
 		T get(const std::string& key) const
 		{
 			return mDictionary.at(key).to<T>();

--- a/test/Dictionary.test.cpp
+++ b/test/Dictionary.test.cpp
@@ -78,6 +78,13 @@ TEST(Dictionary, setGet) {
 	EXPECT_EQ(true, dictionary.get<bool>("Key3"));
 	EXPECT_EQ(1, dictionary.get<int>("Key4"));
 
+	// Read back typed values with deaults
+	EXPECT_EQ("Some string value", dictionary.get<std::string>("Key1", "Default string"));
+	EXPECT_EQ("Default string", dictionary.get<std::string>("KeyDoesNotExist", "Default string"));
+	EXPECT_EQ("Default string", dictionary.get("KeyDoesNotExist", std::string{"Default string"}));
+	EXPECT_EQ(1, dictionary.get("Key4", 2));
+	EXPECT_EQ(2, dictionary.get("KeyDoesNotExist", 2));
+
 	EXPECT_THROW(dictionary.get("KeyDoesNotExist"), std::out_of_range);
 }
 


### PR DESCRIPTION
Add `Dictionary::get` with `defaultValue`. If the lookup key was not found, the `defaultValue` is returned instead.

Improve error message for `Dictionary::get` (without `defaultValue`) to include `key` name that was not found.
