### PR TITLE
Update stringTo<bool> to handle "0" and "1"

### DIFF
--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -39,8 +39,8 @@ namespace NAS2D
 			return value;
 		} else if constexpr (std::is_same_v<T, bool>) {
 			return
-				value == "true" ? true :
-				value == "false" ? false :
+				value == "true" || value == "1" ? true :
+				value == "false" || value == "0" ? false :
 				throw std::invalid_argument("Value must be 'true' or 'false': " + std::string{value});
 		} else if constexpr (std::is_same_v<T, long double>) {
 			return std::stold(value);

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -67,6 +67,8 @@ TEST(String, stringTo) {
 	EXPECT_THROW(NAS2D::stringTo<bool>("random text"), std::invalid_argument);
 	EXPECT_EQ(false, NAS2D::stringTo<bool>("false"));
 	EXPECT_EQ(true, NAS2D::stringTo<bool>("true"));
+	EXPECT_EQ(false, NAS2D::stringTo<bool>("0"));
+	EXPECT_EQ(true, NAS2D::stringTo<bool>("1"));
 
 	EXPECT_THROW(NAS2D::stringTo<char>(std::to_string(std::numeric_limits<char>::min() - 1)), std::out_of_range);
 	EXPECT_THROW(NAS2D::stringTo<char>(std::to_string(std::numeric_limits<char>::max() + 1)), std::out_of_range);


### PR DESCRIPTION
Update `stringTo<bool>` to handle `"0"` and `"1"`.

I've kind of avoided this for a while, since I wanted the parsing to exactly match what was generated, though it's such a common convention to also use `0` and `1` for `bool` values. In particular, OPHD code uses `0` and `1` for bool values in the saved game files. Supporting it here is the easiest way to handle that.
