### PR TITLE
Indent namespaces

### DIFF
--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -17,35 +17,35 @@
 namespace NAS2D {
 
 
-/**
- * Configuration Parser.
- *
- * Parses and interprets Configuration data stored in XML files (e.g., config.xml).
- */
-class Configuration
-{
-public:
-	Configuration() = default;
-	Configuration(std::map<std::string, Dictionary> defaults);
-	Configuration(const Configuration&) = delete;
-	Configuration& operator=(const Configuration&) = delete;
-	Configuration(Configuration&&) = delete;
-	Configuration& operator=(Configuration&&) = delete;
-	~Configuration() = default;
+	/**
+	 * Configuration Parser.
+	 *
+	 * Parses and interprets Configuration data stored in XML files (e.g., config.xml).
+	 */
+	class Configuration
+	{
+	public:
+		Configuration() = default;
+		Configuration(std::map<std::string, Dictionary> defaults);
+		Configuration(const Configuration&) = delete;
+		Configuration& operator=(const Configuration&) = delete;
+		Configuration(Configuration&&) = delete;
+		Configuration& operator=(Configuration&&) = delete;
+		~Configuration() = default;
 
-	const Dictionary& operator[](const std::string& key) const { return mSettings.at(key); }
-	Dictionary& operator[](const std::string& key) { return mSettings.at(key); }
+		const Dictionary& operator[](const std::string& key) const { return mSettings.at(key); }
+		Dictionary& operator[](const std::string& key) { return mSettings.at(key); }
 
-	void loadData(const std::string& fileData);
-	void load(const std::string& filePath);
-	std::string saveData() const;
-	void save(const std::string& filePath) const;
+		void loadData(const std::string& fileData);
+		void load(const std::string& filePath);
+		std::string saveData() const;
+		void save(const std::string& filePath) const;
 
-protected:
-private:
-	const std::map<std::string, Dictionary> mDefaults{};
-	std::map<std::string, Dictionary> mLoadedSettings{};
-	std::map<std::string, Dictionary> mSettings{};
-};
+	protected:
+	private:
+		const std::map<std::string, Dictionary> mDefaults{};
+		std::map<std::string, Dictionary> mLoadedSettings{};
+		std::map<std::string, Dictionary> mSettings{};
+	};
 
 } // namespace

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -17,352 +17,352 @@
 
 namespace NAS2D {
 
-#define SCANCODE_MASK (1<<30)
-#define SCANCODE_TO_KEYCODE(X) (X | SCANCODE_MASK)
+	#define SCANCODE_MASK (1<<30)
+	#define SCANCODE_TO_KEYCODE(X) (X | SCANCODE_MASK)
 
 
-/**
- * Handles and dispatches low-level events.
- */
-class EventHandler
-{
-public:
 	/**
-	* Key Modifiers
-	*/
-	enum class KeyModifier : uint16_t
+	 * Handles and dispatches low-level events.
+	 */
+	class EventHandler
 	{
-		None = 0x0000,
-		ShiftLeft = 0x0001,
-		ShiftRight = 0x0002,
-		Shift = ShiftLeft | ShiftRight,
-		CtrlLeft = 0x0040,
-		CtrlRight = 0x0080,
-		Ctrl = CtrlLeft | CtrlRight,
-		AltLeft = 0x0100,
-		AltRight = 0x0200,
-		Alt = AltLeft | AltRight,
-		MetaLeft = 0x0400,
-		MetaRight = 0x0800,
-		Meta = MetaLeft | MetaRight,
-		Num = 0x1000,
-		Caps = 0x2000,
-		Mode = 0x4000,
-		Reserved = 0x8000
-	};
+	public:
+		/**
+		* Key Modifiers
+		*/
+		enum class KeyModifier : uint16_t
+		{
+			None = 0x0000,
+			ShiftLeft = 0x0001,
+			ShiftRight = 0x0002,
+			Shift = ShiftLeft | ShiftRight,
+			CtrlLeft = 0x0040,
+			CtrlRight = 0x0080,
+			Ctrl = CtrlLeft | CtrlRight,
+			AltLeft = 0x0100,
+			AltRight = 0x0200,
+			Alt = AltLeft | AltRight,
+			MetaLeft = 0x0400,
+			MetaRight = 0x0800,
+			Meta = MetaLeft | MetaRight,
+			Num = 0x1000,
+			Caps = 0x2000,
+			Mode = 0x4000,
+			Reserved = 0x8000
+		};
 
+
+			/**
+			* Keyboard scan codes.
+			*/
+		enum class KeyCode : uint32_t
+		{
+			KEY_UNKNOWN = 0,
+			KEY_FIRST = 0,
+			KEY_BACKSPACE = '\b',
+			KEY_TAB = '\t',
+			KEY_RETURN = '\r',
+			KEY_ENTER = '\r',
+			KEY_ESCAPE = '\033',
+			KEY_SPACE = ' ',
+			KEY_EXCLAIM = '!',
+			KEY_QUOTEDBL = '"',
+			KEY_HASH = '#',
+			KEY_PERCENT = '%',
+			KEY_DOLLAR = '$',
+			KEY_AMPERSAND = '&',
+			KEY_QUOTE = '\'',
+			KEY_LEFTPAREN = '(',
+			KEY_RIGHTPAREN = ')',
+			KEY_ASTERISK = '*',
+			KEY_PLUS = '+',
+			KEY_COMMA = ',',
+			KEY_MINUS = '-',
+			KEY_PERIOD = '.',
+			KEY_SLASH = '/',
+			KEY_0 = '0',
+			KEY_1 = '1',
+			KEY_2 = '2',
+			KEY_3 = '3',
+			KEY_4 = '4',
+			KEY_5 = '5',
+			KEY_6 = '6',
+			KEY_7 = '7',
+			KEY_8 = '8',
+			KEY_9 = '9',
+			KEY_COLON = ':',
+			KEY_SEMICOLON = ';',
+			KEY_LESS = '<',
+			KEY_EQUALS = '=',
+			KEY_GREATER = '>',
+			KEY_QUESTION = '?',
+			KEY_AT = '@',
+
+			// Special Symbols
+			KEY_LEFTBRACKET = '[',
+			KEY_BACKSLASH = '\\',
+			KEY_RIGHTBRACKET = ']',
+			KEY_CARET = '^',
+			KEY_UNDERSCORE = '_',
+			KEY_BACKQUOTE = '`',
+
+			KEY_a = 'a',
+			KEY_b = 'b',
+			KEY_c = 'c',
+			KEY_d = 'd',
+			KEY_e = 'e',
+			KEY_f = 'f',
+			KEY_g = 'g',
+			KEY_h = 'h',
+			KEY_i = 'i',
+			KEY_j = 'j',
+			KEY_k = 'k',
+			KEY_l = 'l',
+			KEY_m = 'm',
+			KEY_n = 'n',
+			KEY_o = 'o',
+			KEY_p = 'p',
+			KEY_q = 'q',
+			KEY_r = 'r',
+			KEY_s = 's',
+			KEY_t = 't',
+			KEY_u = 'u',
+			KEY_v = 'v',
+			KEY_w = 'w',
+			KEY_x = 'x',
+			KEY_y = 'y',
+			KEY_z = 'z',
+
+			// Numeric Keypad
+			KEY_KP1 = SCANCODE_TO_KEYCODE(89),
+			KEY_KP2 = SCANCODE_TO_KEYCODE(90),
+			KEY_KP3 = SCANCODE_TO_KEYCODE(91),
+			KEY_KP4 = SCANCODE_TO_KEYCODE(92),
+			KEY_KP5 = SCANCODE_TO_KEYCODE(93),
+			KEY_KP6 = SCANCODE_TO_KEYCODE(94),
+			KEY_KP7 = SCANCODE_TO_KEYCODE(95),
+			KEY_KP8 = SCANCODE_TO_KEYCODE(96),
+			KEY_KP9 = SCANCODE_TO_KEYCODE(97),
+			KEY_KP0 = SCANCODE_TO_KEYCODE(98),
+			KEY_KP_PERIOD = SCANCODE_TO_KEYCODE(99),
+			KEY_KP_DIVIDE = SCANCODE_TO_KEYCODE(84),
+			KEY_KP_MULTIPLY = SCANCODE_TO_KEYCODE(85),
+			KEY_KP_MINUS = SCANCODE_TO_KEYCODE(86),
+			KEY_KP_PLUS = SCANCODE_TO_KEYCODE(87),
+			KEY_KP_ENTER = SCANCODE_TO_KEYCODE(88),
+			KEY_KP_EQUALS = SCANCODE_TO_KEYCODE(103),
+			KEY_KP_COMMA = SCANCODE_TO_KEYCODE(133),
+
+			// Arrows/Home/End
+			KEY_UP = SCANCODE_TO_KEYCODE(82),
+			KEY_DOWN = SCANCODE_TO_KEYCODE(81),
+			KEY_RIGHT = SCANCODE_TO_KEYCODE(79),
+			KEY_LEFT = SCANCODE_TO_KEYCODE(80),
+			KEY_INSERT = SCANCODE_TO_KEYCODE(73),
+			KEY_PAUSE = SCANCODE_TO_KEYCODE(72),
+			KEY_HOME = SCANCODE_TO_KEYCODE(74),
+			KEY_END = SCANCODE_TO_KEYCODE(77),
+			KEY_DELETE = '\177',
+			KEY_PAGEUP = SCANCODE_TO_KEYCODE(75),
+			KEY_PAGEDOWN = SCANCODE_TO_KEYCODE(78),
+
+			// Function Keys
+			KEY_F1 = SCANCODE_TO_KEYCODE(58),
+			KEY_F2 = SCANCODE_TO_KEYCODE(59),
+			KEY_F3 = SCANCODE_TO_KEYCODE(60),
+			KEY_F4 = SCANCODE_TO_KEYCODE(61),
+			KEY_F5 = SCANCODE_TO_KEYCODE(62),
+			KEY_F6 = SCANCODE_TO_KEYCODE(63),
+			KEY_F7 = SCANCODE_TO_KEYCODE(64),
+			KEY_F8 = SCANCODE_TO_KEYCODE(65),
+			KEY_F9 = SCANCODE_TO_KEYCODE(66),
+			KEY_F10 = SCANCODE_TO_KEYCODE(67),
+			KEY_F11 = SCANCODE_TO_KEYCODE(68),
+			KEY_F12 = SCANCODE_TO_KEYCODE(69),
+			KEY_F13 = SCANCODE_TO_KEYCODE(104),
+			KEY_F14 = SCANCODE_TO_KEYCODE(105),
+			KEY_F15 = SCANCODE_TO_KEYCODE(106),
+			KEY_F16 = SCANCODE_TO_KEYCODE(107),
+			KEY_F17 = SCANCODE_TO_KEYCODE(108),
+			KEY_F18 = SCANCODE_TO_KEYCODE(109),
+			KEY_F19 = SCANCODE_TO_KEYCODE(110),
+			KEY_F20 = SCANCODE_TO_KEYCODE(111),
+			KEY_F21 = SCANCODE_TO_KEYCODE(112),
+			KEY_F22 = SCANCODE_TO_KEYCODE(113),
+			KEY_F23 = SCANCODE_TO_KEYCODE(114),
+			KEY_F24 = SCANCODE_TO_KEYCODE(115),
+
+			// Key State Modifiers
+			KEY_NUMLOCK = SCANCODE_TO_KEYCODE(83),
+			KEY_CAPSLOCK = SCANCODE_TO_KEYCODE(57),
+			KEY_SCROLLOCK = SCANCODE_TO_KEYCODE(71),
+			KEY_RSHIFT = SCANCODE_TO_KEYCODE(229),
+			KEY_LSHIFT = SCANCODE_TO_KEYCODE(225),
+			KEY_RCTRL = SCANCODE_TO_KEYCODE(228),
+			KEY_LCTRL = SCANCODE_TO_KEYCODE(224),
+			KEY_RALT = SCANCODE_TO_KEYCODE(230),
+			KEY_LALT = SCANCODE_TO_KEYCODE(226),
+			KEY_RGUI = SCANCODE_TO_KEYCODE(231),
+			KEY_LGUI = SCANCODE_TO_KEYCODE(227),
+			KEY_MODE = SCANCODE_TO_KEYCODE(257),
+
+			// Miscellaneous function keys
+			KEY_HELP = SCANCODE_TO_KEYCODE(117),
+			KEY_PRINTSCREEN = SCANCODE_TO_KEYCODE(70),
+			KEY_ALTERASE = SCANCODE_TO_KEYCODE(153),
+			KEY_SYSREQ = SCANCODE_TO_KEYCODE(154),
+			KEY_CLEAR = SCANCODE_TO_KEYCODE(159),
+			KEY_MENU = SCANCODE_TO_KEYCODE(118),
+			KEY_POWER = SCANCODE_TO_KEYCODE(102),
+			KEY_UNDO = SCANCODE_TO_KEYCODE(122),
+
+			// Audio Control
+			KEY_MUTE = SCANCODE_TO_KEYCODE(127),
+			KEY_VOLUME_UP = SCANCODE_TO_KEYCODE(128),
+			KEY_VOLUME_DOWN = SCANCODE_TO_KEYCODE(129),
+			KEY_AUDIO_NEXT = SCANCODE_TO_KEYCODE(258),
+			KEY_AUDIO_PREV = SCANCODE_TO_KEYCODE(259),
+			KEY_AUDIO_STOP = SCANCODE_TO_KEYCODE(260),
+			KEY_AUDIO_PLAY = SCANCODE_TO_KEYCODE(261),
+			KEY_AUDIO_MUTE = SCANCODE_TO_KEYCODE(262),
+
+			// Additional Keys here
+			KEY_LAST
+		};
 
 		/**
-		* Keyboard scan codes.
+		* Mouse button identifiers.
 		*/
-	enum class KeyCode : uint32_t
-	{
-		KEY_UNKNOWN = 0,
-		KEY_FIRST = 0,
-		KEY_BACKSPACE = '\b',
-		KEY_TAB = '\t',
-		KEY_RETURN = '\r',
-		KEY_ENTER = '\r',
-		KEY_ESCAPE = '\033',
-		KEY_SPACE = ' ',
-		KEY_EXCLAIM = '!',
-		KEY_QUOTEDBL = '"',
-		KEY_HASH = '#',
-		KEY_PERCENT = '%',
-		KEY_DOLLAR = '$',
-		KEY_AMPERSAND = '&',
-		KEY_QUOTE = '\'',
-		KEY_LEFTPAREN = '(',
-		KEY_RIGHTPAREN = ')',
-		KEY_ASTERISK = '*',
-		KEY_PLUS = '+',
-		KEY_COMMA = ',',
-		KEY_MINUS = '-',
-		KEY_PERIOD = '.',
-		KEY_SLASH = '/',
-		KEY_0 = '0',
-		KEY_1 = '1',
-		KEY_2 = '2',
-		KEY_3 = '3',
-		KEY_4 = '4',
-		KEY_5 = '5',
-		KEY_6 = '6',
-		KEY_7 = '7',
-		KEY_8 = '8',
-		KEY_9 = '9',
-		KEY_COLON = ':',
-		KEY_SEMICOLON = ';',
-		KEY_LESS = '<',
-		KEY_EQUALS = '=',
-		KEY_GREATER = '>',
-		KEY_QUESTION = '?',
-		KEY_AT = '@',
+		enum class MouseButton
+		{
+			None,
+			Left,
+			Middle,
+			Right
+		};
 
-		// Special Symbols
-		KEY_LEFTBRACKET = '[',
-		KEY_BACKSLASH = '\\',
-		KEY_RIGHTBRACKET = ']',
-		KEY_CARET = '^',
-		KEY_UNDERSCORE = '_',
-		KEY_BACKQUOTE = '`',
 
-		KEY_a = 'a',
-		KEY_b = 'b',
-		KEY_c = 'c',
-		KEY_d = 'd',
-		KEY_e = 'e',
-		KEY_f = 'f',
-		KEY_g = 'g',
-		KEY_h = 'h',
-		KEY_i = 'i',
-		KEY_j = 'j',
-		KEY_k = 'k',
-		KEY_l = 'l',
-		KEY_m = 'm',
-		KEY_n = 'n',
-		KEY_o = 'o',
-		KEY_p = 'p',
-		KEY_q = 'q',
-		KEY_r = 'r',
-		KEY_s = 's',
-		KEY_t = 't',
-		KEY_u = 'u',
-		KEY_v = 'v',
-		KEY_w = 'w',
-		KEY_x = 'x',
-		KEY_y = 'y',
-		KEY_z = 'z',
+		using ActivateEventSource = SignalSource<bool>;
+		using WindowHiddenEventSource = SignalSource<bool>;
+		using WindowExposedEventSource = SignalSource<>;
+		using WindowMinimizedEventSource = SignalSource<>;
+		using WindowMaximizedEventSource = SignalSource<>;
+		using WindowRestoredEventSource = SignalSource<>;
+		using WindowResizedEventSource = SignalSource<Vector<int>>;
+		using WindowMouseEnterEventSource = SignalSource<>;
+		using WindowMouseLeaveEventSource = SignalSource<>;
 
-		// Numeric Keypad
-		KEY_KP1 = SCANCODE_TO_KEYCODE(89),
-		KEY_KP2 = SCANCODE_TO_KEYCODE(90),
-		KEY_KP3 = SCANCODE_TO_KEYCODE(91),
-		KEY_KP4 = SCANCODE_TO_KEYCODE(92),
-		KEY_KP5 = SCANCODE_TO_KEYCODE(93),
-		KEY_KP6 = SCANCODE_TO_KEYCODE(94),
-		KEY_KP7 = SCANCODE_TO_KEYCODE(95),
-		KEY_KP8 = SCANCODE_TO_KEYCODE(96),
-		KEY_KP9 = SCANCODE_TO_KEYCODE(97),
-		KEY_KP0 = SCANCODE_TO_KEYCODE(98),
-		KEY_KP_PERIOD = SCANCODE_TO_KEYCODE(99),
-		KEY_KP_DIVIDE = SCANCODE_TO_KEYCODE(84),
-		KEY_KP_MULTIPLY = SCANCODE_TO_KEYCODE(85),
-		KEY_KP_MINUS = SCANCODE_TO_KEYCODE(86),
-		KEY_KP_PLUS = SCANCODE_TO_KEYCODE(87),
-		KEY_KP_ENTER = SCANCODE_TO_KEYCODE(88),
-		KEY_KP_EQUALS = SCANCODE_TO_KEYCODE(103),
-		KEY_KP_COMMA = SCANCODE_TO_KEYCODE(133),
+		using JoystickAxisMotionEventSource = SignalSource<int, int, int>;
+		using JoystickBallMotionEventSource = SignalSource<int, int, int, int>;
+		using JoystickButtonEventSource = SignalSource<int, int>;
+		using JoystickHatMotionEventSource = SignalSource<int, int, int>;
 
-		// Arrows/Home/End
-		KEY_UP = SCANCODE_TO_KEYCODE(82),
-		KEY_DOWN = SCANCODE_TO_KEYCODE(81),
-		KEY_RIGHT = SCANCODE_TO_KEYCODE(79),
-		KEY_LEFT = SCANCODE_TO_KEYCODE(80),
-		KEY_INSERT = SCANCODE_TO_KEYCODE(73),
-		KEY_PAUSE = SCANCODE_TO_KEYCODE(72),
-		KEY_HOME = SCANCODE_TO_KEYCODE(74),
-		KEY_END = SCANCODE_TO_KEYCODE(77),
-		KEY_DELETE = '\177',
-		KEY_PAGEUP = SCANCODE_TO_KEYCODE(75),
-		KEY_PAGEDOWN = SCANCODE_TO_KEYCODE(78),
+		using KeyDownEventSource = SignalSource<KeyCode, KeyModifier, bool>;
+		using KeyUpEventSource = SignalSource<KeyCode, KeyModifier>;
+		using TextInputEventSource = SignalSource<const std::string&>;
 
-		// Function Keys
-		KEY_F1 = SCANCODE_TO_KEYCODE(58),
-		KEY_F2 = SCANCODE_TO_KEYCODE(59),
-		KEY_F3 = SCANCODE_TO_KEYCODE(60),
-		KEY_F4 = SCANCODE_TO_KEYCODE(61),
-		KEY_F5 = SCANCODE_TO_KEYCODE(62),
-		KEY_F6 = SCANCODE_TO_KEYCODE(63),
-		KEY_F7 = SCANCODE_TO_KEYCODE(64),
-		KEY_F8 = SCANCODE_TO_KEYCODE(65),
-		KEY_F9 = SCANCODE_TO_KEYCODE(66),
-		KEY_F10 = SCANCODE_TO_KEYCODE(67),
-		KEY_F11 = SCANCODE_TO_KEYCODE(68),
-		KEY_F12 = SCANCODE_TO_KEYCODE(69),
-		KEY_F13 = SCANCODE_TO_KEYCODE(104),
-		KEY_F14 = SCANCODE_TO_KEYCODE(105),
-		KEY_F15 = SCANCODE_TO_KEYCODE(106),
-		KEY_F16 = SCANCODE_TO_KEYCODE(107),
-		KEY_F17 = SCANCODE_TO_KEYCODE(108),
-		KEY_F18 = SCANCODE_TO_KEYCODE(109),
-		KEY_F19 = SCANCODE_TO_KEYCODE(110),
-		KEY_F20 = SCANCODE_TO_KEYCODE(111),
-		KEY_F21 = SCANCODE_TO_KEYCODE(112),
-		KEY_F22 = SCANCODE_TO_KEYCODE(113),
-		KEY_F23 = SCANCODE_TO_KEYCODE(114),
-		KEY_F24 = SCANCODE_TO_KEYCODE(115),
+		using MouseButtonEventSource = SignalSource<MouseButton, int, int>;
+		using MouseMotionEventSource = SignalSource<int, int, int, int>;
+		using MouseWheelEventSource = SignalSource<int, int>;
 
-		// Key State Modifiers
-		KEY_NUMLOCK = SCANCODE_TO_KEYCODE(83),
-		KEY_CAPSLOCK = SCANCODE_TO_KEYCODE(57),
-		KEY_SCROLLOCK = SCANCODE_TO_KEYCODE(71),
-		KEY_RSHIFT = SCANCODE_TO_KEYCODE(229),
-		KEY_LSHIFT = SCANCODE_TO_KEYCODE(225),
-		KEY_RCTRL = SCANCODE_TO_KEYCODE(228),
-		KEY_LCTRL = SCANCODE_TO_KEYCODE(224),
-		KEY_RALT = SCANCODE_TO_KEYCODE(230),
-		KEY_LALT = SCANCODE_TO_KEYCODE(226),
-		KEY_RGUI = SCANCODE_TO_KEYCODE(231),
-		KEY_LGUI = SCANCODE_TO_KEYCODE(227),
-		KEY_MODE = SCANCODE_TO_KEYCODE(257),
+		using QuitEventSource = SignalSource<>;
 
-		// Miscellaneous function keys
-		KEY_HELP = SCANCODE_TO_KEYCODE(117),
-		KEY_PRINTSCREEN = SCANCODE_TO_KEYCODE(70),
-		KEY_ALTERASE = SCANCODE_TO_KEYCODE(153),
-		KEY_SYSREQ = SCANCODE_TO_KEYCODE(154),
-		KEY_CLEAR = SCANCODE_TO_KEYCODE(159),
-		KEY_MENU = SCANCODE_TO_KEYCODE(118),
-		KEY_POWER = SCANCODE_TO_KEYCODE(102),
-		KEY_UNDO = SCANCODE_TO_KEYCODE(122),
+	public:
+		EventHandler();
+		~EventHandler();
 
-		// Audio Control
-		KEY_MUTE = SCANCODE_TO_KEYCODE(127),
-		KEY_VOLUME_UP = SCANCODE_TO_KEYCODE(128),
-		KEY_VOLUME_DOWN = SCANCODE_TO_KEYCODE(129),
-		KEY_AUDIO_NEXT = SCANCODE_TO_KEYCODE(258),
-		KEY_AUDIO_PREV = SCANCODE_TO_KEYCODE(259),
-		KEY_AUDIO_STOP = SCANCODE_TO_KEYCODE(260),
-		KEY_AUDIO_PLAY = SCANCODE_TO_KEYCODE(261),
-		KEY_AUDIO_MUTE = SCANCODE_TO_KEYCODE(262),
+		ActivateEventSource& activate();
 
-		// Additional Keys here
-		KEY_LAST
+		WindowHiddenEventSource& windowHidden();
+		WindowExposedEventSource& windowExposed();
+
+		WindowMinimizedEventSource& windowMinimized();
+		WindowMaximizedEventSource& windowMaximized();
+		WindowRestoredEventSource& windowRestored();
+		WindowResizedEventSource& windowResized();
+
+		WindowMouseEnterEventSource& windowMouseEnter();
+		WindowMouseLeaveEventSource& windowMouseLeave();
+
+		JoystickAxisMotionEventSource& joystickAxisMotion();
+		JoystickBallMotionEventSource& joystickBallMotion();
+		JoystickButtonEventSource& joystickButtonUp();
+		JoystickButtonEventSource& joystickButtonDown();
+		JoystickHatMotionEventSource& joystickHatMotion();
+
+		KeyUpEventSource& keyUp();
+		KeyDownEventSource& keyDown();
+
+		TextInputEventSource& textInput();
+
+		MouseButtonEventSource& mouseButtonUp();
+		MouseButtonEventSource& mouseButtonDown();
+		MouseButtonEventSource& mouseDoubleClick();
+		MouseMotionEventSource& mouseMotion();
+		MouseWheelEventSource& mouseWheel();
+
+		QuitEventSource& quit();
+
+		void grabMouse();
+		void releaseMouse();
+		void warpMouse(int x, int y);
+		void mouseRelativeMode(bool rel);
+
+		void textInputMode(bool);
+		bool textInputMode();
+
+		bool shift(KeyModifier mod) const;
+		bool numlock(KeyModifier mod) const;
+		bool control(KeyModifier mod) const;
+		bool alt(KeyModifier mod) const;
+
+		bool query_shift() const;
+		bool query_numlock() const;
+		bool query_control() const;
+
+		void pump();
+
+		void disconnectAll();
+
+	private:
+		Signal<bool> mActivateEvent;
+
+		Signal<bool> mWindowHiddenEvent;
+		Signal<> mWindowExposedEvent;
+		Signal<> mWindowMinimizedEvent;
+		Signal<> mWindowMaximizedEvent;
+		Signal<> mWindowRestoredEvent;
+		Signal<Vector<int>> mWindowResizedEvent;
+		Signal<> mWindowMouseEnterEvent;
+		Signal<> mWindowMouseLeaveEvent;
+
+		Signal<int, int, int> mJoystickAxisMotionEvent;
+		Signal<int, int, int, int> mJoystickBallMotionEvent;
+		Signal<int, int> mJoystickButtonUpEvent;
+		Signal<int, int> mJoystickButtonDownEvent;
+		Signal<int, int, int> mJoystickHatMotionEvent;
+
+		Signal<KeyCode, KeyModifier, bool> mKeyDownEvent;
+		Signal<KeyCode, KeyModifier> mKeyUpEvent;
+
+		Signal<const std::string&> mTextInput;
+
+		Signal<MouseButton, int, int> mMouseButtonDownEvent;
+		Signal<MouseButton, int, int> mMouseButtonUpEvent;
+		Signal<MouseButton, int, int> mMouseDoubleClick;
+		Signal<int, int, int, int> mMouseMotionEvent;
+		Signal<int, int> mMouseWheelEvent;
+
+		Signal<> mQuitEvent;
 	};
 
-	/**
-	* Mouse button identifiers.
-	*/
-	enum class MouseButton
-	{
-		None,
-		Left,
-		Middle,
-		Right
-	};
+	void postQuitEvent();
 
 
-	using ActivateEventSource = SignalSource<bool>;
-	using WindowHiddenEventSource = SignalSource<bool>;
-	using WindowExposedEventSource = SignalSource<>;
-	using WindowMinimizedEventSource = SignalSource<>;
-	using WindowMaximizedEventSource = SignalSource<>;
-	using WindowRestoredEventSource = SignalSource<>;
-	using WindowResizedEventSource = SignalSource<Vector<int>>;
-	using WindowMouseEnterEventSource = SignalSource<>;
-	using WindowMouseLeaveEventSource = SignalSource<>;
-
-	using JoystickAxisMotionEventSource = SignalSource<int, int, int>;
-	using JoystickBallMotionEventSource = SignalSource<int, int, int, int>;
-	using JoystickButtonEventSource = SignalSource<int, int>;
-	using JoystickHatMotionEventSource = SignalSource<int, int, int>;
-
-	using KeyDownEventSource = SignalSource<KeyCode, KeyModifier, bool>;
-	using KeyUpEventSource = SignalSource<KeyCode, KeyModifier>;
-	using TextInputEventSource = SignalSource<const std::string&>;
-
-	using MouseButtonEventSource = SignalSource<MouseButton, int, int>;
-	using MouseMotionEventSource = SignalSource<int, int, int, int>;
-	using MouseWheelEventSource = SignalSource<int, int>;
-
-	using QuitEventSource = SignalSource<>;
-
-public:
-	EventHandler();
-	~EventHandler();
-
-	ActivateEventSource& activate();
-
-	WindowHiddenEventSource& windowHidden();
-	WindowExposedEventSource& windowExposed();
-
-	WindowMinimizedEventSource& windowMinimized();
-	WindowMaximizedEventSource& windowMaximized();
-	WindowRestoredEventSource& windowRestored();
-	WindowResizedEventSource& windowResized();
-
-	WindowMouseEnterEventSource& windowMouseEnter();
-	WindowMouseLeaveEventSource& windowMouseLeave();
-
-	JoystickAxisMotionEventSource& joystickAxisMotion();
-	JoystickBallMotionEventSource& joystickBallMotion();
-	JoystickButtonEventSource& joystickButtonUp();
-	JoystickButtonEventSource& joystickButtonDown();
-	JoystickHatMotionEventSource& joystickHatMotion();
-
-	KeyUpEventSource& keyUp();
-	KeyDownEventSource& keyDown();
-
-	TextInputEventSource& textInput();
-
-	MouseButtonEventSource& mouseButtonUp();
-	MouseButtonEventSource& mouseButtonDown();
-	MouseButtonEventSource& mouseDoubleClick();
-	MouseMotionEventSource& mouseMotion();
-	MouseWheelEventSource& mouseWheel();
-
-	QuitEventSource& quit();
-
-	void grabMouse();
-	void releaseMouse();
-	void warpMouse(int x, int y);
-	void mouseRelativeMode(bool rel);
-
-	void textInputMode(bool);
-	bool textInputMode();
-
-	bool shift(KeyModifier mod) const;
-	bool numlock(KeyModifier mod) const;
-	bool control(KeyModifier mod) const;
-	bool alt(KeyModifier mod) const;
-
-	bool query_shift() const;
-	bool query_numlock() const;
-	bool query_control() const;
-
-	void pump();
-
-	void disconnectAll();
-
-private:
-	Signal<bool> mActivateEvent;
-
-	Signal<bool> mWindowHiddenEvent;
-	Signal<> mWindowExposedEvent;
-	Signal<> mWindowMinimizedEvent;
-	Signal<> mWindowMaximizedEvent;
-	Signal<> mWindowRestoredEvent;
-	Signal<Vector<int>> mWindowResizedEvent;
-	Signal<> mWindowMouseEnterEvent;
-	Signal<> mWindowMouseLeaveEvent;
-
-	Signal<int, int, int> mJoystickAxisMotionEvent;
-	Signal<int, int, int, int> mJoystickBallMotionEvent;
-	Signal<int, int> mJoystickButtonUpEvent;
-	Signal<int, int> mJoystickButtonDownEvent;
-	Signal<int, int, int> mJoystickHatMotionEvent;
-
-	Signal<KeyCode, KeyModifier, bool> mKeyDownEvent;
-	Signal<KeyCode, KeyModifier> mKeyUpEvent;
-
-	Signal<const std::string&> mTextInput;
-
-	Signal<MouseButton, int, int> mMouseButtonDownEvent;
-	Signal<MouseButton, int, int> mMouseButtonUpEvent;
-	Signal<MouseButton, int, int> mMouseDoubleClick;
-	Signal<int, int, int, int> mMouseMotionEvent;
-	Signal<int, int> mMouseWheelEvent;
-
-	Signal<> mQuitEvent;
-};
-
-void postQuitEvent();
-
-
-EventHandler::KeyModifier& operator|=(EventHandler::KeyModifier& a, const EventHandler::KeyModifier& b) noexcept;
-EventHandler::KeyModifier& operator&=(EventHandler::KeyModifier& a, const EventHandler::KeyModifier& b) noexcept;
-EventHandler::KeyModifier operator|(EventHandler::KeyModifier a, const EventHandler::KeyModifier& b) noexcept;
-EventHandler::KeyModifier operator&(EventHandler::KeyModifier a, const EventHandler::KeyModifier& b) noexcept;
+	EventHandler::KeyModifier& operator|=(EventHandler::KeyModifier& a, const EventHandler::KeyModifier& b) noexcept;
+	EventHandler::KeyModifier& operator&=(EventHandler::KeyModifier& a, const EventHandler::KeyModifier& b) noexcept;
+	EventHandler::KeyModifier operator|(EventHandler::KeyModifier a, const EventHandler::KeyModifier& b) noexcept;
+	EventHandler::KeyModifier operator&(EventHandler::KeyModifier a, const EventHandler::KeyModifier& b) noexcept;
 
 
 } // namespace

--- a/NAS2D/Exception.h
+++ b/NAS2D/Exception.h
@@ -14,97 +14,97 @@
 
 namespace NAS2D {
 
-namespace Exception {
+	namespace Exception {
 
-/**
- * \page Exceptions Exceptions
- *
- * See <a href="https://github.com/lairworks/nas2d-core/wiki/Exceptions-&-Exception-Handling-in-NAS2D">Wiki Page (Exceptions)</a> for further details.
- */
+		/**
+		 * \page Exceptions Exceptions
+		 *
+		 * See <a href="https://github.com/lairworks/nas2d-core/wiki/Exceptions-&-Exception-Handling-in-NAS2D">Wiki Page (Exceptions)</a> for further details.
+		 */
 
-/**
- * Thrown when the Filesystem is unable to initialize itself.
- */
-class filesystem_backend_init_failure : public std::runtime_error { public: filesystem_backend_init_failure(const std::string& description); filesystem_backend_init_failure(); };
-
-
-/**
- * Thrown when Filesystem::init() is called but the Filesystem is already initialized.
- */
-class filesystem_already_initialized : public std::runtime_error { public: filesystem_already_initialized(); };
+		/**
+		 * Thrown when the Filesystem is unable to initialize itself.
+		 */
+		class filesystem_backend_init_failure : public std::runtime_error { public: filesystem_backend_init_failure(const std::string& description); filesystem_backend_init_failure(); };
 
 
-/**
- * Thrown when the Filesystem is unable to close a file handle.
- */
-class filesystem_file_handle_still_open : public std::runtime_error { public: filesystem_file_handle_still_open(const std::string& description); filesystem_file_handle_still_open();};
+		/**
+		 * Thrown when Filesystem::init() is called but the Filesystem is already initialized.
+		 */
+		class filesystem_already_initialized : public std::runtime_error { public: filesystem_already_initialized(); };
 
 
-/**
- * Thrown when Font::operator=() is called but the font hasn't been loaded yet.
- */
-class font_bad_data : public std::runtime_error { public: font_bad_data(); };
+		/**
+		 * Thrown when the Filesystem is unable to close a file handle.
+		 */
+		class filesystem_file_handle_still_open : public std::runtime_error { public: filesystem_file_handle_still_open(const std::string& description); filesystem_file_handle_still_open();};
 
 
-/**
- * Thrown when a bitmap font is loaded but the texture does not conform to expected paramters.
- */
-class font_invalid_glyph_map : public std::runtime_error { public: font_invalid_glyph_map(); font_invalid_glyph_map(const std::string& description); };
+		/**
+		 * Thrown when Font::operator=() is called but the font hasn't been loaded yet.
+		 */
+		class font_bad_data : public std::runtime_error { public: font_bad_data(); };
 
 
-/**
- * Thrown when an Image resource contains an invalid pixel buffer.
- */
-class image_bad_copy : public std::runtime_error { public: image_bad_copy(); };
+		/**
+		 * Thrown when a bitmap font is loaded but the texture does not conform to expected paramters.
+		 */
+		class font_invalid_glyph_map : public std::runtime_error { public: font_invalid_glyph_map(); font_invalid_glyph_map(const std::string& description); };
 
 
-/**
- * Thrown when an Image resource contains an invalid pixel buffer.
- */
-class image_bad_data : public std::runtime_error { public: image_bad_data(); };
+		/**
+		 * Thrown when an Image resource contains an invalid pixel buffer.
+		 */
+		class image_bad_copy : public std::runtime_error { public: image_bad_copy(); };
 
 
-/**
- * Thrown when an Image resource contains no data in its pixel buffer.
- */
-class image_null_data : public std::runtime_error { public: image_null_data(); };
+		/**
+		 * Thrown when an Image resource contains an invalid pixel buffer.
+		 */
+		class image_bad_data : public std::runtime_error { public: image_bad_data(); };
 
 
-/**
- * Thrown when attempting to load or perform operations on an image file in
- * an 8-bit or 16-bit format. See Image for further details.
- */
-class image_unsupported_bit_depth : public std::runtime_error { public: image_unsupported_bit_depth(); };
+		/**
+		 * Thrown when an Image resource contains no data in its pixel buffer.
+		 */
+		class image_null_data : public std::runtime_error { public: image_null_data(); };
 
 
-/**
- * Thrown when a derived Mixer type is unable to initialize itself.
- */
-class mixer_backend_init_failure : public std::runtime_error { public: mixer_backend_init_failure(const std::string& description); mixer_backend_init_failure(); };
+		/**
+		 * Thrown when attempting to load or perform operations on an image file in
+		 * an 8-bit or 16-bit format. See Image for further details.
+		 */
+		class image_unsupported_bit_depth : public std::runtime_error { public: image_unsupported_bit_depth(); };
 
 
-/**
- * Thrown when the RendererOpenGL determines that no GLSL shading language is available.
- */
-class renderer_no_glsl : public std::runtime_error { public: renderer_no_glsl(); };
+		/**
+		 * Thrown when a derived Mixer type is unable to initialize itself.
+		 */
+		class mixer_backend_init_failure : public std::runtime_error { public: mixer_backend_init_failure(const std::string& description); mixer_backend_init_failure(); };
 
 
-/**
- * Thrown when a derived Renderer type is unable to initialize itself.
- */
-class renderer_backend_init_failure : public std::runtime_error { public: renderer_backend_init_failure(const std::string& description); renderer_backend_init_failure();};
+		/**
+		 * Thrown when the RendererOpenGL determines that no GLSL shading language is available.
+		 */
+		class renderer_no_glsl : public std::runtime_error { public: renderer_no_glsl(); };
 
 
-/**
- * Thrown when a window context can't be created.
- */
-class renderer_window_creation_failure : public std::runtime_error { public: renderer_window_creation_failure(); };
+		/**
+		 * Thrown when a derived Renderer type is unable to initialize itself.
+		 */
+		class renderer_backend_init_failure : public std::runtime_error { public: renderer_backend_init_failure(const std::string& description); renderer_backend_init_failure();};
 
 
-/**
- * Thrown when the RendererOpenGL can't create an OpenGL context.
- */
-class renderer_opengl_context_failure : public std::runtime_error { public: renderer_opengl_context_failure(); };
+		/**
+		 * Thrown when a window context can't be created.
+		 */
+		class renderer_window_creation_failure : public std::runtime_error { public: renderer_window_creation_failure(); };
 
-} // exception namespace
+
+		/**
+		 * Thrown when the RendererOpenGL can't create an OpenGL context.
+		 */
+		class renderer_opengl_context_failure : public std::runtime_error { public: renderer_opengl_context_failure(); };
+
+	} // exception namespace
 } // NAS2D namespace

--- a/NAS2D/File.h
+++ b/NAS2D/File.h
@@ -16,196 +16,196 @@
 
 namespace NAS2D {
 
-/**
- * Represent a File object.
- *
- * The File object represents a file as a stream of bytes.
- */
-class File
-{
-public:
-
-	using byte = char; /**< Byte. */
-	using const_byte = const char; /**< Const byte. */
-	using RawByteStream = const_byte*; /**< Pointer to a const_byte. */
-
-	using iterator = std::string::iterator; /**< Forward iterator for a File byte stream. */
-	using reverse_iterator = std::string::reverse_iterator; /**< Reverse iterator for a File byte stream. */
-	using ByteStream = std::string; /**< Byte stream. */
-
-
-	File()
-	{}
-
 	/**
-	 * \param	stream	A ByteStream representing the file.
-	 * \param	name	The full name of the file including path.
+	 * Represent a File object.
+	 *
+	 * The File object represents a file as a stream of bytes.
 	 */
-	File(ByteStream stream, std::string name) :
-		mByteStream(std::move(stream)),
-		mFileName(std::move(name))
-	{}
-
-	~File()
-	{}
-
-
-	File(const File& _f) :
-		mByteStream(_f.mByteStream),
-		mFileName(_f.mFileName)
-	{}
-
-
-	/**
-	 * Copy operator.
-	 */
-	File& operator=(const File& _f)
+	class File
 	{
-		mByteStream = _f.mByteStream;
-		mFileName = _f.mFileName;
-		return *this;
-	}
+	public:
 
-	/**
-	 * Gets a reference to the internal ByteStream.
-	 *
-	 * \note	This gets a \c non-const reference to the internal \c ByteStream
-	 *			so that modifications can be made as necessary.
-	 */
-	ByteStream& bytes() { return mByteStream; }
+		using byte = char; /**< Byte. */
+		using const_byte = const char; /**< Const byte. */
+		using RawByteStream = const_byte*; /**< Pointer to a const_byte. */
+
+		using iterator = std::string::iterator; /**< Forward iterator for a File byte stream. */
+		using reverse_iterator = std::string::reverse_iterator; /**< Reverse iterator for a File byte stream. */
+		using ByteStream = std::string; /**< Byte stream. */
 
 
-	/**
-	 * Gets a reference to the internal ByteStream.
-	 *
-	 * \note	This gets a \c const reference to the internal \c ByteStream.
-	 */
-	const ByteStream& bytes() const { return mByteStream; }
+		File()
+		{}
+
+		/**
+		 * \param	stream	A ByteStream representing the file.
+		 * \param	name	The full name of the file including path.
+		 */
+		File(ByteStream stream, std::string name) :
+			mByteStream(std::move(stream)),
+			mFileName(std::move(name))
+		{}
+
+		~File()
+		{}
 
 
-	/**
-	 * Gets a raw pointer to a \c const \c byte stream.
-	 *
-	 * \note	This function is provided as a convenience for
-	 *			use with low-level and legacy C libraries that
-	 *			need a const char* byte stream.
-	 */
-	RawByteStream raw_bytes() const { return mByteStream.c_str(); }
+		File(const File& _f) :
+			mByteStream(_f.mByteStream),
+			mFileName(_f.mFileName)
+		{}
 
 
-	/**
-	 * Gets the size, in bytes, of the File.
-	 */
-	std::size_t size() const { return mByteStream.size(); }
+		/**
+		 * Copy operator.
+		 */
+		File& operator=(const File& _f)
+		{
+			mByteStream = _f.mByteStream;
+			mFileName = _f.mFileName;
+			return *this;
+		}
+
+		/**
+		 * Gets a reference to the internal ByteStream.
+		 *
+		 * \note	This gets a \c non-const reference to the internal \c ByteStream
+		 *			so that modifications can be made as necessary.
+		 */
+		ByteStream& bytes() { return mByteStream; }
 
 
-	/**
-	 * Gets the size, in bytes, of the File.
-	 */
-	std::size_t length() const { return size(); }
-
-	/**
-	 * Resizes the File.
-	 *
-	 * \param	size	Number of bytes to resize the File to.
-	 *
-	 * \warning		Providing a size parameter smaller than the current File
-	 *				will truncate the existing data. There is no way to
-	 *				recover the data once the File is resized.
-	 */
-	void resize(std::size_t size) { mByteStream.resize(size); }
+		/**
+		 * Gets a reference to the internal ByteStream.
+		 *
+		 * \note	This gets a \c const reference to the internal \c ByteStream.
+		 */
+		const ByteStream& bytes() const { return mByteStream; }
 
 
-	/**
-	 * Resizes the File.
-	 *
-	 * \param	size	Number of bytes to resize the File to.
-	 * \param	b		Byte value to use to fill any additional bytes gained after resizing.
-	 *
-	 * \warning		Providing a size parameter smaller than the current File
-	 *				will truncate the existing data. There is no way to
-	 *				recover the data once the File is resized.
-	 */
-	void resize(std::size_t size, byte b) { mByteStream.resize(size, b); }
-
-	/**
-	 * Indicates that the File is empty.
-	 */
-	bool empty() const { return mByteStream.empty(); }
-
-	/**
-	 * Gets an iterator to the beginning of the File's byte stream.
-	 */
-	iterator begin() { return mByteStream.begin(); }
-
-	/**
-	 * Gets an iterator to the end of the File's byte stream.
-	 */
-	iterator end() { return mByteStream.end(); }
-
-	/**
-	 * Gets a reverse iterator to the beginning of the File's byte stream.
-	 */
-	reverse_iterator rbegin() { return mByteStream.rbegin(); }
-
-	/**
-	 * Gets a reverse iterator to the end of the File's byte stream.
-	 */
-	reverse_iterator rend() { return mByteStream.rend(); }
-
-	/**
-	 * Gets an iterator to the byte at a specified position.
-	 *
-	 * \param pos	Position of the iterator to get.
-	 */
-	iterator seek(std::ptrdiff_t pos) { iterator it = mByteStream.begin() + pos; return it; }
-
-	/**
-	 * Gets a reverse iterator to the byte at a specified position.
-	 *
-	 * \param pos	Position of the iterator to get.
-	 *
-	 * \see seek
-	 */
-	reverse_iterator rseek(std::ptrdiff_t pos) { reverse_iterator it = mByteStream.rbegin() + pos; return it; }
-
-	/**
-	 * Gets a byte from the byte stream at a specified position.
-	 *
-	 * \param pos Position of the byte to get.
-	 *
-	 * \warning	Out of range positions yield undefined behavior. Some compilers will
-	 *			throw an \c out_of_range exception.
-	 */
-	byte& operator[](std::size_t pos) { return mByteStream[pos]; }
-
-	/**
-	 * Gets a const byte from the byte stream at a specified position.
-	 *
-	 * \param pos Position of the byte to get.
-	 *
-	 * \warning	Out of range positions yield undefined behavior. Some compilers will
-	 *			throw an \c out_of_range exception.
-	 */
-	const_byte& operator[](std::size_t pos) const { return mByteStream[pos]; }
-
-	/**
-	 * Clears the File and leaves it completely empty.
-	 */
-	void clear() { mByteStream = ""; mFileName = ""; }
+		/**
+		 * Gets a raw pointer to a \c const \c byte stream.
+		 *
+		 * \note	This function is provided as a convenience for
+		 *			use with low-level and legacy C libraries that
+		 *			need a const char* byte stream.
+		 */
+		RawByteStream raw_bytes() const { return mByteStream.c_str(); }
 
 
-	/**
-	 * Gets the file name.
-	 *
-	 * \note	Filenames include both the individual file's
-	 *			name and full directory path.
-	 */
-	std::string filename() const { return mFileName; }
+		/**
+		 * Gets the size, in bytes, of the File.
+		 */
+		std::size_t size() const { return mByteStream.size(); }
 
-private:
-	ByteStream mByteStream; /**< Internal stream of bytes. */
-	std::string mFileName; /**< Internal filename including directory path. */
-};
+
+		/**
+		 * Gets the size, in bytes, of the File.
+		 */
+		std::size_t length() const { return size(); }
+
+		/**
+		 * Resizes the File.
+		 *
+		 * \param	size	Number of bytes to resize the File to.
+		 *
+		 * \warning		Providing a size parameter smaller than the current File
+		 *				will truncate the existing data. There is no way to
+		 *				recover the data once the File is resized.
+		 */
+		void resize(std::size_t size) { mByteStream.resize(size); }
+
+
+		/**
+		 * Resizes the File.
+		 *
+		 * \param	size	Number of bytes to resize the File to.
+		 * \param	b		Byte value to use to fill any additional bytes gained after resizing.
+		 *
+		 * \warning		Providing a size parameter smaller than the current File
+		 *				will truncate the existing data. There is no way to
+		 *				recover the data once the File is resized.
+		 */
+		void resize(std::size_t size, byte b) { mByteStream.resize(size, b); }
+
+		/**
+		 * Indicates that the File is empty.
+		 */
+		bool empty() const { return mByteStream.empty(); }
+
+		/**
+		 * Gets an iterator to the beginning of the File's byte stream.
+		 */
+		iterator begin() { return mByteStream.begin(); }
+
+		/**
+		 * Gets an iterator to the end of the File's byte stream.
+		 */
+		iterator end() { return mByteStream.end(); }
+
+		/**
+		 * Gets a reverse iterator to the beginning of the File's byte stream.
+		 */
+		reverse_iterator rbegin() { return mByteStream.rbegin(); }
+
+		/**
+		 * Gets a reverse iterator to the end of the File's byte stream.
+		 */
+		reverse_iterator rend() { return mByteStream.rend(); }
+
+		/**
+		 * Gets an iterator to the byte at a specified position.
+		 *
+		 * \param pos	Position of the iterator to get.
+		 */
+		iterator seek(std::ptrdiff_t pos) { iterator it = mByteStream.begin() + pos; return it; }
+
+		/**
+		 * Gets a reverse iterator to the byte at a specified position.
+		 *
+		 * \param pos	Position of the iterator to get.
+		 *
+		 * \see seek
+		 */
+		reverse_iterator rseek(std::ptrdiff_t pos) { reverse_iterator it = mByteStream.rbegin() + pos; return it; }
+
+		/**
+		 * Gets a byte from the byte stream at a specified position.
+		 *
+		 * \param pos Position of the byte to get.
+		 *
+		 * \warning	Out of range positions yield undefined behavior. Some compilers will
+		 *			throw an \c out_of_range exception.
+		 */
+		byte& operator[](std::size_t pos) { return mByteStream[pos]; }
+
+		/**
+		 * Gets a const byte from the byte stream at a specified position.
+		 *
+		 * \param pos Position of the byte to get.
+		 *
+		 * \warning	Out of range positions yield undefined behavior. Some compilers will
+		 *			throw an \c out_of_range exception.
+		 */
+		const_byte& operator[](std::size_t pos) const { return mByteStream[pos]; }
+
+		/**
+		 * Clears the File and leaves it completely empty.
+		 */
+		void clear() { mByteStream = ""; mFileName = ""; }
+
+
+		/**
+		 * Gets the file name.
+		 *
+		 * \note	Filenames include both the individual file's
+		 *			name and full directory path.
+		 */
+		std::string filename() const { return mFileName; }
+
+	private:
+		ByteStream mByteStream; /**< Internal stream of bytes. */
+		std::string mFileName; /**< Internal filename including directory path. */
+	};
 
 } // namespace

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -18,50 +18,50 @@
 
 namespace NAS2D {
 
-/**
- * Implements a virtual file system.
- *
- * Provides cross-platform and transparent archive Filesystem functions.
- */
-class Filesystem
-{
-public:
-	Filesystem() = delete;
-	Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName);
-	Filesystem(const Filesystem&) = delete;
-	Filesystem& operator=(const Filesystem&) = delete;
-	Filesystem(Filesystem&&) = delete;
-	Filesystem& operator=(Filesystem&&) = delete;
-	~Filesystem();
+	/**
+	 * Implements a virtual file system.
+	 *
+	 * Provides cross-platform and transparent archive Filesystem functions.
+	 */
+	class Filesystem
+	{
+	public:
+		Filesystem() = delete;
+		Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName);
+		Filesystem(const Filesystem&) = delete;
+		Filesystem& operator=(const Filesystem&) = delete;
+		Filesystem(Filesystem&&) = delete;
+		Filesystem& operator=(Filesystem&&) = delete;
+		~Filesystem();
 
 
-	std::string basePath() const;
-	std::string prefPath() const;
+		std::string basePath() const;
+		std::string prefPath() const;
 
-	std::string workingPath(const std::string& filename) const;
-	std::vector<std::string> searchPath() const;
-	int mountSoftFail(const std::string& path) const;
-	void mount(const std::string& path) const;
-	void mountReadWrite(const std::string& path) const;
-	void unmount(const std::string& path) const;
+		std::string workingPath(const std::string& filename) const;
+		std::vector<std::string> searchPath() const;
+		int mountSoftFail(const std::string& path) const;
+		void mount(const std::string& path) const;
+		void mountReadWrite(const std::string& path) const;
+		void unmount(const std::string& path) const;
 
-	std::vector<std::string> directoryList(const std::string& dir, const std::string& filter = std::string {}) const;
+		std::vector<std::string> directoryList(const std::string& dir, const std::string& filter = std::string {}) const;
 
-	File open(const std::string& filename) const;
-	void write(const File& file, bool overwrite = true) const;
-	void del(const std::string& path) const;
-	bool exists(const std::string& filename) const;
+		File open(const std::string& filename) const;
+		void write(const File& file, bool overwrite = true) const;
+		void del(const std::string& path) const;
+		bool exists(const std::string& filename) const;
 
-	std::string extension(const std::string& path) const;
+		std::string extension(const std::string& path) const;
 
-	std::string dirSeparator() const;
+		std::string dirSeparator() const;
 
-	bool isDirectory(const std::string& path) const;
-	void makeDirectory(const std::string& path) const;
+		bool isDirectory(const std::string& path) const;
+		void makeDirectory(const std::string& path) const;
 
-private:
-	std::string mAppName;
-	std::string mOrganizationName;
-};
+	private:
+		std::string mAppName;
+		std::string mOrganizationName;
+	};
 
 }

--- a/NAS2D/FpsCounter.h
+++ b/NAS2D/FpsCounter.h
@@ -11,23 +11,23 @@
 
 namespace NAS2D {
 
-/**
- * Implements a basic FPS Counter.
- *
- * FPS values are only approximates. As the FPS count gets higher, the returned value
- * becomes a more average count.
- */
-class FpsCounter
-{
-public:
-	unsigned int fps();
+	/**
+	 * Implements a basic FPS Counter.
+	 *
+	 * FPS values are only approximates. As the FPS count gets higher, the returned value
+	 * becomes a more average count.
+	 */
+	class FpsCounter
+	{
+	public:
+		unsigned int fps();
 
-private:
-	static constexpr unsigned int FpsCountsSize = 25;
-	unsigned int fpsCounts[FpsCountsSize] = { 0 };
+	private:
+		static constexpr unsigned int FpsCountsSize = 25;
+		unsigned int fpsCounts[FpsCountsSize] = { 0 };
 
-	unsigned int currentTick = 0;
-	unsigned int fpsCountIndex = 0;
-};
+		unsigned int currentTick = 0;
+		unsigned int fpsCountIndex = 0;
+	};
 
 } // namespace

--- a/NAS2D/Game.h
+++ b/NAS2D/Game.h
@@ -15,54 +15,54 @@
 
 namespace NAS2D {
 
-class State;
+	class State;
 
 
-/**
- * A simple way to start a NAS2D application.
- *
- * The Game class is a simple way to quickly delve right into developing a NAS2D
- * application without having to worry about initializing the core utilities. It
- * also provides a method of mounting directories and/or archives to the file
- * system and provides a simple entry point that handles the main application
- * loop.
- *
- * Most NAS2D applications that use the Game object will look something like this:
- *
- * \code{.cpp}
- * #include "NAS2D.h"
- * #include "MyState.h"
- *
- * #include <iostream>
- *
- * int main(int argc, char *argv[])
- * {
- *	try
- *	{
- *		Game game("My NAS2D Application", "ApplicationName", "OrganizationName", argv[0]);
- *		game.mount("gfx.zip");
- *		game.go(new MyState());
- *	}
- *	catch (const std::exception& e)
- *	{
- *		std::cout << "Error: " << e.what() << std::endl;
- *	}
- *	catch (...)
- *	{
- *	}
- *	return 0;
- * }
- * \endcode
- */
-class Game
-{
-public:
-	Game(const std::string& title, const std::string& appName, const std::string& organizationName, const std::string& argv_0, const std::string& configPath = "config.xml", const std::string& dataPath = "data");
-	~Game();
+	/**
+	 * A simple way to start a NAS2D application.
+	 *
+	 * The Game class is a simple way to quickly delve right into developing a NAS2D
+	 * application without having to worry about initializing the core utilities. It
+	 * also provides a method of mounting directories and/or archives to the file
+	 * system and provides a simple entry point that handles the main application
+	 * loop.
+	 *
+	 * Most NAS2D applications that use the Game object will look something like this:
+	 *
+	 * \code{.cpp}
+	 * #include "NAS2D.h"
+	 * #include "MyState.h"
+	 *
+	 * #include <iostream>
+	 *
+	 * int main(int argc, char *argv[])
+	 * {
+	 *	try
+	 *	{
+	 *		Game game("My NAS2D Application", "ApplicationName", "OrganizationName", argv[0]);
+	 *		game.mount("gfx.zip");
+	 *		game.go(new MyState());
+	 *	}
+	 *	catch (const std::exception& e)
+	 *	{
+	 *		std::cout << "Error: " << e.what() << std::endl;
+	 *	}
+	 *	catch (...)
+	 *	{
+	 *	}
+	 *	return 0;
+	 * }
+	 * \endcode
+	 */
+	class Game
+	{
+	public:
+		Game(const std::string& title, const std::string& appName, const std::string& organizationName, const std::string& argv_0, const std::string& configPath = "config.xml", const std::string& dataPath = "data");
+		~Game();
 
-	void mount(const std::string& path);
+		void mount(const std::string& path);
 
-	void go(State* state);
-};
+		void go(State* state);
+	};
 
 } // namespace

--- a/NAS2D/MathUtils.cpp
+++ b/NAS2D/MathUtils.cpp
@@ -14,58 +14,58 @@
 
 namespace NAS2D {
 
-/**
- * Determines if a given line intersects a given circle.
- *
- * \param	p	First point of a line segment.
- * \param	q	Second point of a line segment.
- * \param	c	Center point of a circle.
- * \param	r	Radius of a circle.
- */
-bool lineIntersectsCircle(Point<int> p, Point<int> q, Point<int> c, float r)
-{
-	const auto centerToStart = (p - c).to<float>();
-	const auto lineSize = (q - p).to<float>();
+	/**
+	 * Determines if a given line intersects a given circle.
+	 *
+	 * \param	p	First point of a line segment.
+	 * \param	q	Second point of a line segment.
+	 * \param	c	Center point of a circle.
+	 * \param	r	Radius of a circle.
+	 */
+	bool lineIntersectsCircle(Point<int> p, Point<int> q, Point<int> c, float r)
+	{
+		const auto centerToStart = (p - c).to<float>();
+		const auto lineSize = (q - p).to<float>();
 
-	const auto t = std::clamp<float>(-centerToStart.dotProduct(lineSize) / lineSize.lengthSquared(), 0, 1);
-	const auto minDistance = lineSize * t + centerToStart;
+		const auto t = std::clamp<float>(-centerToStart.dotProduct(lineSize) / lineSize.lengthSquared(), 0, 1);
+		const auto minDistance = lineSize * t + centerToStart;
 
-	return minDistance.lengthSquared() < (r * r);
-}
-
-
-/**
- * Basic integer division that rounds up to the nearest whole number.
- *
- * \param	to_divide	Number to be divided.
- * \param	divisor		Divisor.
- *
- * \return	Returns the divided number rounded up to the nearest whole number.
- */
-int divideUp(int to_divide, int divisor)
-{
-	if (divisor == 0) {
-		throw std::domain_error("Division by zero: divideUp(to_divide, 0)");
+		return minDistance.lengthSquared() < (r * r);
 	}
-	return (to_divide + (divisor - 1)) / divisor;
-}
 
-/**
- * Rounds a number up to a power of 2
- *
- * Domain: 1 .. 2^31
- * Values outside the domain may map to 0 (which is not a power of 2)
- * Note: 0 is outside the domain
- */
-uint32_t roundUpPowerOf2(uint32_t number)
-{
-	--number;
-	number |= number >> 1;
-	number |= number >> 2;
-	number |= number >> 4;
-	number |= number >> 8;
-	number |= number >> 16;
-	return ++number;
-}
+
+	/**
+	 * Basic integer division that rounds up to the nearest whole number.
+	 *
+	 * \param	to_divide	Number to be divided.
+	 * \param	divisor		Divisor.
+	 *
+	 * \return	Returns the divided number rounded up to the nearest whole number.
+	 */
+	int divideUp(int to_divide, int divisor)
+	{
+		if (divisor == 0) {
+			throw std::domain_error("Division by zero: divideUp(to_divide, 0)");
+		}
+		return (to_divide + (divisor - 1)) / divisor;
+	}
+
+	/**
+	 * Rounds a number up to a power of 2
+	 *
+	 * Domain: 1 .. 2^31
+	 * Values outside the domain may map to 0 (which is not a power of 2)
+	 * Note: 0 is outside the domain
+	 */
+	uint32_t roundUpPowerOf2(uint32_t number)
+	{
+		--number;
+		number |= number >> 1;
+		number |= number >> 2;
+		number |= number >> 4;
+		number |= number >> 8;
+		number |= number >> 16;
+		return ++number;
+	}
 
 } // namespace

--- a/NAS2D/MathUtils.h
+++ b/NAS2D/MathUtils.h
@@ -25,33 +25,33 @@ namespace NAS2D
 
 	uint32_t roundUpPowerOf2(uint32_t number);
 
-/**
- * Applies a linear conversion to map an input domain to an output range.
- *
- * \param	value	The value to be converted from the input domain to the output range.
- * \param	domainPoint1	A known fixed point in the domain.
- * \param	domainPoint2	Another corresponding known fixed point in the domain.
- * \param	rangePoint1	A known fixed point in the range.
- * \param	rangePoint2	Another corresponding known fixed point in the range.
- * \return	Returns value as mapped to the output range.
- * \remarks
- * `value` is not required to start within [domainPoint1,domainPoint2]. E.g. temperature conversions:
- *
- *     scaleLinear(98.6f, 32.0f, 212.0f, 0.0f, 100.0f)
- *
- * will convert 98.6 degees Fahrenheit (average human body temperature) to its corresponding value `37.0` degrees Celsius.
- * 
- * Avoid inputs such that the difference of domainPoint2 and domainPoint1 is zero. Otherwise, a divide by zero error could occur.
- * 
- * If the difference of rangePoint2 and rangePoint1 is zero. The result of the function is always rangePoint1.
- * 
- * InputType and OutputType must support all arithmetic operators and all arithmetic operators between each other.
- */
-template<typename InputType, typename OutputType>
-OutputType scaleLinear(const InputType& value, const InputType& domainPoint1, const InputType& domainPoint2, const OutputType& rangePoint1, const OutputType& rangePoint2)
-{
-	return (value - domainPoint1) * (rangePoint2 - rangePoint1) / (domainPoint2 - domainPoint1) + rangePoint1;
-}
+	/**
+	 * Applies a linear conversion to map an input domain to an output range.
+	 *
+	 * \param	value	The value to be converted from the input domain to the output range.
+	 * \param	domainPoint1	A known fixed point in the domain.
+	 * \param	domainPoint2	Another corresponding known fixed point in the domain.
+	 * \param	rangePoint1	A known fixed point in the range.
+	 * \param	rangePoint2	Another corresponding known fixed point in the range.
+	 * \return	Returns value as mapped to the output range.
+	 * \remarks
+	 * `value` is not required to start within [domainPoint1,domainPoint2]. E.g. temperature conversions:
+	 *
+	 *     scaleLinear(98.6f, 32.0f, 212.0f, 0.0f, 100.0f)
+	 *
+	 * will convert 98.6 degees Fahrenheit (average human body temperature) to its corresponding value `37.0` degrees Celsius.
+	 * 
+	 * Avoid inputs such that the difference of domainPoint2 and domainPoint1 is zero. Otherwise, a divide by zero error could occur.
+	 * 
+	 * If the difference of rangePoint2 and rangePoint1 is zero. The result of the function is always rangePoint1.
+	 * 
+	 * InputType and OutputType must support all arithmetic operators and all arithmetic operators between each other.
+	 */
+	template<typename InputType, typename OutputType>
+	OutputType scaleLinear(const InputType& value, const InputType& domainPoint1, const InputType& domainPoint2, const OutputType& rangePoint1, const OutputType& rangePoint2)
+	{
+		return (value - domainPoint1) * (rangePoint2 - rangePoint1) / (domainPoint2 - domainPoint1) + rangePoint1;
+	}
 
 } // namespace NAS2D
 

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -15,146 +15,146 @@
 
 namespace NAS2D {
 
-class Sound;
-class Music;
+	class Sound;
+	class Music;
 
 
-/**
- * Mixer base class.
- *
- * Provides a standard Mixer interface. The base Mixer can be used
- * but will act as a NULL interface.
- */
-class Mixer
-{
-public:
-	static const int CONTINUOUS = -1; /**< Constant representing a continuous loop. */
-	static const int DEFAULT_FADE_TIME = 500; /**< Default fade time. */
-
-public:
-	Mixer() = default;
-	Mixer(const Mixer&) = default;
-	Mixer& operator=(const Mixer&) = default;
-	Mixer(Mixer&&) = default;
-	Mixer& operator=(Mixer&&) = default;
-	virtual ~Mixer() = default;
-
-public:
 	/**
-	 * Plays a sound on the first available sound channel.
+	 * Mixer base class.
 	 *
-	 * \param	sound	A reference to a Sound Resource.
+	 * Provides a standard Mixer interface. The base Mixer can be used
+	 * but will act as a NULL interface.
 	 */
-	virtual void playSound(const Sound& sound) = 0;
+	class Mixer
+	{
+	public:
+		static const int CONTINUOUS = -1; /**< Constant representing a continuous loop. */
+		static const int DEFAULT_FADE_TIME = 500; /**< Default fade time. */
 
-	/**
-	 * Stops playing all sounds on all channels.
-	 */
-	virtual void stopSound() = 0;
+	public:
+		Mixer() = default;
+		Mixer(const Mixer&) = default;
+		Mixer& operator=(const Mixer&) = default;
+		Mixer(Mixer&&) = default;
+		Mixer& operator=(Mixer&&) = default;
+		virtual ~Mixer() = default;
 
-	/**
-	 * Pauses sound on all channels.
-	 */
-	virtual void pauseSound() = 0;
+	public:
+		/**
+		 * Plays a sound on the first available sound channel.
+		 *
+		 * \param	sound	A reference to a Sound Resource.
+		 */
+		virtual void playSound(const Sound& sound) = 0;
 
-	/**
-	 * Resumes sound on all channels.
-	 */
-	virtual void resumeSound() = 0;
+		/**
+		 * Stops playing all sounds on all channels.
+		 */
+		virtual void stopSound() = 0;
 
-	/**
-	 * Starts playing a Music track.
-	 *
-	 * \param music	Reference to a Music Resource.
-	 * \param loops	Number of times to repeat the music.
-	 */
-	void playMusic(const Music& music, int loops = Mixer::CONTINUOUS);
+		/**
+		 * Pauses sound on all channels.
+		 */
+		virtual void pauseSound() = 0;
 
-	/**
-	 * Stops all playing music.
-	 */
-	virtual void stopMusic() = 0;
+		/**
+		 * Resumes sound on all channels.
+		 */
+		virtual void resumeSound() = 0;
 
-	/**
-	 * Pauses the currently playing Music.
-	 */
-	virtual void pauseMusic() = 0;
+		/**
+		 * Starts playing a Music track.
+		 *
+		 * \param music	Reference to a Music Resource.
+		 * \param loops	Number of times to repeat the music.
+		 */
+		void playMusic(const Music& music, int loops = Mixer::CONTINUOUS);
 
-	/**
-	 * Resumes the currently paused Music.
-	 *
-	 * \note	It is safe to call this function if the music is stopped or already playing.
-	 */
-	virtual void resumeMusic() = 0;
+		/**
+		 * Stops all playing music.
+		 */
+		virtual void stopMusic() = 0;
 
-	/**
-	 * Starts a Music track and fades it in to the current Music volume.
-	 *
-	 * \param	music	Reference to a Music Resource.
-	 * \param	loops	Number of times the Music should be repeated. -1 for continuous loop.
-	 * \param	time	Time, in miliseconds, for the fade to last. Default is 500.
-	 */
-	virtual void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) = 0;
+		/**
+		 * Pauses the currently playing Music.
+		 */
+		virtual void pauseMusic() = 0;
 
-	/**
-	 * Fades out the currently playing Music track.
-	 *
-	 * \param	time	Time, in miliseconds, for the fade to last. Default is 500.
-	 */
-	virtual void fadeOutMusic(int time = Mixer::DEFAULT_FADE_TIME) = 0;
+		/**
+		 * Resumes the currently paused Music.
+		 *
+		 * \note	It is safe to call this function if the music is stopped or already playing.
+		 */
+		virtual void resumeMusic() = 0;
 
-	/**
-	 * Gets whether or not music is currently playing.
-	 */
-	virtual bool musicPlaying() const = 0;
+		/**
+		 * Starts a Music track and fades it in to the current Music volume.
+		 *
+		 * \param	music	Reference to a Music Resource.
+		 * \param	loops	Number of times the Music should be repeated. -1 for continuous loop.
+		 * \param	time	Time, in miliseconds, for the fade to last. Default is 500.
+		 */
+		virtual void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) = 0;
 
-	/**
-	 * Stops all music and sound.
-	 */
-	void stopAllAudio();
+		/**
+		 * Fades out the currently playing Music track.
+		 *
+		 * \param	time	Time, in miliseconds, for the fade to last. Default is 500.
+		 */
+		virtual void fadeOutMusic(int time = Mixer::DEFAULT_FADE_TIME) = 0;
 
-	/**
-	 * Pauses all music and sound.
-	 */
-	void pauseAllAudio();
+		/**
+		 * Gets whether or not music is currently playing.
+		 */
+		virtual bool musicPlaying() const = 0;
 
-	/**
-	 * Resumes all paused music and sound.
-	 */
-	void resumeAllAudio();
+		/**
+		 * Stops all music and sound.
+		 */
+		void stopAllAudio();
 
-	/**
-	 * Sets the sound volume.
-	 *
-	 * \param	level	Volume level to set. Valid values are 0 - 128.
-	 */
-	virtual void soundVolume(int level) = 0;
+		/**
+		 * Pauses all music and sound.
+		 */
+		void pauseAllAudio();
 
-	/**
-	 * Sets the music volume.
-	 *
-	 * \param	level	Volume level to set. Valid values are 0 - 128.
-	 */
-	virtual void musicVolume(int level) = 0;
+		/**
+		 * Resumes all paused music and sound.
+		 */
+		void resumeAllAudio();
 
-	/**
-	 * Gets the sound volume.
-	 *
-	 * \return	Volume level. Valid values are 0 - 128.
-	 */
-	virtual int soundVolume() const = 0;
+		/**
+		 * Sets the sound volume.
+		 *
+		 * \param	level	Volume level to set. Valid values are 0 - 128.
+		 */
+		virtual void soundVolume(int level) = 0;
 
-	/**
-	 * Gets the music volume.
-	 *
-	 * \return	Volume level. Valid values are 0 - 128.
-	 */
-	virtual int musicVolume() const = 0;
+		/**
+		 * Sets the music volume.
+		 *
+		 * \param	level	Volume level to set. Valid values are 0 - 128.
+		 */
+		virtual void musicVolume(int level) = 0;
 
-	SignalSource<>& musicCompleteSignalSource();
+		/**
+		 * Gets the sound volume.
+		 *
+		 * \return	Volume level. Valid values are 0 - 128.
+		 */
+		virtual int soundVolume() const = 0;
 
-protected:
-	Signal<> mMusicComplete; /**< Signal used when music finished playing. */
-};
+		/**
+		 * Gets the music volume.
+		 *
+		 * \return	Volume level. Valid values are 0 - 128.
+		 */
+		virtual int musicVolume() const = 0;
+
+		SignalSource<>& musicCompleteSignalSource();
+
+	protected:
+		Signal<> mMusicComplete; /**< Signal used when music finished playing. */
+	};
 
 } // namespace

--- a/NAS2D/Mixer/MixerSDL.h
+++ b/NAS2D/Mixer/MixerSDL.h
@@ -14,63 +14,63 @@
 
 namespace NAS2D {
 
-/**
- * SDL Mixer.
- *
- * Implements all Mixer functions with the SDL API.
- *
- * \warning	Ensure that the mixer is not playing any audio resources
- *			before freeing them. Not doing so results in crashes.
- */
-class MixerSDL : public Mixer
-{
-public:
-	struct Options
+	/**
+	 * SDL Mixer.
+	 *
+	 * Implements all Mixer functions with the SDL API.
+	 *
+	 * \warning	Ensure that the mixer is not playing any audio resources
+	 *			before freeing them. Not doing so results in crashes.
+	 */
+	class MixerSDL : public Mixer
 	{
-		int mixRate;
-		int numChannels;
-		int sfxVolume;
-		int musicVolume;
-		int bufferSize;
+	public:
+		struct Options
+		{
+			int mixRate;
+			int numChannels;
+			int sfxVolume;
+			int musicVolume;
+			int bufferSize;
+		};
+
+		static Options InvalidToDefault(const Options& options);
+		static Options ReadConfigurationOptions();
+		static void WriteConfigurationOptions(const Options& options);
+
+		MixerSDL();
+		MixerSDL(const Options& options);
+		MixerSDL(const MixerSDL&) = delete;
+		MixerSDL& operator=(const MixerSDL&) = delete;
+		MixerSDL(MixerSDL&&) = default;
+		MixerSDL& operator=(MixerSDL&&) = default;
+		~MixerSDL() override;
+
+		// Sound Functions
+		void playSound(const Sound& sound) override;
+		void stopSound() override;
+		void pauseSound() override;
+		void resumeSound() override;
+
+		// Music Functions
+		void stopMusic() override;
+		void pauseMusic() override;
+		void resumeMusic() override;
+
+		void fadeInMusic(const Music& music, int loops, int time) override;
+		void fadeOutMusic(int time) override;
+
+		bool musicPlaying() const override;
+
+		// Global Functions
+		void soundVolume(int level) override;
+		void musicVolume(int level) override;
+
+		int soundVolume() const override;
+		int musicVolume() const override;
+
+	private:
+		void onMusicFinished();
 	};
-
-	static Options InvalidToDefault(const Options& options);
-	static Options ReadConfigurationOptions();
-	static void WriteConfigurationOptions(const Options& options);
-
-	MixerSDL();
-	MixerSDL(const Options& options);
-	MixerSDL(const MixerSDL&) = delete;
-	MixerSDL& operator=(const MixerSDL&) = delete;
-	MixerSDL(MixerSDL&&) = default;
-	MixerSDL& operator=(MixerSDL&&) = default;
-	~MixerSDL() override;
-
-	// Sound Functions
-	void playSound(const Sound& sound) override;
-	void stopSound() override;
-	void pauseSound() override;
-	void resumeSound() override;
-
-	// Music Functions
-	void stopMusic() override;
-	void pauseMusic() override;
-	void resumeMusic() override;
-
-	void fadeInMusic(const Music& music, int loops, int time) override;
-	void fadeOutMusic(int time) override;
-
-	bool musicPlaying() const override;
-
-	// Global Functions
-	void soundVolume(int level) override;
-	void musicVolume(int level) override;
-
-	int soundVolume() const override;
-	int musicVolume() const override;
-
-private:
-	void onMusicFinished();
-};
 
 }

--- a/NAS2D/Renderer/Color.h
+++ b/NAS2D/Renderer/Color.h
@@ -14,47 +14,47 @@
 
 namespace NAS2D {
 
-/**
- * RGBA Color.
- */
-struct Color
-{
-	uint8_t red = 255;
-	uint8_t green = 255;
-	uint8_t blue = 255;
-	uint8_t alpha = 255;
+	/**
+	 * RGBA Color.
+	 */
+	struct Color
+	{
+		uint8_t red = 255;
+		uint8_t green = 255;
+		uint8_t blue = 255;
+		uint8_t alpha = 255;
 
 
-	bool operator==(Color other) const;
-	bool operator!=(Color other) const;
+		bool operator==(Color other) const;
+		bool operator!=(Color other) const;
 
-	Color alphaFade(uint8_t newAlpha) const;
+		Color alphaFade(uint8_t newAlpha) const;
 
 
-	static const Color Black;
-	static const Color Blue;
-	static const Color Green;
-	static const Color Cyan;
-	static const Color DarkGreen;
-	static const Color DarkGray;
-	static const Color Gray;
-	static const Color LightGray;
-	static const Color CoolGray;
-	static const Color CoolLightGray;
-	static const Color CoolDarkGray;
-	static const Color WarmGray;
-	static const Color WarmLightGray;
-	static const Color WarmDarkGray;
-	static const Color Magenta;
-	static const Color Navy;
-	static const Color Orange;
-	static const Color Red;
-	static const Color Silver;
-	static const Color White;
-	static const Color Yellow;
-	static const Color Normal;
-	static const Color NormalZ;
-	static const Color NoAlpha;
-};
+		static const Color Black;
+		static const Color Blue;
+		static const Color Green;
+		static const Color Cyan;
+		static const Color DarkGreen;
+		static const Color DarkGray;
+		static const Color Gray;
+		static const Color LightGray;
+		static const Color CoolGray;
+		static const Color CoolLightGray;
+		static const Color CoolDarkGray;
+		static const Color WarmGray;
+		static const Color WarmLightGray;
+		static const Color WarmDarkGray;
+		static const Color Magenta;
+		static const Color Navy;
+		static const Color Orange;
+		static const Color Red;
+		static const Color Silver;
+		static const Color White;
+		static const Color Yellow;
+		static const Color Normal;
+		static const Color NormalZ;
+		static const Color NoAlpha;
+	};
 
 } // namespace

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -7,40 +7,40 @@
 
 namespace NAS2D {
 
-class Renderer;
+	class Renderer;
 
 
-class Fade
-{
-public:
-	Fade(Color fadeColor = Color::Black);
-
-	SignalSource<>& fadeComplete();
-
-	void fadeIn(unsigned int durationInMilliseconds);
-	void fadeOut(unsigned int durationInMilliseconds);
-
-	bool isFading() const;
-	bool isFaded() const;
-
-	void update();
-	void draw(Renderer& renderer) const;
-
-private:
-	void setDuration(unsigned int durationInMilliseconds);
-
-	enum class FadeDirection
+	class Fade
 	{
-		None,
-		In,
-		Out
-	};
+	public:
+		Fade(Color fadeColor = Color::Black);
 
-	Color mFadeColor{Color::Black};
-	FadeDirection mDirection{FadeDirection::None};
-	unsigned int mDuration{0};
-	Timer mFadeTimer;
-	Signal<> mFadeComplete;
-};
+		SignalSource<>& fadeComplete();
+
+		void fadeIn(unsigned int durationInMilliseconds);
+		void fadeOut(unsigned int durationInMilliseconds);
+
+		bool isFading() const;
+		bool isFaded() const;
+
+		void update();
+		void draw(Renderer& renderer) const;
+
+	private:
+		void setDuration(unsigned int durationInMilliseconds);
+
+		enum class FadeDirection
+		{
+			None,
+			In,
+			Out
+		};
+
+		Color mFadeColor{Color::Black};
+		FadeDirection mDirection{FadeDirection::None};
+		unsigned int mDuration{0};
+		Timer mFadeTimer;
+		Signal<> mFadeComplete;
+	};
 
 }

--- a/NAS2D/Renderer/Point.cpp
+++ b/NAS2D/Renderer/Point.cpp
@@ -13,12 +13,12 @@
 namespace NAS2D {
 
 
-// Explicit template instantiation
-template struct Point<int>;
+	// Explicit template instantiation
+	template struct Point<int>;
 
 
-// Explicit template instantiation
-template struct Point<float>;
+	// Explicit template instantiation
+	template struct Point<float>;
 
 
 }

--- a/NAS2D/Renderer/Point.h
+++ b/NAS2D/Renderer/Point.h
@@ -16,93 +16,93 @@
 namespace NAS2D {
 
 
-template <typename BaseType>
-struct Point {
-	BaseType x = 0;
-	BaseType y = 0;
+	template <typename BaseType>
+	struct Point {
+		BaseType x = 0;
+		BaseType y = 0;
 
-	constexpr bool operator==(const Point& point) const {
-		return (x == point.x) && (y == point.y);
-	}
-	constexpr bool operator!=(const Point& point) const {
-		return !(*this == point);
-	}
-
-	Point& operator+=(const Vector<BaseType>& vector) {
-		x += vector.x;
-		y += vector.y;
-		return *this;
-	}
-
-	Point& operator-=(const Vector<BaseType>& vector) {
-		x -= vector.x;
-		y -= vector.y;
-		return *this;
-	}
-
-	constexpr Point operator+(const Vector<BaseType>& vector) const {
-		return {x + vector.x, y + vector.y};
-	}
-
-	constexpr Point operator-(const Vector<BaseType>& vector) const {
-		return {x - vector.x, y - vector.y};
-	}
-
-	constexpr Vector<BaseType> operator-(const Point& point) const {
-		return {x - point.x, y - point.y};
-	}
-
-	constexpr Point skewBy(const Vector<BaseType>& other) const {
-		return {x * other.x, y * other.y};
-	}
-
-	constexpr Point skewInverseBy(const Vector<BaseType>& other) const {
-		if (other.x == 0 || other.y == 0) {
-			throw std::domain_error("Cannot skewInverseBy a vector with a zero component");
+		constexpr bool operator==(const Point& point) const {
+			return (x == point.x) && (y == point.y);
 		}
-		return {x / other.x, y / other.y};
+		constexpr bool operator!=(const Point& point) const {
+			return !(*this == point);
+		}
+
+		Point& operator+=(const Vector<BaseType>& vector) {
+			x += vector.x;
+			y += vector.y;
+			return *this;
+		}
+
+		Point& operator-=(const Vector<BaseType>& vector) {
+			x -= vector.x;
+			y -= vector.y;
+			return *this;
+		}
+
+		constexpr Point operator+(const Vector<BaseType>& vector) const {
+			return {x + vector.x, y + vector.y};
+		}
+
+		constexpr Point operator-(const Vector<BaseType>& vector) const {
+			return {x - vector.x, y - vector.y};
+		}
+
+		constexpr Vector<BaseType> operator-(const Point& point) const {
+			return {x - point.x, y - point.y};
+		}
+
+		constexpr Point skewBy(const Vector<BaseType>& other) const {
+			return {x * other.x, y * other.y};
+		}
+
+		constexpr Point skewInverseBy(const Vector<BaseType>& other) const {
+			if (other.x == 0 || other.y == 0) {
+				throw std::domain_error("Cannot skewInverseBy a vector with a zero component");
+			}
+			return {x / other.x, y / other.y};
+		}
+
+		template <typename NewBaseType>
+		constexpr operator Point<NewBaseType>() const {
+			return {
+				static_cast<NewBaseType>(x),
+				static_cast<NewBaseType>(y)
+			};
+		}
+
+		template <typename NewBaseType>
+		constexpr Point<NewBaseType> to() const {
+			return static_cast<Point<NewBaseType>>(*this);
+		}
+	};
+
+
+	template <typename BaseType>
+	Point(BaseType, BaseType) -> Point<BaseType>;
+
+
+	// Partial order comparisons
+
+	template <typename BaseType>
+	bool operator<=(Point<BaseType> p1, Point<BaseType> p2) {
+		return (p1.x <= p2.x) && (p1.y <= p2.y);
 	}
 
-	template <typename NewBaseType>
-	constexpr operator Point<NewBaseType>() const {
-		return {
-			static_cast<NewBaseType>(x),
-			static_cast<NewBaseType>(y)
-		};
+	template <typename BaseType>
+	bool operator>=(Point<BaseType> p1, Point<BaseType> p2) {
+		return p2 <= p1;
 	}
 
-	template <typename NewBaseType>
-	constexpr Point<NewBaseType> to() const {
-		return static_cast<Point<NewBaseType>>(*this);
+	template <typename BaseType>
+	bool operator<(Point<BaseType> p1, Point<BaseType> p2) {
+		return (p1.x < p2.x) && (p1.y < p2.y);
 	}
-};
 
-
-template <typename BaseType>
-Point(BaseType, BaseType) -> Point<BaseType>;
-
-
-// Partial order comparisons
-
-template <typename BaseType>
-bool operator<=(Point<BaseType> p1, Point<BaseType> p2) {
-	return (p1.x <= p2.x) && (p1.y <= p2.y);
-}
-
-template <typename BaseType>
-bool operator>=(Point<BaseType> p1, Point<BaseType> p2) {
-	return p2 <= p1;
-}
-
-template <typename BaseType>
-bool operator<(Point<BaseType> p1, Point<BaseType> p2) {
-	return (p1.x < p2.x) && (p1.y < p2.y);
-}
-
-template <typename BaseType>
-bool operator>(Point<BaseType> p1, Point<BaseType> p2) {
-	return p2 < p1;
-}
+	template <typename BaseType>
+	bool operator>(Point<BaseType> p1, Point<BaseType> p2) {
+		return p2 < p1;
+	}
 
 
 } // namespace

--- a/NAS2D/Renderer/PointInRectangleRange.h
+++ b/NAS2D/Renderer/PointInRectangleRange.h
@@ -10,60 +10,60 @@
 namespace NAS2D {
 
 
-template <typename BaseType>
-class PointInRectangleRange {
-public:
-	class Iterator {
+	template <typename BaseType>
+	class PointInRectangleRange {
 	public:
-		Iterator(const Rectangle<BaseType>& rect, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
-			mIterator(rect.size(), initial),
-			mStartPoint(rect.startPoint())
+		class Iterator {
+		public:
+			Iterator(const Rectangle<BaseType>& rect, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
+				mIterator(rect.size(), initial),
+				mStartPoint(rect.startPoint())
+			{}
+			Iterator(const Iterator& other) = default;
+			Iterator& operator=(const Iterator& other) = default;
+
+			Iterator& operator++() {
+				++mIterator;
+				return *this;
+			}
+
+			Iterator& operator--() {
+				--mIterator;
+				return *this;
+			}
+
+			bool operator==(const Iterator& other) const {
+				return **this == *other;
+			}
+
+			bool operator!=(const Iterator& other) const {
+				return !(*this == other);
+			}
+
+			Point<BaseType> operator*() const {
+				return mStartPoint + *mIterator;
+			}
+
+		private:
+			typename VectorSizeRange<BaseType>::Iterator mIterator;
+			const Point<BaseType> mStartPoint;
+		};
+
+
+		PointInRectangleRange(Rectangle<BaseType> rect) :
+			mRect(rect)
 		{}
-		Iterator(const Iterator& other) = default;
-		Iterator& operator=(const Iterator& other) = default;
 
-		Iterator& operator++() {
-			++mIterator;
-			return *this;
+		Iterator begin() const {
+			return Iterator{mRect};
 		}
 
-		Iterator& operator--() {
-			--mIterator;
-			return *this;
-		}
-
-		bool operator==(const Iterator& other) const {
-			return **this == *other;
-		}
-
-		bool operator!=(const Iterator& other) const {
-			return !(*this == other);
-		}
-
-		Point<BaseType> operator*() const {
-			return mStartPoint + *mIterator;
+		Iterator end() const {
+			return Iterator{mRect, Vector<BaseType>{0, mRect.height}};
 		}
 
 	private:
-		typename VectorSizeRange<BaseType>::Iterator mIterator;
-		const Point<BaseType> mStartPoint;
+		const Rectangle<BaseType> mRect;
 	};
-
-
-	PointInRectangleRange(Rectangle<BaseType> rect) :
-		mRect(rect)
-	{}
-
-	Iterator begin() const {
-		return Iterator{mRect};
-	}
-
-	Iterator end() const {
-		return Iterator{mRect, Vector<BaseType>{0, mRect.height}};
-	}
-
-private:
-	const Rectangle<BaseType> mRect;
-};
 
 } // namespace

--- a/NAS2D/Renderer/Rectangle.cpp
+++ b/NAS2D/Renderer/Rectangle.cpp
@@ -13,12 +13,12 @@
 namespace NAS2D {
 
 
-// Explicit template instantiation
-template struct Rectangle<int>;
+	// Explicit template instantiation
+	template struct Rectangle<int>;
 
 
-// Explicit template instantiation
-template struct Rectangle<float>;
+	// Explicit template instantiation
+	template struct Rectangle<float>;
 
 
 }

--- a/NAS2D/Renderer/Rectangle.h
+++ b/NAS2D/Renderer/Rectangle.h
@@ -17,129 +17,129 @@
 namespace NAS2D {
 
 
-template <typename BaseType>
-struct Rectangle
-{
-	BaseType x = 0;
-	BaseType y = 0;
-	BaseType width = 0;
-	BaseType height = 0;
+	template <typename BaseType>
+	struct Rectangle
+	{
+		BaseType x = 0;
+		BaseType y = 0;
+		BaseType width = 0;
+		BaseType height = 0;
 
-	// Factory method
-	constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Vector<BaseType> size) {
-		return {
-			startPoint.x,
-			startPoint.y,
-			size.x,
-			size.y
-		};
-	}
+		// Factory method
+		constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Vector<BaseType> size) {
+			return {
+				startPoint.x,
+				startPoint.y,
+				size.x,
+				size.y
+			};
+		}
 
-	// Factory method
-	constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Point<BaseType> endPoint) {
-		return {
-			startPoint.x,
-			startPoint.y,
-			endPoint.x - startPoint.x,
-			endPoint.y - startPoint.y
-		};
-	}
+		// Factory method
+		constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Point<BaseType> endPoint) {
+			return {
+				startPoint.x,
+				startPoint.y,
+				endPoint.x - startPoint.x,
+				endPoint.y - startPoint.y
+			};
+		}
 
-	constexpr bool operator==(const Rectangle& rect) const {
-		return (x == rect.x) && (y == rect.y) && (width == rect.width) && (height == rect.height);
-	}
-	constexpr bool operator!=(const Rectangle& rect) const {
-		return !(*this == rect);
-	}
+		constexpr bool operator==(const Rectangle& rect) const {
+			return (x == rect.x) && (y == rect.y) && (width == rect.width) && (height == rect.height);
+		}
+		constexpr bool operator!=(const Rectangle& rect) const {
+			return !(*this == rect);
+		}
 
-	constexpr Vector<BaseType> size() const {
-		return {width, height};
-	}
+		constexpr Vector<BaseType> size() const {
+			return {width, height};
+		}
 
-	constexpr Point<BaseType> startPoint() const {
-		return {x, y};
-	}
+		constexpr Point<BaseType> startPoint() const {
+			return {x, y};
+		}
 
-	constexpr Point<BaseType> endPoint() const {
-		return Point{x, y} + Vector{width, height};
-	}
+		constexpr Point<BaseType> endPoint() const {
+			return Point{x, y} + Vector{width, height};
+		}
 
-	constexpr Point<BaseType> crossXPoint() const {
-		return {x + width, y};
-	}
+		constexpr Point<BaseType> crossXPoint() const {
+			return {x + width, y};
+		}
 
-	constexpr Point<BaseType> crossYPoint() const {
-		return {x, y + height};
-	}
+		constexpr Point<BaseType> crossYPoint() const {
+			return {x, y + height};
+		}
 
-	constexpr bool null() const {
-		return (width == 0) || (height == 0);
-	}
+		constexpr bool null() const {
+			return (width == 0) || (height == 0);
+		}
 
-	void size(NAS2D::Vector<BaseType> newSize) {
-		width = newSize.x;
-		height = newSize.y;
-	}
+		void size(NAS2D::Vector<BaseType> newSize) {
+			width = newSize.x;
+			height = newSize.y;
+		}
 
-	void startPoint(NAS2D::Point<BaseType> newStartPoint) {
-		x = newStartPoint.x;
-		y = newStartPoint.y;
-	}
+		void startPoint(NAS2D::Point<BaseType> newStartPoint) {
+			x = newStartPoint.x;
+			y = newStartPoint.y;
+		}
 
-	constexpr Rectangle inset(BaseType amount) const {
-		return {x + amount, y + amount, width - 2 * amount, height - 2 * amount};
-	}
+		constexpr Rectangle inset(BaseType amount) const {
+			return {x + amount, y + amount, width - 2 * amount, height - 2 * amount};
+		}
 
-	constexpr Rectangle inset(Vector<BaseType> amount) const {
-		return {x + amount.x, y + amount.y, width - 2 * amount.x, height - 2 * amount.y};
-	}
+		constexpr Rectangle inset(Vector<BaseType> amount) const {
+			return {x + amount.x, y + amount.y, width - 2 * amount.x, height - 2 * amount.y};
+		}
 
-	constexpr Rectangle inset(Vector<BaseType> amountStart, Vector<BaseType> amountEnd) const {
-		return {x + amountStart.x, y + amountStart.y, width - amountStart.x - amountEnd.x, height - amountStart.y - amountEnd.y};
-	}
+		constexpr Rectangle inset(Vector<BaseType> amountStart, Vector<BaseType> amountEnd) const {
+			return {x + amountStart.x, y + amountStart.y, width - amountStart.x - amountEnd.x, height - amountStart.y - amountEnd.y};
+		}
 
-	constexpr Rectangle skewBy(const Vector<BaseType>& scaleFactor) const {
-		return Create(startPoint().skewBy(scaleFactor), size().skewBy(scaleFactor));
-	}
+		constexpr Rectangle skewBy(const Vector<BaseType>& scaleFactor) const {
+			return Create(startPoint().skewBy(scaleFactor), size().skewBy(scaleFactor));
+		}
 
-	constexpr Rectangle skewInverseBy(const Vector<BaseType>& scaleFactor) const {
-		return Create(startPoint().skewInverseBy(scaleFactor), size().skewInverseBy(scaleFactor));
-	}
+		constexpr Rectangle skewInverseBy(const Vector<BaseType>& scaleFactor) const {
+			return Create(startPoint().skewInverseBy(scaleFactor), size().skewInverseBy(scaleFactor));
+		}
 
-	template <typename NewBaseType>
-	constexpr operator Rectangle<NewBaseType>() const {
-		return {
-			static_cast<NewBaseType>(x),
-			static_cast<NewBaseType>(y),
-			static_cast<NewBaseType>(width),
-			static_cast<NewBaseType>(height)
-		};
-	}
+		template <typename NewBaseType>
+		constexpr operator Rectangle<NewBaseType>() const {
+			return {
+				static_cast<NewBaseType>(x),
+				static_cast<NewBaseType>(y),
+				static_cast<NewBaseType>(width),
+				static_cast<NewBaseType>(height)
+			};
+		}
 
-	template <typename NewBaseType>
-	constexpr Rectangle<NewBaseType> to() const {
-		return static_cast<Rectangle<NewBaseType>>(*this);
-	}
+		template <typename NewBaseType>
+		constexpr Rectangle<NewBaseType> to() const {
+			return static_cast<Rectangle<NewBaseType>>(*this);
+		}
 
-	// Start point inclusive (x, y), endpoint exclusive (x + width, y + height)
-	// Area in interval notation: [x .. x + width), [y .. y + height)
-	constexpr bool contains(const Point<BaseType>& point) const {
-		return startPoint() <= point && point < endPoint();
-	}
+		// Start point inclusive (x, y), endpoint exclusive (x + width, y + height)
+		// Area in interval notation: [x .. x + width), [y .. y + height)
+		constexpr bool contains(const Point<BaseType>& point) const {
+			return startPoint() <= point && point < endPoint();
+		}
 
-	// Start point inclusive (x, y), endpoint exclusive (x + width, y + height)
-	// Area in interval notation: [x .. x + width), [y .. y + height)
-	constexpr bool overlaps(const Rectangle& rect) const {
-		return startPoint() < rect.endPoint() && rect.startPoint() < endPoint();
-	}
+		// Start point inclusive (x, y), endpoint exclusive (x + width, y + height)
+		// Area in interval notation: [x .. x + width), [y .. y + height)
+		constexpr bool overlaps(const Rectangle& rect) const {
+			return startPoint() < rect.endPoint() && rect.startPoint() < endPoint();
+		}
 
-	constexpr Point<BaseType> center() const {
-		return {x + (width / 2), y + (height / 2)};
-	}
-};
+		constexpr Point<BaseType> center() const {
+			return {x + (width / 2), y + (height / 2)};
+		}
+	};
 
 
-template <typename BaseType>
-Rectangle(BaseType, BaseType, BaseType, BaseType) -> Rectangle<BaseType>;
+	template <typename BaseType>
+	Rectangle(BaseType, BaseType, BaseType, BaseType) -> Rectangle<BaseType>;
 
 } // namespace

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -24,135 +24,135 @@
 
 namespace NAS2D {
 
-class Font;
-class Image;
-template <typename BaseType> struct Rectangle;
+	class Font;
+	class Image;
+	template <typename BaseType> struct Rectangle;
 
-
-/**
- * Renderer base class.
- *
- * Provides a standard Renderer interface. The base Renderer can be used
- * but will act as a NULL interface.
- */
-class Renderer
-{
-public:
-	Renderer() = default;
-	Renderer(const Renderer& rhs) = default;
-	Renderer& operator=(const Renderer& rhs) = default;
-	Renderer(Renderer&& rhs) = default;
-	Renderer& operator=(Renderer&& rhs) = default;
-	virtual ~Renderer();
-	
-	virtual std::vector<DisplayDesc> getDisplayModes() const = 0;
-	virtual DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const = 0;
-	virtual Vector<int> getWindowClientArea() const noexcept = 0;
-
-	const std::string& driverName() const;
-
-	const std::string& title() const;
-	void title(const std::string& title);
-
-	virtual void window_icon(const std::string& path) = 0;
-
-	virtual void drawImage(const Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) = 0;
-	virtual void drawSubImage(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, Color color = Color::Normal) = 0;
-	virtual void drawSubImageRotated(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, float degrees, Color color = Color::Normal) = 0;
-	virtual void drawImageRotated(const Image& image, Point<float> position, float degrees, Color color = Color::Normal, float scale = 1.0f) = 0;
-	virtual void drawImageStretched(const Image& image, const Rectangle<float>& rect, Color color = Color::Normal) = 0;
-	virtual void drawImageRepeated(const Image& image, const Rectangle<float>& rect) = 0;
-	virtual void drawSubImageRepeated(const Image& image, const Rectangle<float>& destination, const Rectangle<float>& source) = 0;
-
-	virtual void drawImageToImage(const Image& source, const Image& destination, Point<float> dstPoint) = 0;
-
-	virtual void drawPoint(Point<float> position, Color color = Color::White) = 0;
-	virtual void drawLine(Point<float> startPosition, Point<float> endPosition, Color color = Color::White, int line_width = 1) = 0;
-	virtual void drawBox(const Rectangle<float>& rect, Color color = Color::White) = 0;
-	virtual void drawBoxFilled(const Rectangle<float>& rect, Color color = Color::White) = 0;
-	virtual void drawCircle(Point<float> position, float radius, Color color, int num_segments = 10, Vector<float> scale = Vector{1.0f, 1.0f}) = 0;
 
 	/**
-	 * Draws a rectangular area with a color gradient.
+	 * Renderer base class.
 	 *
-	 * Each point of the rectangular area can be given a different color value to
-	 * produce a variety of effects. The vertex orders are as follows:
-	 *
-	 * 1-----4
-	 * |     |
-	 * |     |
-	 * 2-----3
+	 * Provides a standard Renderer interface. The base Renderer can be used
+	 * but will act as a NULL interface.
 	 */
-	virtual void drawGradient(const Rectangle<float>& rect, Color c1, Color c2, Color c3, Color c4) = 0;
-
-	virtual void drawText(const Font& font, std::string_view text, Point<float> position, Color color = Color::White) = 0;
-	void drawTextShadow(const Font& font, std::string_view text, Point<float> position, Vector<float> shadowOffset, Color textColor, Color shadowColor);
-
-	void fadeColor(Color color);
-	void fadeIn(float delayTime);
-	void fadeOut(float delayTime);
-	bool isFading() const;
-	bool isFaded() const;
-	SignalSource<>& fadeComplete();
-
-	virtual void showSystemPointer(bool) = 0;
-	virtual void addCursor(const std::string& filePath, int cursorId, int offx, int offy) = 0;
-	virtual void setCursor(int cursorId) = 0;
-
-	virtual void clearScreen(Color color = Color::Black) = 0;
-
-	virtual Vector<int> size() const = 0;
-	virtual void size(Vector<int> newSize) = 0;
-
-	virtual void minimumSize(Vector<int> newSize) = 0;
-
-	Point<int> center() const;
-
-	/**
-	 * Sets a rectangular area of the screen outside of which nothing is drawn.
-	 *
-	 * \see clipRectClear()
-	 */
-	virtual void clipRect(const Rectangle<float>& rect) = 0;
-	virtual void clipRectClear() = 0;
-
-	virtual void fullscreen(bool fs, bool maintain = false) = 0;
-	virtual bool fullscreen() const = 0;
-
-	virtual void resizeable(bool _r) = 0;
-	virtual bool resizeable() const = 0;
-
-	virtual void update();
-
-	virtual void setViewport(const Rectangle<int>& viewport) = 0;
-	virtual void setOrthoProjection(const Rectangle<float>& orthoBounds) = 0;
-	void setResolution(Vector<int> newResolution);
-
-protected:
-	Renderer(const std::string& appTitle);
-
-	void driverName(const std::string& name);
-
-	Vector<int> mResolution{1600,900}; /**< Screen resolution. Reasonable default in 2019*/
-
-private:
-	enum class FadeType
+	class Renderer
 	{
-		In = -1,
-		None = 0,
-		Out = 1
+	public:
+		Renderer() = default;
+		Renderer(const Renderer& rhs) = default;
+		Renderer& operator=(const Renderer& rhs) = default;
+		Renderer(Renderer&& rhs) = default;
+		Renderer& operator=(Renderer&& rhs) = default;
+		virtual ~Renderer();
+		
+		virtual std::vector<DisplayDesc> getDisplayModes() const = 0;
+		virtual DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const = 0;
+		virtual Vector<int> getWindowClientArea() const noexcept = 0;
+
+		const std::string& driverName() const;
+
+		const std::string& title() const;
+		void title(const std::string& title);
+
+		virtual void window_icon(const std::string& path) = 0;
+
+		virtual void drawImage(const Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) = 0;
+		virtual void drawSubImage(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, Color color = Color::Normal) = 0;
+		virtual void drawSubImageRotated(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, float degrees, Color color = Color::Normal) = 0;
+		virtual void drawImageRotated(const Image& image, Point<float> position, float degrees, Color color = Color::Normal, float scale = 1.0f) = 0;
+		virtual void drawImageStretched(const Image& image, const Rectangle<float>& rect, Color color = Color::Normal) = 0;
+		virtual void drawImageRepeated(const Image& image, const Rectangle<float>& rect) = 0;
+		virtual void drawSubImageRepeated(const Image& image, const Rectangle<float>& destination, const Rectangle<float>& source) = 0;
+
+		virtual void drawImageToImage(const Image& source, const Image& destination, Point<float> dstPoint) = 0;
+
+		virtual void drawPoint(Point<float> position, Color color = Color::White) = 0;
+		virtual void drawLine(Point<float> startPosition, Point<float> endPosition, Color color = Color::White, int line_width = 1) = 0;
+		virtual void drawBox(const Rectangle<float>& rect, Color color = Color::White) = 0;
+		virtual void drawBoxFilled(const Rectangle<float>& rect, Color color = Color::White) = 0;
+		virtual void drawCircle(Point<float> position, float radius, Color color, int num_segments = 10, Vector<float> scale = Vector{1.0f, 1.0f}) = 0;
+
+		/**
+		 * Draws a rectangular area with a color gradient.
+		 *
+		 * Each point of the rectangular area can be given a different color value to
+		 * produce a variety of effects. The vertex orders are as follows:
+		 *
+		 * 1-----4
+		 * |     |
+		 * |     |
+		 * 2-----3
+		 */
+		virtual void drawGradient(const Rectangle<float>& rect, Color c1, Color c2, Color c3, Color c4) = 0;
+
+		virtual void drawText(const Font& font, std::string_view text, Point<float> position, Color color = Color::White) = 0;
+		void drawTextShadow(const Font& font, std::string_view text, Point<float> position, Vector<float> shadowOffset, Color textColor, Color shadowColor);
+
+		void fadeColor(Color color);
+		void fadeIn(float delayTime);
+		void fadeOut(float delayTime);
+		bool isFading() const;
+		bool isFaded() const;
+		SignalSource<>& fadeComplete();
+
+		virtual void showSystemPointer(bool) = 0;
+		virtual void addCursor(const std::string& filePath, int cursorId, int offx, int offy) = 0;
+		virtual void setCursor(int cursorId) = 0;
+
+		virtual void clearScreen(Color color = Color::Black) = 0;
+
+		virtual Vector<int> size() const = 0;
+		virtual void size(Vector<int> newSize) = 0;
+
+		virtual void minimumSize(Vector<int> newSize) = 0;
+
+		Point<int> center() const;
+
+		/**
+		 * Sets a rectangular area of the screen outside of which nothing is drawn.
+		 *
+		 * \see clipRectClear()
+		 */
+		virtual void clipRect(const Rectangle<float>& rect) = 0;
+		virtual void clipRectClear() = 0;
+
+		virtual void fullscreen(bool fs, bool maintain = false) = 0;
+		virtual bool fullscreen() const = 0;
+
+		virtual void resizeable(bool _r) = 0;
+		virtual bool resizeable() const = 0;
+
+		virtual void update();
+
+		virtual void setViewport(const Rectangle<int>& viewport) = 0;
+		virtual void setOrthoProjection(const Rectangle<float>& orthoBounds) = 0;
+		void setResolution(Vector<int> newResolution);
+
+	protected:
+		Renderer(const std::string& appTitle);
+
+		void driverName(const std::string& name);
+
+		Vector<int> mResolution{1600,900}; /**< Screen resolution. Reasonable default in 2019*/
+
+	private:
+		enum class FadeType
+		{
+			In = -1,
+			None = 0,
+			Out = 1
+		};
+
+		std::string mDriverName{"NULL Renderer"}; /**< OS Driver name */
+		std::string mTitle{"Default Application"}; /**< Title to use for the application. */
+
+		Color mFadeColor{0,0,0,255}; /**< Fade Color. */
+		float mFadeStep{0.0f}; /**< Amount of fading to do per milisecond. */
+		float mCurrentFade{0.0f}; /**< Current fade amount. */
+
+		FadeType mCurrentFadeType{FadeType::None};
+		Timer fadeTimer;
+		Signal<> fadeCompleteSignal;
 	};
-
-	std::string mDriverName{"NULL Renderer"}; /**< OS Driver name */
-	std::string mTitle{"Default Application"}; /**< Title to use for the application. */
-
-	Color mFadeColor{0,0,0,255}; /**< Fade Color. */
-	float mFadeStep{0.0f}; /**< Amount of fading to do per milisecond. */
-	float mCurrentFade{0.0f}; /**< Current fade amount. */
-
-	FadeType mCurrentFadeType{FadeType::None};
-	Timer fadeTimer;
-	Signal<> fadeCompleteSignal;
-};
 
 } // namespace

--- a/NAS2D/Renderer/RendererNull.h
+++ b/NAS2D/Renderer/RendererNull.h
@@ -14,65 +14,65 @@
 
 namespace NAS2D {
 
-class RendererNull : public Renderer
-{
-public:
-	RendererNull() = default;
+	class RendererNull : public Renderer
+	{
+	public:
+		RendererNull() = default;
 
-	~RendererNull() override {}
+		~RendererNull() override {}
 
-	std::vector<DisplayDesc> getDisplayModes() const override { return {}; }
-	DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc&) const override { return{}; }
-	Vector<int> getWindowClientArea() const noexcept override { return {}; }
+		std::vector<DisplayDesc> getDisplayModes() const override { return {}; }
+		DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc&) const override { return{}; }
+		Vector<int> getWindowClientArea() const noexcept override { return {}; }
 
-	void drawImage(const Image&, Point<float>, float = 1.0, Color = Color::Normal) override {}
+		void drawImage(const Image&, Point<float>, float = 1.0, Color = Color::Normal) override {}
 
-	void drawSubImage(const Image&, Point<float>, const Rectangle<float>&, Color = Color::Normal) override {}
-	void drawSubImageRotated(const Image&, Point<float>, const Rectangle<float>&, float, Color = Color::Normal) override {}
+		void drawSubImage(const Image&, Point<float>, const Rectangle<float>&, Color = Color::Normal) override {}
+		void drawSubImageRotated(const Image&, Point<float>, const Rectangle<float>&, float, Color = Color::Normal) override {}
 
-	void drawImageRotated(const Image&, Point<float>, float, Color = Color::Normal, float = 1.0f) override {}
-	void drawImageStretched(const Image&, const Rectangle<float>&, Color = Color::Normal) override {}
+		void drawImageRotated(const Image&, Point<float>, float, Color = Color::Normal, float = 1.0f) override {}
+		void drawImageStretched(const Image&, const Rectangle<float>&, Color = Color::Normal) override {}
 
-	void drawImageRepeated(const Image&, const Rectangle<float>&) override {}
-	void drawSubImageRepeated(const Image&, const Rectangle<float>&, const Rectangle<float>&) override {}
+		void drawImageRepeated(const Image&, const Rectangle<float>&) override {}
+		void drawSubImageRepeated(const Image&, const Rectangle<float>&, const Rectangle<float>&) override {}
 
-	void drawImageToImage(const Image&, const Image&, Point<float>) override {}
+		void drawImageToImage(const Image&, const Image&, Point<float>) override {}
 
-	void drawPoint(Point<float>, Color = Color::White) override {}
-	void drawLine(Point<float>, Point<float>, Color = Color::White, int = 1) override {}
-	void drawBox(const Rectangle<float>&, Color = Color::White) override {}
-	void drawBoxFilled(const Rectangle<float>&, Color = Color::White) override {}
-	void drawCircle(Point<float>, float, Color, int = 10, Vector<float> = Vector{1.0f, 1.0f}) override {}
+		void drawPoint(Point<float>, Color = Color::White) override {}
+		void drawLine(Point<float>, Point<float>, Color = Color::White, int = 1) override {}
+		void drawBox(const Rectangle<float>&, Color = Color::White) override {}
+		void drawBoxFilled(const Rectangle<float>&, Color = Color::White) override {}
+		void drawCircle(Point<float>, float, Color, int = 10, Vector<float> = Vector{1.0f, 1.0f}) override {}
 
-	void drawGradient(const Rectangle<float>&, Color, Color, Color, Color) override {}
+		void drawGradient(const Rectangle<float>&, Color, Color, Color, Color) override {}
 
-	void drawText(const Font&, std::string_view, Point<float>, Color = Color::White) override {}
+		void drawText(const Font&, std::string_view, Point<float>, Color = Color::White) override {}
 
-	void showSystemPointer(bool) override {}
-	void addCursor(const std::string&, int, int, int) override {}
-	void setCursor(int) override {}
+		void showSystemPointer(bool) override {}
+		void addCursor(const std::string&, int, int, int) override {}
+		void setCursor(int) override {}
 
-	void clearScreen(Color = Color::Black) override {}
+		void clearScreen(Color = Color::Black) override {}
 
-	Vector<int> size() const override { return {}; }
-	void size(Vector<int>) override {}
-	void minimumSize(Vector<int>) override {}
+		Vector<int> size() const override { return {}; }
+		void size(Vector<int>) override {}
+		void minimumSize(Vector<int>) override {}
 
-	void fullscreen(bool, bool = false) override {}
-	bool fullscreen() const override { return false; }
+		void fullscreen(bool, bool = false) override {}
+		bool fullscreen() const override { return false; }
 
-	void resizeable(bool) override {}
-	bool resizeable() const override { return false; }
+		void resizeable(bool) override {}
+		bool resizeable() const override { return false; }
 
-	void clipRect(const Rectangle<float>&) override {}
-	void clipRectClear() override {}
+		void clipRect(const Rectangle<float>&) override {}
+		void clipRectClear() override {}
 
-	void window_icon(const std::string&) override {}
+		void window_icon(const std::string&) override {}
 
-	void update() override {}
+		void update() override {}
 
-	void setViewport(const Rectangle<int>&) override {}
-	void setOrthoProjection(const Rectangle<float>&) override {}
-};
+		void setViewport(const Rectangle<int>&) override {}
+		void setOrthoProjection(const Rectangle<float>&) override {}
+	};
 
 } // namespace

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -800,201 +800,201 @@ Vector<int> RendererOpenGL::getWindowClientArea() const noexcept
 // ==================================================================================
 
 namespace {
-/**
- * Draws a textured rectangle using a vertex and texture coordinate array
- */
-void drawTexturedQuad(GLuint textureId, const std::array<GLfloat, 12>& verticies, const std::array<GLfloat, 12>& textureCoords)
-{
-	glBindTexture(GL_TEXTURE_2D, textureId);
-	glVertexPointer(2, GL_FLOAT, 0, verticies.data());
-	glTexCoordPointer(2, GL_FLOAT, 0, textureCoords.data());
-	glDrawArrays(GL_TRIANGLE_STRIP, 0, 6);
-}
+	/**
+	 * Draws a textured rectangle using a vertex and texture coordinate array
+	 */
+	void drawTexturedQuad(GLuint textureId, const std::array<GLfloat, 12>& verticies, const std::array<GLfloat, 12>& textureCoords)
+	{
+		glBindTexture(GL_TEXTURE_2D, textureId);
+		glVertexPointer(2, GL_FLOAT, 0, verticies.data());
+		glTexCoordPointer(2, GL_FLOAT, 0, textureCoords.data());
+		glDrawArrays(GL_TRIANGLE_STRIP, 0, 6);
+	}
 
 
-/**
- * The following code was developed by Chris Tsang and lifted from:
- *
- * http://www.codeproject.com/KB/openGL/gllinedraw.aspx
- *
- * Modified: Removed option for non-alpha blending and general code cleanup.
- *
- * This is drop-in code that may be replaced in the future.
- */
-void line(Point<float> p1, Point<float> p2, float lineWidth, Color color)
-{
-	float Cr = color.red / 255.0f;
-	float Cg = color.green / 255.0f;
-	float Cb = color.blue / 255.0f;
-	float Ca = color.alpha / 255.0f;
+	/**
+	 * The following code was developed by Chris Tsang and lifted from:
+	 *
+	 * http://www.codeproject.com/KB/openGL/gllinedraw.aspx
+	 *
+	 * Modified: Removed option for non-alpha blending and general code cleanup.
+	 *
+	 * This is drop-in code that may be replaced in the future.
+	 */
+	void line(Point<float> p1, Point<float> p2, float lineWidth, Color color)
+	{
+		float Cr = color.red / 255.0f;
+		float Cg = color.green / 255.0f;
+		float Cb = color.blue / 255.0f;
+		float Ca = color.alpha / 255.0f;
 
-	// What are these values for?
-	float t = 0.0f;
-	float R = 0.0f;
-	float f = lineWidth - static_cast<int>(lineWidth);
+		// What are these values for?
+		float t = 0.0f;
+		float R = 0.0f;
+		float f = lineWidth - static_cast<int>(lineWidth);
 
-	// HOLY CRAP magic numbers!
-	//determine parameters t, R
-	if (lineWidth >= 0.0f && lineWidth < 1.0f)
-	{
-		t = 0.05f;
-		R = 0.48f + 0.32f * f;
-	}
-	else if (lineWidth >= 1.0f && lineWidth < 2.0f)
-	{
-		t = 0.05f + f * 0.33f;
-		R = 0.768f + 0.312f * f;
-	}
-	else if (lineWidth >= 2.0f && lineWidth < 3.0f)
-	{
-		t = 0.38f + f * 0.58f;
-		R = 1.08f;
-	}
-	else if (lineWidth >= 3.0f && lineWidth < 4.0f)
-	{
-		t = 0.96f + f * 0.48f;
-		R = 1.08f;
-	}
-	else if (lineWidth >= 4.0f && lineWidth < 5.0f)
-	{
-		t = 1.44f + f * 0.46f;
-		R = 1.08f;
-	}
-	else if (lineWidth >= 5.0f && lineWidth < 6.0f)
-	{
-		t = 1.9f + f * 0.6f;
-		R = 1.08f;
-	}
-	else if (lineWidth >= 6.0f)
-	{
-		float ff = lineWidth - 6.0f;
-		t = 2.5f + ff * 0.50f;
-		R = 1.08f;
-	}
-	//printf( "lineWidth=%f, f=%f, C=%.4f\n", lineWidth, f, C);
-
-	//determine angle of the line to horizontal
-	float tx = 0.0f, ty = 0.0f; //core thinkness of a line
-	float Rx = 0.0f, Ry = 0.0f; //fading edge of a line
-	float cx = 0.0f, cy = 0.0f; //cap of a line
-	float ALW = 0.01f; // Dafuq is this?
-	float dx = p2.x - p1.x;
-	float dy = p2.y - p1.y;
-
-	if (std::abs(dx) < ALW)
-	{
-		//vertical
-		tx = t; ty = 0.0f;
-		Rx = R; Ry = 0.0f;
-		if (lineWidth > 0.0f && lineWidth <= 1.0f)
+		// HOLY CRAP magic numbers!
+		//determine parameters t, R
+		if (lineWidth >= 0.0f && lineWidth < 1.0f)
 		{
-			tx = 0.5f;
-			Rx = 0.0f;
+			t = 0.05f;
+			R = 0.48f + 0.32f * f;
 		}
-	}
-	else if (std::abs(dy) < ALW)
-	{
-		//horizontal
-		tx = 0.0f; ty = t;
-		Rx = 0.0f; Ry = R;
-		if (lineWidth > 0.0f && lineWidth <= 1.0f)
+		else if (lineWidth >= 1.0f && lineWidth < 2.0f)
 		{
-			ty = 0.5f;
-			Ry = 0.0f;
+			t = 0.05f + f * 0.33f;
+			R = 0.768f + 0.312f * f;
 		}
-	}
-	else
-	{
-		dx = p1.y - p2.y;
-		dy = p2.x - p1.x;
-
-		float L = sqrt(dx * dx + dy * dy);
-
-		dx /= L;
-		dy /= L;
-
-		cx = -dy;
-		cy = dx;
-
-		tx = t * dx;
-		ty = t * dy;
-
-		Rx = R * dx;
-		Ry = R * dy;
-	}
-
-	p1.x += cx * 0.5f;
-	p1.y += cy * 0.5f;
-
-	p2.x -= cx * 0.5f;
-	p2.y -= cy * 0.5f;
-
-	//draw the line by triangle strip
-	float line_vertex[] =
-	{
-		p1.x - tx - Rx - cx, p1.y - ty - Ry - cy, //fading edge1
-		p2.x - tx - Rx + cx, p2.y - ty - Ry + cy,
-		p1.x - tx - cx, p1.y - ty - cy,        //core
-		p2.x - tx + cx, p2.y - ty + cy,
-		p1.x + tx - cx, p1.y + ty - cy,
-		p2.x + tx + cx, p2.y + ty + cy,
-		p1.x + tx + Rx - cx, p1.y + ty + Ry - cy, //fading edge2
-		p2.x + tx + Rx + cx, p2.y + ty + Ry + cy
-	};
-
-	float line_color[] =
-	{
-		Cr, Cg, Cb, 0,
-		Cr, Cg, Cb, 0,
-		Cr, Cg, Cb, Ca,
-		Cr, Cg, Cb, Ca,
-		Cr, Cg, Cb, Ca,
-		Cr, Cg, Cb, Ca,
-		Cr, Cg, Cb, 0,
-		Cr, Cg, Cb, 0
-	};
-
-	glVertexPointer(2, GL_FLOAT, 0, line_vertex);
-	glColorPointer(4, GL_FLOAT, 0, line_color);
-	glDrawArrays(GL_TRIANGLE_STRIP, 0, 8);
-
-	// Line End Caps
-	if (lineWidth > 3.0f) // <<< Arbitrary number.
-	{
-		float line_vertex2[] =
+		else if (lineWidth >= 2.0f && lineWidth < 3.0f)
 		{
-			p1.x - tx - cx, p1.y - ty - cy,
-			p1.x + tx + Rx, p1.y + ty + Ry,
-			p1.x + tx - cx, p1.y + ty - cy,
-			p1.x + tx + Rx - cx, p1.y + ty + Ry - cy,
-			p2.x - tx - Rx + cx, p2.y - ty - Ry + cy, //cap2
-			p2.x - tx - Rx, p2.y - ty - Ry,
+			t = 0.38f + f * 0.58f;
+			R = 1.08f;
+		}
+		else if (lineWidth >= 3.0f && lineWidth < 4.0f)
+		{
+			t = 0.96f + f * 0.48f;
+			R = 1.08f;
+		}
+		else if (lineWidth >= 4.0f && lineWidth < 5.0f)
+		{
+			t = 1.44f + f * 0.46f;
+			R = 1.08f;
+		}
+		else if (lineWidth >= 5.0f && lineWidth < 6.0f)
+		{
+			t = 1.9f + f * 0.6f;
+			R = 1.08f;
+		}
+		else if (lineWidth >= 6.0f)
+		{
+			float ff = lineWidth - 6.0f;
+			t = 2.5f + ff * 0.50f;
+			R = 1.08f;
+		}
+		//printf( "lineWidth=%f, f=%f, C=%.4f\n", lineWidth, f, C);
+
+		//determine angle of the line to horizontal
+		float tx = 0.0f, ty = 0.0f; //core thinkness of a line
+		float Rx = 0.0f, Ry = 0.0f; //fading edge of a line
+		float cx = 0.0f, cy = 0.0f; //cap of a line
+		float ALW = 0.01f; // Dafuq is this?
+		float dx = p2.x - p1.x;
+		float dy = p2.y - p1.y;
+
+		if (std::abs(dx) < ALW)
+		{
+			//vertical
+			tx = t; ty = 0.0f;
+			Rx = R; Ry = 0.0f;
+			if (lineWidth > 0.0f && lineWidth <= 1.0f)
+			{
+				tx = 0.5f;
+				Rx = 0.0f;
+			}
+		}
+		else if (std::abs(dy) < ALW)
+		{
+			//horizontal
+			tx = 0.0f; ty = t;
+			Rx = 0.0f; Ry = R;
+			if (lineWidth > 0.0f && lineWidth <= 1.0f)
+			{
+				ty = 0.5f;
+				Ry = 0.0f;
+			}
+		}
+		else
+		{
+			dx = p1.y - p2.y;
+			dy = p2.x - p1.x;
+
+			float L = sqrt(dx * dx + dy * dy);
+
+			dx /= L;
+			dy /= L;
+
+			cx = -dy;
+			cy = dx;
+
+			tx = t * dx;
+			ty = t * dy;
+
+			Rx = R * dx;
+			Ry = R * dy;
+		}
+
+		p1.x += cx * 0.5f;
+		p1.y += cy * 0.5f;
+
+		p2.x -= cx * 0.5f;
+		p2.y -= cy * 0.5f;
+
+		//draw the line by triangle strip
+		float line_vertex[] =
+		{
+			p1.x - tx - Rx - cx, p1.y - ty - Ry - cy, //fading edge1
+			p2.x - tx - Rx + cx, p2.y - ty - Ry + cy,
+			p1.x - tx - cx, p1.y - ty - cy,        //core
 			p2.x - tx + cx, p2.y - ty + cy,
-			p2.x + tx + Rx, p2.y + ty + Ry,
+			p1.x + tx - cx, p1.y + ty - cy,
 			p2.x + tx + cx, p2.y + ty + cy,
+			p1.x + tx + Rx - cx, p1.y + ty + Ry - cy, //fading edge2
 			p2.x + tx + Rx + cx, p2.y + ty + Ry + cy
 		};
 
-		float line_color2[] =
+		float line_color[] =
 		{
-			Cr, Cg, Cb, 0, //cap1
+			Cr, Cg, Cb, 0,
 			Cr, Cg, Cb, 0,
 			Cr, Cg, Cb, Ca,
-			Cr, Cg, Cb, 0,
+			Cr, Cg, Cb, Ca,
+			Cr, Cg, Cb, Ca,
 			Cr, Cg, Cb, Ca,
 			Cr, Cg, Cb, 0,
-			Cr, Cg, Cb, 0, //cap2
-			Cr, Cg, Cb, 0,
-			Cr, Cg, Cb, Ca,
-			Cr, Cg, Cb, 0,
-			Cr, Cg, Cb, Ca,
 			Cr, Cg, Cb, 0
 		};
 
-		glVertexPointer(2, GL_FLOAT, 0, line_vertex2);
-		glColorPointer(4, GL_FLOAT, 0, line_color2);
-		glDrawArrays(GL_TRIANGLE_STRIP, 0, 12);
+		glVertexPointer(2, GL_FLOAT, 0, line_vertex);
+		glColorPointer(4, GL_FLOAT, 0, line_color);
+		glDrawArrays(GL_TRIANGLE_STRIP, 0, 8);
+
+		// Line End Caps
+		if (lineWidth > 3.0f) // <<< Arbitrary number.
+		{
+			float line_vertex2[] =
+			{
+				p1.x - tx - cx, p1.y - ty - cy,
+				p1.x + tx + Rx, p1.y + ty + Ry,
+				p1.x + tx - cx, p1.y + ty - cy,
+				p1.x + tx + Rx - cx, p1.y + ty + Ry - cy,
+				p2.x - tx - Rx + cx, p2.y - ty - Ry + cy, //cap2
+				p2.x - tx - Rx, p2.y - ty - Ry,
+				p2.x - tx + cx, p2.y - ty + cy,
+				p2.x + tx + Rx, p2.y + ty + Ry,
+				p2.x + tx + cx, p2.y + ty + cy,
+				p2.x + tx + Rx + cx, p2.y + ty + Ry + cy
+			};
+
+			float line_color2[] =
+			{
+				Cr, Cg, Cb, 0, //cap1
+				Cr, Cg, Cb, 0,
+				Cr, Cg, Cb, Ca,
+				Cr, Cg, Cb, 0,
+				Cr, Cg, Cb, Ca,
+				Cr, Cg, Cb, 0,
+				Cr, Cg, Cb, 0, //cap2
+				Cr, Cg, Cb, 0,
+				Cr, Cg, Cb, Ca,
+				Cr, Cg, Cb, 0,
+				Cr, Cg, Cb, Ca,
+				Cr, Cg, Cb, 0
+			};
+
+			glVertexPointer(2, GL_FLOAT, 0, line_vertex2);
+			glColorPointer(4, GL_FLOAT, 0, line_color2);
+			glDrawArrays(GL_TRIANGLE_STRIP, 0, 12);
+		}
 	}
-}
 
 }

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -20,97 +20,97 @@ struct SDL_Cursor;
 
 namespace NAS2D {
 
-/**
- * OpenGL Renderer.
- *
- * Implements an OpenGL based Renderer.
- */
-class RendererOpenGL : public Renderer
-{
-public:
-	struct Options
+	/**
+	 * OpenGL Renderer.
+	 *
+	 * Implements an OpenGL based Renderer.
+	 */
+	class RendererOpenGL : public Renderer
 	{
-		Vector<int> resolution;
-		bool fullscreen;
-		bool vsync;
+	public:
+		struct Options
+		{
+			Vector<int> resolution;
+			bool fullscreen;
+			bool vsync;
+		};
+
+		static Options ReadConfigurationOptions();
+		static void WriteConfigurationOptions(const Options& options);
+
+		RendererOpenGL() = delete;
+		explicit RendererOpenGL(const std::string& title);
+		RendererOpenGL(const std::string& title, const Options& options);
+		RendererOpenGL(const RendererOpenGL& other) = delete;
+		RendererOpenGL(RendererOpenGL&& other) = delete;
+		RendererOpenGL& operator=(const RendererOpenGL& rhs) = delete;
+		RendererOpenGL& operator=(RendererOpenGL&& rhs) = delete;
+		virtual ~RendererOpenGL() override;
+
+		std::vector<DisplayDesc> getDisplayModes() const override;
+		DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const override;
+		Vector<int> getWindowClientArea() const noexcept override;
+
+		void drawImage(const Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) override;
+
+		void drawSubImage(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, Color color = Color::Normal) override;
+		void drawSubImageRotated(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, float degrees, Color color = Color::Normal) override;
+
+		void drawImageRotated(const Image& image, Point<float> position, float degrees, Color color = Color::Normal, float scale = 1.0f) override;
+		void drawImageStretched(const Image& image, const Rectangle<float>& rect, Color color = Color::Normal) override;
+
+		void drawImageRepeated(const Image& image, const Rectangle<float>& rect) override;
+		void drawSubImageRepeated(const Image& image, const Rectangle<float>& destination, const Rectangle<float>& source) override;
+
+		void drawImageToImage(const Image& source, const Image& destination, Point<float> dstPoint) override;
+
+		void drawPoint(Point<float> position, Color color = Color::White) override;
+		void drawLine(Point<float> startPosition, Point<float> endPosition, Color color = Color::White, int line_width = 1) override;
+		void drawBox(const Rectangle<float>& rect, Color color = Color::White) override;
+		void drawBoxFilled(const Rectangle<float>& rect, Color color = Color::White) override;
+		void drawCircle(Point<float> position, float radius, Color color, int num_segments = 10, Vector<float> scale = Vector{1.0f, 1.0f}) override;
+
+		void drawGradient(const Rectangle<float>& rect, Color c1, Color c2, Color c3, Color c4) override;
+
+		void drawText(const Font& font, std::string_view text, Point<float> position, Color color = Color::White) override;
+
+		void showSystemPointer(bool) override;
+		void addCursor(const std::string& filePath, int cursorId, int offx, int offy) override;
+		void setCursor(int cursorId) override;
+
+		void clearScreen(Color color = Color::Black) override;
+
+		Vector<int> size() const override;
+		void size(Vector<int> newSize) override;
+		void minimumSize(Vector<int> newSize) override;
+
+		void fullscreen(bool fs, bool maintain = false) override;
+		bool fullscreen() const override;
+
+		void resizeable(bool resizable) override;
+		bool resizeable() const override;
+
+		void clipRect(const Rectangle<float>& rect) override;
+		void clipRectClear() override;
+
+		void window_icon(const std::string& path) override;
+
+		void update() override;
+
+		void setViewport(const Rectangle<int>& viewport) override;
+		void setOrthoProjection(const Rectangle<float>& orthoBounds) override;
+
+	private:
+
+		void initGL();
+		void initVideo(Vector<int> resolution, bool fullscreen, bool vsync);
+
+		void onResize(Vector<int> newSize);
+
+
+		SDL_GLContext sdlOglContext; /**< Primary OpenGL render context. */
+		Vector<int> desktopResolution;
+		std::map<int, SDL_Cursor*> cursors;
 	};
-
-	static Options ReadConfigurationOptions();
-	static void WriteConfigurationOptions(const Options& options);
-
-	RendererOpenGL() = delete;
-	explicit RendererOpenGL(const std::string& title);
-	RendererOpenGL(const std::string& title, const Options& options);
-	RendererOpenGL(const RendererOpenGL& other) = delete;
-	RendererOpenGL(RendererOpenGL&& other) = delete;
-	RendererOpenGL& operator=(const RendererOpenGL& rhs) = delete;
-	RendererOpenGL& operator=(RendererOpenGL&& rhs) = delete;
-	virtual ~RendererOpenGL() override;
-
-	std::vector<DisplayDesc> getDisplayModes() const override;
-	DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const override;
-	Vector<int> getWindowClientArea() const noexcept override;
-
-	void drawImage(const Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) override;
-
-	void drawSubImage(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, Color color = Color::Normal) override;
-	void drawSubImageRotated(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, float degrees, Color color = Color::Normal) override;
-
-	void drawImageRotated(const Image& image, Point<float> position, float degrees, Color color = Color::Normal, float scale = 1.0f) override;
-	void drawImageStretched(const Image& image, const Rectangle<float>& rect, Color color = Color::Normal) override;
-
-	void drawImageRepeated(const Image& image, const Rectangle<float>& rect) override;
-	void drawSubImageRepeated(const Image& image, const Rectangle<float>& destination, const Rectangle<float>& source) override;
-
-	void drawImageToImage(const Image& source, const Image& destination, Point<float> dstPoint) override;
-
-	void drawPoint(Point<float> position, Color color = Color::White) override;
-	void drawLine(Point<float> startPosition, Point<float> endPosition, Color color = Color::White, int line_width = 1) override;
-	void drawBox(const Rectangle<float>& rect, Color color = Color::White) override;
-	void drawBoxFilled(const Rectangle<float>& rect, Color color = Color::White) override;
-	void drawCircle(Point<float> position, float radius, Color color, int num_segments = 10, Vector<float> scale = Vector{1.0f, 1.0f}) override;
-
-	void drawGradient(const Rectangle<float>& rect, Color c1, Color c2, Color c3, Color c4) override;
-
-	void drawText(const Font& font, std::string_view text, Point<float> position, Color color = Color::White) override;
-
-	void showSystemPointer(bool) override;
-	void addCursor(const std::string& filePath, int cursorId, int offx, int offy) override;
-	void setCursor(int cursorId) override;
-
-	void clearScreen(Color color = Color::Black) override;
-
-	Vector<int> size() const override;
-	void size(Vector<int> newSize) override;
-	void minimumSize(Vector<int> newSize) override;
-
-	void fullscreen(bool fs, bool maintain = false) override;
-	bool fullscreen() const override;
-
-	void resizeable(bool resizable) override;
-	bool resizeable() const override;
-
-	void clipRect(const Rectangle<float>& rect) override;
-	void clipRectClear() override;
-
-	void window_icon(const std::string& path) override;
-
-	void update() override;
-
-	void setViewport(const Rectangle<int>& viewport) override;
-	void setOrthoProjection(const Rectangle<float>& orthoBounds) override;
-
-private:
-
-	void initGL();
-	void initVideo(Vector<int> resolution, bool fullscreen, bool vsync);
-
-	void onResize(Vector<int> newSize);
-
-
-	SDL_GLContext sdlOglContext; /**< Primary OpenGL render context. */
-	Vector<int> desktopResolution;
-	std::map<int, SDL_Cursor*> cursors;
-};
 
 } // namespace

--- a/NAS2D/Renderer/Vector.h
+++ b/NAS2D/Renderer/Vector.h
@@ -6,134 +6,134 @@
 namespace NAS2D {
 
 
-template <typename BaseType>
-struct Vector {
-	BaseType x = 0;
-	BaseType y = 0;
+	template <typename BaseType>
+	struct Vector {
+		BaseType x = 0;
+		BaseType y = 0;
 
-	constexpr bool operator==(const Vector& vector) const {
-		return (x == vector.x) && (y == vector.y);
-	}
-	constexpr bool operator!=(const Vector& vector) const {
-		return !(*this == vector);
-	}
-
-	Vector& operator+=(const Vector& vector) {
-		x += vector.x;
-		y += vector.y;
-		return *this;
-	}
-	Vector& operator-=(const Vector& vector) {
-		x -= vector.x;
-		y -= vector.y;
-		return *this;
-	}
-
-	constexpr Vector operator+(const Vector& vector) const {
-		return {
-			x + vector.x,
-			y + vector.y
-		};
-	}
-	constexpr Vector operator-(const Vector& vector) const {
-		return {
-			x - vector.x,
-			y - vector.y
-		};
-	}
-
-	Vector& operator*=(BaseType scalar) {
-		x *= scalar;
-		y *= scalar;
-		return *this;
-	}
-	Vector& operator/=(BaseType scalar) {
-		if (scalar == 0) {
-			throw std::domain_error("Cannot divide vector by 0");
+		constexpr bool operator==(const Vector& vector) const {
+			return (x == vector.x) && (y == vector.y);
 		}
-		x /= scalar;
-		y /= scalar;
-		return *this;
-	}
-
-	constexpr Vector operator*(BaseType scalar) const {
-		return {x * scalar, y * scalar};
-	}
-	constexpr Vector operator/(BaseType scalar) const {
-		if (scalar == 0) {
-			throw std::domain_error("Cannot divide vector by 0");
+		constexpr bool operator!=(const Vector& vector) const {
+			return !(*this == vector);
 		}
-		return {x / scalar, y / scalar};
-	}
 
-	constexpr Vector skewBy(const Vector& other) const {
-		return {x * other.x, y * other.y};
-	}
-
-	constexpr Vector skewInverseBy(const Vector& other) const {
-		if (other.x == 0 || other.y == 0) {
-			throw std::domain_error("Cannot skewInverseBy a vector with a zero component");
+		Vector& operator+=(const Vector& vector) {
+			x += vector.x;
+			y += vector.y;
+			return *this;
 		}
-		return {x / other.x, y / other.y};
+		Vector& operator-=(const Vector& vector) {
+			x -= vector.x;
+			y -= vector.y;
+			return *this;
+		}
+
+		constexpr Vector operator+(const Vector& vector) const {
+			return {
+				x + vector.x,
+				y + vector.y
+			};
+		}
+		constexpr Vector operator-(const Vector& vector) const {
+			return {
+				x - vector.x,
+				y - vector.y
+			};
+		}
+
+		Vector& operator*=(BaseType scalar) {
+			x *= scalar;
+			y *= scalar;
+			return *this;
+		}
+		Vector& operator/=(BaseType scalar) {
+			if (scalar == 0) {
+				throw std::domain_error("Cannot divide vector by 0");
+			}
+			x /= scalar;
+			y /= scalar;
+			return *this;
+		}
+
+		constexpr Vector operator*(BaseType scalar) const {
+			return {x * scalar, y * scalar};
+		}
+		constexpr Vector operator/(BaseType scalar) const {
+			if (scalar == 0) {
+				throw std::domain_error("Cannot divide vector by 0");
+			}
+			return {x / scalar, y / scalar};
+		}
+
+		constexpr Vector skewBy(const Vector& other) const {
+			return {x * other.x, y * other.y};
+		}
+
+		constexpr Vector skewInverseBy(const Vector& other) const {
+			if (other.x == 0 || other.y == 0) {
+				throw std::domain_error("Cannot skewInverseBy a vector with a zero component");
+			}
+			return {x / other.x, y / other.y};
+		}
+
+		constexpr BaseType lengthSquared() const {
+			return (x * x) + (y * y);
+		}
+
+		constexpr BaseType dotProduct(const Vector& other) const {
+			return (x * other.x) + (y * other.y);
+		}
+
+		// Reflect the x-coordinate (flip across Y-axis)
+		constexpr Vector reflectX() const {
+			return {-x, y};
+		}
+
+		// Reflect the y-coordinate (flip across X-axis)
+		constexpr Vector reflectY() const {
+			return {x, -y};
+		}
+
+		template <typename NewBaseType>
+		constexpr operator Vector<NewBaseType>() const {
+			return {
+				static_cast<NewBaseType>(x),
+				static_cast<NewBaseType>(y)
+			};
+		}
+
+		template <typename NewBaseType>
+		constexpr Vector<NewBaseType> to() const {
+			return static_cast<Vector<NewBaseType>>(*this);
+		}
+	};
+
+
+	template <typename BaseType>
+	Vector(BaseType, BaseType) -> Vector<BaseType>;
+
+
+	// Partial order comparisons
+
+	template <typename BaseType>
+	bool operator<=(Vector<BaseType> v1, Vector<BaseType> v2) {
+		return (v1.x <= v2.x) && (v1.y <= v2.y);
 	}
 
-	constexpr BaseType lengthSquared() const {
-		return (x * x) + (y * y);
+	template <typename BaseType>
+	bool operator>=(Vector<BaseType> v1, Vector<BaseType> v2) {
+		return v2 <= v1;
 	}
 
-	constexpr BaseType dotProduct(const Vector& other) const {
-		return (x * other.x) + (y * other.y);
+	template <typename BaseType>
+	bool operator<(Vector<BaseType> v1, Vector<BaseType> v2) {
+		return (v1.x < v2.x) && (v1.y < v2.y);
 	}
 
-	// Reflect the x-coordinate (flip across Y-axis)
-	constexpr Vector reflectX() const {
-		return {-x, y};
+	template <typename BaseType>
+	bool operator>(Vector<BaseType> v1, Vector<BaseType> v2) {
+		return v2 < v1;
 	}
-
-	// Reflect the y-coordinate (flip across X-axis)
-	constexpr Vector reflectY() const {
-		return {x, -y};
-	}
-
-	template <typename NewBaseType>
-	constexpr operator Vector<NewBaseType>() const {
-		return {
-			static_cast<NewBaseType>(x),
-			static_cast<NewBaseType>(y)
-		};
-	}
-
-	template <typename NewBaseType>
-	constexpr Vector<NewBaseType> to() const {
-		return static_cast<Vector<NewBaseType>>(*this);
-	}
-};
-
-
-template <typename BaseType>
-Vector(BaseType, BaseType) -> Vector<BaseType>;
-
-
-// Partial order comparisons
-
-template <typename BaseType>
-bool operator<=(Vector<BaseType> v1, Vector<BaseType> v2) {
-	return (v1.x <= v2.x) && (v1.y <= v2.y);
-}
-
-template <typename BaseType>
-bool operator>=(Vector<BaseType> v1, Vector<BaseType> v2) {
-	return v2 <= v1;
-}
-
-template <typename BaseType>
-bool operator<(Vector<BaseType> v1, Vector<BaseType> v2) {
-	return (v1.x < v2.x) && (v1.y < v2.y);
-}
-
-template <typename BaseType>
-bool operator>(Vector<BaseType> v1, Vector<BaseType> v2) {
-	return v2 < v1;
-}
 
 }

--- a/NAS2D/Renderer/VectorSizeRange.h
+++ b/NAS2D/Renderer/VectorSizeRange.h
@@ -7,68 +7,68 @@
 namespace NAS2D {
 
 
-template <typename BaseType>
-class VectorSizeRange {
-public:
-	class Iterator {
+	template <typename BaseType>
+	class VectorSizeRange {
 	public:
-		Iterator(const Vector<BaseType>& size, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
-			mCurrent(initial),
+		class Iterator {
+		public:
+			Iterator(const Vector<BaseType>& size, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
+				mCurrent(initial),
+				mSize(size)
+			{}
+			Iterator(const Iterator& other) = default;
+			Iterator& operator=(const Iterator& other) = default;
+
+			Iterator& operator++() {
+				++mCurrent.x;
+				if (mCurrent.x >= mSize.x) {
+					mCurrent.x = 0;
+					++mCurrent.y;
+				}
+				return *this;
+			}
+
+			Iterator& operator--() {
+				if (mCurrent.x <= 0) {
+					mCurrent.x = mSize.x;
+					--mCurrent.y;
+				}
+				--mCurrent.x;
+				return *this;
+			}
+
+			bool operator==(const Iterator& other) const {
+				return mCurrent == other.mCurrent;
+			}
+
+			bool operator!=(const Iterator& other) const {
+				return !(*this == other);
+			}
+
+			Vector<BaseType> operator*() const {
+				return mCurrent;
+			}
+
+		private:
+			Vector<BaseType> mCurrent;
+			const Vector<BaseType> mSize;
+		};
+
+
+		VectorSizeRange(Vector<BaseType> size) :
 			mSize(size)
 		{}
-		Iterator(const Iterator& other) = default;
-		Iterator& operator=(const Iterator& other) = default;
 
-		Iterator& operator++() {
-			++mCurrent.x;
-			if (mCurrent.x >= mSize.x) {
-				mCurrent.x = 0;
-				++mCurrent.y;
-			}
-			return *this;
+		Iterator begin() const {
+			return Iterator{mSize};
 		}
 
-		Iterator& operator--() {
-			if (mCurrent.x <= 0) {
-				mCurrent.x = mSize.x;
-				--mCurrent.y;
-			}
-			--mCurrent.x;
-			return *this;
-		}
-
-		bool operator==(const Iterator& other) const {
-			return mCurrent == other.mCurrent;
-		}
-
-		bool operator!=(const Iterator& other) const {
-			return !(*this == other);
-		}
-
-		Vector<BaseType> operator*() const {
-			return mCurrent;
+		Iterator end() const {
+			return Iterator{mSize, Vector<BaseType>{0, mSize.y}};
 		}
 
 	private:
-		Vector<BaseType> mCurrent;
 		const Vector<BaseType> mSize;
 	};
-
-
-	VectorSizeRange(Vector<BaseType> size) :
-		mSize(size)
-	{}
-
-	Iterator begin() const {
-		return Iterator{mSize};
-	}
-
-	Iterator end() const {
-		return Iterator{mSize, Vector<BaseType>{0, mSize.y}};
-	}
-
-private:
-	const Vector<BaseType> mSize;
-};
 
 } // namespace

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -65,244 +65,244 @@ const std::vector<AnimationSet::Frame>& AnimationSet::frames(const std::string& 
 
 namespace {
 
-/**
- * Parses a Sprite XML Definition File.
- *
- * \param filePath	File path of the sprite XML definition file.
- */
-AnimationSet processXml(std::string filePath, ImageCache& imageCache)
-{
-	try
+	/**
+	 * Parses a Sprite XML Definition File.
+	 *
+	 * \param filePath	File path of the sprite XML definition file.
+	 */
+	AnimationSet processXml(std::string filePath, ImageCache& imageCache)
 	{
-		auto& filesystem = Utility<Filesystem>::get();
-		const auto basePath = filesystem.workingPath(filePath);
-
-		Xml::XmlDocument xmlDoc;
-		xmlDoc.parse(filesystem.open(filePath).raw_bytes());
-
-		if (xmlDoc.error())
+		try
 		{
-			throw std::runtime_error("Sprite file has malformed XML: Row: " + std::to_string(xmlDoc.errorRow()) + " Column: " + std::to_string(xmlDoc.errorCol()) + " : " + xmlDoc.errorDesc());
-		}
+			auto& filesystem = Utility<Filesystem>::get();
+			const auto basePath = filesystem.workingPath(filePath);
 
-		// Find the Sprite node.
-		const auto* xmlRootElement = xmlDoc.firstChildElement("sprite");
-		if (!xmlRootElement)
-		{
-			throw std::runtime_error("Sprite file does not contain required <sprite> tag");
-		}
+			Xml::XmlDocument xmlDoc;
+			xmlDoc.parse(filesystem.open(filePath).raw_bytes());
 
-		// Get the Sprite version.
-		const auto* version = xmlRootElement->firstAttribute();
-		if (!version || version->value().empty())
-		{
-			throw std::runtime_error("Sprite file's root element does not specify a version");
-		}
-		if (version->value() != SPRITE_VERSION)
-		{
-			throw std::runtime_error("Sprite version mismatch. Expected: " + std::string{SPRITE_VERSION} + " Actual: " + versionString());
-		}
-
-		// Note:
-		// Here instead of going through each element and calling a processing function to handle
-		// it, we just iterate through all nodes to find sprite sheets. This allows us to define
-		// image sheets anywhere in the sprite file.
-		auto imageSheetMap = processImageSheets(basePath, xmlRootElement, imageCache);
-		auto actions = processActions(imageSheetMap, xmlRootElement, imageCache);
-		return {std::move(filePath), std::move(imageSheetMap), std::move(actions)};
-	}
-	catch(const std::runtime_error& error)
-	{
-		throw std::runtime_error("Error parsing Sprite file: " + filePath + "\nError: " + error.what());
-	}
-}
-
-
-/**
- * Iterates through all elements of a Sprite XML definition looking
- * for 'imagesheet' elements and processes them.
- *
- * \note	Since 'imagesheet' elements are processed before any other
- *			element in a sprite definition, these elements can appear
- *			anywhere in a Sprite XML definition.
- */
-std::map<std::string, std::string> processImageSheets(const std::string& basePath, const Xml::XmlElement* element, ImageCache& imageCache)
-{
-	std::map<std::string, std::string> imageSheetMap;
-
-	for (const auto* node = element->iterateChildren(nullptr);
-		node != nullptr;
-		node = element->iterateChildren(node))
-	{
-		if (node->value() == "imagesheet" && node->toElement())
-		{
-			std::string id, src;
-			const auto* attribute = node->toElement()->firstAttribute();
-			while (attribute)
+			if (xmlDoc.error())
 			{
-				if (toLowercase(attribute->name()) == "id") { id = attribute->value(); }
-				else if (toLowercase(attribute->name()) == "src") { src = attribute->value(); }
-
-				attribute = attribute->next();
+				throw std::runtime_error("Sprite file has malformed XML: Row: " + std::to_string(xmlDoc.errorRow()) + " Column: " + std::to_string(xmlDoc.errorCol()) + " : " + xmlDoc.errorDesc());
 			}
 
-			if (id.empty())
+			// Find the Sprite node.
+			const auto* xmlRootElement = xmlDoc.firstChildElement("sprite");
+			if (!xmlRootElement)
 			{
-				throw std::runtime_error("Sprite imagesheet definition has `id` of length zero: " + endTag(node->row()));
+				throw std::runtime_error("Sprite file does not contain required <sprite> tag");
 			}
 
-			if (src.empty())
+			// Get the Sprite version.
+			const auto* version = xmlRootElement->firstAttribute();
+			if (!version || version->value().empty())
 			{
-				throw std::runtime_error("Sprite imagesheet definition has `src` of length zero: " + endTag(node->row()));
+				throw std::runtime_error("Sprite file's root element does not specify a version");
+			}
+			if (version->value() != SPRITE_VERSION)
+			{
+				throw std::runtime_error("Sprite version mismatch. Expected: " + std::string{SPRITE_VERSION} + " Actual: " + versionString());
 			}
 
-			if (imageSheetMap.find(id) != imageSheetMap.end())
-			{
-				throw std::runtime_error("Sprite image sheet redefinition: id: '" + id + "' " + endTag(node->row()));
-			}
-
-			const auto imagePath = basePath + src;
-			imageSheetMap.try_emplace(id, imagePath);
-			imageCache.load(imagePath);
+			// Note:
+			// Here instead of going through each element and calling a processing function to handle
+			// it, we just iterate through all nodes to find sprite sheets. This allows us to define
+			// image sheets anywhere in the sprite file.
+			auto imageSheetMap = processImageSheets(basePath, xmlRootElement, imageCache);
+			auto actions = processActions(imageSheetMap, xmlRootElement, imageCache);
+			return {std::move(filePath), std::move(imageSheetMap), std::move(actions)};
+		}
+		catch(const std::runtime_error& error)
+		{
+			throw std::runtime_error("Error parsing Sprite file: " + filePath + "\nError: " + error.what());
 		}
 	}
 
-	return imageSheetMap;
-}
 
-
-/**
- * Iterates through all elements of a Sprite XML definition looking
- * for 'action' elements and processes them.
- *
- * \note	Action names are not case sensitive. "Case", "caSe",
- *			"CASE", etc. will all be viewed as identical.
- */
-std::map<std::string, std::vector<AnimationSet::Frame>> processActions(const std::map<std::string, std::string>& imageSheetMap, const Xml::XmlElement* element, ImageCache& imageCache)
-{
-	std::map<std::string, std::vector<AnimationSet::Frame>> actions;
-
-	for (const auto* node = element->iterateChildren(nullptr);
-		node != nullptr;
-		node = element->iterateChildren(node))
+	/**
+	 * Iterates through all elements of a Sprite XML definition looking
+	 * for 'imagesheet' elements and processes them.
+	 *
+	 * \note	Since 'imagesheet' elements are processed before any other
+	 *			element in a sprite definition, these elements can appear
+	 *			anywhere in a Sprite XML definition.
+	 */
+	std::map<std::string, std::string> processImageSheets(const std::string& basePath, const Xml::XmlElement* element, ImageCache& imageCache)
 	{
-		if (toLowercase(node->value()) == "action" && node->toElement())
-		{
+		std::map<std::string, std::string> imageSheetMap;
 
-			std::string actionName;
-			const auto* attribute = node->toElement()->firstAttribute();
-			while (attribute)
+		for (const auto* node = element->iterateChildren(nullptr);
+			node != nullptr;
+			node = element->iterateChildren(node))
+		{
+			if (node->value() == "imagesheet" && node->toElement())
 			{
-				if (toLowercase(attribute->name()) == "name")
+				std::string id, src;
+				const auto* attribute = node->toElement()->firstAttribute();
+				while (attribute)
 				{
-					actionName = attribute->value();
+					if (toLowercase(attribute->name()) == "id") { id = attribute->value(); }
+					else if (toLowercase(attribute->name()) == "src") { src = attribute->value(); }
+
+					attribute = attribute->next();
+				}
+
+				if (id.empty())
+				{
+					throw std::runtime_error("Sprite imagesheet definition has `id` of length zero: " + endTag(node->row()));
+				}
+
+				if (src.empty())
+				{
+					throw std::runtime_error("Sprite imagesheet definition has `src` of length zero: " + endTag(node->row()));
+				}
+
+				if (imageSheetMap.find(id) != imageSheetMap.end())
+				{
+					throw std::runtime_error("Sprite image sheet redefinition: id: '" + id + "' " + endTag(node->row()));
+				}
+
+				const auto imagePath = basePath + src;
+				imageSheetMap.try_emplace(id, imagePath);
+				imageCache.load(imagePath);
+			}
+		}
+
+		return imageSheetMap;
+	}
+
+
+	/**
+	 * Iterates through all elements of a Sprite XML definition looking
+	 * for 'action' elements and processes them.
+	 *
+	 * \note	Action names are not case sensitive. "Case", "caSe",
+	 *			"CASE", etc. will all be viewed as identical.
+	 */
+	std::map<std::string, std::vector<AnimationSet::Frame>> processActions(const std::map<std::string, std::string>& imageSheetMap, const Xml::XmlElement* element, ImageCache& imageCache)
+	{
+		std::map<std::string, std::vector<AnimationSet::Frame>> actions;
+
+		for (const auto* node = element->iterateChildren(nullptr);
+			node != nullptr;
+			node = element->iterateChildren(node))
+		{
+			if (toLowercase(node->value()) == "action" && node->toElement())
+			{
+
+				std::string actionName;
+				const auto* attribute = node->toElement()->firstAttribute();
+				while (attribute)
+				{
+					if (toLowercase(attribute->name()) == "name")
+					{
+						actionName = attribute->value();
+					}
+
+					attribute = attribute->next();
+				}
+
+				if (actionName.empty())
+				{
+					throw std::runtime_error("Sprite Action definition has 'name' of length zero: " + endTag(node->row()));
+				}
+				if (actions.find(actionName) != actions.end())
+				{
+					throw std::runtime_error("Sprite Action redefinition: '" + actionName + "' " + endTag(node->row()));
+				}
+
+				actions[actionName] = processFrames(imageSheetMap, actionName, node, imageCache);
+			}
+		}
+
+		return actions;
+	}
+
+
+	/**
+	 * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
+	 */
+	std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, std::string>& imageSheetMap, const std::string& action, const Xml::XmlNode* node, ImageCache& imageCache)
+	{
+		std::vector<AnimationSet::Frame> frameList;
+
+		for (const auto* frame = node->iterateChildren(nullptr);
+			frame != nullptr;
+			frame = node->iterateChildren(frame))
+		{
+			int currentRow = frame->row();
+
+			if (frame->value() != "frame" || !frame->toElement())
+			{
+				throw std::runtime_error("Sprite frame tag unexpected: <" + frame->value() + "> : " + endTag(currentRow));
+			}
+
+			std::string sheetId;
+			int delay = 0;
+			int x = 0, y = 0;
+			int width = 0, height = 0;
+			int anchorx = 0, anchory = 0;
+
+			const auto* attribute = frame->toElement()->firstAttribute();
+			while (attribute)
+			{
+				if (toLowercase(attribute->name()) == "sheetid") { sheetId = attribute->value(); }
+				else if (toLowercase(attribute->name()) == "delay") { attribute->queryIntValue(delay); }
+				else if (toLowercase(attribute->name()) == "x") { attribute->queryIntValue(x); }
+				else if (toLowercase(attribute->name()) == "y") { attribute->queryIntValue(y); }
+				else if (toLowercase(attribute->name()) == "width") { attribute->queryIntValue(width); }
+				else if (toLowercase(attribute->name()) == "height") { attribute->queryIntValue(height); }
+				else if (toLowercase(attribute->name()) == "anchorx") { attribute->queryIntValue(anchorx); }
+				else if (toLowercase(attribute->name()) == "anchory") { attribute->queryIntValue(anchory); }
+				else {
+					throw std::runtime_error("Sprite frame attribute unexpected: '" + attribute->name() + "' : " + endTag(currentRow));
 				}
 
 				attribute = attribute->next();
 			}
 
-			if (actionName.empty())
+			if (sheetId.empty())
 			{
-				throw std::runtime_error("Sprite Action definition has 'name' of length zero: " + endTag(node->row()));
+				throw std::runtime_error("Sprite Frame definition has 'sheetid' of length zero: " + endTag(currentRow));
 			}
-			if (actions.find(actionName) != actions.end())
+			const auto iterator = imageSheetMap.find(sheetId);
+			if (iterator == imageSheetMap.end())
 			{
-				throw std::runtime_error("Sprite Action redefinition: '" + actionName + "' " + endTag(node->row()));
+				throw std::runtime_error("Sprite Frame definition references undefined imagesheet: '" + sheetId + "' " + endTag(currentRow));
 			}
 
-			actions[actionName] = processFrames(imageSheetMap, actionName, node, imageCache);
-		}
-	}
-
-	return actions;
-}
-
-
-/**
- * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
- */
-std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, std::string>& imageSheetMap, const std::string& action, const Xml::XmlNode* node, ImageCache& imageCache)
-{
-	std::vector<AnimationSet::Frame> frameList;
-
-	for (const auto* frame = node->iterateChildren(nullptr);
-		frame != nullptr;
-		frame = node->iterateChildren(frame))
-	{
-		int currentRow = frame->row();
-
-		if (frame->value() != "frame" || !frame->toElement())
-		{
-			throw std::runtime_error("Sprite frame tag unexpected: <" + frame->value() + "> : " + endTag(currentRow));
-		}
-
-		std::string sheetId;
-		int delay = 0;
-		int x = 0, y = 0;
-		int width = 0, height = 0;
-		int anchorx = 0, anchory = 0;
-
-		const auto* attribute = frame->toElement()->firstAttribute();
-		while (attribute)
-		{
-			if (toLowercase(attribute->name()) == "sheetid") { sheetId = attribute->value(); }
-			else if (toLowercase(attribute->name()) == "delay") { attribute->queryIntValue(delay); }
-			else if (toLowercase(attribute->name()) == "x") { attribute->queryIntValue(x); }
-			else if (toLowercase(attribute->name()) == "y") { attribute->queryIntValue(y); }
-			else if (toLowercase(attribute->name()) == "width") { attribute->queryIntValue(width); }
-			else if (toLowercase(attribute->name()) == "height") { attribute->queryIntValue(height); }
-			else if (toLowercase(attribute->name()) == "anchorx") { attribute->queryIntValue(anchorx); }
-			else if (toLowercase(attribute->name()) == "anchory") { attribute->queryIntValue(anchory); }
-			else {
-				throw std::runtime_error("Sprite frame attribute unexpected: '" + attribute->name() + "' : " + endTag(currentRow));
+			const auto& image = imageCache.load(iterator->second);
+			// X-Coordinate
+			if (x < 0 || x > image.size().x)
+			{
+				throw std::runtime_error("Sprite frame attribute 'x' is out of bounds: " + endTag(currentRow));
+			}
+			// Y-Coordinate
+			if (y < 0 || y > image.size().y)
+			{
+				throw std::runtime_error("Sprite frame attribute 'y' is out of bounds: " + endTag(currentRow));
+			}
+			// Width
+			if (width <= 0 || width > image.size().x - x)
+			{
+				throw std::runtime_error("Sprite frame attribute 'width' is out of bounds: " + endTag(currentRow));
+			}
+			// Height
+			if (height <= 0 || height > image.size().y - y)
+			{
+				throw std::runtime_error("Sprite frame attribute 'height' is out of bounds: " + endTag(currentRow));
 			}
 
-			attribute = attribute->next();
+			const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
+			const auto anchorOffset = Vector{anchorx, anchory};
+			frameList.push_back(AnimationSet::Frame{image, bounds, anchorOffset, static_cast<unsigned int>(delay)});
 		}
 
-		if (sheetId.empty())
+		if (frameList.size() <= 0)
 		{
-			throw std::runtime_error("Sprite Frame definition has 'sheetid' of length zero: " + endTag(currentRow));
-		}
-		const auto iterator = imageSheetMap.find(sheetId);
-		if (iterator == imageSheetMap.end())
-		{
-			throw std::runtime_error("Sprite Frame definition references undefined imagesheet: '" + sheetId + "' " + endTag(currentRow));
+			throw std::runtime_error("Sprite Action contains no valid frames: " + action);
 		}
 
-		const auto& image = imageCache.load(iterator->second);
-		// X-Coordinate
-		if (x < 0 || x > image.size().x)
-		{
-			throw std::runtime_error("Sprite frame attribute 'x' is out of bounds: " + endTag(currentRow));
-		}
-		// Y-Coordinate
-		if (y < 0 || y > image.size().y)
-		{
-			throw std::runtime_error("Sprite frame attribute 'y' is out of bounds: " + endTag(currentRow));
-		}
-		// Width
-		if (width <= 0 || width > image.size().x - x)
-		{
-			throw std::runtime_error("Sprite frame attribute 'width' is out of bounds: " + endTag(currentRow));
-		}
-		// Height
-		if (height <= 0 || height > image.size().y - y)
-		{
-			throw std::runtime_error("Sprite frame attribute 'height' is out of bounds: " + endTag(currentRow));
-		}
-
-		const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
-		const auto anchorOffset = Vector{anchorx, anchory};
-		frameList.push_back(AnimationSet::Frame{image, bounds, anchorOffset, static_cast<unsigned int>(delay)});
+		return frameList;
 	}
-
-	if (frameList.size() <= 0)
-	{
-		throw std::runtime_error("Sprite Action contains no valid frames: " + action);
-	}
-
-	return frameList;
-}
 
 }

--- a/NAS2D/Resource/AnimationSet.h
+++ b/NAS2D/Resource/AnimationSet.h
@@ -11,27 +11,27 @@
 
 namespace NAS2D {
 
-class AnimationSet
-{
-public:
-	struct Frame
+	class AnimationSet
 	{
-		const Image& image;
-		Rectangle<int> bounds;
-		Vector<int> anchorOffset;
-		unsigned int frameDelay;
+	public:
+		struct Frame
+		{
+			const Image& image;
+			Rectangle<int> bounds;
+			Vector<int> anchorOffset;
+			unsigned int frameDelay;
+		};
+
+		AnimationSet(std::string fileName);
+		AnimationSet(std::string fileName, std::map<std::string, std::string> imageSheetMap, std::map<std::string, std::vector<Frame>> actions);
+
+		std::vector<std::string> actionNames() const;
+		const std::vector<Frame>& frames(const std::string& actionName) const;
+
+	private:
+		std::string mFileName;
+		std::map<std::string, std::string> mImageSheetMap;
+		std::map<std::string, std::vector<Frame>> mActions;
 	};
-
-	AnimationSet(std::string fileName);
-	AnimationSet(std::string fileName, std::map<std::string, std::string> imageSheetMap, std::map<std::string, std::vector<Frame>> actions);
-
-	std::vector<std::string> actionNames() const;
-	const std::vector<Frame>& frames(const std::string& actionName) const;
-
-private:
-	std::string mFileName;
-	std::map<std::string, std::string> mImageSheetMap;
-	std::map<std::string, std::vector<Frame>> mActions;
-};
 
 } // namespace

--- a/NAS2D/Resource/Font.h
+++ b/NAS2D/Resource/Font.h
@@ -19,72 +19,72 @@
 
 namespace NAS2D {
 
-/**
- * Font resource.
- *
- * The Font class can be used to render TrueType, OpenType and Bitmap fonts. Two
- * contructors are provided for these types.
- *
- * TrueType and OpenType fonts generate their own glyph map internally. Only
- * the ASCII values 0 - 255 are used. Unicode/UTF is not supported.
- *
- * Bitmap fonts are expected to be in a 16x16 glyph matrix with the top left
- * glyph cell equating to ASCII value '0'. Glyph values increase from left to
- * right up to ASCII value 255.
- */
-class Font
-{
-public:
-
-	struct GlyphMetrics
-	{
-		Rectangle<float> uvRect{};
-		int minX{0};
-		int minY{0};
-		int maxX{0};
-		int maxY{0};
-		int advance{0};
-	};
-
 	/**
-	 * Struct containing basic information related to Fonts. Not part of the public
-	 * interface.
+	 * Font resource.
+	 *
+	 * The Font class can be used to render TrueType, OpenType and Bitmap fonts. Two
+	 * contructors are provided for these types.
+	 *
+	 * TrueType and OpenType fonts generate their own glyph map internally. Only
+	 * the ASCII values 0 - 255 are used. Unicode/UTF is not supported.
+	 *
+	 * Bitmap fonts are expected to be in a 16x16 glyph matrix with the top left
+	 * glyph cell equating to ASCII value '0'. Glyph values increase from left to
+	 * right up to ASCII value 255.
 	 */
-	struct FontInfo
+	class Font
 	{
-		unsigned int textureId{0u};
-		unsigned int pointSize{0u};
-		int height{0};
-		int ascent{0};
-		Vector<int> glyphSize;
-		std::vector<GlyphMetrics> metrics;
+	public:
+
+		struct GlyphMetrics
+		{
+			Rectangle<float> uvRect{};
+			int minX{0};
+			int minY{0};
+			int maxX{0};
+			int maxY{0};
+			int advance{0};
+		};
+
+		/**
+		 * Struct containing basic information related to Fonts. Not part of the public
+		 * interface.
+		 */
+		struct FontInfo
+		{
+			unsigned int textureId{0u};
+			unsigned int pointSize{0u};
+			int height{0};
+			int ascent{0};
+			Vector<int> glyphSize;
+			std::vector<GlyphMetrics> metrics;
+		};
+
+
+		Font(const std::string& filePath, unsigned int ptSize);
+		explicit Font(const std::string& filePath);
+		Font(const Font& font) = delete;
+		Font& operator=(const Font& font) = delete;
+		~Font();
+
+		const std::string& name() const { return mResourceName; }
+
+		Vector<int> glyphCellSize() const;
+		Vector<int> size(std::string_view string) const;
+		int width(std::string_view string) const;
+		int height() const;
+		int ascent() const;
+		unsigned int ptSize() const;
+		const std::vector<GlyphMetrics>& metrics() const;
+
+		// Temporary method, that will be removed in a future refactor
+		// Intended only to be used by RendererOpenGL
+		// As it is so specific, it should not be part of the Font class, nor FontInfo
+		unsigned int textureId() const;
+
+	private:
+		std::string mResourceName; /**< File path */
+		FontInfo mFontInfo;
 	};
-
-
-	Font(const std::string& filePath, unsigned int ptSize);
-	explicit Font(const std::string& filePath);
-	Font(const Font& font) = delete;
-	Font& operator=(const Font& font) = delete;
-	~Font();
-
-	const std::string& name() const { return mResourceName; }
-
-	Vector<int> glyphCellSize() const;
-	Vector<int> size(std::string_view string) const;
-	int width(std::string_view string) const;
-	int height() const;
-	int ascent() const;
-	unsigned int ptSize() const;
-	const std::vector<GlyphMetrics>& metrics() const;
-
-	// Temporary method, that will be removed in a future refactor
-	// Intended only to be used by RendererOpenGL
-	// As it is so specific, it should not be part of the Font class, nor FontInfo
-	unsigned int textureId() const;
-
-private:
-	std::string mResourceName; /**< File path */
-	FontInfo mFontInfo;
-};
 
 } // namespace

--- a/NAS2D/Resource/Image.h
+++ b/NAS2D/Resource/Image.h
@@ -23,46 +23,46 @@ struct SDL_Surface;
 
 namespace NAS2D {
 
-/**
- * Image Class
- *
- * Provides a high level interface for image files. Can load the following formats:
- * - BMP
- * - JPEG
- * - PCX
- * - PNG
- * - TGA
- * - TIFF
- * - WEBP
- */
-class Image
-{
-public:
-	explicit Image(const std::string& filePath);
-	Image(void* buffer, int bytesPerPixel, Vector<int> size);
+	/**
+	 * Image Class
+	 *
+	 * Provides a high level interface for image files. Can load the following formats:
+	 * - BMP
+	 * - JPEG
+	 * - PCX
+	 * - PNG
+	 * - TGA
+	 * - TIFF
+	 * - WEBP
+	 */
+	class Image
+	{
+	public:
+		explicit Image(const std::string& filePath);
+		Image(void* buffer, int bytesPerPixel, Vector<int> size);
 
-	Image(const Image &rhs) = delete;
-	Image& operator=(const Image& rhs) = delete;
+		Image(const Image &rhs) = delete;
+		Image& operator=(const Image& rhs) = delete;
 
-	~Image();
+		~Image();
 
-	const std::string& name() const { return mResourceName; }
+		const std::string& name() const { return mResourceName; }
 
-	Vector<int> size() const;
+		Vector<int> size() const;
 
-	Color pixelColor(Point<int> point) const;
+		Color pixelColor(Point<int> point) const;
 
-protected:
-	friend class RendererOpenGL;
-	unsigned int textureId() const;
-	unsigned int frameBufferObjectId() const;
+	protected:
+		friend class RendererOpenGL;
+		unsigned int textureId() const;
+		unsigned int frameBufferObjectId() const;
 
-private:
-	std::string mResourceName; /**< File path or internal identifier. */
-	SDL_Surface* mSurface{nullptr};
-	unsigned int mTextureId{0u};
-	mutable unsigned int mFrameBufferObjectId{0u};
-	Vector<int> mSize{0, 0};
-};
+	private:
+		std::string mResourceName; /**< File path or internal identifier. */
+		SDL_Surface* mSurface{nullptr};
+		unsigned int mTextureId{0u};
+		mutable unsigned int mFrameBufferObjectId{0u};
+		Vector<int> mSize{0, 0};
+	};
 
 } // namespace

--- a/NAS2D/Resource/Music.h
+++ b/NAS2D/Resource/Music.h
@@ -21,29 +21,29 @@ typedef struct _Mix_Music Mix_Music;
 
 namespace NAS2D {
 
-/**
- *  Music resource.
- */
-class Music
-{
-public:
-	explicit Music(const std::string& filePath);
+	/**
+	 *  Music resource.
+	 */
+	class Music
+	{
+	public:
+		explicit Music(const std::string& filePath);
 
-	Music(const Music& rhs) = delete;
-	Music& operator=(const Music& rhs) = delete;
+		Music(const Music& rhs) = delete;
+		Music& operator=(const Music& rhs) = delete;
 
-	~Music();
+		~Music();
 
-	const std::string& name() const { return mResourceName; }
+		const std::string& name() const { return mResourceName; }
 
-protected:
-	friend class MixerSDL;
-	Mix_Music* music() const;
+	protected:
+		friend class MixerSDL;
+		Mix_Music* music() const;
 
-private:
-	std::string mResourceName; /**< File path */
-	const File mBuffer;
-	Mix_Music* mMusic{nullptr};
-};
+	private:
+		std::string mResourceName; /**< File path */
+		const File mBuffer;
+		Mix_Music* mMusic{nullptr};
+	};
 
 } // namespace

--- a/NAS2D/Resource/ResourceCache.h
+++ b/NAS2D/Resource/ResourceCache.h
@@ -6,51 +6,51 @@
 
 namespace NAS2D {
 
-template <typename Resource, typename ... Params>
-class ResourceCache
-{
-public:
-	using Key = std::tuple<Params...>;
-
-
-	const Resource& load(Params... params)
+	template <typename Resource, typename ... Params>
+	class ResourceCache
 	{
-		// Cache lookup key is a tuple of all Resource constructor parameters
-		const auto key = Key{params...};
+	public:
+		using Key = std::tuple<Params...>;
 
-		// Try to find resource from the cache
-		auto iter = cache.find(key);
-		if (iter == cache.end())
+
+		const Resource& load(Params... params)
 		{
-			// Resource wasn't found, so create new one using constructor parameters
-			const auto pairIterBool = cache.try_emplace(key, params...);
-			iter = pairIterBool.first;
+			// Cache lookup key is a tuple of all Resource constructor parameters
+			const auto key = Key{params...};
+
+			// Try to find resource from the cache
+			auto iter = cache.find(key);
+			if (iter == cache.end())
+			{
+				// Resource wasn't found, so create new one using constructor parameters
+				const auto pairIterBool = cache.try_emplace(key, params...);
+				iter = pairIterBool.first;
+			}
+
+			// Return reference to found or created cached object
+			return iter->second;
 		}
 
-		// Return reference to found or created cached object
-		return iter->second;
-	}
+
+		void unload(Params... params)
+		{
+			cache.erase(Key{params...});
+		}
 
 
-	void unload(Params... params)
-	{
-		cache.erase(Key{params...});
-	}
+		void clear()
+		{
+			cache.clear();
+		}
 
 
-	void clear()
-	{
-		cache.clear();
-	}
+		auto size() const
+		{
+			return cache.size();
+		}
 
-
-	auto size() const
-	{
-		return cache.size();
-	}
-
-private:
-	std::map<Key, Resource> cache;
-};
+	private:
+		std::map<Key, Resource> cache;
+	};
 
 } // namespace

--- a/NAS2D/Resource/Sound.h
+++ b/NAS2D/Resource/Sound.h
@@ -17,32 +17,32 @@ struct Mix_Chunk;
 
 namespace NAS2D {
 
-/**
- *  Sound resource.
- *
- *  Represents a Sound.
- */
-class Sound
-{
-public:
-	explicit Sound(const std::string& filePath);
+	/**
+	 *  Sound resource.
+	 *
+	 *  Represents a Sound.
+	 */
+	class Sound
+	{
+	public:
+		explicit Sound(const std::string& filePath);
 
-	Sound(const Sound& other) = delete;
-	Sound(Sound&& other) = delete;
-	Sound& operator=(const Sound& rhs) = delete;
-	Sound& operator=(Sound&& other) = delete;
+		Sound(const Sound& other) = delete;
+		Sound(Sound&& other) = delete;
+		Sound& operator=(const Sound& rhs) = delete;
+		Sound& operator=(Sound&& other) = delete;
 
-	~Sound();
+		~Sound();
 
-	const std::string& name() const { return mResourceName; }
+		const std::string& name() const { return mResourceName; }
 
-protected:
-	friend class MixerSDL;
-	Mix_Chunk* sound() const;
+	protected:
+		friend class MixerSDL;
+		Mix_Chunk* sound() const;
 
-private:
-	std::string mResourceName; /**< File path */
-	Mix_Chunk* mMixChunk{nullptr};
-};
+	private:
+		std::string mResourceName; /**< File path */
+		Mix_Chunk* mMixChunk{nullptr};
+	};
 
 } // namespace

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -21,57 +21,57 @@
 
 namespace NAS2D {
 
-/**
- * Sprite resource.
- *
- * The Sprite Class is a self-contained group of Image resources that displays
- * Images at a specified screen coordinate in sequence to display an animation.
- */
-class Sprite
-{
-public:
-	using AnimationCompleteSignal = Signal<>; /**< Signal used when action animations complete. */
+	/**
+	 * Sprite resource.
+	 *
+	 * The Sprite Class is a self-contained group of Image resources that displays
+	 * Images at a specified screen coordinate in sequence to display an animation.
+	 */
+	class Sprite
+	{
+	public:
+		using AnimationCompleteSignal = Signal<>; /**< Signal used when action animations complete. */
 
-	Sprite(const std::string& filePath, const std::string& initialAction);
+		Sprite(const std::string& filePath, const std::string& initialAction);
 
-	Vector<int> size() const;
-	Point<int> origin(Point<int> point) const;
+		Vector<int> size() const;
+		Point<int> origin(Point<int> point) const;
 
-	std::vector<std::string> actions() const;
+		std::vector<std::string> actions() const;
 
-	void play(const std::string& action);
-	void pause();
-	void resume();
+		void play(const std::string& action);
+		void pause();
+		void resume();
 
-	void setFrame(std::size_t frameIndex);
-	void incrementFrame();
-	void decrementFrame();
+		void setFrame(std::size_t frameIndex);
+		void incrementFrame();
+		void decrementFrame();
 
-	void update(Point<float> position);
+		void update(Point<float> position);
 
-	void rotation(float angle);
-	float rotation() const;
+		void rotation(float angle);
+		float rotation() const;
 
-	void alpha(uint8_t alpha);
-	uint8_t alpha() const;
-	void color(Color color);
-	Color color() const;
+		void alpha(uint8_t alpha);
+		uint8_t alpha() const;
+		void color(Color color);
+		Color color() const;
 
-	AnimationCompleteSignal::Source& animationCompleteSignalSource();
+		AnimationCompleteSignal::Source& animationCompleteSignalSource();
 
-private:
-	std::string mSpriteName;
+	private:
+		std::string mSpriteName;
 
-	const AnimationSet* mAnimationSet;
-	const std::vector<AnimationSet::Frame>* mCurrentAction{nullptr};
-	std::size_t mCurrentFrame{0};
+		const AnimationSet* mAnimationSet;
+		const std::vector<AnimationSet::Frame>* mCurrentAction{nullptr};
+		std::size_t mCurrentFrame{0};
 
-	bool mPaused{false};
-	Timer mTimer;
-	AnimationCompleteSignal mAnimationCompleteSignal;
+		bool mPaused{false};
+		Timer mTimer;
+		AnimationCompleteSignal mAnimationCompleteSignal;
 
-	Color mColor{Color::Normal}; /**< Color tint to use for drawing the sprite. */
-	float mRotationAngle{0.0f}; /**< Angle of rotation in degrees. */
-};
+		Color mColor{Color::Normal}; /**< Color tint to use for drawing the sprite. */
+		float mRotationAngle{0.0f}; /**< Angle of rotation in degrees. */
+	};
 
 } // namespace

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -54,430 +54,430 @@
 
 namespace NAS2D {
 
-namespace detail {
+	namespace detail {
 
-template <typename OutputClass, typename InputClass>
-union horrible_union { OutputClass out; InputClass in; };
+		template <typename OutputClass, typename InputClass>
+		union horrible_union { OutputClass out; InputClass in; };
 
-template <typename OutputClass, typename InputClass>
-inline OutputClass horrible_cast(const InputClass input)
-{
-	horrible_union<OutputClass, InputClass> u;
-	static_assert(sizeof(InputClass) != sizeof(u) || sizeof(InputClass) != sizeof(OutputClass), "Can't use horrible cast");
-	u.in = input;
-	return u.out;
-}
-
-
-// ==================================================================================
-// = WORKAROUNDS
-// ==================================================================================
-using DefaultVoid = void;
-
-// Translate from 'DefaultVoid' to 'void'.
-template <typename T>
-struct DefaultVoidToVoid { using type = T; };
-
-template <>
-struct DefaultVoidToVoid<DefaultVoid> { using type = void; };
-
-// Translate from 'void' into 'DefaultVoid'
-template <typename T>
-struct VoidToDefaultVoid { using type = T; };
-
-template <>
-struct VoidToDefaultVoid<void> { using type = DefaultVoid; };
-
-
-template <typename GenericMemFuncType, typename XFuncType>
-GenericMemFuncType CastMemFuncPtr(XFuncType function_to_bind)
-{
-	#if __GNUC__ >= 8
-	#pragma GCC diagnostic push
-	#pragma GCC diagnostic ignored "-Wcast-function-type"
-	#endif
-	return reinterpret_cast<GenericMemFuncType>(function_to_bind);
-	#if __GNUC__ >= 8
-	#pragma GCC diagnostic pop
-	#endif
-}
-
-// GenericClass is a fake class, ONLY used to provide a type. It is vitally important
-// that it is never defined.
-#ifdef FASTDLGT_MICROSOFT_MFP
-
-#ifdef FASTDLGT_HASINHERITANCE_KEYWORDS
-	class __single_inheritance GenericClass;
-#endif
-	class GenericClass {};
-#else
-	class GenericClass;
-#endif
-
-const int SINGLE_MEMFUNCPTR_SIZE = sizeof(void (GenericClass::*)());
-
-template <int N>
-struct SimplifyMemFunc
-{
-	template <typename X, typename XFuncType, typename GenericMemFuncType>
-	inline static GenericClass* Convert(X* /*pthis*/, XFuncType /*function_to_bind*/, GenericMemFuncType& /*bound_func*/)
-	{
-		static_assert(N < 100, "Unsupported member function pointer on this compiler");
-		return nullptr;
-	}
-};
-
-template <>
-struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE>
-{
-	template <typename X, typename XFuncType, typename GenericMemFuncType>
-	inline static GenericClass* Convert(X* pthis, XFuncType function_to_bind, GenericMemFuncType& bound_func)
-	{
-		#if defined __DMC__
-		bound_func = horrible_cast<GenericMemFuncType>(function_to_bind);
-		#else
-		bound_func = CastMemFuncPtr<GenericMemFuncType>(function_to_bind);
-		#endif
-		return reinterpret_cast<GenericClass*>(pthis);
-	}
-};
-
-#ifdef FASTDLGT_MICROSOFT_MFP
-
-template <>
-struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE + sizeof(int)>
-{
-	template <typename X, typename XFuncType, typename GenericMemFuncType>
-	inline static GenericClass* Convert(X* pthis, XFuncType function_to_bind, GenericMemFuncType& bound_func)
-	{
-		union
+		template <typename OutputClass, typename InputClass>
+		inline OutputClass horrible_cast(const InputClass input)
 		{
-			XFuncType func;
-			struct { GenericMemFuncType funcaddress; int delta; } s;
-		} u;
-
-		static_assert(sizeof(function_to_bind) == sizeof(u.s), "Can't use horrible cast");
-		u.func = function_to_bind;
-		bound_func = u.s.funcaddress;
-		return reinterpret_cast<GenericClass*>(reinterpret_cast<char*>(pthis) + u.s.delta);
-	}
-};
-
-
-struct MicrosoftVirtualMFP
-{
-	void (GenericClass::*codeptr)();
-	int delta;
-	int vtable_index;
-};
-
-
-struct GenericVirtualClass : virtual public GenericClass
-{
-	using ProbePtrType = GenericVirtualClass* (GenericVirtualClass::*)();
-	GenericVirtualClass* GetThis() { return this; }
-};
-
-
-template <>
-struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE + 2 * sizeof(int)>
-{
-	template <typename X, typename XFuncType, typename GenericMemFuncType>
-	inline static GenericClass* Convert(X* pthis, XFuncType function_to_bind, GenericMemFuncType& bound_func)
-	{
-		union { XFuncType func; GenericClass* (X::*ProbeFunc)(); MicrosoftVirtualMFP s; } u;
-		u.func = function_to_bind;
-		bound_func = CastMemFuncPtr<GenericMemFuncType>(u.s.codeptr);
-		union { GenericVirtualClass::ProbePtrType virtfunc; MicrosoftVirtualMFP s; } u2;
-
-		static_assert(sizeof(function_to_bind) == sizeof(u.s) && sizeof(function_to_bind) == sizeof(u.ProbeFunc) && sizeof(u2.virtfunc) == sizeof(u2.s), "Can't use horrible cast");
-
-		u2.virtfunc = &GenericVirtualClass::GetThis;
-		u.s.codeptr = u2.s.codeptr;
-		return (pthis->*u.ProbeFunc)();
-	}
-};
-
-
-#if (_MSC_VER <1300)
-#error Support for this compiler is no longer provided. Please upgrade.
-#else
-template <>
-struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE + 3 * sizeof(int)>
-{
-	template <typename X, typename XFuncType, typename GenericMemFuncType>
-	inline static GenericClass* Convert(X* pthis, XFuncType function_to_bind, GenericMemFuncType& bound_func)
-	{
-		union
-		{
-			XFuncType func;
-			struct
-			{
-				GenericMemFuncType m_funcaddress;
-				int delta;
-				int vtordisp;
-				int vtable_index;
-			} s;
-		} u;
-
-		static_assert(sizeof(XFuncType) != sizeof(u.s), "Can't use horrible cast");
-		u.func = function_to_bind;
-		bound_func = u.s.funcaddress;
-		int virtual_delta = 0;
-		if (u.s.vtable_index)
-		{
-			const int* vtable = *reinterpret_cast<const int* const*>(reinterpret_cast<const char*>(pthis) + u.s.vtordisp );
-			virtual_delta = u.s.vtordisp + *reinterpret_cast<const int*>(reinterpret_cast<const char*>(vtable) + u.s.vtable_index);
+			horrible_union<OutputClass, InputClass> u;
+			static_assert(sizeof(InputClass) != sizeof(u) || sizeof(InputClass) != sizeof(OutputClass), "Can't use horrible cast");
+			u.in = input;
+			return u.out;
 		}
-		return reinterpret_cast<GenericClass*>(reinterpret_cast<char*>(pthis) + u.s.delta + virtual_delta);
+
+
+		// ==================================================================================
+		// = WORKAROUNDS
+		// ==================================================================================
+		using DefaultVoid = void;
+
+		// Translate from 'DefaultVoid' to 'void'.
+		template <typename T>
+		struct DefaultVoidToVoid { using type = T; };
+
+		template <>
+		struct DefaultVoidToVoid<DefaultVoid> { using type = void; };
+
+		// Translate from 'void' into 'DefaultVoid'
+		template <typename T>
+		struct VoidToDefaultVoid { using type = T; };
+
+		template <>
+		struct VoidToDefaultVoid<void> { using type = DefaultVoid; };
+
+
+		template <typename GenericMemFuncType, typename XFuncType>
+		GenericMemFuncType CastMemFuncPtr(XFuncType function_to_bind)
+		{
+			#if __GNUC__ >= 8
+			#pragma GCC diagnostic push
+			#pragma GCC diagnostic ignored "-Wcast-function-type"
+			#endif
+			return reinterpret_cast<GenericMemFuncType>(function_to_bind);
+			#if __GNUC__ >= 8
+			#pragma GCC diagnostic pop
+			#endif
+		}
+
+		// GenericClass is a fake class, ONLY used to provide a type. It is vitally important
+		// that it is never defined.
+		#ifdef FASTDLGT_MICROSOFT_MFP
+
+		#ifdef FASTDLGT_HASINHERITANCE_KEYWORDS
+			class __single_inheritance GenericClass;
+		#endif
+			class GenericClass {};
+		#else
+			class GenericClass;
+		#endif
+
+		const int SINGLE_MEMFUNCPTR_SIZE = sizeof(void (GenericClass::*)());
+
+		template <int N>
+		struct SimplifyMemFunc
+		{
+			template <typename X, typename XFuncType, typename GenericMemFuncType>
+			inline static GenericClass* Convert(X* /*pthis*/, XFuncType /*function_to_bind*/, GenericMemFuncType& /*bound_func*/)
+			{
+				static_assert(N < 100, "Unsupported member function pointer on this compiler");
+				return nullptr;
+			}
+		};
+
+		template <>
+		struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE>
+		{
+			template <typename X, typename XFuncType, typename GenericMemFuncType>
+			inline static GenericClass* Convert(X* pthis, XFuncType function_to_bind, GenericMemFuncType& bound_func)
+			{
+				#if defined __DMC__
+				bound_func = horrible_cast<GenericMemFuncType>(function_to_bind);
+				#else
+				bound_func = CastMemFuncPtr<GenericMemFuncType>(function_to_bind);
+				#endif
+				return reinterpret_cast<GenericClass*>(pthis);
+			}
+		};
+
+		#ifdef FASTDLGT_MICROSOFT_MFP
+
+		template <>
+		struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE + sizeof(int)>
+		{
+			template <typename X, typename XFuncType, typename GenericMemFuncType>
+			inline static GenericClass* Convert(X* pthis, XFuncType function_to_bind, GenericMemFuncType& bound_func)
+			{
+				union
+				{
+					XFuncType func;
+					struct { GenericMemFuncType funcaddress; int delta; } s;
+				} u;
+
+				static_assert(sizeof(function_to_bind) == sizeof(u.s), "Can't use horrible cast");
+				u.func = function_to_bind;
+				bound_func = u.s.funcaddress;
+				return reinterpret_cast<GenericClass*>(reinterpret_cast<char*>(pthis) + u.s.delta);
+			}
+		};
+
+
+		struct MicrosoftVirtualMFP
+		{
+			void (GenericClass::*codeptr)();
+			int delta;
+			int vtable_index;
+		};
+
+
+		struct GenericVirtualClass : virtual public GenericClass
+		{
+			using ProbePtrType = GenericVirtualClass* (GenericVirtualClass::*)();
+			GenericVirtualClass* GetThis() { return this; }
+		};
+
+
+		template <>
+		struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE + 2 * sizeof(int)>
+		{
+			template <typename X, typename XFuncType, typename GenericMemFuncType>
+			inline static GenericClass* Convert(X* pthis, XFuncType function_to_bind, GenericMemFuncType& bound_func)
+			{
+				union { XFuncType func; GenericClass* (X::*ProbeFunc)(); MicrosoftVirtualMFP s; } u;
+				u.func = function_to_bind;
+				bound_func = CastMemFuncPtr<GenericMemFuncType>(u.s.codeptr);
+				union { GenericVirtualClass::ProbePtrType virtfunc; MicrosoftVirtualMFP s; } u2;
+
+				static_assert(sizeof(function_to_bind) == sizeof(u.s) && sizeof(function_to_bind) == sizeof(u.ProbeFunc) && sizeof(u2.virtfunc) == sizeof(u2.s), "Can't use horrible cast");
+
+				u2.virtfunc = &GenericVirtualClass::GetThis;
+				u.s.codeptr = u2.s.codeptr;
+				return (pthis->*u.ProbeFunc)();
+			}
+		};
+
+
+		#if (_MSC_VER <1300)
+		#error Support for this compiler is no longer provided. Please upgrade.
+		#else
+		template <>
+		struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE + 3 * sizeof(int)>
+		{
+			template <typename X, typename XFuncType, typename GenericMemFuncType>
+			inline static GenericClass* Convert(X* pthis, XFuncType function_to_bind, GenericMemFuncType& bound_func)
+			{
+				union
+				{
+					XFuncType func;
+					struct
+					{
+						GenericMemFuncType m_funcaddress;
+						int delta;
+						int vtordisp;
+						int vtable_index;
+					} s;
+				} u;
+
+				static_assert(sizeof(XFuncType) != sizeof(u.s), "Can't use horrible cast");
+				u.func = function_to_bind;
+				bound_func = u.s.funcaddress;
+				int virtual_delta = 0;
+				if (u.s.vtable_index)
+				{
+					const int* vtable = *reinterpret_cast<const int* const*>(reinterpret_cast<const char*>(pthis) + u.s.vtordisp );
+					virtual_delta = u.s.vtordisp + *reinterpret_cast<const int*>(reinterpret_cast<const char*>(vtable) + u.s.vtable_index);
+				}
+				return reinterpret_cast<GenericClass*>(reinterpret_cast<char*>(pthis) + u.s.delta + virtual_delta);
+			};
+		};
+		#endif
+		#endif
+	}
+
+
+	class DelegateMemento
+	{
+	protected:
+		using GenericMemFuncType = void (detail::GenericClass::*)();
+		detail::GenericClass* m_pthis;
+		GenericMemFuncType m_pFunction;
+
+	#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
+		using GenericFuncPtr = void(*)();
+		GenericFuncPtr m_pStaticFunction;
+	#endif
+
+	public:
+	#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
+		DelegateMemento() : m_pthis(nullptr), m_pFunction(nullptr), m_pStaticFunction(nullptr) {};
+		void clear() { m_pthis = nullptr; m_pFunction = nullptr; m_pStaticFunction = nullptr; }
+	#else
+		DelegateMemento() : m_pthis(nullptr), m_pFunction(nullptr) {}
+		void clear() { m_pthis = nullptr; m_pFunction = nullptr; }
+	#endif
+	public:
+	#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
+		inline bool IsEqual(const DelegateMemento& x) const
+		{
+			if (m_pFunction != x.m_pFunction) return false;
+			if (m_pStaticFunction != x.m_pStaticFunction) return false;
+			if (m_pStaticFunction) return m_pthis == x.m_pthis;
+			else return true;
+		}
+	#else
+		inline bool IsEqual(const DelegateMemento& x) const { return m_pthis == x.m_pthis && m_pFunction == x.m_pFunction; }
+	#endif
+		inline bool IsLess(const DelegateMemento& right) const
+		{
+			#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
+			if (m_pStaticFunction || right.m_pStaticFunction) return m_pStaticFunction < right.m_pStaticFunction;
+			#endif
+			if (m_pthis != right.m_pthis) return m_pthis < right.m_pthis;
+
+			return memcmp(&m_pFunction, &right.m_pFunction, sizeof(m_pFunction)) < 0;
+		}
+
+		inline bool operator ! () const { return !m_pthis && !m_pFunction; }
+		inline bool empty() const { return !m_pthis && !m_pFunction; }
+
+	public:
+		DelegateMemento& operator = (const DelegateMemento& right) { SetMementoFrom(right); return *this; }
+		inline bool operator <(const DelegateMemento& right) { return IsLess(right); }
+		inline bool operator >(const DelegateMemento& right) { return right.IsLess(*this); }
+		DelegateMemento(const DelegateMemento& right) : m_pthis(right.m_pthis), m_pFunction(right.m_pFunction)
+			#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
+			, m_pStaticFunction(right.m_pStaticFunction)
+			#endif
+		{}
+
+	protected:
+		void SetMementoFrom(const DelegateMemento& right)
+		{
+			m_pFunction = right.m_pFunction;
+			m_pthis = right.m_pthis;
+			#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
+			m_pStaticFunction = right.m_pStaticFunction;
+			#endif
+		}
 	};
-};
-#endif
-#endif
-}
 
 
-class DelegateMemento
-{
-protected:
-	using GenericMemFuncType = void (detail::GenericClass::*)();
-	detail::GenericClass* m_pthis;
-	GenericMemFuncType m_pFunction;
-
-#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-	using GenericFuncPtr = void(*)();
-	GenericFuncPtr m_pStaticFunction;
-#endif
-
-public:
-#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-	DelegateMemento() : m_pthis(nullptr), m_pFunction(nullptr), m_pStaticFunction(nullptr) {};
-	void clear() { m_pthis = nullptr; m_pFunction = nullptr; m_pStaticFunction = nullptr; }
-#else
-	DelegateMemento() : m_pthis(nullptr), m_pFunction(nullptr) {}
-	void clear() { m_pthis = nullptr; m_pFunction = nullptr; }
-#endif
-public:
-#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-	inline bool IsEqual(const DelegateMemento& x) const
+	namespace detail
 	{
-		if (m_pFunction != x.m_pFunction) return false;
-		if (m_pStaticFunction != x.m_pStaticFunction) return false;
-		if (m_pStaticFunction) return m_pthis == x.m_pthis;
-		else return true;
-	}
-#else
-	inline bool IsEqual(const DelegateMemento& x) const { return m_pthis == x.m_pthis && m_pFunction == x.m_pFunction; }
-#endif
-	inline bool IsLess(const DelegateMemento& right) const
-	{
-		#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-		if (m_pStaticFunction || right.m_pStaticFunction) return m_pStaticFunction < right.m_pStaticFunction;
+		template <typename GenericMemFunc, typename StaticFuncPtr, typename UnvoidStaticFuncPtr>
+		class ClosurePtr : public DelegateMemento
+		{
+		public:
+			template <typename X, typename XMemFunc>
+			inline void bindmemfunc(X* pthis, XMemFunc function_to_bind)
+			{
+				m_pthis = SimplifyMemFunc<sizeof(function_to_bind)>::Convert(pthis, function_to_bind, m_pFunction);
+				#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
+				m_pStaticFunction = nullptr;
+				#endif
+			}
+
+			template <typename X, typename XMemFunc>
+			inline void bindconstmemfunc(const X* pthis, XMemFunc function_to_bind)
+			{
+				m_pthis = SimplifyMemFunc<sizeof(function_to_bind)>::Convert(const_cast<X*>(pthis), function_to_bind, m_pFunction);
+				#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
+				m_pStaticFunction = nullptr;
+				#endif
+			}
+
+		#ifdef FASTDELEGATE_GCC_BUG_8271 // At present, GCC doesn't recognize constness of MFPs in templates
+			template <typename X, typename XMemFunc>
+			inline void bindmemfunc(const X* pthis, XMemFunc function_to_bind)
+			{
+				bindconstmemfunc(pthis, function_to_bind);
+				#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
+				m_pStaticFunction = nullptr;
+				#endif
+			}
 		#endif
-		if (m_pthis != right.m_pthis) return m_pthis < right.m_pthis;
 
-		return memcmp(&m_pFunction, &right.m_pFunction, sizeof(m_pFunction)) < 0;
-	}
+			inline GenericClass* GetClosureThis() const { return m_pthis; }
+			inline GenericMemFunc GetClosureMemPtr() const { return CastMemFuncPtr<GenericMemFunc>(m_pFunction); }
 
-	inline bool operator ! () const { return !m_pthis && !m_pFunction; }
-	inline bool empty() const { return !m_pthis && !m_pFunction; }
-
-public:
-	DelegateMemento& operator = (const DelegateMemento& right) { SetMementoFrom(right); return *this; }
-	inline bool operator <(const DelegateMemento& right) { return IsLess(right); }
-	inline bool operator >(const DelegateMemento& right) { return right.IsLess(*this); }
-	DelegateMemento(const DelegateMemento& right) : m_pthis(right.m_pthis), m_pFunction(right.m_pFunction)
 		#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-		, m_pStaticFunction(right.m_pStaticFunction)
+
+		public:
+			template <typename DerivedClass>
+			inline void CopyFrom(DerivedClass* pParent, const DelegateMemento& x)
+			{
+				SetMementoFrom(x);
+				if (m_pStaticFunction) m_pthis = reinterpret_cast<GenericClass*>(pParent);
+			}
+
+			template <typename DerivedClass, typename ParentInvokerSig>
+			inline void bindstaticfunc(DerivedClass* pParent, ParentInvokerSig static_function_invoker, StaticFuncPtr function_to_bind)
+			{
+				if (!function_to_bind) m_pFunction = nullptr;
+				else bindmemfunc(pParent, static_function_invoker);
+				m_pStaticFunction = reinterpret_cast<GenericFuncPtr>(function_to_bind);
+			}
+			inline UnvoidStaticFuncPtr GetStaticFunction() const { return reinterpret_cast<UnvoidStaticFuncPtr>(m_pStaticFunction); }
+		#else
+
+			template <typename DerivedClass>
+			inline void CopyFrom(DerivedClass*, const DelegateMemento& right) { SetMementoFrom(right); }
+
+			template <typename DerivedClass, typename ParentInvokerSig>
+			inline void bindstaticfunc(DerivedClass* pParent, ParentInvokerSig static_function_invoker, StaticFuncPtr function_to_bind)
+			{
+				if (!function_to_bind) m_pFunction = nullptr;
+				else bindmemfunc(pParent, static_function_invoker);
+				static_assert(sizeof(GenericClass*) != sizeof(function_to_bind), "Can't use evil method");
+				m_pthis = horrible_cast<GenericClass*>(function_to_bind);
+			}
+
+			inline UnvoidStaticFuncPtr GetStaticFunction() const
+			{
+				static_assert(sizeof(UnvoidStaticFuncPtr) != sizeof(this), "Can't use evil method");
+				return horrible_cast<UnvoidStaticFuncPtr>(this);
+			}
 		#endif
-	{}
 
-protected:
-	void SetMementoFrom(const DelegateMemento& right)
-	{
-		m_pFunction = right.m_pFunction;
-		m_pthis = right.m_pthis;
-		#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-		m_pStaticFunction = right.m_pStaticFunction;
-		#endif
-	}
-};
+			inline bool IsEqualToStaticFuncPtr(StaticFuncPtr funcptr)
+			{
+				if (!funcptr) return empty();
+				else return funcptr == reinterpret_cast<StaticFuncPtr>(GetStaticFunction());
+			}
+		};
 
-
-namespace detail
-{
-template <typename GenericMemFunc, typename StaticFuncPtr, typename UnvoidStaticFuncPtr>
-class ClosurePtr : public DelegateMemento
-{
-public:
-	template <typename X, typename XMemFunc>
-	inline void bindmemfunc(X* pthis, XMemFunc function_to_bind)
-	{
-		m_pthis = SimplifyMemFunc<sizeof(function_to_bind)>::Convert(pthis, function_to_bind, m_pFunction);
-		#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-		m_pStaticFunction = nullptr;
-		#endif
 	}
 
-	template <typename X, typename XMemFunc>
-	inline void bindconstmemfunc(const X* pthis, XMemFunc function_to_bind)
+
+	template <typename RetType, typename ... Params>
+	class DelegateX
 	{
-		m_pthis = SimplifyMemFunc<sizeof(function_to_bind)>::Convert(const_cast<X*>(pthis), function_to_bind, m_pFunction);
-		#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-		m_pStaticFunction = nullptr;
-		#endif
-	}
+	private:
+		using DesiredRetType = typename detail::DefaultVoidToVoid<RetType>::type;
+		using StaticFunctionPtr = DesiredRetType(*)(Params...);
+		using UnvoidStaticFunctionPtr = RetType(*)(Params...);
+		using GenericMemFn = RetType(detail::GenericClass::*)(Params...);
+		using ClosureType = detail::ClosurePtr<GenericMemFn, StaticFunctionPtr, UnvoidStaticFunctionPtr>;
+		ClosureType m_Closure;
 
-#ifdef FASTDELEGATE_GCC_BUG_8271 // At present, GCC doesn't recognize constness of MFPs in templates
-	template <typename X, typename XMemFunc>
-	inline void bindmemfunc(const X* pthis, XMemFunc function_to_bind)
+	public:
+		using type = DelegateX;
+
+		DelegateX() { clear(); }
+		DelegateX(const DelegateX& x) { m_Closure.CopyFrom(this, x.m_Closure); }
+		DelegateX& operator = (const DelegateX& x) { m_Closure.CopyFrom(this, x.m_Closure); return *this; }
+		bool operator ==(const DelegateX& x) const { return m_Closure.IsEqual(x.m_Closure); }
+		bool operator !=(const DelegateX& x) const { return !m_Closure.IsEqual(x.m_Closure); }
+		bool operator <(const DelegateX& x) const { return m_Closure.IsLess(x.m_Closure); }
+		bool operator >(const DelegateX& x) const { return x.m_Closure.IsLess(m_Closure); }
+
+		template <typename X, typename Y>
+		DelegateX(Y* pthis, DesiredRetType(X::*function_to_bind)(Params...)) { m_Closure.bindmemfunc(static_cast<X*>(pthis), function_to_bind); }
+		template <typename X, typename Y>
+		inline void Bind(Y* pthis, DesiredRetType(X::*function_to_bind)(Params...)) { m_Closure.bindmemfunc(static_cast<X*>(pthis), function_to_bind); }
+
+		template <typename X, typename Y>
+		DelegateX(const Y* pthis, DesiredRetType(X::*function_to_bind)(Params...) const) { m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind); }
+		template <typename X, typename Y>
+		inline void Bind(const Y* pthis, DesiredRetType(X::*function_to_bind)(Params...) const) { m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind); }
+
+		DelegateX(DesiredRetType(*function_to_bind)(Params...)) { Bind(function_to_bind); }
+		DelegateX& operator = (DesiredRetType(*function_to_bind)(Params...)) { Bind(function_to_bind); return *this; }
+		inline void Bind(DesiredRetType(*function_to_bind)(Params...)) { m_Closure.bindstaticfunc(this, &DelegateX::InvokeStaticFunction, function_to_bind); }
+		RetType operator() (Params...params) const { return (m_Closure.GetClosureThis()->*(m_Closure.GetClosureMemPtr()))(params...); }
+
+	private:
+		using UselessTypedef = struct SafeBoolStruct { int a_data_pointer_to_this_is_0_on_buggy_compilers; StaticFunctionPtr m_nonzero; };
+		using unspecified_bool_type = StaticFunctionPtr SafeBoolStruct::*;
+
+	public:
+		operator unspecified_bool_type() const { return empty() ? 0 : &SafeBoolStruct::m_nonzero; }
+
+		inline bool operator==(StaticFunctionPtr funcptr) { return m_Closure.IsEqualToStaticFuncPtr(funcptr); }
+		inline bool operator!=(StaticFunctionPtr funcptr) { return !m_Closure.IsEqualToStaticFuncPtr(funcptr); }
+		inline bool operator!() const { return !m_Closure; }
+		inline bool empty() const { return !m_Closure; }
+		void clear() { m_Closure.clear(); }
+
+		const DelegateMemento& GetMemento() { return m_Closure; }
+		void SetMemento(const DelegateMemento& any) { m_Closure.CopyFrom(this, any); }
+
+	private:
+		RetType InvokeStaticFunction(Params...params) const { return (*(m_Closure.GetStaticFunction()))(params...); }
+	};
+
+
+	#ifdef FASTDELEGATE_ALLOW_FUNCTION_TYPE_SYNTAX
+
+	template <typename Signature>
+	class Delegate;
+
+	template <typename RetType, typename ... Params>
+	class Delegate<RetType(Params...)> : public DelegateX<RetType, Params...>
 	{
-		bindconstmemfunc(pthis, function_to_bind);
-		#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-		m_pStaticFunction = nullptr;
-		#endif
-	}
-#endif
+	public:
+		using BaseType = DelegateX<RetType, Params...>;
+		using SelfType = Delegate;
 
-	inline GenericClass* GetClosureThis() const { return m_pthis; }
-	inline GenericMemFunc GetClosureMemPtr() const { return CastMemFuncPtr<GenericMemFunc>(m_pFunction); }
+		Delegate() : BaseType() {}
 
-#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
+		template <typename X, typename Y>
+		Delegate(Y* pthis, RetType(X::*function_to_bind)(Params...)) : BaseType(pthis, function_to_bind) {}
 
-public:
-	template <typename DerivedClass>
-	inline void CopyFrom(DerivedClass* pParent, const DelegateMemento& x)
-	{
-		SetMementoFrom(x);
-		if (m_pStaticFunction) m_pthis = reinterpret_cast<GenericClass*>(pParent);
-	}
+		template <typename X, typename Y>
+		Delegate(const Y* pthis, RetType(X::*function_to_bind)(Params...) const) : BaseType(pthis, function_to_bind) {}
 
-	template <typename DerivedClass, typename ParentInvokerSig>
-	inline void bindstaticfunc(DerivedClass* pParent, ParentInvokerSig static_function_invoker, StaticFuncPtr function_to_bind)
-	{
-		if (!function_to_bind) m_pFunction = nullptr;
-		else bindmemfunc(pParent, static_function_invoker);
-		m_pStaticFunction = reinterpret_cast<GenericFuncPtr>(function_to_bind);
-	}
-	inline UnvoidStaticFuncPtr GetStaticFunction() const { return reinterpret_cast<UnvoidStaticFuncPtr>(m_pStaticFunction); }
-#else
+		Delegate(RetType(*function_to_bind)(Params...)) : BaseType(function_to_bind) {}
+		Delegate& operator = (const BaseType& x) { *static_cast<BaseType*>(this) = x; return *this; }
+	};
 
-	template <typename DerivedClass>
-	inline void CopyFrom(DerivedClass*, const DelegateMemento& right) { SetMementoFrom(right); }
+	#endif
 
-	template <typename DerivedClass, typename ParentInvokerSig>
-	inline void bindstaticfunc(DerivedClass* pParent, ParentInvokerSig static_function_invoker, StaticFuncPtr function_to_bind)
-	{
-		if (!function_to_bind) m_pFunction = nullptr;
-		else bindmemfunc(pParent, static_function_invoker);
-		static_assert(sizeof(GenericClass*) != sizeof(function_to_bind), "Can't use evil method");
-		m_pthis = horrible_cast<GenericClass*>(function_to_bind);
-	}
-
-	inline UnvoidStaticFuncPtr GetStaticFunction() const
-	{
-		static_assert(sizeof(UnvoidStaticFuncPtr) != sizeof(this), "Can't use evil method");
-		return horrible_cast<UnvoidStaticFuncPtr>(this);
-	}
-#endif
-
-	inline bool IsEqualToStaticFuncPtr(StaticFuncPtr funcptr)
-	{
-		if (!funcptr) return empty();
-		else return funcptr == reinterpret_cast<StaticFuncPtr>(GetStaticFunction());
-	}
-};
-
-}
-
-
-template <typename RetType, typename ... Params>
-class DelegateX
-{
-private:
-	using DesiredRetType = typename detail::DefaultVoidToVoid<RetType>::type;
-	using StaticFunctionPtr = DesiredRetType(*)(Params...);
-	using UnvoidStaticFunctionPtr = RetType(*)(Params...);
-	using GenericMemFn = RetType(detail::GenericClass::*)(Params...);
-	using ClosureType = detail::ClosurePtr<GenericMemFn, StaticFunctionPtr, UnvoidStaticFunctionPtr>;
-	ClosureType m_Closure;
-
-public:
-	using type = DelegateX;
-
-	DelegateX() { clear(); }
-	DelegateX(const DelegateX& x) { m_Closure.CopyFrom(this, x.m_Closure); }
-	DelegateX& operator = (const DelegateX& x) { m_Closure.CopyFrom(this, x.m_Closure); return *this; }
-	bool operator ==(const DelegateX& x) const { return m_Closure.IsEqual(x.m_Closure); }
-	bool operator !=(const DelegateX& x) const { return !m_Closure.IsEqual(x.m_Closure); }
-	bool operator <(const DelegateX& x) const { return m_Closure.IsLess(x.m_Closure); }
-	bool operator >(const DelegateX& x) const { return x.m_Closure.IsLess(m_Closure); }
-
-	template <typename X, typename Y>
-	DelegateX(Y* pthis, DesiredRetType(X::*function_to_bind)(Params...)) { m_Closure.bindmemfunc(static_cast<X*>(pthis), function_to_bind); }
-	template <typename X, typename Y>
-	inline void Bind(Y* pthis, DesiredRetType(X::*function_to_bind)(Params...)) { m_Closure.bindmemfunc(static_cast<X*>(pthis), function_to_bind); }
-
-	template <typename X, typename Y>
-	DelegateX(const Y* pthis, DesiredRetType(X::*function_to_bind)(Params...) const) { m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind); }
-	template <typename X, typename Y>
-	inline void Bind(const Y* pthis, DesiredRetType(X::*function_to_bind)(Params...) const) { m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind); }
-
-	DelegateX(DesiredRetType(*function_to_bind)(Params...)) { Bind(function_to_bind); }
-	DelegateX& operator = (DesiredRetType(*function_to_bind)(Params...)) { Bind(function_to_bind); return *this; }
-	inline void Bind(DesiredRetType(*function_to_bind)(Params...)) { m_Closure.bindstaticfunc(this, &DelegateX::InvokeStaticFunction, function_to_bind); }
-	RetType operator() (Params...params) const { return (m_Closure.GetClosureThis()->*(m_Closure.GetClosureMemPtr()))(params...); }
-
-private:
-	using UselessTypedef = struct SafeBoolStruct { int a_data_pointer_to_this_is_0_on_buggy_compilers; StaticFunctionPtr m_nonzero; };
-	using unspecified_bool_type = StaticFunctionPtr SafeBoolStruct::*;
-
-public:
-	operator unspecified_bool_type() const { return empty() ? 0 : &SafeBoolStruct::m_nonzero; }
-
-	inline bool operator==(StaticFunctionPtr funcptr) { return m_Closure.IsEqualToStaticFuncPtr(funcptr); }
-	inline bool operator!=(StaticFunctionPtr funcptr) { return !m_Closure.IsEqualToStaticFuncPtr(funcptr); }
-	inline bool operator!() const { return !m_Closure; }
-	inline bool empty() const { return !m_Closure; }
-	void clear() { m_Closure.clear(); }
-
-	const DelegateMemento& GetMemento() { return m_Closure; }
-	void SetMemento(const DelegateMemento& any) { m_Closure.CopyFrom(this, any); }
-
-private:
-	RetType InvokeStaticFunction(Params...params) const { return (*(m_Closure.GetStaticFunction()))(params...); }
-};
-
-
-#ifdef FASTDELEGATE_ALLOW_FUNCTION_TYPE_SYNTAX
-
-template <typename Signature>
-class Delegate;
-
-template <typename RetType, typename ... Params>
-class Delegate<RetType(Params...)> : public DelegateX<RetType, Params...>
-{
-public:
-	using BaseType = DelegateX<RetType, Params...>;
-	using SelfType = Delegate;
-
-	Delegate() : BaseType() {}
-
-	template <typename X, typename Y>
-	Delegate(Y* pthis, RetType(X::*function_to_bind)(Params...)) : BaseType(pthis, function_to_bind) {}
-
-	template <typename X, typename Y>
-	Delegate(const Y* pthis, RetType(X::*function_to_bind)(Params...) const) : BaseType(pthis, function_to_bind) {}
-
-	Delegate(RetType(*function_to_bind)(Params...)) : BaseType(function_to_bind) {}
-	Delegate& operator = (const BaseType& x) { *static_cast<BaseType*>(this) = x; return *this; }
-};
-
-#endif
-
-template <typename X, typename Y, typename RetType, typename ... Params>
-DelegateX<RetType, Params...> MakeDelegate(Y* x, RetType(X::*func)(Params...)) { return DelegateX<RetType, Params...>(x, func); }
-template <typename X, typename Y, typename RetType, typename ... Params>
-DelegateX<RetType, Params...> MakeDelegate(Y* x, RetType(X::*func)(Params...) const) { return DelegateX<RetType, Params...>(x, func); }
+	template <typename X, typename Y, typename RetType, typename ... Params>
+	DelegateX<RetType, Params...> MakeDelegate(Y* x, RetType(X::*func)(Params...)) { return DelegateX<RetType, Params...>(x, func); }
+	template <typename X, typename Y, typename RetType, typename ... Params>
+	DelegateX<RetType, Params...> MakeDelegate(Y* x, RetType(X::*func)(Params...) const) { return DelegateX<RetType, Params...>(x, func); }
 
 }

--- a/NAS2D/Signal/Signal.h
+++ b/NAS2D/Signal/Signal.h
@@ -31,18 +31,18 @@
 namespace NAS2D {
 
 
-/**
- * Signal with preset number of parameters
- *
- * See https://github.com/lairworks/nas2d-core/wiki/Signal-&-Slots for usage documentation.
- */
-template<typename ... Params>
-class Signal : public SignalSource<Params...>
-{
-public:
-	void emit(Params...params) const { for (auto& delegate : this->delegateList) { delegate(params...); } }
-	void operator() (Params...params) const { emit(params...); }
-};
+	/**
+	 * Signal with preset number of parameters
+	 *
+	 * See https://github.com/lairworks/nas2d-core/wiki/Signal-&-Slots for usage documentation.
+	 */
+	template<typename ... Params>
+	class Signal : public SignalSource<Params...>
+	{
+	public:
+		void emit(Params...params) const { for (auto& delegate : this->delegateList) { delegate(params...); } }
+		void operator() (Params...params) const { emit(params...); }
+	};
 
 
 } // namespace

--- a/NAS2D/Signal/SignalConnection.h
+++ b/NAS2D/Signal/SignalConnection.h
@@ -7,38 +7,38 @@
 namespace NAS2D {
 
 
-template<typename ... Params>
-class SignalConnection
-{
-public:
-	using SignalType = SignalSource<Params...>;
-	using DelegateType = typename SignalType::DelegateType;
-
-	// No copy/move construction/assignment
-	// This class is designed to handle a parent object's connection to a signal
-	// The delegate parameter is likely tied to the address of the parent object
-	// When parent object is copied/moved, a new updated connection must be formed
-	// Disable copy/move to remove default copy/move from parent objects
-	SignalConnection(const SignalConnection&) = delete;
-	SignalConnection(SignalConnection&&) = delete;
-	SignalConnection& operator=(const SignalConnection&) = delete;
-	SignalConnection& operator=(SignalConnection&&) = delete;
-
-	SignalConnection(SignalType& signalSource, DelegateType delegate) :
-		mSignalSource{signalSource},
-		mDelegate{delegate}
+	template<typename ... Params>
+	class SignalConnection
 	{
-		mSignalSource.connect(mDelegate);
-	}
+	public:
+		using SignalType = SignalSource<Params...>;
+		using DelegateType = typename SignalType::DelegateType;
 
-	~SignalConnection()
-	{
-		mSignalSource.disconnect(mDelegate);
-	}
+		// No copy/move construction/assignment
+		// This class is designed to handle a parent object's connection to a signal
+		// The delegate parameter is likely tied to the address of the parent object
+		// When parent object is copied/moved, a new updated connection must be formed
+		// Disable copy/move to remove default copy/move from parent objects
+		SignalConnection(const SignalConnection&) = delete;
+		SignalConnection(SignalConnection&&) = delete;
+		SignalConnection& operator=(const SignalConnection&) = delete;
+		SignalConnection& operator=(SignalConnection&&) = delete;
 
-private:
-	SignalType& mSignalSource;
-	DelegateType mDelegate;
-};
+		SignalConnection(SignalType& signalSource, DelegateType delegate) :
+			mSignalSource{signalSource},
+			mDelegate{delegate}
+		{
+			mSignalSource.connect(mDelegate);
+		}
+
+		~SignalConnection()
+		{
+			mSignalSource.disconnect(mDelegate);
+		}
+
+	private:
+		SignalType& mSignalSource;
+		DelegateType mDelegate;
+	};
 
 }

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -7,37 +7,37 @@
 namespace NAS2D {
 
 
-template<typename ... Params>
-class SignalSource
-{
-public:
-	using Source = SignalSource; // Restricted base interface for use in derived
-	using DelegateType = DelegateX<void, Params...>;
+	template<typename ... Params>
+	class SignalSource
+	{
+	public:
+		using Source = SignalSource; // Restricted base interface for use in derived
+		using DelegateType = DelegateX<void, Params...>;
 
-public:
-	bool empty() const { return delegateList.empty(); }
+	public:
+		bool empty() const { return delegateList.empty(); }
 
-	void clear() { delegateList.clear(); }
+		void clear() { delegateList.clear(); }
 
-	void connect(DelegateType delegate) { delegateList.insert(delegate); }
+		void connect(DelegateType delegate) { delegateList.insert(delegate); }
 
-	template<typename X, typename Y>
-	void connect(Y * obj, void (X::*func)(Params...)) { delegateList.insert(MakeDelegate(obj, func)); }
+		template<typename X, typename Y>
+		void connect(Y * obj, void (X::*func)(Params...)) { delegateList.insert(MakeDelegate(obj, func)); }
 
-	template<typename X, typename Y>
-	void connect(Y * obj, void (X::*func)(Params...) const) { delegateList.insert(MakeDelegate(obj, func)); }
+		template<typename X, typename Y>
+		void connect(Y * obj, void (X::*func)(Params...) const) { delegateList.insert(MakeDelegate(obj, func)); }
 
-	void disconnect(DelegateType delegate) { delegateList.erase(delegate); }
+		void disconnect(DelegateType delegate) { delegateList.erase(delegate); }
 
-	template<typename X, typename Y>
-	void disconnect(Y * obj, void (X::*func)(Params...)) { delegateList.erase(MakeDelegate(obj, func)); }
+		template<typename X, typename Y>
+		void disconnect(Y * obj, void (X::*func)(Params...)) { delegateList.erase(MakeDelegate(obj, func)); }
 
-	template<typename X, typename Y>
-	void disconnect(Y * obj, void (X::*func)(Params...) const) { delegateList.erase(MakeDelegate(obj, func)); }
+		template<typename X, typename Y>
+		void disconnect(Y * obj, void (X::*func)(Params...) const) { delegateList.erase(MakeDelegate(obj, func)); }
 
-protected:
-	std::set<DelegateType> delegateList;
-};
+	protected:
+		std::set<DelegateType> delegateList;
+	};
 
 
 } // namespace

--- a/NAS2D/State.h
+++ b/NAS2D/State.h
@@ -13,99 +13,99 @@
 
 namespace NAS2D {
 
-/**
- * The State class operates within a StateManager as a separate unit of
- *			logic.
- *
- * States make it easy to break certain parts of your program into separate and
- * distinct modes of operation. Using them is pretty straightforward although
- * there are a few requirements.
- *
- * First and foremost, your custom state will derive from State. State has two
- * pure virtual functions that you need to override:
- *
- * \code
- * void initialize() and
- * State* update
- * \endcode
- *
- * \section state-init Initializing the State
- *
- * After the State is constructed, the \c initialize() function is called. This only
- * happens once and is usually where event hooks are setup. Also, any GUI layouts
- * and other initialization that is inappapropriate to do in a constructor are done
- * in this function.
- *
- * \section state-update State Updates
- *
- * Updates to the State are done once every frame via the \c update() function. Updates
- * include logic, drawing, event handling, state changes, etc.
- *
- * \section state-template Base Template
- *
- * The following is a template State object. Use this as a starting point for building
- * your own States. This is about as much boiler plate code as you'll need to start
- * a new State object:
- *
- * \code
- * class MyState: public State
- * {
- * public:
- * 	MyState() {}
- * 	~MyState() {}
- *
- * protected:
- *
- * 	void initialize() {}
- * 	State* update() {}
- *
- * private:
- *
- * 	State* mReturnState;
- * };
- * \endcode
- *
- * Note that the pointer to a State object as a member of the template class
- * is not required but recommended as a best practice for handling state switches.
- *
- * \note	The State class has twp functions ('initialize()', 'upate()') that all
- *			derived State objects must override.
- */
-class State
-{
-public:
-	State() {}
-
-	virtual ~State() = default;
-
-protected:
-	friend class StateManager;
-
 	/**
-	 * Called immediately after the State is constructed.
+	 * The State class operates within a StateManager as a separate unit of
+	 *			logic.
 	 *
-	 * All derived State objects must override this function.
+	 * States make it easy to break certain parts of your program into separate and
+	 * distinct modes of operation. Using them is pretty straightforward although
+	 * there are a few requirements.
 	 *
-	 * The initialize() function is called immediately after construction
-	 * of the State object. Use it for one-time initialization of any
-	 * members, event hooks, etc.
+	 * First and foremost, your custom state will derive from State. State has two
+	 * pure virtual functions that you need to override:
+	 *
+	 * \code
+	 * void initialize() and
+	 * State* update
+	 * \endcode
+	 *
+	 * \section state-init Initializing the State
+	 *
+	 * After the State is constructed, the \c initialize() function is called. This only
+	 * happens once and is usually where event hooks are setup. Also, any GUI layouts
+	 * and other initialization that is inappapropriate to do in a constructor are done
+	 * in this function.
+	 *
+	 * \section state-update State Updates
+	 *
+	 * Updates to the State are done once every frame via the \c update() function. Updates
+	 * include logic, drawing, event handling, state changes, etc.
+	 *
+	 * \section state-template Base Template
+	 *
+	 * The following is a template State object. Use this as a starting point for building
+	 * your own States. This is about as much boiler plate code as you'll need to start
+	 * a new State object:
+	 *
+	 * \code
+	 * class MyState: public State
+	 * {
+	 * public:
+	 * 	MyState() {}
+	 * 	~MyState() {}
+	 *
+	 * protected:
+	 *
+	 * 	void initialize() {}
+	 * 	State* update() {}
+	 *
+	 * private:
+	 *
+	 * 	State* mReturnState;
+	 * };
+	 * \endcode
+	 *
+	 * Note that the pointer to a State object as a member of the template class
+	 * is not required but recommended as a best practice for handling state switches.
+	 *
+	 * \note	The State class has twp functions ('initialize()', 'upate()') that all
+	 *			derived State objects must override.
 	 */
-	virtual void initialize() = 0;
+	class State
+	{
+	public:
+		State() {}
+
+		virtual ~State() = default;
+
+	protected:
+		friend class StateManager;
+
+		/**
+		 * Called immediately after the State is constructed.
+		 *
+		 * All derived State objects must override this function.
+		 *
+		 * The initialize() function is called immediately after construction
+		 * of the State object. Use it for one-time initialization of any
+		 * members, event hooks, etc.
+		 */
+		virtual void initialize() = 0;
 
 
-	/**
-	 * Called once every frame.
-	 *
-	 * All derived states must override this function.
-	 *
-	 * As this function is called every frame, this is generally
-	 * where you will be doing most of your logic updates, drawing,
-	 * etc.
-	 *
-	 * \return	A pointer to a State object. NULL to terminate the
-	 *			NAS2D application.
-	 */
-	virtual State* update() = 0;
-};
+		/**
+		 * Called once every frame.
+		 *
+		 * All derived states must override this function.
+		 *
+		 * As this function is called every frame, this is generally
+		 * where you will be doing most of your logic updates, drawing,
+		 * etc.
+		 *
+		 * \return	A pointer to a State object. NULL to terminate the
+		 *			NAS2D application.
+		 */
+		virtual State* update() = 0;
+	};
 
 } // namespace

--- a/NAS2D/StateManager.h
+++ b/NAS2D/StateManager.h
@@ -15,36 +15,36 @@
 
 namespace NAS2D {
 
-class State;
+	class State;
 
 
-/**
- * Implements a Finite State Machine model that switches between
- *			State objects.
- *
- * \note	StateManager handles distribution of input and system events to
- *			both State objects and to the Gui.
- */
-class StateManager
-{
-public:
-	// Constructor & destructor
-	StateManager();
-	~StateManager();
+	/**
+	 * Implements a Finite State Machine model that switches between
+	 *			State objects.
+	 *
+	 * \note	StateManager handles distribution of input and system events to
+	 *			both State objects and to the Gui.
+	 */
+	class StateManager
+	{
+	public:
+		// Constructor & destructor
+		StateManager();
+		~StateManager();
 
-	void setState(State* state);
-	bool update();
+		void setState(State* state);
+		bool update();
 
-	bool active() const;
+		bool active() const;
 
-	void forceStopAudio(bool);
+		void forceStopAudio(bool);
 
-private:
-	void handleQuit();
+	private:
+		void handleQuit();
 
-	std::unique_ptr<State> mActiveState;
-	bool mActive;
-	bool mForceStopAudio = true;
-};
+		std::unique_ptr<State> mActiveState;
+		bool mActive;
+		bool mForceStopAudio = true;
+	};
 
 } // namespace

--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -19,129 +19,129 @@
 
 namespace NAS2D {
 
-/**
- * Converts a string to lowercase.
- *
- * \param str	Source string.
- *
- * \return	Returns the converted string.
- */
-std::string toLowercase(std::string str)
-{
-	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept->unsigned char { return static_cast<unsigned char>(::tolower(c)); });
-	return str;
-}
-
-/**
- * Converts a string to uppercase.
- *
- * \param str	Source string.
- *
- * \return	Returns the converted string.
- */
-std::string toUppercase(std::string str)
-{
-	std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept->unsigned char { return static_cast<unsigned char>(::toupper(c)); });
-	return str;
-}
-
-std::vector<std::string> split(const std::string& str, char delim /*= ','*/)
-{
-	const auto potentialCount = static_cast<std::size_t>(1 + std::count(std::begin(str), std::end(str), delim));
-	StringList result{};
-	result.reserve(potentialCount);
-
-	std::istringstream ss(str);
-
-	std::string curString{};
-	while (std::getline(ss, curString, delim))
+	/**
+	 * Converts a string to lowercase.
+	 *
+	 * \param str	Source string.
+	 *
+	 * \return	Returns the converted string.
+	 */
+	std::string toLowercase(std::string str)
 	{
-		result.push_back(curString);
+		std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept->unsigned char { return static_cast<unsigned char>(::tolower(c)); });
+		return str;
 	}
-	if (ss.eof() && !str.empty() && str.back() == delim)
-	{
-		result.push_back(std::string{});
-	}
-	result.shrink_to_fit();
-	return result;
-}
 
-std::pair<std::string, std::string> splitOnFirst(const std::string& str, char delim)
-{
-	const auto delim_loc = str.find_first_of(delim);
-	if (delim_loc == std::string::npos)
+	/**
+	 * Converts a string to uppercase.
+	 *
+	 * \param str	Source string.
+	 *
+	 * \return	Returns the converted string.
+	 */
+	std::string toUppercase(std::string str)
 	{
-		return std::make_pair(str, std::string{});
+		std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept->unsigned char { return static_cast<unsigned char>(::toupper(c)); });
+		return str;
 	}
-	else
-	{
-		return std::make_pair(str.substr(0, delim_loc), str.substr(delim_loc + 1));
-	}
-}
 
-std::pair<std::string, std::string> splitOnLast(const std::string& str, char delim)
-{
-	const auto delim_loc = str.find_last_of(delim);
-	if (delim_loc == std::string::npos)
+	std::vector<std::string> split(const std::string& str, char delim /*= ','*/)
 	{
-		return std::make_pair(std::string{}, str);
-	}
-	else
-	{
-		return std::make_pair(str.substr(0, delim_loc), str.substr(delim_loc + 1));
-	}
-}
+		const auto potentialCount = static_cast<std::size_t>(1 + std::count(std::begin(str), std::end(str), delim));
+		StringList result{};
+		result.reserve(potentialCount);
 
-std::string join(const std::vector<std::string>& strs, std::string_view delimiter)
-{
-	std::string result;
+		std::istringstream ss(str);
 
-	if (!strs.empty())
-	{
-		const auto totalStringSize = flattenSize(strs);
-		const auto delimiterSize = (strs.size() - 1) * delimiter.size();
-		result.reserve(totalStringSize + delimiterSize);
-
-		result += strs.front();
-		for (auto iter = std::begin(strs) + 1; iter != std::end(strs); ++iter)
+		std::string curString{};
+		while (std::getline(ss, curString, delim))
 		{
-			result += delimiter;
-			result += (*iter);
+			result.push_back(curString);
+		}
+		if (ss.eof() && !str.empty() && str.back() == delim)
+		{
+			result.push_back(std::string{});
+		}
+		result.shrink_to_fit();
+		return result;
+	}
+
+	std::pair<std::string, std::string> splitOnFirst(const std::string& str, char delim)
+	{
+		const auto delim_loc = str.find_first_of(delim);
+		if (delim_loc == std::string::npos)
+		{
+			return std::make_pair(str, std::string{});
+		}
+		else
+		{
+			return std::make_pair(str.substr(0, delim_loc), str.substr(delim_loc + 1));
 		}
 	}
 
-	return result;
-}
-
-std::string trimWhitespace(std::string_view string)
-{
-	const auto first_non_space = string.find_first_not_of(" \r\n\t\v\f");
-	if (first_non_space == std::string::npos)
+	std::pair<std::string, std::string> splitOnLast(const std::string& str, char delim)
 	{
-		return std::string{};
+		const auto delim_loc = str.find_last_of(delim);
+		if (delim_loc == std::string::npos)
+		{
+			return std::make_pair(std::string{}, str);
+		}
+		else
+		{
+			return std::make_pair(str.substr(0, delim_loc), str.substr(delim_loc + 1));
+		}
 	}
-	const auto last_non_space = string.find_last_not_of(" \r\n\t\v\f");
-	return std::string{string.substr(first_non_space, last_non_space - first_non_space + 1)};
-}
 
-bool startsWith(std::string_view string, std::string_view start) noexcept
-{
-	return string.compare(0, start.size(), start) == 0;
-}
+	std::string join(const std::vector<std::string>& strs, std::string_view delimiter)
+	{
+		std::string result;
 
-bool endsWith(std::string_view string, std::string_view end) noexcept
-{
-	return string.compare(string.size() - end.size(), end.size(), end) == 0;
-}
+		if (!strs.empty())
+		{
+			const auto totalStringSize = flattenSize(strs);
+			const auto delimiterSize = (strs.size() - 1) * delimiter.size();
+			result.reserve(totalStringSize + delimiterSize);
 
-bool startsWith(std::string_view string, char start) noexcept
-{
-	return !string.empty() && string.front() == start;
-}
+			result += strs.front();
+			for (auto iter = std::begin(strs) + 1; iter != std::end(strs); ++iter)
+			{
+				result += delimiter;
+				result += (*iter);
+			}
+		}
 
-bool endsWith(std::string_view string, char end) noexcept
-{
-	return !string.empty() && string.back() == end;
-}
+		return result;
+	}
+
+	std::string trimWhitespace(std::string_view string)
+	{
+		const auto first_non_space = string.find_first_not_of(" \r\n\t\v\f");
+		if (first_non_space == std::string::npos)
+		{
+			return std::string{};
+		}
+		const auto last_non_space = string.find_last_not_of(" \r\n\t\v\f");
+		return std::string{string.substr(first_non_space, last_non_space - first_non_space + 1)};
+	}
+
+	bool startsWith(std::string_view string, std::string_view start) noexcept
+	{
+		return string.compare(0, start.size(), start) == 0;
+	}
+
+	bool endsWith(std::string_view string, std::string_view end) noexcept
+	{
+		return string.compare(string.size() - end.size(), end.size(), end) == 0;
+	}
+
+	bool startsWith(std::string_view string, char start) noexcept
+	{
+		return !string.empty() && string.front() == start;
+	}
+
+	bool endsWith(std::string_view string, char end) noexcept
+	{
+		return !string.empty() && string.back() == end;
+	}
 
 } // namespace

--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -95,12 +95,12 @@ namespace NAS2D
 	bool endsWith(std::string_view string, char end) noexcept;
 
 	/**
- * \typedef StringList
- * A list of std::string's.
- *
- * The StringList is provided primarily as a convenience typedef
- * but is also used by some of NAS2D's functions.
- */
+	* \typedef StringList
+	* A list of std::string's.
+	*
+	* The StringList is provided primarily as a convenience typedef
+	* but is also used by some of NAS2D's functions.
+	*/
 	using StringList = std::vector<std::string>;
 
 } // namespace NAS2D

--- a/NAS2D/Timer.h
+++ b/NAS2D/Timer.h
@@ -12,62 +12,62 @@
 
 namespace NAS2D {
 
-/**
- * A timing class that provides high-resolution, millisecond-precision timing services.
- *
- * The Timer class provides three different method for getting and managing timing.
- *
- * \section Raw Tick
- *
- * By far the simplest method, raw ticks provide the current tick in milliseconds since the application
- * started. You can get this value by calling the function <tt>unsigned int tick() const</tt>.
- *
- * As a note, according to SDL documentation, values will roll back over to 0 if the application runs
- * for more than 49 days. In practice this should cause no noticable side effects (as all values are
- * in <tt>unsigned int</tt>'s).
- *
- * \section Delta Change
- *
- * This is a basic method of getting delta times, or the difference in time from the last time <tt>delta()</tt>
- * was called to the current call.
- *
- * This is the simplest timing method in that physics simulations can use a raw delta value like this
- * to determine how far to advance the simulation, etc.
- *
- * \section Accumulators
- *
- * The third and final method for handling timing is through the use of an Accumulator. In essence, an accumulator
- * is just what it sounds like. It accumulates the elapsed time every time it is updated. The accumulator will continue
- * to report the current accumulated time in milliseconds since the Timer was created or since the last call to
- * <tt>void reset()</tt>.
- *
- * Additionally, the accumulator provides a method to adjust the accumulated time. Calling <tt>void adjust_accumulator(unsigned int a)</tt>
- * will adjust the accumulated time counter by the amount indicated by \c 'a'. E.g., a positive value will adjust the
- * accumulator forward vs. a negative value which will adjust it backward.
- *
- * Using accumulators are very useful when it comes to timing things like animation accurately to account for
- * jumps and gaps in time, for instance if the application stalls for a few seconds.
- *
- * Accumulators are used internally in the Sprite animation handling to account for time desynchs between frames. As
- * time passes the frame counter loses accuracy. Using an accumulator corrects for these inaccuracies by skipping
- * frames whenever needed.
- */
-class Timer
-{
-public:
-	Timer() = default;
+	/**
+	 * A timing class that provides high-resolution, millisecond-precision timing services.
+	 *
+	 * The Timer class provides three different method for getting and managing timing.
+	 *
+	 * \section Raw Tick
+	 *
+	 * By far the simplest method, raw ticks provide the current tick in milliseconds since the application
+	 * started. You can get this value by calling the function <tt>unsigned int tick() const</tt>.
+	 *
+	 * As a note, according to SDL documentation, values will roll back over to 0 if the application runs
+	 * for more than 49 days. In practice this should cause no noticable side effects (as all values are
+	 * in <tt>unsigned int</tt>'s).
+	 *
+	 * \section Delta Change
+	 *
+	 * This is a basic method of getting delta times, or the difference in time from the last time <tt>delta()</tt>
+	 * was called to the current call.
+	 *
+	 * This is the simplest timing method in that physics simulations can use a raw delta value like this
+	 * to determine how far to advance the simulation, etc.
+	 *
+	 * \section Accumulators
+	 *
+	 * The third and final method for handling timing is through the use of an Accumulator. In essence, an accumulator
+	 * is just what it sounds like. It accumulates the elapsed time every time it is updated. The accumulator will continue
+	 * to report the current accumulated time in milliseconds since the Timer was created or since the last call to
+	 * <tt>void reset()</tt>.
+	 *
+	 * Additionally, the accumulator provides a method to adjust the accumulated time. Calling <tt>void adjust_accumulator(unsigned int a)</tt>
+	 * will adjust the accumulated time counter by the amount indicated by \c 'a'. E.g., a positive value will adjust the
+	 * accumulator forward vs. a negative value which will adjust it backward.
+	 *
+	 * Using accumulators are very useful when it comes to timing things like animation accurately to account for
+	 * jumps and gaps in time, for instance if the application stalls for a few seconds.
+	 *
+	 * Accumulators are used internally in the Sprite animation handling to account for time desynchs between frames. As
+	 * time passes the frame counter loses accuracy. Using an accumulator corrects for these inaccuracies by skipping
+	 * frames whenever needed.
+	 */
+	class Timer
+	{
+	public:
+		Timer() = default;
 
-	unsigned int tick() const;
-	unsigned int delta();
+		unsigned int tick() const;
+		unsigned int delta();
 
-	unsigned int accumulator();
-	void adjust_accumulator(unsigned int a);
+		unsigned int accumulator();
+		void adjust_accumulator(unsigned int a);
 
-	void reset();
+		void reset();
 
-private:
-	unsigned int mCurrentTick = 0;
-	unsigned int mAccumulator = 0;
-};
+	private:
+		unsigned int mCurrentTick = 0;
+		unsigned int mAccumulator = 0;
+	};
 
 } // namespace

--- a/NAS2D/Trig.cpp
+++ b/NAS2D/Trig.cpp
@@ -15,39 +15,39 @@
 
 namespace NAS2D {
 
-/**
- * Gets an angle in radians from degrees.
- */
-float degToRad(float degree)
-{
-	return degree * DEG2RAD;
-}
+	/**
+	 * Gets an angle in radians from degrees.
+	 */
+	float degToRad(float degree)
+	{
+		return degree * DEG2RAD;
+	}
 
 
-/**
- * Gets an angle in degrees from radians.
- */
-float radToDeg(float rad)
-{
-	return rad * RAD2DEG;
-}
+	/**
+	 * Gets an angle in degrees from radians.
+	 */
+	float radToDeg(float rad)
+	{
+		return rad * RAD2DEG;
+	}
 
 
-/**
- * Gets the angle of a direction vector
- */
-float getAngle(Vector<float> direction)
-{
-	return std::atan2(direction.y, direction.x);
-}
+	/**
+	 * Gets the angle of a direction vector
+	 */
+	float getAngle(Vector<float> direction)
+	{
+		return std::atan2(direction.y, direction.x);
+	}
 
 
-/**
- * Gets a directional vector from an angle in radians.
- */
-Vector<float> getDirectionVector(float radian)
-{
-	return {std::cos(radian), std::sin(radian)};
-}
+	/**
+	 * Gets a directional vector from an angle in radians.
+	 */
+	Vector<float> getDirectionVector(float radian)
+	{
+		return {std::cos(radian), std::sin(radian)};
+	}
 
 }

--- a/NAS2D/Trig.h
+++ b/NAS2D/Trig.h
@@ -15,16 +15,16 @@
 
 namespace NAS2D {
 
-constexpr float PI = 3.14159265f;
-constexpr float PI_2 = PI * 2;
+	constexpr float PI = 3.14159265f;
+	constexpr float PI_2 = PI * 2;
 
-constexpr float DEG2RAD = PI / 180;
-constexpr float RAD2DEG = 180 / PI;
+	constexpr float DEG2RAD = PI / 180;
+	constexpr float RAD2DEG = 180 / PI;
 
 
-float degToRad(float degree);
-float radToDeg(float rad);
-float getAngle(Vector<float> direction);
-Vector<float> getDirectionVector(float angle);
+	float degToRad(float degree);
+	float radToDeg(float rad);
+	float getAngle(Vector<float> direction);
+	Vector<float> getDirectionVector(float angle);
 
 }

--- a/NAS2D/Utility.h
+++ b/NAS2D/Utility.h
@@ -16,148 +16,148 @@
 
 namespace NAS2D {
 
-/**
- * Provides a simple interface to classes that should only be instantiated
- *			once globally for a NAS2D application.
- *
- * \c Utility is a simple templated class designed to provide easy access to 'global'
- * objects that should only ever be instantiated once (for instance the Renderer,
- * Filesystem and Mixer classes).
- *
- * Most often usage cases are a simple matter of asking for a reference to a specific
- * type that is used several times within a section of code. For instance, if you
- * wanted to get a reference to a Renderer:
- *
- * \code{.cpp}
- * // Keep a reference to use multiple times in a code block.
- * Renderer& r Utility<Renderer>::get();
- *
- * r.drawBox(0, 0, 10, 10, 255, 255, 255, 255);
- * r.drawLine( 10, 10, 400, 200, 255, 0, 0, 255, 4);
- * // and so on
- * \endcode
- *
- * If you only need to use the reference for one or two calls, it may make more
- * sense to just use the provided reference:
- *
- * \code{.cpp}
- * // Only need to make a single call.
- * Utility<Mixer>::get().stopAllAudio();
- * \endcode
- *
- * \sa <a href="https://github.com/lairworks/nas2d-core/wiki/Using-Derived-Types-with-Utility">Using Utility<T> with Derived Types</a>
- *
- * \note	\c Utility does not catch exceptions. If any instantiated object
- *			throws the client will be responsible for handling it.
- */
-template<typename T>
-class Utility
-{
-public:
-	Utility<T>() = delete;
-	~Utility() = delete;
-	Utility<T>(const Utility& s) = delete;
-	Utility<T>& operator=(const Utility& s) = delete;
-
 	/**
-	 * Gets a reference to a global instance of the specified type
-	 * \c T. If an instance doesn't exist, one is created.
-	 * Type \c T must be default constructible to use this overload.
+	 * Provides a simple interface to classes that should only be instantiated
+	 *			once globally for a NAS2D application.
+	 *
+	 * \c Utility is a simple templated class designed to provide easy access to 'global'
+	 * objects that should only ever be instantiated once (for instance the Renderer,
+	 * Filesystem and Mixer classes).
+	 *
+	 * Most often usage cases are a simple matter of asking for a reference to a specific
+	 * type that is used several times within a section of code. For instance, if you
+	 * wanted to get a reference to a Renderer:
+	 *
+	 * \code{.cpp}
+	 * // Keep a reference to use multiple times in a code block.
+	 * Renderer& r Utility<Renderer>::get();
+	 *
+	 * r.drawBox(0, 0, 10, 10, 255, 255, 255, 255);
+	 * r.drawLine( 10, 10, 400, 200, 255, 0, 0, 255, 4);
+	 * // and so on
+	 * \endcode
+	 *
+	 * If you only need to use the reference for one or two calls, it may make more
+	 * sense to just use the provided reference:
+	 *
+	 * \code{.cpp}
+	 * // Only need to make a single call.
+	 * Utility<Mixer>::get().stopAllAudio();
+	 * \endcode
+	 *
+	 * \sa <a href="https://github.com/lairworks/nas2d-core/wiki/Using-Derived-Types-with-Utility">Using Utility<T> with Derived Types</a>
+	 *
+	 * \note	\c Utility does not catch exceptions. If any instantiated object
+	 *			throws the client will be responsible for handling it.
 	 */
-	template<typename Type = T>
-	static
-	std::enable_if_t<std::is_default_constructible<Type>::value, T&>
-	get()
+	template<typename T>
+	class Utility
 	{
-		if (!mInstance)
+	public:
+		Utility<T>() = delete;
+		~Utility() = delete;
+		Utility<T>(const Utility& s) = delete;
+		Utility<T>& operator=(const Utility& s) = delete;
+
+		/**
+		 * Gets a reference to a global instance of the specified type
+		 * \c T. If an instance doesn't exist, one is created.
+		 * Type \c T must be default constructible to use this overload.
+		 */
+		template<typename Type = T>
+		static
+		std::enable_if_t<std::is_default_constructible<Type>::value, T&>
+		get()
 		{
-			mInstance = new T();
+			if (!mInstance)
+			{
+				mInstance = new T();
+			}
+
+			return *mInstance;
 		}
 
-		return *mInstance;
-	}
 
-
-	/**
-	 * Gets a reference to a global instance of the specified type
-	 * \c T. If an instance doesn't exist, an exception is thrown.
-	 * Type \c T is not default constructible for this overload.
-	 */
-	template<typename Type = T>
-	static
-	std::enable_if_t<!std::is_default_constructible<Type>::value, T&>
-	get()
-	{
-		if (!mInstance)
+		/**
+		 * Gets a reference to a global instance of the specified type
+		 * \c T. If an instance doesn't exist, an exception is thrown.
+		 * Type \c T is not default constructible for this overload.
+		 */
+		template<typename Type = T>
+		static
+		std::enable_if_t<!std::is_default_constructible<Type>::value, T&>
+		get()
 		{
-			throw std::runtime_error("Type must be default constructible or initialized with `init`");
+			if (!mInstance)
+			{
+				throw std::runtime_error("Type must be default constructible or initialized with `init`");
+			}
+
+			return *mInstance;
 		}
 
-		return *mInstance;
-	}
+
+		/**
+		 * Creates a \c Utility<T> interface for a newly created object of type
+		 * \c Type. \c Type must be derived from type \c T specified in the
+		 * template class argument list, and defaults to \c T if not explicitly
+		 * specified.
+		 *
+		 * \c Type should be explicitly specified when instantiating a derived type
+		 * and polymorphic behavior is desired.
+		 *
+		 * \code{.cpp}
+		 * // Instantiate Mixer (default Type is Mixer)
+		 * Utility<Mixer>::init();
+		 * \endcode
+		 *
+		 * \code{.cpp}
+		 * // Instantiate derived type MixerSDL, of base type Mixer
+		 * Utility<Mixer>::init<MixerSDL>();
+		 * \endcode
+		 *
+		 * \code{.cpp}
+		 * // Instantiate derived type with constructor arguments, as base type reference
+		 * Utility<Base>::init<Derived>(arg1, arg2, arg3);
+		 * \endcode
+		 *
+		 * \param	args	A list of arguments to be forwarded to the \c Type objects's constructor
+		 *
+		 * \return Reference to the newly created object as \c Type.
+		 * This allows further method calls to complete initialization or setup
+		 * of the object, using the full interface of the derived type.
+		 *
+		 * \note	This method should be called before <tt>Utility::get()</tt>.
+		 */
+		template<typename Type = T, typename... Args>
+		static Type& init(Args&&... args)
+		{
+			// Instantiate a new object with forwarded constructor arguments
+			auto newInstance = new Type(std::forward<Args>(args)...);
+
+			delete mInstance;
+
+			mInstance = newInstance;
+			return *newInstance;
+		}
 
 
-	/**
-	 * Creates a \c Utility<T> interface for a newly created object of type
-	 * \c Type. \c Type must be derived from type \c T specified in the
-	 * template class argument list, and defaults to \c T if not explicitly
-	 * specified.
-	 *
-	 * \c Type should be explicitly specified when instantiating a derived type
-	 * and polymorphic behavior is desired.
-	 *
-	 * \code{.cpp}
-	 * // Instantiate Mixer (default Type is Mixer)
-	 * Utility<Mixer>::init();
-	 * \endcode
-	 *
-	 * \code{.cpp}
-	 * // Instantiate derived type MixerSDL, of base type Mixer
-	 * Utility<Mixer>::init<MixerSDL>();
-	 * \endcode
-	 *
-	 * \code{.cpp}
-	 * // Instantiate derived type with constructor arguments, as base type reference
-	 * Utility<Base>::init<Derived>(arg1, arg2, arg3);
-	 * \endcode
-	 *
-	 * \param	args	A list of arguments to be forwarded to the \c Type objects's constructor
-	 *
-	 * \return Reference to the newly created object as \c Type.
-	 * This allows further method calls to complete initialization or setup
-	 * of the object, using the full interface of the derived type.
-	 *
-	 * \note	This method should be called before <tt>Utility::get()</tt>.
-	 */
-	template<typename Type = T, typename... Args>
-	static Type& init(Args&&... args)
-	{
-		// Instantiate a new object with forwarded constructor arguments
-		auto newInstance = new Type(std::forward<Args>(args)...);
+		/**
+		 * Frees any currently instantiated instances of \c T.
+		 *
+		 * \warning	Any remaining references to the object \c T that
+		 *			the \c Utility manages will be invalidated.
+		 */
+		static void clear()
+		{
+			delete mInstance;
+			mInstance = nullptr;
+		}
 
-		delete mInstance;
+	private:
+		static T* mInstance; /**< Internal instance of type \c T. */
+	};
 
-		mInstance = newInstance;
-		return *newInstance;
-	}
-
-
-	/**
-	 * Frees any currently instantiated instances of \c T.
-	 *
-	 * \warning	Any remaining references to the object \c T that
-	 *			the \c Utility manages will be invalidated.
-	 */
-	static void clear()
-	{
-		delete mInstance;
-		mInstance = nullptr;
-	}
-
-private:
-	static T* mInstance; /**< Internal instance of type \c T. */
-};
-
-template<typename T> T* Utility<T>::mInstance = nullptr;
+	template<typename T> T* Utility<T>::mInstance = nullptr;
 
 } // namespace

--- a/NAS2D/Version.h
+++ b/NAS2D/Version.h
@@ -19,8 +19,8 @@ namespace NAS2D
 	constexpr int NAS2D_PATCH_VERSION = 2;
 
 	/**
-    * Gets a string containing the version of NAS2D being used.
-    */
+	* Gets a string containing the version of NAS2D being used.
+	*/
 	const std::string versionString();
 
 	/**
@@ -29,13 +29,13 @@ namespace NAS2D
 	constexpr int versionMajor();
 
 	/**
-    * Gets version minor.
-    */
+	* Gets version minor.
+	*/
 	constexpr int versionMinor();
 
 	/**
-    * Gets version patch.
-    */
+	* Gets version patch.
+	*/
 	constexpr int versionPatch();
 
 } // namespace NAS2D


### PR DESCRIPTION
Reference: #893

We were a bit inconsistent about namespace indentation. I think that stems from namespace wrapping coming later in development, and the indentation never having been updated. Newer code seems to indent namespaces, and there seems to have been a trend of indenting older code too.

By doing this now, and setting a consistent style, we'll get a lot less noise when working on setting up a `.clang-format` file.
