### PR TITLE
Update clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,7 +32,7 @@ ColumnLimit: 0
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 FixNamespaceComments: true
-IncludeBlocks: Regroup
+IncludeBlocks: Preserve
 IncludeCategories:
 # Prefer project-specific includes first
 #i.e. Prefer "my" includes before other libraries
@@ -60,7 +60,7 @@ IndentWrappedFunctionNames: false
 NamespaceIndentation: All
 PointerAlignment: Left
 ReflowComments: false
-SortIncludes : true
+SortIncludes : false
 SortUsingDeclarations: true
 SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true

--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
 Language: Cpp
+AccessModifierOffset: -4
 AlignTrailingComments: true
 AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true

--- a/.clang-format
+++ b/.clang-format
@@ -63,7 +63,7 @@ PointerAlignment: Left
 ReflowComments: false
 SortIncludes : false
 SortUsingDeclarations: true
-SpaceAfterTemplateKeyword: false
+SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true

--- a/.clang-format
+++ b/.clang-format
@@ -57,6 +57,7 @@ IndentCaseLabels: false
 IndentPPDirectives: BeforeHash
 IndentWidth: 4
 IndentWrappedFunctionNames: false
+MaxEmptyLinesToKeep: 2
 NamespaceIndentation: All
 PointerAlignment: Left
 ReflowComments: false

--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 Language: Cpp
 AccessModifierOffset: -4
-AlignTrailingComments: true
+AlignTrailingComments: false
 AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: true

--- a/.clang-format
+++ b/.clang-format
@@ -27,10 +27,10 @@ BraceWrapping:
     SplitEmptyNamespace: false
 
 BreakBeforeBinaryOperators: NonAssignment
-BreakConstructorInitializers: BeforeComma
+BreakConstructorInitializers: AfterColon
 ColumnLimit: 0
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 0
+ConstructorInitializerIndentWidth: 4
 FixNamespaceComments: true
 IncludeBlocks: Regroup
 IncludeCategories:

--- a/makefile
+++ b/makefile
@@ -154,7 +154,7 @@ cppclean:
 
 .PHONY: format
 format:
-	find NAS2D/ -name '*.cpp' -o -name '*.h' | xargs clang-format -i
+	find NAS2D/ -path NAS2D/Xml -prune -name '*.cpp' -o -name '*.h' | xargs clang-format -i
 
 ### Linux development package dependencies ###
 # This section contains install rules to aid setup and compiling on Linux.

--- a/makefile
+++ b/makefile
@@ -152,6 +152,10 @@ cppcheck:
 cppclean:
 	cppclean "$(SRCDIR)"
 
+.PHONY: format
+format:
+	find NAS2D/ -name '*.cpp' -o -name '*.h' | xargs clang-format -i
+
 ### Linux development package dependencies ###
 # This section contains install rules to aid setup and compiling on Linux.
 # Only a few common Linux distributions are covered. Other distributions


### PR DESCRIPTION
Reference: #893

Update the `.clang-format` rules to make them a little closer to what we are actually doing. It's not perfect, but it at least reduces enough of the noise to start being useful.

Resulted in cleanup in: #894, #895, #896
