### PR TITLE
Reflow template class braces

### DIFF
--- a/NAS2D/Renderer/Point.h
+++ b/NAS2D/Renderer/Point.h
@@ -15,57 +15,68 @@
 
 namespace NAS2D
 {
-
-
 	template <typename BaseType>
-	struct Point {
+	struct Point
+	{
 		BaseType x = 0;
 		BaseType y = 0;
 
-		constexpr bool operator==(const Point& point) const {
+		constexpr bool operator==(const Point& point) const
+		{
 			return (x == point.x) && (y == point.y);
 		}
-		constexpr bool operator!=(const Point& point) const {
+
+		constexpr bool operator!=(const Point& point) const
+		{
 			return !(*this == point);
 		}
 
-		Point& operator+=(const Vector<BaseType>& vector) {
+		Point& operator+=(const Vector<BaseType>& vector)
+		{
 			x += vector.x;
 			y += vector.y;
 			return *this;
 		}
 
-		Point& operator-=(const Vector<BaseType>& vector) {
+		Point& operator-=(const Vector<BaseType>& vector)
+		{
 			x -= vector.x;
 			y -= vector.y;
 			return *this;
 		}
 
-		constexpr Point operator+(const Vector<BaseType>& vector) const {
+		constexpr Point operator+(const Vector<BaseType>& vector) const
+		{
 			return {x + vector.x, y + vector.y};
 		}
 
-		constexpr Point operator-(const Vector<BaseType>& vector) const {
+		constexpr Point operator-(const Vector<BaseType>& vector) const
+		{
 			return {x - vector.x, y - vector.y};
 		}
 
-		constexpr Vector<BaseType> operator-(const Point& point) const {
+		constexpr Vector<BaseType> operator-(const Point& point) const
+		{
 			return {x - point.x, y - point.y};
 		}
 
-		constexpr Point skewBy(const Vector<BaseType>& other) const {
+		constexpr Point skewBy(const Vector<BaseType>& other) const
+		{
 			return {x * other.x, y * other.y};
 		}
 
-		constexpr Point skewInverseBy(const Vector<BaseType>& other) const {
-			if (other.x == 0 || other.y == 0) {
+		constexpr Point skewInverseBy(const Vector<BaseType>& other) const
+		{
+			if (other.x == 0 || other.y == 0)
+			{
 				throw std::domain_error("Cannot skewInverseBy a vector with a zero component");
 			}
 			return {x / other.x, y / other.y};
 		}
 
 		template <typename NewBaseType>
-		constexpr operator Point<NewBaseType>() const {
+		constexpr operator Point<NewBaseType>() const
+		{
 			return {
 				static_cast<NewBaseType>(x),
 				static_cast<NewBaseType>(y)
@@ -73,7 +84,8 @@ namespace NAS2D
 		}
 
 		template <typename NewBaseType>
-		constexpr Point<NewBaseType> to() const {
+		constexpr Point<NewBaseType> to() const
+		{
 			return static_cast<Point<NewBaseType>>(*this);
 		}
 	};
@@ -86,24 +98,26 @@ namespace NAS2D
 	// Partial order comparisons
 
 	template <typename BaseType>
-	bool operator<=(Point<BaseType> p1, Point<BaseType> p2) {
+	bool operator<=(Point<BaseType> p1, Point<BaseType> p2)
+	{
 		return (p1.x <= p2.x) && (p1.y <= p2.y);
 	}
 
 	template <typename BaseType>
-	bool operator>=(Point<BaseType> p1, Point<BaseType> p2) {
+	bool operator>=(Point<BaseType> p1, Point<BaseType> p2)
+	{
 		return p2 <= p1;
 	}
 
 	template <typename BaseType>
-	bool operator<(Point<BaseType> p1, Point<BaseType> p2) {
+	bool operator<(Point<BaseType> p1, Point<BaseType> p2)
+	{
 		return (p1.x < p2.x) && (p1.y < p2.y);
 	}
 
 	template <typename BaseType>
-	bool operator>(Point<BaseType> p1, Point<BaseType> p2) {
+	bool operator>(Point<BaseType> p1, Point<BaseType> p2)
+	{
 		return p2 < p1;
 	}
-
-
 } // namespace

--- a/NAS2D/Renderer/PointInRectangleRange.h
+++ b/NAS2D/Renderer/PointInRectangleRange.h
@@ -9,12 +9,12 @@
 
 namespace NAS2D
 {
-
-
 	template <typename BaseType>
-	class PointInRectangleRange {
+	class PointInRectangleRange
+	{
 	public:
-		class Iterator {
+		class Iterator
+		{
 		public:
 			Iterator(const Rectangle<BaseType>& rect, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
 				mIterator(rect.size(), initial),
@@ -23,25 +23,30 @@ namespace NAS2D
 			Iterator(const Iterator& other) = default;
 			Iterator& operator=(const Iterator& other) = default;
 
-			Iterator& operator++() {
+			Iterator& operator++()
+			{
 				++mIterator;
 				return *this;
 			}
 
-			Iterator& operator--() {
+			Iterator& operator--()
+			{
 				--mIterator;
 				return *this;
 			}
 
-			bool operator==(const Iterator& other) const {
+			bool operator==(const Iterator& other) const
+			{
 				return **this == *other;
 			}
 
-			bool operator!=(const Iterator& other) const {
+			bool operator!=(const Iterator& other) const
+			{
 				return !(*this == other);
 			}
 
-			Point<BaseType> operator*() const {
+			Point<BaseType> operator*() const
+			{
 				return mStartPoint + *mIterator;
 			}
 
@@ -55,16 +60,17 @@ namespace NAS2D
 			mRect(rect)
 		{}
 
-		Iterator begin() const {
+		Iterator begin() const
+		{
 			return Iterator{mRect};
 		}
 
-		Iterator end() const {
+		Iterator end() const
+		{
 			return Iterator{mRect, Vector<BaseType>{0, mRect.height}};
 		}
 
 	private:
 		const Rectangle<BaseType> mRect;
 	};
-
 } // namespace

--- a/NAS2D/Renderer/Rectangle.h
+++ b/NAS2D/Renderer/Rectangle.h
@@ -16,8 +16,6 @@
 
 namespace NAS2D
 {
-
-
 	template <typename BaseType>
 	struct Rectangle
 	{
@@ -27,7 +25,8 @@ namespace NAS2D
 		BaseType height = 0;
 
 		// Factory method
-		constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Vector<BaseType> size) {
+		constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Vector<BaseType> size)
+		{
 			return {
 				startPoint.x,
 				startPoint.y,
@@ -37,7 +36,8 @@ namespace NAS2D
 		}
 
 		// Factory method
-		constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Point<BaseType> endPoint) {
+		constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Point<BaseType> endPoint)
+		{
 			return {
 				startPoint.x,
 				startPoint.y,
@@ -46,69 +46,86 @@ namespace NAS2D
 			};
 		}
 
-		constexpr bool operator==(const Rectangle& rect) const {
+		constexpr bool operator==(const Rectangle& rect) const
+		{
 			return (x == rect.x) && (y == rect.y) && (width == rect.width) && (height == rect.height);
 		}
-		constexpr bool operator!=(const Rectangle& rect) const {
+
+		constexpr bool operator!=(const Rectangle& rect) const
+		{
 			return !(*this == rect);
 		}
 
-		constexpr Vector<BaseType> size() const {
+		constexpr Vector<BaseType> size() const
+		{
 			return {width, height};
 		}
 
-		constexpr Point<BaseType> startPoint() const {
+		constexpr Point<BaseType> startPoint() const
+		{
 			return {x, y};
 		}
 
-		constexpr Point<BaseType> endPoint() const {
+		constexpr Point<BaseType> endPoint() const
+		{
 			return Point{x, y} + Vector{width, height};
 		}
 
-		constexpr Point<BaseType> crossXPoint() const {
+		constexpr Point<BaseType> crossXPoint() const
+		{
 			return {x + width, y};
 		}
 
-		constexpr Point<BaseType> crossYPoint() const {
+		constexpr Point<BaseType> crossYPoint() const
+		{
 			return {x, y + height};
 		}
 
-		constexpr bool null() const {
+		constexpr bool null() const
+		{
 			return (width == 0) || (height == 0);
 		}
 
-		void size(NAS2D::Vector<BaseType> newSize) {
+		void size(NAS2D::Vector<BaseType> newSize)
+		{
 			width = newSize.x;
 			height = newSize.y;
 		}
 
-		void startPoint(NAS2D::Point<BaseType> newStartPoint) {
+		void startPoint(NAS2D::Point<BaseType> newStartPoint)
+		{
 			x = newStartPoint.x;
 			y = newStartPoint.y;
 		}
 
-		constexpr Rectangle inset(BaseType amount) const {
+		constexpr Rectangle inset(BaseType amount) const
+		{
 			return {x + amount, y + amount, width - 2 * amount, height - 2 * amount};
 		}
 
-		constexpr Rectangle inset(Vector<BaseType> amount) const {
+		constexpr Rectangle inset(Vector<BaseType> amount) const
+		{
 			return {x + amount.x, y + amount.y, width - 2 * amount.x, height - 2 * amount.y};
 		}
 
-		constexpr Rectangle inset(Vector<BaseType> amountStart, Vector<BaseType> amountEnd) const {
+		constexpr Rectangle inset(Vector<BaseType> amountStart, Vector<BaseType> amountEnd) const
+		{
 			return {x + amountStart.x, y + amountStart.y, width - amountStart.x - amountEnd.x, height - amountStart.y - amountEnd.y};
 		}
 
-		constexpr Rectangle skewBy(const Vector<BaseType>& scaleFactor) const {
+		constexpr Rectangle skewBy(const Vector<BaseType>& scaleFactor) const
+		{
 			return Create(startPoint().skewBy(scaleFactor), size().skewBy(scaleFactor));
 		}
 
-		constexpr Rectangle skewInverseBy(const Vector<BaseType>& scaleFactor) const {
+		constexpr Rectangle skewInverseBy(const Vector<BaseType>& scaleFactor) const
+		{
 			return Create(startPoint().skewInverseBy(scaleFactor), size().skewInverseBy(scaleFactor));
 		}
 
 		template <typename NewBaseType>
-		constexpr operator Rectangle<NewBaseType>() const {
+		constexpr operator Rectangle<NewBaseType>() const
+		{
 			return {
 				static_cast<NewBaseType>(x),
 				static_cast<NewBaseType>(y),
@@ -118,23 +135,27 @@ namespace NAS2D
 		}
 
 		template <typename NewBaseType>
-		constexpr Rectangle<NewBaseType> to() const {
+		constexpr Rectangle<NewBaseType> to() const
+		{
 			return static_cast<Rectangle<NewBaseType>>(*this);
 		}
 
 		// Start point inclusive (x, y), endpoint exclusive (x + width, y + height)
 		// Area in interval notation: [x .. x + width), [y .. y + height)
-		constexpr bool contains(const Point<BaseType>& point) const {
+		constexpr bool contains(const Point<BaseType>& point) const
+		{
 			return startPoint() <= point && point < endPoint();
 		}
 
 		// Start point inclusive (x, y), endpoint exclusive (x + width, y + height)
 		// Area in interval notation: [x .. x + width), [y .. y + height)
-		constexpr bool overlaps(const Rectangle& rect) const {
+		constexpr bool overlaps(const Rectangle& rect) const
+		{
 			return startPoint() < rect.endPoint() && rect.startPoint() < endPoint();
 		}
 
-		constexpr Point<BaseType> center() const {
+		constexpr Point<BaseType> center() const
+		{
 			return {x + (width / 2), y + (height / 2)};
 		}
 	};
@@ -142,5 +163,4 @@ namespace NAS2D
 
 	template <typename BaseType>
 	Rectangle(BaseType, BaseType, BaseType, BaseType) -> Rectangle<BaseType>;
-
 } // namespace

--- a/NAS2D/Renderer/Vector.h
+++ b/NAS2D/Renderer/Vector.h
@@ -5,51 +5,60 @@
 
 namespace NAS2D
 {
-
-
 	template <typename BaseType>
-	struct Vector {
+	struct Vector
+	{
 		BaseType x = 0;
 		BaseType y = 0;
 
-		constexpr bool operator==(const Vector& vector) const {
+		constexpr bool operator==(const Vector& vector) const
+		{
 			return (x == vector.x) && (y == vector.y);
 		}
-		constexpr bool operator!=(const Vector& vector) const {
+
+		constexpr bool operator!=(const Vector& vector) const
+		{
 			return !(*this == vector);
 		}
 
-		Vector& operator+=(const Vector& vector) {
+		Vector& operator+=(const Vector& vector)
+		{
 			x += vector.x;
 			y += vector.y;
 			return *this;
 		}
-		Vector& operator-=(const Vector& vector) {
+		Vector& operator-=(const Vector& vector)
+		{
 			x -= vector.x;
 			y -= vector.y;
 			return *this;
 		}
 
-		constexpr Vector operator+(const Vector& vector) const {
+		constexpr Vector operator+(const Vector& vector) const
+		{
 			return {
 				x + vector.x,
 				y + vector.y
 			};
 		}
-		constexpr Vector operator-(const Vector& vector) const {
+		constexpr Vector operator-(const Vector& vector) const
+		{
 			return {
 				x - vector.x,
 				y - vector.y
 			};
 		}
 
-		Vector& operator*=(BaseType scalar) {
+		Vector& operator*=(BaseType scalar)
+		{
 			x *= scalar;
 			y *= scalar;
 			return *this;
 		}
-		Vector& operator/=(BaseType scalar) {
-			if (scalar == 0) {
+		Vector& operator/=(BaseType scalar)
+		{
+			if (scalar == 0)
+			{
 				throw std::domain_error("Cannot divide vector by 0");
 			}
 			x /= scalar;
@@ -57,47 +66,59 @@ namespace NAS2D
 			return *this;
 		}
 
-		constexpr Vector operator*(BaseType scalar) const {
+		constexpr Vector operator*(BaseType scalar) const
+		{
 			return {x * scalar, y * scalar};
 		}
-		constexpr Vector operator/(BaseType scalar) const {
-			if (scalar == 0) {
+
+		constexpr Vector operator/(BaseType scalar) const
+		{
+			if (scalar == 0)
+			{
 				throw std::domain_error("Cannot divide vector by 0");
 			}
 			return {x / scalar, y / scalar};
 		}
 
-		constexpr Vector skewBy(const Vector& other) const {
+		constexpr Vector skewBy(const Vector& other) const
+		{
 			return {x * other.x, y * other.y};
 		}
 
-		constexpr Vector skewInverseBy(const Vector& other) const {
-			if (other.x == 0 || other.y == 0) {
+		constexpr Vector skewInverseBy(const Vector& other) const
+		{
+			if (other.x == 0 || other.y == 0)
+			{
 				throw std::domain_error("Cannot skewInverseBy a vector with a zero component");
 			}
 			return {x / other.x, y / other.y};
 		}
 
-		constexpr BaseType lengthSquared() const {
+		constexpr BaseType lengthSquared() const
+		{
 			return (x * x) + (y * y);
 		}
 
-		constexpr BaseType dotProduct(const Vector& other) const {
+		constexpr BaseType dotProduct(const Vector& other) const
+		{
 			return (x * other.x) + (y * other.y);
 		}
 
 		// Reflect the x-coordinate (flip across Y-axis)
-		constexpr Vector reflectX() const {
+		constexpr Vector reflectX() const
+		{
 			return {-x, y};
 		}
 
 		// Reflect the y-coordinate (flip across X-axis)
-		constexpr Vector reflectY() const {
+		constexpr Vector reflectY() const
+		{
 			return {x, -y};
 		}
 
 		template <typename NewBaseType>
-		constexpr operator Vector<NewBaseType>() const {
+		constexpr operator Vector<NewBaseType>() const
+		{
 			return {
 				static_cast<NewBaseType>(x),
 				static_cast<NewBaseType>(y)
@@ -105,7 +126,8 @@ namespace NAS2D
 		}
 
 		template <typename NewBaseType>
-		constexpr Vector<NewBaseType> to() const {
+		constexpr Vector<NewBaseType> to() const
+		{
 			return static_cast<Vector<NewBaseType>>(*this);
 		}
 	};
@@ -118,23 +140,26 @@ namespace NAS2D
 	// Partial order comparisons
 
 	template <typename BaseType>
-	bool operator<=(Vector<BaseType> v1, Vector<BaseType> v2) {
+	bool operator<=(Vector<BaseType> v1, Vector<BaseType> v2)
+	{
 		return (v1.x <= v2.x) && (v1.y <= v2.y);
 	}
 
 	template <typename BaseType>
-	bool operator>=(Vector<BaseType> v1, Vector<BaseType> v2) {
+	bool operator>=(Vector<BaseType> v1, Vector<BaseType> v2)
+	{
 		return v2 <= v1;
 	}
 
 	template <typename BaseType>
-	bool operator<(Vector<BaseType> v1, Vector<BaseType> v2) {
+	bool operator<(Vector<BaseType> v1, Vector<BaseType> v2)
+	{
 		return (v1.x < v2.x) && (v1.y < v2.y);
 	}
 
 	template <typename BaseType>
-	bool operator>(Vector<BaseType> v1, Vector<BaseType> v2) {
+	bool operator>(Vector<BaseType> v1, Vector<BaseType> v2)
+	{
 		return v2 < v1;
 	}
-
 }

--- a/NAS2D/Renderer/VectorSizeRange.h
+++ b/NAS2D/Renderer/VectorSizeRange.h
@@ -6,12 +6,12 @@
 
 namespace NAS2D
 {
-
-
 	template <typename BaseType>
-	class VectorSizeRange {
+	class VectorSizeRange
+	{
 	public:
-		class Iterator {
+		class Iterator
+		{
 		public:
 			Iterator(const Vector<BaseType>& size, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
 				mCurrent(initial),
@@ -20,17 +20,21 @@ namespace NAS2D
 			Iterator(const Iterator& other) = default;
 			Iterator& operator=(const Iterator& other) = default;
 
-			Iterator& operator++() {
+			Iterator& operator++()
+			{
 				++mCurrent.x;
-				if (mCurrent.x >= mSize.x) {
+				if (mCurrent.x >= mSize.x)
+				{
 					mCurrent.x = 0;
 					++mCurrent.y;
 				}
 				return *this;
 			}
 
-			Iterator& operator--() {
-				if (mCurrent.x <= 0) {
+			Iterator& operator--()
+			{
+				if (mCurrent.x <= 0)
+				{
 					mCurrent.x = mSize.x;
 					--mCurrent.y;
 				}
@@ -38,15 +42,18 @@ namespace NAS2D
 				return *this;
 			}
 
-			bool operator==(const Iterator& other) const {
+			bool operator==(const Iterator& other) const
+			{
 				return mCurrent == other.mCurrent;
 			}
 
-			bool operator!=(const Iterator& other) const {
+			bool operator!=(const Iterator& other) const
+			{
 				return !(*this == other);
 			}
 
-			Vector<BaseType> operator*() const {
+			Vector<BaseType> operator*() const
+			{
 				return mCurrent;
 			}
 
@@ -60,16 +67,17 @@ namespace NAS2D
 			mSize(size)
 		{}
 
-		Iterator begin() const {
+		Iterator begin() const
+		{
 			return Iterator{mSize};
 		}
 
-		Iterator end() const {
+		Iterator end() const
+		{
 			return Iterator{mSize, Vector<BaseType>{0, mSize.y}};
 		}
 
 	private:
 		const Vector<BaseType> mSize;
 	};
-
 } // namespace


### PR DESCRIPTION
Reference: #893

Reflow braces in template classes `Point`, `Vector`, `Rectangle`, and related helper classes `PointInRectangleRange`, and `VectorSizeRange`.
