### PR TITLE
Refactor AnimationSet XML parsing

### DIFF
--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -187,14 +187,14 @@ namespace
 
 		for (const auto* node = element->firstChildElement(); node; node = node->nextSiblingElement())
 		{
-			if (toLowercase(node->value()) == "action")
+			if (node->value() == "action")
 			{
 
 				std::string actionName;
 				const auto* attribute = node->firstAttribute();
 				while (attribute)
 				{
-					if (toLowercase(attribute->name()) == "name")
+					if (attribute->name() == "name")
 					{
 						actionName = attribute->value();
 					}

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -31,7 +31,7 @@ namespace
 	AnimationSet processXml(std::string filePath, ImageCache& imageCache);
 	std::map<std::string, std::string> processImageSheets(const std::string& basePath, const Xml::XmlElement* element, ImageCache& imageCache);
 	std::map<std::string, std::vector<AnimationSet::Frame>> processActions(const std::map<std::string, std::string>& imageSheetMap, const Xml::XmlElement* element, ImageCache& imageCache);
-	std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, std::string>& imageSheetMap, const std::string& action, const Xml::XmlNode* node, ImageCache& imageCache);
+	std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, std::string>& imageSheetMap, const std::string& action, const Xml::XmlElement* element, ImageCache& imageCache);
 }
 
 
@@ -204,11 +204,11 @@ namespace
 	/**
 	 * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
 	 */
-	std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, std::string>& imageSheetMap, const std::string& action, const Xml::XmlNode* node, ImageCache& imageCache)
+	std::vector<AnimationSet::Frame> processFrames(const std::map<std::string, std::string>& imageSheetMap, const std::string& action, const Xml::XmlElement* element, ImageCache& imageCache)
 	{
 		std::vector<AnimationSet::Frame> frameList;
 
-		for (const auto* frame = node->firstChildElement(); frame; frame = frame->nextSiblingElement())
+		for (const auto* frame = element->firstChildElement(); frame; frame = frame->nextSiblingElement())
 		{
 			int currentRow = frame->row();
 

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -189,18 +189,8 @@ namespace
 		{
 			if (node->value() == "action")
 			{
-
-				std::string actionName;
-				const auto* attribute = node->firstAttribute();
-				while (attribute)
-				{
-					if (attribute->name() == "name")
-					{
-						actionName = attribute->value();
-					}
-
-					attribute = attribute->next();
-				}
+				const auto dictionary = attributesToDictionary(*node);
+				const auto actionName = dictionary.get("name");
 
 				if (actionName.empty())
 				{

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -185,15 +185,13 @@ namespace
 	{
 		std::map<std::string, std::vector<AnimationSet::Frame>> actions;
 
-		for (const auto* node = element->iterateChildren(nullptr);
-			node != nullptr;
-			node = element->iterateChildren(node))
+		for (const auto* node = element->firstChildElement(); node; node = node->nextSiblingElement())
 		{
-			if (toLowercase(node->value()) == "action" && node->toElement())
+			if (toLowercase(node->value()) == "action")
 			{
 
 				std::string actionName;
-				const auto* attribute = node->toElement()->firstAttribute();
+				const auto* attribute = node->firstAttribute();
 				while (attribute)
 				{
 					if (toLowercase(attribute->name()) == "name")

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -96,12 +96,12 @@ namespace
 			}
 
 			// Get the Sprite version.
-			const auto* version = xmlRootElement->firstAttribute();
-			if (!version || version->value().empty())
+			const auto version = xmlRootElement->attribute("version");
+			if (version.empty())
 			{
 				throw std::runtime_error("Sprite file's root element does not specify a version");
 			}
-			if (version->value() != SPRITE_VERSION)
+			if (version != SPRITE_VERSION)
 			{
 				throw std::runtime_error("Sprite version mismatch. Expected: " + std::string{SPRITE_VERSION} + " Actual: " + versionString());
 			}

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -227,13 +227,11 @@ namespace
 	{
 		std::vector<AnimationSet::Frame> frameList;
 
-		for (const auto* frame = node->iterateChildren(nullptr);
-			frame != nullptr;
-			frame = node->iterateChildren(frame))
+		for (const auto* frame = node->firstChildElement(); frame; frame = frame->nextSiblingElement())
 		{
 			int currentRow = frame->row();
 
-			if (frame->value() != "frame" || !frame->toElement())
+			if (frame->value() != "frame")
 			{
 				throw std::runtime_error("Sprite frame tag unexpected: <" + frame->value() + "> : " + endTag(currentRow));
 			}
@@ -244,7 +242,7 @@ namespace
 			int width = 0, height = 0;
 			int anchorx = 0, anchory = 0;
 
-			const auto* attribute = frame->toElement()->firstAttribute();
+			const auto* attribute = frame->firstAttribute();
 			while (attribute)
 			{
 				if (toLowercase(attribute->name()) == "sheetid") { sheetId = attribute->value(); }

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -177,23 +177,23 @@ namespace
 	{
 		std::map<std::string, std::vector<AnimationSet::Frame>> actions;
 
-		for (const auto* node = element->firstChildElement(); node; node = node->nextSiblingElement())
+		for (const auto* action = element->firstChildElement(); action; action = action->nextSiblingElement())
 		{
-			if (node->value() == "action")
+			if (action->value() == "action")
 			{
-				const auto dictionary = attributesToDictionary(*node);
+				const auto dictionary = attributesToDictionary(*action);
 				const auto actionName = dictionary.get("name");
 
 				if (actionName.empty())
 				{
-					throw std::runtime_error("Sprite Action definition has 'name' of length zero: " + endTag(node->row()));
+					throw std::runtime_error("Sprite Action definition has 'name' of length zero: " + endTag(action->row()));
 				}
 				if (actions.find(actionName) != actions.end())
 				{
-					throw std::runtime_error("Sprite Action redefinition: '" + actionName + "' " + endTag(node->row()));
+					throw std::runtime_error("Sprite Action redefinition: '" + actionName + "' " + endTag(action->row()));
 				}
 
-				actions[actionName] = processFrames(imageSheetMap, actionName, node, imageCache);
+				actions[actionName] = processFrames(imageSheetMap, actionName, action, imageCache);
 			}
 		}
 

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -141,8 +141,8 @@ namespace
 				const auto* attribute = node->firstAttribute();
 				while (attribute)
 				{
-					if (toLowercase(attribute->name()) == "id") { id = attribute->value(); }
-					else if (toLowercase(attribute->name()) == "src") { src = attribute->value(); }
+					if (attribute->name() == "id") { id = attribute->value(); }
+					else if (attribute->name() == "src") { src = attribute->value(); }
 
 					attribute = attribute->next();
 				}

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -133,14 +133,12 @@ namespace
 	{
 		std::map<std::string, std::string> imageSheetMap;
 
-		for (const auto* node = element->iterateChildren(nullptr);
-			node != nullptr;
-			node = element->iterateChildren(node))
+		for (const auto* node = element->firstChildElement(); node; node = node->nextSiblingElement())
 		{
-			if (node->value() == "imagesheet" && node->toElement())
+			if (node->value() == "imagesheet")
 			{
 				std::string id, src;
-				const auto* attribute = node->toElement()->firstAttribute();
+				const auto* attribute = node->firstAttribute();
 				while (attribute)
 				{
 					if (toLowercase(attribute->name()) == "id") { id = attribute->value(); }

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -137,15 +137,9 @@ namespace
 		{
 			if (node->value() == "imagesheet")
 			{
-				std::string id, src;
-				const auto* attribute = node->firstAttribute();
-				while (attribute)
-				{
-					if (attribute->name() == "id") { id = attribute->value(); }
-					else if (attribute->name() == "src") { src = attribute->value(); }
-
-					attribute = attribute->next();
-				}
+				const auto dictionary = attributesToDictionary(*node);
+				const auto id = dictionary.get("id");
+				const auto src = dictionary.get("src");
 
 				if (id.empty())
 				{

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -6,6 +6,7 @@
 #include "../Filesystem.h"
 #include "../ContainerUtils.h"
 #include "../StringUtils.h"
+#include "../ParserHelper.h"
 #include "../Version.h"
 #include "../Xml/Xml.h"
 
@@ -236,30 +237,17 @@ namespace
 				throw std::runtime_error("Sprite frame tag unexpected: <" + frame->value() + "> : " + endTag(currentRow));
 			}
 
-			std::string sheetId;
-			int delay = 0;
-			int x = 0, y = 0;
-			int width = 0, height = 0;
-			int anchorx = 0, anchory = 0;
+			const auto dictionary = attributesToDictionary(*frame);
+			reportMissingOrUnexpected(dictionary.keys(), {"sheetid", "delay", "x", "y", "width", "height", "anchorx", "anchory"}, {});
 
-			const auto* attribute = frame->firstAttribute();
-			while (attribute)
-			{
-				if (toLowercase(attribute->name()) == "sheetid") { sheetId = attribute->value(); }
-				else if (toLowercase(attribute->name()) == "delay") { attribute->queryIntValue(delay); }
-				else if (toLowercase(attribute->name()) == "x") { attribute->queryIntValue(x); }
-				else if (toLowercase(attribute->name()) == "y") { attribute->queryIntValue(y); }
-				else if (toLowercase(attribute->name()) == "width") { attribute->queryIntValue(width); }
-				else if (toLowercase(attribute->name()) == "height") { attribute->queryIntValue(height); }
-				else if (toLowercase(attribute->name()) == "anchorx") { attribute->queryIntValue(anchorx); }
-				else if (toLowercase(attribute->name()) == "anchory") { attribute->queryIntValue(anchory); }
-				else
-				{
-					throw std::runtime_error("Sprite frame attribute unexpected: '" + attribute->name() + "' : " + endTag(currentRow));
-				}
-
-				attribute = attribute->next();
-			}
+			const auto sheetId = dictionary.get("sheetid");
+			const auto delay = dictionary.get<int>("delay");
+			const auto x = dictionary.get<int>("x");
+			const auto y = dictionary.get<int>("y");
+			const auto width = dictionary.get<int>("width");
+			const auto height = dictionary.get<int>("height");
+			const auto anchorx = dictionary.get<int>("anchorx");
+			const auto anchory = dictionary.get<int>("anchory");
 
 			if (sheetId.empty())
 			{


### PR DESCRIPTION
Reference: #797

Refactor `AnimationSet` XML parsing code.

Use `attributesToDictionary` rather than raw XML calls. Remove `toLowercase` calls on tag and value names, making format errors more likely to be caught. Be specific that the `"version"` attribute is being checked.
