### PR TITLE
Window interface class

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -265,6 +265,7 @@
     <ClInclude Include="Renderer\RectangleSkin.h" />
     <ClInclude Include="Renderer\Renderer.h" />
     <ClInclude Include="Renderer\RendererOpenGL.h" />
+    <ClInclude Include="Renderer\Window.h" />
     <ClInclude Include="Resource\ResourceCache.h" />
     <ClInclude Include="Resource\AnimationSet.h" />
     <ClInclude Include="Resource\Font.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -344,6 +344,9 @@
     <ClInclude Include="Dictionary.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Renderer\Window.h">
+      <Filter>Header Files\Renderer</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.clang-format" />

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -3,103 +3,108 @@
 #include <string>
 #include <utility>
 
-enum class WindowDisplayMode
+namespace NAS2D
 {
-	Windowed
-	,Borderless
-	,Borderless_Fullscreen
-};
 
-struct WindowDesc
-{
-	//The client dimensions
-	//Window creation process should automatically add space for borders, menus and title bars
-	std::pair<int, int> dimensions{1600,900};
-	std::pair<int, int> position{0,0};
-	WindowDisplayMode mode{WindowDisplayMode::Windowed};
-};
+	enum class WindowDisplayMode
+	{
+		Windowed,
+		Borderless,
+		Borderless_Fullscreen,
+	};
 
-class Window
-{
-public:
-	virtual ~Window() noexcept {}
+	struct WindowDesc
+	{
+		//The client dimensions
+		//Window creation process should automatically add space for borders, menus and title bars
+		std::pair<int, int> dimensions{1600,900};
+		std::pair<int, int> position{0,0};
+		WindowDisplayMode mode{WindowDisplayMode::Windowed};
+	};
 
-	virtual void open() noexcept = 0;
-	virtual void close() noexcept = 0;
+	class Window
+	{
+	public:
+		virtual ~Window() noexcept {}
 
-	virtual void show() noexcept = 0;
-	virtual void hide() noexcept = 0;
-	virtual void unhide() noexcept = 0;
+		virtual void open() noexcept = 0;
+		virtual void close() noexcept = 0;
 
-	[[nodiscard]] virtual bool isOpen() const noexcept = 0;
-	[[nodiscard]] virtual bool isClosed() const noexcept = 0;
-	[[nodiscard]] virtual bool isFullscreen() const noexcept = 0;
-	[[nodiscard]] virtual bool isWindowed() const noexcept = 0;
+		virtual void show() noexcept = 0;
+		virtual void hide() noexcept = 0;
+		virtual void unhide() noexcept = 0;
 
-	/**
-	 * @brief Get the underlying OS-specific window handle.
-	 * @return void* Handle to the window. static_cast to appropriate OS-specific type. For Windows this would be HWND.
-	*/
-	[[nodiscard]] virtual void* nativeHandle() const noexcept = 0;
+		[[nodiscard]] virtual bool isOpen() const noexcept = 0;
+		[[nodiscard]] virtual bool isClosed() const noexcept = 0;
+		[[nodiscard]] virtual bool isFullscreen() const noexcept = 0;
+		[[nodiscard]] virtual bool isWindowed() const noexcept = 0;
 
-	/**
-	 * @brief Set the underlying OS-specific window handle.
-	 * @param handle: The handle to the window. For Windows this would be a variable of type HWND.
-	 * @return None
-	*/
-	virtual void nativeHandle(void* handle) noexcept = 0;
+		/**
+		 * @brief Get the underlying OS-specific window handle.
+		 * @return void* Handle to the window. static_cast to appropriate OS-specific type. For Windows this would be HWND.
+		*/
+		[[nodiscard]] virtual void* nativeHandle() const noexcept = 0;
 
-	/**
-	 * @brief Get the underlying OS-specific window-owned device context.
-	 * @return void* handle to the Device Context. static_cast to appropriate OS-specific type. For Windows this would be HDC.
-	*/
-	[[nodiscard]] virtual void* nativeDeviceContext() const noexcept = 0;
+		/**
+		 * @brief Set the underlying OS-specific window handle.
+		 * @param handle: The handle to the window. For Windows this would be a variable of type HWND.
+		 * @return None
+		*/
+		virtual void nativeHandle(void* handle) noexcept = 0;
 
-	/**
-	 * @brief Set the underlying OS-specific window-owned device context.
-	 * @param hDC: The handle to the device context this window will now own.
-	 * @comment For Windows this would be a variable of type HDC.
-	 * @return None
-	*/
-	virtual void nativeDeviceContext(void* hDC) noexcept = 0;
+		/**
+		 * @brief Get the underlying OS-specific window-owned device context.
+		 * @return void* handle to the Device Context. static_cast to appropriate OS-specific type. For Windows this would be HDC.
+		*/
+		[[nodiscard]] virtual void* nativeDeviceContext() const noexcept = 0;
 
-	/**
-	 * @brief Dimensions of the entire window including any border, menus, or title bars.
-	 * @return std::pair<int, int> x/y components of the window dimensions
-	*/
-	[[nodiscard]] virtual std::pair<int, int> dimensions() const noexcept = 0;
+		/**
+		 * @brief Set the underlying OS-specific window-owned device context.
+		 * @param hDC: The handle to the device context this window will now own.
+		 * @comment For Windows this would be a variable of type HDC.
+		 * @return None
+		*/
+		virtual void nativeDeviceContext(void* hDC) noexcept = 0;
 
-	/**
-	 * @brief Dimensions of the renderable area of the window not including any borders, menus, or title bars.
-	 * @return std::pair<int, int> x/y components of the client area dimensions
-	*/
-	[[nodiscard]] virtual std::pair<int, int> clientDimensions() const noexcept = 0;
-	virtual void dimensions(std::pair<int, int> newClientDimensions) noexcept = 0;
+		/**
+		 * @brief Dimensions of the entire window including any border, menus, or title bars.
+		 * @return std::pair<int, int> x/y components of the window dimensions
+		*/
+		[[nodiscard]] virtual std::pair<int, int> dimensions() const noexcept = 0;
 
-	virtual void title(std::string newTitle) noexcept = 0;
-	[[nodiscard]] virtual std::string title() noexcept = 0;
+		/**
+		 * @brief Dimensions of the renderable area of the window not including any borders, menus, or title bars.
+		 * @return std::pair<int, int> x/y components of the client area dimensions
+		*/
+		[[nodiscard]] virtual std::pair<int, int> clientDimensions() const noexcept = 0;
+		virtual void dimensions(std::pair<int, int> newClientDimensions) noexcept = 0;
 
-	virtual void displayMode(WindowDisplayMode newDisplayMode) noexcept = 0;
-	[[nodiscard]] virtual WindowDisplayMode displayMode() noexcept = 0;
+		virtual void title(std::string newTitle) noexcept = 0;
+		[[nodiscard]] virtual std::string title() noexcept = 0;
 
-	[[nodiscard]] virtual std::pair<int, int> position() const noexcept = 0;
-	virtual void position(std::pair<int, int> newPosition) noexcept = 0;
+		virtual void displayMode(WindowDisplayMode newDisplayMode) noexcept = 0;
+		[[nodiscard]] virtual WindowDisplayMode displayMode() noexcept = 0;
 
-	virtual void setDimensionsAndPosition(std::pair<int, int> newClientDimensions, std::pair<int, int> newPosition) noexcept = 0;
+		[[nodiscard]] virtual std::pair<int, int> position() const noexcept = 0;
+		virtual void position(std::pair<int, int> newPosition) noexcept = 0;
 
-	/**
-	 * @brief Set the native OS-specific window icon resource.
-	 * @param iconResource: Handle to the icon resource.
-	 * @return 
-	*/
-	virtual void icon(void* iconResource) noexcept = 0;
+		virtual void setDimensionsAndPosition(std::pair<int, int> newClientDimensions, std::pair<int, int> newPosition) noexcept = 0;
 
-	/**
-	 * @brief Get the native OS-specific window icon resource.
-	 * @return void* handle to the native OS-specific window icon resource.
-	*/
-	[[nodiscard]] virtual void* icon() const noexcept = 0;
-protected:
-private:
-	
-};
+		/**
+		 * @brief Set the native OS-specific window icon resource.
+		 * @param iconResource: Handle to the icon resource.
+		 * @return
+		*/
+		virtual void icon(void* iconResource) noexcept = 0;
+
+		/**
+		 * @brief Get the native OS-specific window icon resource.
+		 * @return void* handle to the native OS-specific window icon resource.
+		*/
+		[[nodiscard]] virtual void* icon() const noexcept = 0;
+	protected:
+	private:
+
+	};
+
+}

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -85,6 +85,18 @@ public:
 
 	virtual void SetDimensionsAndPosition(std::pair<int, int> newClientDimensions, std::pair<int, int> newPosition) noexcept = 0;
 
+	/**
+	 * @brief Set the native OS-specific window icon resource.
+	 * @param iconResource: Handle to the icon resource.
+	 * @return 
+	*/
+	virtual void Icon(void* iconResource) noexcept = 0;
+
+	/**
+	 * @brief Get the native OS-specific window icon resource.
+	 * @return void* handle to the native OS-specific window icon resource.
+	*/
+	[[nodiscard]] virtual void* Icon() const noexcept = 0;
 protected:
 private:
 	

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -14,7 +14,7 @@ struct WindowDesc
 {
 	//The client dimensions
 	//Window creation process should automatically add space for borders, menus and title bars
-	std::pair<int, int> dimensions{1600,600};
+	std::pair<int, int> dimensions{1600,900};
 	std::pair<int, int> position{0,0};
 	WindowDisplayMode mode{WindowDisplayMode::Windowed};
 };

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -3,13 +3,15 @@
 #include <string>
 #include <utility>
 
-enum class WindowDisplayMode {
+enum class WindowDisplayMode
+{
 	Windowed
 	,Borderless
 	,Borderless_Fullscreen
 };
 
-struct WindowDesc {
+struct WindowDesc
+{
 	//The client dimensions
 	//Window creation process should automatically add space for borders, menus and title bars
 	std::pair<int, int> dimensions{1600,600};
@@ -17,40 +19,41 @@ struct WindowDesc {
 	WindowDisplayMode mode{WindowDisplayMode::Windowed};
 };
 
-class Window {
+class Window
+{
 public:
 	virtual ~Window() noexcept {}
 
-	virtual void Open() noexcept = 0;
-	virtual void Close() noexcept = 0;
+	virtual void open() noexcept = 0;
+	virtual void close() noexcept = 0;
 
-	virtual void Show() noexcept = 0;
-	virtual void Hide() noexcept = 0;
-	virtual void Unhide() noexcept = 0;
+	virtual void show() noexcept = 0;
+	virtual void hide() noexcept = 0;
+	virtual void unhide() noexcept = 0;
 
-	[[nodiscard]] virtual bool IsOpen() const noexcept = 0;
-	[[nodiscard]] virtual bool IsClosed() const noexcept = 0;
-	[[nodiscard]] virtual bool IsFullscreen() const noexcept = 0;
-	[[nodiscard]] virtual bool IsWindowed() const noexcept = 0;
+	[[nodiscard]] virtual bool isOpen() const noexcept = 0;
+	[[nodiscard]] virtual bool isClosed() const noexcept = 0;
+	[[nodiscard]] virtual bool isFullscreen() const noexcept = 0;
+	[[nodiscard]] virtual bool isWindowed() const noexcept = 0;
 
 	/**
 	 * @brief Get the underlying OS-specific window handle.
 	 * @return void* Handle to the window. static_cast to appropriate OS-specific type. For Windows this would be HWND.
 	*/
-	[[nodiscard]] virtual void* NativeHandle() const noexcept = 0;
+	[[nodiscard]] virtual void* nativeHandle() const noexcept = 0;
 
 	/**
 	 * @brief Set the underlying OS-specific window handle.
 	 * @param handle: The handle to the window. For Windows this would be a variable of type HWND.
 	 * @return None
 	*/
-	virtual void NativeHandle(void* handle) noexcept = 0;
+	virtual void nativeHandle(void* handle) noexcept = 0;
 
 	/**
 	 * @brief Get the underlying OS-specific window-owned device context.
 	 * @return void* handle to the Device Context. static_cast to appropriate OS-specific type. For Windows this would be HDC.
 	*/
-	[[nodiscard]] virtual void* NativeDeviceContext() const noexcept = 0;
+	[[nodiscard]] virtual void* nativeDeviceContext() const noexcept = 0;
 
 	/**
 	 * @brief Set the underlying OS-specific window-owned device context.
@@ -58,45 +61,44 @@ public:
 	 * @comment For Windows this would be a variable of type HDC.
 	 * @return None
 	*/
-	virtual void NativeDeviceContext(void* hDC) noexcept = 0;
+	virtual void nativeDeviceContext(void* hDC) noexcept = 0;
 
 	/**
 	 * @brief Dimensions of the entire window including any border, menus, or title bars.
 	 * @return std::pair<int, int> x/y components of the window dimensions
 	*/
-	[[nodiscard]] virtual std::pair<int, int> GetDimensions() const noexcept = 0;
-	
+	[[nodiscard]] virtual std::pair<int, int> dimensions() const noexcept = 0;
+
 	/**
 	 * @brief Dimensions of the renderable area of the window not including any borders, menus, or title bars.
 	 * @return std::pair<int, int> x/y components of the client area dimensions
 	*/
-	[[nodiscard]] virtual std::pair<int, int> GetClientDimensions() const noexcept = 0;
+	[[nodiscard]] virtual std::pair<int, int> clientDimensions() const noexcept = 0;
+	virtual void dimensions(std::pair<int, int> newClientDimensions) noexcept = 0;
 
-	virtual void Dimensions(std::pair<int, int> newClientDimensions) noexcept = 0;
+	virtual void title(std::string newTitle) noexcept = 0;
+	[[nodiscard]] virtual std::string title() noexcept = 0;
 
-	virtual void Title(std::string title) noexcept = 0;
-	[[nodiscard]] virtual std::string Title() noexcept = 0;
+	virtual void displayMode(WindowDisplayMode newDisplayMode) noexcept = 0;
+	[[nodiscard]] virtual WindowDisplayMode displayMode() noexcept = 0;
 
-	virtual void DisplayMode(WindowDisplayMode mode) noexcept = 0;
-	[[nodiscard]] virtual WindowDisplayMode DisplayMode() noexcept = 0;
+	[[nodiscard]] virtual std::pair<int, int> position() const noexcept = 0;
+	virtual void position(std::pair<int, int> newPosition) noexcept = 0;
 
-	[[nodiscard]] virtual std::pair<int, int> Position() const noexcept = 0;
-	virtual void Position(std::pair<int, int> newPosition) noexcept = 0;
-
-	virtual void SetDimensionsAndPosition(std::pair<int, int> newClientDimensions, std::pair<int, int> newPosition) noexcept = 0;
+	virtual void setDimensionsAndPosition(std::pair<int, int> newClientDimensions, std::pair<int, int> newPosition) noexcept = 0;
 
 	/**
 	 * @brief Set the native OS-specific window icon resource.
 	 * @param iconResource: Handle to the icon resource.
 	 * @return 
 	*/
-	virtual void Icon(void* iconResource) noexcept = 0;
+	virtual void icon(void* iconResource) noexcept = 0;
 
 	/**
 	 * @brief Get the native OS-specific window icon resource.
 	 * @return void* handle to the native OS-specific window icon resource.
 	*/
-	[[nodiscard]] virtual void* Icon() const noexcept = 0;
+	[[nodiscard]] virtual void* icon() const noexcept = 0;
 protected:
 private:
 	

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -92,20 +92,6 @@ namespace NAS2D
 
 		virtual void setPositionAndDimensions(Point<int> newPosition, Vector<int> newClientDimensions) noexcept = 0;
 		virtual void setPositionAndDimensions(Rectangle<int> newPositionAndClientDimensions) noexcept = 0;
-
-		/**
-		 * @brief Set the native OS-specific window icon resource.
-		 * @param iconResource: Handle to the icon resource.
-		 * @return
-		*/
-		virtual void icon(void* iconResource) noexcept = 0;
-
-		/**
-		 * @brief Get the native OS-specific window icon resource.
-		 * @return void* handle to the native OS-specific window icon resource.
-		*/
-		[[nodiscard]] virtual void* icon() const noexcept = 0;
-	
 	};
 
 }

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -21,8 +21,8 @@ namespace NAS2D
 	{
 		//The client dimensions
 		//Window creation process should automatically add space for borders, menus and title bars
-		Vector<int> dimensions{1600,900};
-		Point<int> position{0,0};
+		Vector<int> dimensions{1600, 900};
+		Point<int> position{0, 0};
 		WindowDisplayMode mode{WindowDisplayMode::Windowed};
 	};
 

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "Rectangle.h"
+#include "Point.h"
+#include "Vector.h"
+
 #include <string>
 #include <utility>
 
@@ -17,8 +21,8 @@ namespace NAS2D
 	{
 		//The client dimensions
 		//Window creation process should automatically add space for borders, menus and title bars
-		std::pair<int, int> dimensions{1600,900};
-		std::pair<int, int> position{0,0};
+		Vector<int> dimensions{1600,900};
+		Point<int> position{0,0};
 		WindowDisplayMode mode{WindowDisplayMode::Windowed};
 	};
 
@@ -70,14 +74,14 @@ namespace NAS2D
 		 * @brief Dimensions of the entire window including any border, menus, or title bars.
 		 * @return std::pair<int, int> x/y components of the window dimensions
 		*/
-		[[nodiscard]] virtual std::pair<int, int> dimensions() const noexcept = 0;
+		[[nodiscard]] virtual Vector<int> dimensions() const noexcept = 0;
 
 		/**
 		 * @brief Dimensions of the renderable area of the window not including any borders, menus, or title bars.
 		 * @return std::pair<int, int> x/y components of the client area dimensions
 		*/
-		[[nodiscard]] virtual std::pair<int, int> clientDimensions() const noexcept = 0;
-		virtual void dimensions(std::pair<int, int> newClientDimensions) noexcept = 0;
+		[[nodiscard]] virtual Vector<int> clientDimensions() const noexcept = 0;
+		virtual void dimensions(Vector<int> newClientDimensions) noexcept = 0;
 
 		virtual void title(std::string newTitle) noexcept = 0;
 		[[nodiscard]] virtual std::string title() noexcept = 0;
@@ -85,10 +89,11 @@ namespace NAS2D
 		virtual void displayMode(WindowDisplayMode newDisplayMode) noexcept = 0;
 		[[nodiscard]] virtual WindowDisplayMode displayMode() noexcept = 0;
 
-		[[nodiscard]] virtual std::pair<int, int> position() const noexcept = 0;
-		virtual void position(std::pair<int, int> newPosition) noexcept = 0;
+		[[nodiscard]] virtual Point<int> position() const noexcept = 0;
+		virtual void position(Point<int> newPosition) noexcept = 0;
 
-		virtual void setDimensionsAndPosition(std::pair<int, int> newClientDimensions, std::pair<int, int> newPosition) noexcept = 0;
+		virtual void setPositionAndDimensions(Point<int> newPosition, Vector<int> newClientDimensions) noexcept = 0;
+		virtual void setPositionAndDimensions(Rectangle<int> newPositionAndClientDimensions) noexcept = 0;
 
 		/**
 		 * @brief Set the native OS-specific window icon resource.

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -107,9 +107,7 @@ namespace NAS2D
 		 * @return void* handle to the native OS-specific window icon resource.
 		*/
 		[[nodiscard]] virtual void* icon() const noexcept = 0;
-	protected:
-	private:
-
+	
 	};
 
 }

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <string>
+#include <utility>
+
+enum class WindowDisplayMode {
+	Windowed
+	,Borderless
+	,Borderless_Fullscreen
+};
+
+struct WindowDesc {
+	//The client dimensions
+	//Window creation process should automatically add space for borders, menus and title bars
+	std::pair<int, int> dimensions{1600,600};
+	std::pair<int, int> position{0,0};
+	WindowDisplayMode mode{WindowDisplayMode::Windowed};
+};
+
+class Window {
+public:
+	virtual ~Window() noexcept {}
+
+	virtual void Open() noexcept = 0;
+	virtual void Close() noexcept = 0;
+
+	virtual void Show() noexcept = 0;
+	virtual void Hide() noexcept = 0;
+	virtual void Unhide() noexcept = 0;
+
+	[[nodiscard]] virtual bool IsOpen() const noexcept = 0;
+	[[nodiscard]] virtual bool IsClosed() const noexcept = 0;
+	[[nodiscard]] virtual bool IsFullscreen() const noexcept = 0;
+	[[nodiscard]] virtual bool IsWindowed() const noexcept = 0;
+
+	/**
+	 * @brief Get the underlying OS-specific window handle.
+	 * @return void* Handle to the window. static_cast to appropriate OS-specific type. For Windows this would be HWND.
+	*/
+	[[nodiscard]] virtual void* NativeHandle() const noexcept = 0;
+
+	/**
+	 * @brief Set the underlying OS-specific window handle.
+	 * @param handle: The handle to the window. For Windows this would be a variable of type HWND.
+	 * @return None
+	*/
+	virtual void NativeHandle(void* handle) noexcept = 0;
+
+	/**
+	 * @brief Get the underlying OS-specific window-owned device context.
+	 * @return void* handle to the Device Context. static_cast to appropriate OS-specific type. For Windows this would be HDC.
+	*/
+	[[nodiscard]] virtual void* NativeDeviceContext() const noexcept = 0;
+
+	/**
+	 * @brief Set the underlying OS-specific window-owned device context.
+	 * @param hDC: The handle to the device context this window will now own.
+	 * @comment For Windows this would be a variable of type HDC.
+	 * @return None
+	*/
+	virtual void NativeDeviceContext(void* hDC) noexcept = 0;
+
+	/**
+	 * @brief Dimensions of the entire window including any border, menus, or title bars.
+	 * @return std::pair<int, int> x/y components of the window dimensions
+	*/
+	[[nodiscard]] virtual std::pair<int, int> GetDimensions() const noexcept = 0;
+	
+	/**
+	 * @brief Dimensions of the renderable area of the window not including any borders, menus, or title bars.
+	 * @return std::pair<int, int> x/y components of the client area dimensions
+	*/
+	[[nodiscard]] virtual std::pair<int, int> GetClientDimensions() const noexcept = 0;
+
+	virtual void Dimensions(std::pair<int, int> newClientDimensions) noexcept = 0;
+
+	virtual void Title(std::string title) noexcept = 0;
+	[[nodiscard]] virtual std::string Title() noexcept = 0;
+
+	virtual void DisplayMode(WindowDisplayMode mode) noexcept = 0;
+	[[nodiscard]] virtual WindowDisplayMode DisplayMode() noexcept = 0;
+
+	[[nodiscard]] virtual std::pair<int, int> Position() const noexcept = 0;
+	virtual void Position(std::pair<int, int> newPosition) noexcept = 0;
+
+	virtual void SetDimensionsAndPosition(std::pair<int, int> newClientDimensions, std::pair<int, int> newPosition) noexcept = 0;
+
+protected:
+private:
+	
+};

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -19,9 +19,7 @@ namespace NAS2D
 
 	struct WindowDesc
 	{
-		//The client dimensions
-		//Window creation process should automatically add space for borders, menus and title bars
-		Vector<int> dimensions{1600, 900};
+		Vector<int> clientDimensions{1600, 900};
 		Point<int> position{0, 0};
 		WindowDisplayMode mode{WindowDisplayMode::Windowed};
 	};


### PR DESCRIPTION
Ref: #701

This is the first step in refactoring out a self-contained Window class.

I've added comments where I think there would be confusion. Otherwise, I think it's self-explanatory.

I have reservations about using `std::pair<int,int>` instead of an explicit `IntVector`-like type, but, with the advent of structured bindings and initializer lists:

```cpp
window.Dimensions({800,600});
auto& [x,y] = window.GetClientDimensions();
```

The code ends up looking exactly the same from a user standpoint, so I guess I can live with it.

