### PR TITLE
Filesystem read write methods

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -87,7 +87,7 @@ void Configuration::save(const std::string& filePath) const
 {
 	try
 	{
-		Utility<Filesystem>::get().write(File(saveData(), filePath));
+		Utility<Filesystem>::get().write(filePath, saveData());
 	}
 	catch (const std::runtime_error& e)
 	{

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -59,8 +59,8 @@ void Configuration::load(const std::string& filePath)
 		try
 		{
 			// Read in the Config File.
-			auto xmlFile = Utility<Filesystem>::get().open(filePath);
-			loadData(xmlFile.raw_bytes());
+			auto xmlData = Utility<Filesystem>::get().read(filePath);
+			loadData(xmlData.c_str());
 			std::cout << "done." << std::endl;
 		}
 		catch (const std::runtime_error& e)

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -230,6 +230,12 @@ void Filesystem::del(const std::string& filename) const
  */
 File Filesystem::open(const std::string& filename) const
 {
+	return File{read(filename), filename};
+}
+
+
+std::string Filesystem::read(const std::string& filename) const
+{
 	PHYSFS_file* myFile = PHYSFS_openRead(filename.c_str());
 	if (!myFile)
 	{
@@ -260,7 +266,7 @@ File Filesystem::open(const std::string& filename) const
 		throw std::runtime_error(std::string("Unable to load '") + filename + "': " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}
 
-	return File{std::move(fileBuffer), filename};
+	return fileBuffer;
 }
 
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -317,13 +317,14 @@ bool Filesystem::exists(const std::string& filename) const
  */
 void Filesystem::write(const File& file, bool overwrite) const
 {
-	write(file.filename(), file.bytes(), overwrite);
+	const auto writeFlags = overwrite ? WriteFlags::Overwrite : WriteFlags::NoOverwrite;
+	write(file.filename(), file.bytes(), writeFlags);
 }
 
 
-void Filesystem::write(const std::string& filename, const std::string& data, bool overwrite) const
+void Filesystem::write(const std::string& filename, const std::string& data, WriteFlags flags) const
 {
-	if (!overwrite && exists(filename))
+	if (flags != WriteFlags::Overwrite && exists(filename))
 	{
 		throw std::runtime_error(std::string("File exists: ") + filename);
 	}

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -317,21 +317,27 @@ bool Filesystem::exists(const std::string& filename) const
  */
 void Filesystem::write(const File& file, bool overwrite) const
 {
-	if (!overwrite && exists(file.filename()))
+	write(file.filename(), file.bytes(), overwrite);
+}
+
+
+void Filesystem::write(const std::string& filename, const std::string& data, bool overwrite) const
+{
+	if (!overwrite && exists(filename))
 	{
-		throw std::runtime_error(std::string("File exists: ") + file.filename());
+		throw std::runtime_error(std::string("File exists: ") + filename);
 	}
 
-	PHYSFS_file* myFile = PHYSFS_openWrite(file.filename().c_str());
+	PHYSFS_file* myFile = PHYSFS_openWrite(filename.c_str());
 	if (!myFile)
 	{
-		throw std::runtime_error(std::string("Couldn't open '") + file.filename() + "' for writing: " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+		throw std::runtime_error(std::string("Couldn't open '") + filename + "' for writing: " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}
 
-	if (PHYSFS_writeBytes(myFile, file.bytes().c_str(), static_cast<PHYSFS_uint32>(file.size())) < static_cast<PHYSFS_sint64>(file.size()))
+	if (PHYSFS_writeBytes(myFile, data.c_str(), static_cast<PHYSFS_uint32>(data.size())) < static_cast<PHYSFS_sint64>(data.size()))
 	{
 		closeFile(myFile);
-		throw std::runtime_error(std::string("Error occured while writing to file '") + file.filename() + "': " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+		throw std::runtime_error(std::string("Error occured while writing to file '") + filename + "': " + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	}
 
 	closeFile(myFile);

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -27,6 +27,12 @@ namespace NAS2D
 	class Filesystem
 	{
 	public:
+		enum class WriteFlags
+		{
+			NoOverwrite,
+			Overwrite,
+		};
+
 		Filesystem() = delete;
 		Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName);
 		Filesystem(const Filesystem&) = delete;
@@ -52,7 +58,7 @@ namespace NAS2D
 		void write(const File& file, bool overwrite = true) const;
 
 		std::string read(const std::string& filename) const;
-		void write(const std::string& filename, const std::string& data, bool overwrite = true) const;
+		void write(const std::string& filename, const std::string& data, WriteFlags flags = WriteFlags::Overwrite) const;
 
 		void del(const std::string& path) const;
 		bool exists(const std::string& filename) const;

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -50,6 +50,9 @@ namespace NAS2D
 
 		File open(const std::string& filename) const;
 		void write(const File& file, bool overwrite = true) const;
+
+		std::string read(const std::string& filename) const;
+
 		void del(const std::string& path) const;
 		bool exists(const std::string& filename) const;
 

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -52,6 +52,7 @@ namespace NAS2D
 		void write(const File& file, bool overwrite = true) const;
 
 		std::string read(const std::string& filename) const;
+		void write(const std::string& filename, const std::string& data, bool overwrite = true) const;
 
 		void del(const std::string& path) const;
 		bool exists(const std::string& filename) const;

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -479,14 +479,14 @@ void RendererOpenGL::showSystemPointer(bool _b)
 
 void RendererOpenGL::addCursor(const std::string& filePath, int cursorId, int offx, int offy)
 {
-	auto imageFile = Utility<Filesystem>::get().open(filePath);
-	if (imageFile.size() == 0)
+	auto imageData = Utility<Filesystem>::get().read(filePath);
+	if (imageData.size() == 0)
 	{
 		std::cout << "RendererOpenGL::addCursor(): '" << filePath << "' is empty." << std::endl;
 		return;
 	}
 
-	SDL_Surface* surface = IMG_Load_RW(SDL_RWFromConstMem(imageFile.raw_bytes(), static_cast<int>(imageFile.size())), 1);
+	SDL_Surface* surface = IMG_Load_RW(SDL_RWFromConstMem(imageData.c_str(), static_cast<int>(imageData.size())), 1);
 	if (!surface)
 	{
 		std::cout << "RendererOpenGL::addCursor(): " << SDL_GetError() << std::endl;
@@ -650,8 +650,8 @@ void RendererOpenGL::window_icon(const std::string& path)
 {
 	if (!Utility<Filesystem>::get().exists(path)) { return; }
 
-	auto iconFile = Utility<Filesystem>::get().open(path);
-	SDL_Surface* icon = IMG_Load_RW(SDL_RWFromConstMem(iconFile.raw_bytes(), static_cast<int>(iconFile.size())), 1);
+	auto iconData = Utility<Filesystem>::get().read(path);
+	SDL_Surface* icon = IMG_Load_RW(SDL_RWFromConstMem(iconData.c_str(), static_cast<int>(iconData.size())), 1);
 	if (!icon)
 	{
 		std::cout << "RendererOpenGL::window_icon(): " << SDL_GetError() << std::endl;

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -81,7 +81,7 @@ namespace
 			const auto basePath = filesystem.workingPath(filePath);
 
 			Xml::XmlDocument xmlDoc;
-			xmlDoc.parse(filesystem.open(filePath).raw_bytes());
+			xmlDoc.parse(filesystem.read(filePath).c_str());
 
 			if (xmlDoc.error())
 			{

--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -187,13 +187,13 @@ namespace
 			}
 		}
 
-		auto fontBuffer = Utility<Filesystem>::get().open(path);
+		auto fontBuffer = Utility<Filesystem>::get().read(path);
 		if (fontBuffer.empty())
 		{
 			throw std::runtime_error("Font file is empty: " + path);
 		}
 
-		auto* font = TTF_OpenFontRW(SDL_RWFromConstMem(fontBuffer.raw_bytes(), static_cast<int>(fontBuffer.size())), 1, static_cast<int>(ptSize));
+		auto* font = TTF_OpenFontRW(SDL_RWFromConstMem(fontBuffer.c_str(), static_cast<int>(fontBuffer.size())), 1, static_cast<int>(ptSize));
 		if (!font)
 		{
 			throw std::runtime_error("Font load function failed: " + std::string{TTF_GetError()});
@@ -225,13 +225,13 @@ namespace
 	 */
 	Font::FontInfo loadBitmap(const std::string& path)
 	{
-		auto fontBuffer = Utility<Filesystem>::get().open(path);
+		auto fontBuffer = Utility<Filesystem>::get().read(path);
 		if (fontBuffer.empty())
 		{
 			throw std::runtime_error("Font file is empty: " + path);
 		}
 
-		SDL_Surface* fontSurface = IMG_Load_RW(SDL_RWFromConstMem(fontBuffer.raw_bytes(), static_cast<int>(fontBuffer.size())), 1);
+		SDL_Surface* fontSurface = IMG_Load_RW(SDL_RWFromConstMem(fontBuffer.c_str(), static_cast<int>(fontBuffer.size())), 1);
 		if (!fontSurface)
 		{
 			throw std::runtime_error("Font loadBitmap function failed: " + std::string{SDL_GetError()});

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -47,13 +47,13 @@ namespace
 Image::Image(const std::string& filePath) :
 	mResourceName{filePath}
 {
-	auto imageFile = Utility<Filesystem>::get().open(mResourceName);
-	if (imageFile.size() == 0)
+	auto data = Utility<Filesystem>::get().read(mResourceName);
+	if (data.size() == 0)
 	{
 		throw std::runtime_error("Image file is empty: " + mResourceName);
 	}
 
-	mSurface = IMG_Load_RW(SDL_RWFromConstMem(imageFile.raw_bytes(), static_cast<int>(imageFile.size())), 1);
+	mSurface = IMG_Load_RW(SDL_RWFromConstMem(data.c_str(), static_cast<int>(data.size())), 1);
 	if (!mSurface)
 	{
 		throw std::runtime_error("Image failed to load: " + std::string{SDL_GetError()});

--- a/NAS2D/Resource/Music.cpp
+++ b/NAS2D/Resource/Music.cpp
@@ -25,7 +25,7 @@ using namespace NAS2D;
 
 Music::Music(const std::string& filePath) :
 	mResourceName{filePath},
-	mBuffer{Utility<Filesystem>::get().open(mResourceName).bytes()}
+	mBuffer{Utility<Filesystem>::get().read(mResourceName)}
 {
 	if (mBuffer.empty())
 	{

--- a/NAS2D/Resource/Music.cpp
+++ b/NAS2D/Resource/Music.cpp
@@ -25,14 +25,14 @@ using namespace NAS2D;
 
 Music::Music(const std::string& filePath) :
 	mResourceName{filePath},
-	mBuffer{Utility<Filesystem>::get().open(mResourceName)}
+	mBuffer{Utility<Filesystem>::get().open(mResourceName).bytes()}
 {
 	if (mBuffer.empty())
 	{
 		throw std::runtime_error("Music file is empty: " + mResourceName);
 	}
 
-	mMusic = Mix_LoadMUS_RW(SDL_RWFromConstMem(mBuffer.raw_bytes(), static_cast<int>(mBuffer.size())), 1);
+	mMusic = Mix_LoadMUS_RW(SDL_RWFromConstMem(mBuffer.c_str(), static_cast<int>(mBuffer.size())), 1);
 	if (!mMusic)
 	{
 		throw std::runtime_error("Music::load() error: " + std::string{Mix_GetError()});

--- a/NAS2D/Resource/Music.h
+++ b/NAS2D/Resource/Music.h
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include "../File.h"
-
 #include <string>
 #include <map>
 
@@ -43,7 +41,7 @@ namespace NAS2D
 
 	private:
 		std::string mResourceName; /**< File path */
-		const File mBuffer;
+		const std::string mBuffer;
 		Mix_Music* mMusic{nullptr};
 	};
 

--- a/NAS2D/Resource/Sound.cpp
+++ b/NAS2D/Resource/Sound.cpp
@@ -28,13 +28,13 @@ using namespace NAS2D;
 Sound::Sound(const std::string& filePath) :
 	mResourceName{filePath}
 {
-	auto soundFile = Utility<Filesystem>::get().open(mResourceName);
-	if (soundFile.empty())
+	auto data = Utility<Filesystem>::get().read(mResourceName);
+	if (data.empty())
 	{
 		throw std::runtime_error("Sound file is empty: " + mResourceName);
 	}
 
-	mMixChunk = Mix_LoadWAV_RW(SDL_RWFromConstMem(soundFile.raw_bytes(), static_cast<int>(soundFile.size())), 1);
+	mMixChunk = Mix_LoadWAV_RW(SDL_RWFromConstMem(data.c_str(), static_cast<int>(data.size())), 1);
 	if (!mMixChunk)
 	{
 		throw std::runtime_error("Sound file could not be loaded: " + mResourceName + " : " + std::string{Mix_GetError()});

--- a/NAS2D/Xml/XmlMemoryBuffer.h
+++ b/NAS2D/Xml/XmlMemoryBuffer.h
@@ -30,7 +30,7 @@ namespace Xml {
  * XmlMemoryBuffer buff;
  * doc.Accept(&buff);
  *
- * Utility<Filesystem>::get().write(File(buff.buffer(), mConfigPath));
+ * Utility<Filesystem>::get().write(filePath, buff.buffer());
  * \endcode
  */
 class XmlMemoryBuffer : public XmlVisitor

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -76,6 +76,11 @@ TEST_F(FilesystemTest, open) {
 	EXPECT_EQ("Test data\n", file.bytes());
 }
 
+TEST_F(FilesystemTest, read) {
+	const auto data = fs.read("file.txt");
+	EXPECT_EQ("Test data\n", data);
+}
+
 // Test a few related methods. Some don't test well standalone.
 TEST_F(FilesystemTest, writeReadDeleteExists) {
 	const std::string testFilename = "TestFile.txt";
@@ -89,8 +94,8 @@ TEST_F(FilesystemTest, writeReadDeleteExists) {
 	EXPECT_NO_THROW(fs.write(file));
 	EXPECT_THROW(fs.write(file, false), std::runtime_error);
 
-	const auto fileRead = fs.open(testFilename);
-	EXPECT_EQ(testData, fileRead.bytes());
+	const auto data = fs.read(testFilename);
+	EXPECT_EQ(testData, data);
 
 	EXPECT_NO_THROW(fs.del(testFilename));
 	EXPECT_FALSE(fs.exists(testFilename));

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -85,14 +85,13 @@ TEST_F(FilesystemTest, read) {
 TEST_F(FilesystemTest, writeReadDeleteExists) {
 	const std::string testFilename = "TestFile.txt";
 	const std::string testData = "Test file contents";
-	const auto file = NAS2D::File(testData, testFilename);
 
-	EXPECT_NO_THROW(fs.write(file));
+	EXPECT_NO_THROW(fs.write(testFilename, testData));
 	EXPECT_TRUE(fs.exists(testFilename));
 
 	// Try to overwrite file, with and without permission
-	EXPECT_NO_THROW(fs.write(file));
-	EXPECT_THROW(fs.write(file, false), std::runtime_error);
+	EXPECT_NO_THROW(fs.write(testFilename, testData));
+	EXPECT_THROW(fs.write(testFilename, testData, false), std::runtime_error);
 
 	const auto data = fs.read(testFilename);
 	EXPECT_EQ(testData, data);

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -91,7 +91,7 @@ TEST_F(FilesystemTest, writeReadDeleteExists) {
 
 	// Try to overwrite file, with and without permission
 	EXPECT_NO_THROW(fs.write(testFilename, testData));
-	EXPECT_THROW(fs.write(testFilename, testData, false), std::runtime_error);
+	EXPECT_THROW(fs.write(testFilename, testData, NAS2D::Filesystem::WriteFlags::NoOverwrite), std::runtime_error);
 
 	const auto data = fs.read(testFilename);
 	EXPECT_EQ(testData, data);


### PR DESCRIPTION
Add `Filesystem` methods `read` and `write` that take a `filename` and either write or return raw data as a `std::string`. This bypasses the `File` object, which is currently underused. It seems reasonable to deprecate or remove the `File` object.

In the future, we might end up supporting streaming, rather than only full memory loads. That could provide a replacement for the `File` object. It would also be good to use with the `open` method, which kind of implies streaming capability.

As a side note, the Ruby language has an API with separate `read` and `open` methods, where `read` does a full file read into memory as a string, while `open` returns a file stream object, which can be used to read the file in pieces. Streaming becomes particularly important when dealing with large files that may exceed the size of memory, or where stream processing is possible without doing a full memory load.

Tagging #321 as somewhat related.
