### PR TITLE
Set default config in Game

### DIFF
--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -55,7 +55,31 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 	fs.mountSoftFail(fs.basePath() + dataPath);
 	fs.mountReadWrite(fs.prefPath());
 
-	Configuration& cf = Utility<Configuration>::get();
+	Configuration& cf = Utility<Configuration>::init(
+		std::map<std::string, NAS2D::Dictionary>{
+			{
+				"graphics",
+				{{
+					{"screenwidth", 1000},
+					{"screenheight", 700},
+					{"bitdepth", 32},
+					{"fullscreen", false},
+					{"vsync", true}
+				}}
+			},
+			{
+				"audio",
+				{{
+					{"mixer", "SDL"},
+					{"musicvolume", 100},
+					{"sfxvolume", 128},
+					{"channels", 2},
+					{"mixrate", 22050},
+					{"bufferlength", 1024}
+				}}
+			}
+		}
+	);
 	cf.load(configPath);
 
 	try

--- a/test-graphics/main.cpp
+++ b/test-graphics/main.cpp
@@ -23,32 +23,6 @@ int main(int /*argc*/, char *argv[])
 {
 	try
 	{
-		NAS2D::Utility<NAS2D::Configuration>::init(
-			std::map<std::string, NAS2D::Dictionary>{
-				{
-					"graphics",
-					{{
-						{"screenwidth", 1000},
-						{"screenheight", 700},
-						{"bitdepth", 32},
-						{"fullscreen", false},
-						{"vsync", true}
-					}}
-				},
-				{
-					"audio",
-					{{
-						{"mixer", "SDL"},
-						{"musicvolume", 100},
-						{"sfxvolume", 128},
-						{"channels", 2},
-						{"mixrate", 22050},
-						{"bufferlength", 1024}
-					}}
-				}
-			}
-		);
-
 		NAS2D::Game game("NAS2D Graphics Test", "NAS2D_GraphicsTest", "LairWorks", argv[0]);
 		game.go(new TestGraphics());
 	}


### PR DESCRIPTION
To make `Game` more useful (and to fix nas2d-tests), set default `Configuration` values suitable for initializing `RendererOpenGL` and `MixerSDL`.
