### PR TITLE
Fix fullscreen resize bug

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -611,6 +611,7 @@ void RendererOpenGL::fullscreen(bool fullscreen, bool maintain)
 		SDL_SetWindowFullscreen(underlyingWindow, 0);
 		const auto windowSize = size();
 		SDL_SetWindowSize(underlyingWindow, windowSize.x, windowSize.y);
+		onResize(windowSize);
 		SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 	}
 }

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -76,11 +76,17 @@ void TestGraphics::onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandl
 		NAS2D::postQuitEvent();
 		break;
 	case NAS2D::EventHandler::KeyCode::KEY_F1:
-		NAS2D::Utility<NAS2D::Renderer>::get().fullscreen(!NAS2D::Utility<NAS2D::Renderer>::get().fullscreen());
+	{
+		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+		renderer.fullscreen(!renderer.fullscreen());
 		break;
+	}
 	case NAS2D::EventHandler::KeyCode::KEY_F2:
-		NAS2D::Utility<NAS2D::Renderer>::get().resizeable(!NAS2D::Utility<NAS2D::Renderer>::get().resizeable());
+	{
+		auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+		renderer.resizeable(!renderer.resizeable());
 		break;
+	}
 	default:
 		break;
 	}


### PR DESCRIPTION
When exiting from fullscreen, there was a bug where output would cease to appear, until the window was resized. This fixes that bug.

This can be seen in the **test-graphics** project, as well as the nas2d-tests repository's **RendererFunctions** project.

Tagging #78 as possibly related.
Tagging #701 as somewhat related.
