### PR TITLE
Commutative operations Vector + Point, scalar * Vector

### DIFF
--- a/NAS2D/Renderer/Point.h
+++ b/NAS2D/Renderer/Point.h
@@ -91,6 +91,14 @@ namespace NAS2D
 	};
 
 
+	// Commutative Vector + Point
+	template <typename BaseType>
+	constexpr Point<BaseType> operator+(Vector<BaseType> vector, Point<BaseType> point)
+	{
+		return point + vector;
+	}
+
+
 	template <typename BaseType>
 	Point(BaseType, BaseType) -> Point<BaseType>;
 

--- a/NAS2D/Renderer/Vector.h
+++ b/NAS2D/Renderer/Vector.h
@@ -55,6 +55,7 @@ namespace NAS2D
 			y *= scalar;
 			return *this;
 		}
+
 		Vector& operator/=(BaseType scalar)
 		{
 			if (scalar == 0)
@@ -131,6 +132,14 @@ namespace NAS2D
 			return static_cast<Vector<NewBaseType>>(*this);
 		}
 	};
+
+
+	// Commutative scalar * vector
+	template <typename BaseType>
+	constexpr Vector<BaseType> operator*(BaseType scalar, Vector<BaseType> vector)
+	{
+		return vector * scalar;
+	}
 
 
 	template <typename BaseType>

--- a/test/Renderer/Point.test.cpp
+++ b/test/Renderer/Point.test.cpp
@@ -81,6 +81,10 @@ TEST(Point, to) {
 	EXPECT_EQ((NAS2D::Point<float>{1.0, 2.0}), (NAS2D::Point<int>{1, 2}.to<float>()));
 }
 
+TEST(Vector, VectorPointAdd) {
+	EXPECT_EQ((NAS2D::Point{2, 3}), (NAS2D::Vector{1, 2} + NAS2D::Point<int>{1, 1}));
+}
+
 TEST(Point, PartialOrderLessEqual) {
 	EXPECT_LE((NAS2D::Point{0, 0}), (NAS2D::Point{1, 1}));
 	EXPECT_LE((NAS2D::Point{0, 1}), (NAS2D::Point{1, 1}));

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -182,6 +182,10 @@ TEST(Vector, to) {
 	EXPECT_EQ((NAS2D::Vector<float>{1.0, 2.0}), (NAS2D::Vector<int>{1, 2}.to<float>()));
 }
 
+TEST(Vector, scalarVectorMultiply) {
+	EXPECT_EQ((NAS2D::Vector{2, 4}), (2 * NAS2D::Vector{1, 2}));
+}
+
 TEST(Vector, PartialOrderLessEqual) {
 	EXPECT_LE((NAS2D::Vector{0, 0}), (NAS2D::Vector{1, 1}));
 	EXPECT_LE((NAS2D::Vector{0, 1}), (NAS2D::Vector{1, 1}));


### PR DESCRIPTION
Add commutative operations:
- `Vector + Point` (matches `Point + Vector`)
- `scalar * Vector` (matches `Vector * scalar`)

Closes #362
