### PR TITLE
Refactor Filesystem lexical methods

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -365,7 +365,7 @@ std::string Filesystem::dirSeparator() const
  *
  * \return The path up to and including the last '/', or empty string if no '/'
  */
-std::string Filesystem::workingPath(const std::string& filePath) const
+std::string Filesystem::parentPath(const std::string& filePath) const
 {
 	const auto pos = filePath.rfind("/");
 	return filePath.substr(0, pos + 1);

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -367,8 +367,8 @@ std::string Filesystem::dirSeparator() const
  */
 std::string Filesystem::workingPath(const std::string& filename) const
 {
-	std::string tmpStr(filename);
 	std::size_t pos = filename.rfind("/");
+	std::string tmpStr(filename);
 	tmpStr = tmpStr.substr(0, pos + 1);
 	return tmpStr;
 }

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -389,5 +389,5 @@ std::string Filesystem::extension(const std::string& filePath) const
 	{
 		return filePath.substr(pos);
 	}
-	return std::string();
+	return std::string{};
 }

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -359,11 +359,11 @@ std::string Filesystem::dirSeparator() const
 
 
 /**
- * Convenience function to get the working directory of a file.
+ * Convenience function to get the parent directory of a file.
  *
- * \param filename	A file path.
+ * \param filename A file path.
  *
- * \note	File paths should not have any trailing '/' characters.
+ * \return The path up to and including the last '/', or empty string if no '/'
  */
 std::string Filesystem::workingPath(const std::string& filename) const
 {

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -367,7 +367,7 @@ std::string Filesystem::dirSeparator() const
  */
 std::string Filesystem::workingPath(const std::string& filename) const
 {
-	std::size_t pos = filename.rfind("/");
+	const auto pos = filename.rfind("/");
 	return filename.substr(0, pos + 1);
 }
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -368,7 +368,7 @@ std::string Filesystem::dirSeparator() const
  */
 std::string Filesystem::parentPath(const std::string& filePath) const
 {
-	const auto pos = filePath.rfind("/");
+	const auto pos = filePath.rfind('/');
 	return filePath.substr(0, pos + 1);
 }
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -367,8 +367,7 @@ std::string Filesystem::dirSeparator() const
  */
 std::string Filesystem::parentPath(std::string_view filePath) const
 {
-	const auto pos = filePath.rfind('/');
-	return std::string{filePath.substr(0, pos + 1)};
+	return std::string{filePath.substr(0, filePath.rfind('/') + 1)};
 }
 
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -361,33 +361,33 @@ std::string Filesystem::dirSeparator() const
 /**
  * Convenience function to get the parent directory of a file.
  *
- * \param filename A file path.
+ * \param filePath A file path.
  *
  * \return The path up to and including the last '/', or empty string if no '/'
  */
-std::string Filesystem::workingPath(const std::string& filename) const
+std::string Filesystem::workingPath(const std::string& filePath) const
 {
-	const auto pos = filename.rfind("/");
-	return filename.substr(0, pos + 1);
+	const auto pos = filePath.rfind("/");
+	return filePath.substr(0, pos + 1);
 }
 
 
 /**
  * Gets the extension of a given file path.
  *
- * \param	path	Path to check for an extension.
+ * \param	filePath	Path to check for an extension.
  *
  * \return	Returns a string containing the file extension, including the dot (".").
  *			An empty string will be returned if the file has no extension.
  */
-std::string Filesystem::extension(const std::string& path) const
+std::string Filesystem::extension(const std::string& filePath) const
 {
 	// This is a naive approach but works for most cases.
-	std::size_t pos = path.find_last_of(".");
+	std::size_t pos = filePath.find_last_of(".");
 
 	if (pos != std::string::npos)
 	{
-		return path.substr(pos);
+		return filePath.substr(pos);
 	}
 	return std::string();
 }

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -368,7 +368,7 @@ std::string Filesystem::dirSeparator() const
 std::string Filesystem::workingPath(const std::string& filename) const
 {
 	std::string tmpStr(filename);
-	std::size_t pos = tmpStr.rfind("/");
+	std::size_t pos = filename.rfind("/");
 	tmpStr = tmpStr.substr(0, pos + 1);
 	return tmpStr;
 }

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -383,8 +383,8 @@ std::string Filesystem::parentPath(const std::string& filePath) const
  */
 std::string Filesystem::extension(const std::string& filePath) const
 {
-	const auto fileName = std::string_view{filePath}.substr(filePath.find_last_of('/') + 1);
-	const auto pos = fileName.find_last_of('.');
+	const auto fileName = std::string_view{filePath}.substr(filePath.rfind('/') + 1);
+	const auto pos = fileName.rfind('.');
 
 	if (pos != std::string::npos)
 	{

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -15,7 +15,6 @@
 #include <climits>
 #include <cstring>
 #include <string>
-#include <string_view>
 #include <iostream>
 #include <sstream>
 #include <utility>
@@ -366,10 +365,10 @@ std::string Filesystem::dirSeparator() const
  *
  * \return The path up to and including the last '/', or empty string if no '/'
  */
-std::string Filesystem::parentPath(const std::string& filePath) const
+std::string Filesystem::parentPath(std::string_view filePath) const
 {
 	const auto pos = filePath.rfind('/');
-	return filePath.substr(0, pos + 1);
+	return std::string{filePath.substr(0, pos + 1)};
 }
 
 
@@ -381,9 +380,9 @@ std::string Filesystem::parentPath(const std::string& filePath) const
  * \return	Returns a string containing the file extension, including the dot (".").
  *			An empty string will be returned if the file has no extension.
  */
-std::string Filesystem::extension(const std::string& filePath) const
+std::string Filesystem::extension(std::string_view filePath) const
 {
-	const auto fileName = std::string_view{filePath}.substr(filePath.rfind('/') + 1);
+	const auto fileName = filePath.substr(filePath.rfind('/') + 1);
 	const auto pos = fileName.rfind('.');
 
 	if (pos != std::string::npos)

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -346,6 +346,19 @@ void Filesystem::write(const std::string& filename, const std::string& data, Wri
 
 
 /**
+ * Gets the dir separator for the current platform
+ *
+ * The dir separator separates the directories within a path. This is typically either "\\" for Windows, or "/" for Linux.
+ *
+ * \note The path separator may be more than one character
+ */
+std::string Filesystem::dirSeparator() const
+{
+	return PHYSFS_getDirSeparator();
+}
+
+
+/**
  * Convenience function to get the working directory of a file.
  *
  * \param filename	A file path.
@@ -386,16 +399,4 @@ std::string Filesystem::extension(const std::string& path) const
 		return path.substr(pos);
 	}
 	return std::string();
-}
-
-/**
- * Gets the dir separator for the current platform
- *
- * The dir separator separates the directories within a path. This is typically either "\\" for Windows, or "/" for Linux.
- *
- * \note The path separator may be more than one character
- */
-std::string Filesystem::dirSeparator() const
-{
-	return PHYSFS_getDirSeparator();
 }

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -15,6 +15,7 @@
 #include <climits>
 #include <cstring>
 #include <string>
+#include <string_view>
 #include <iostream>
 #include <sstream>
 #include <utility>
@@ -382,12 +383,12 @@ std::string Filesystem::parentPath(const std::string& filePath) const
  */
 std::string Filesystem::extension(const std::string& filePath) const
 {
-	// This is a naive approach but works for most cases.
-	std::size_t pos = filePath.find_last_of(".");
+	const auto fileName = std::string_view{filePath}.substr(filePath.find_last_of('/') + 1);
+	const auto pos = fileName.find_last_of('.');
 
 	if (pos != std::string::npos)
 	{
-		return filePath.substr(pos);
+		return std::string{fileName.substr(pos)};
 	}
 	return std::string{};
 }

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -367,17 +367,10 @@ std::string Filesystem::dirSeparator() const
  */
 std::string Filesystem::workingPath(const std::string& filename) const
 {
-	if (!filename.empty())
-	{
-		std::string tmpStr(filename);
-		std::size_t pos = tmpStr.rfind("/");
-		tmpStr = tmpStr.substr(0, pos + 1);
-		return tmpStr;
-	}
-	else
-	{
-		return std::string();
-	}
+	std::string tmpStr(filename);
+	std::size_t pos = tmpStr.rfind("/");
+	tmpStr = tmpStr.substr(0, pos + 1);
+	return tmpStr;
 }
 
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -368,9 +368,7 @@ std::string Filesystem::dirSeparator() const
 std::string Filesystem::workingPath(const std::string& filename) const
 {
 	std::size_t pos = filename.rfind("/");
-	std::string tmpStr(filename);
-	tmpStr = tmpStr.substr(0, pos + 1);
-	return tmpStr;
+	return filename.substr(0, pos + 1);
 }
 
 

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -66,7 +66,7 @@ namespace NAS2D
 		void makeDirectory(const std::string& path) const;
 
 		std::string dirSeparator() const;
-		std::string workingPath(const std::string& filePath) const;
+		std::string parentPath(const std::string& filePath) const;
 		std::string extension(const std::string& filePath) const;
 
 	private:

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -45,7 +45,6 @@ namespace NAS2D
 		std::string basePath() const;
 		std::string prefPath() const;
 
-		std::string workingPath(const std::string& filename) const;
 		std::vector<std::string> searchPath() const;
 		int mountSoftFail(const std::string& path) const;
 		void mount(const std::string& path) const;
@@ -63,12 +62,12 @@ namespace NAS2D
 		void del(const std::string& path) const;
 		bool exists(const std::string& filename) const;
 
-		std::string extension(const std::string& path) const;
-
-		std::string dirSeparator() const;
-
 		bool isDirectory(const std::string& path) const;
 		void makeDirectory(const std::string& path) const;
+
+		std::string dirSeparator() const;
+		std::string workingPath(const std::string& filename) const;
+		std::string extension(const std::string& path) const;
 
 	private:
 		std::string mAppName;

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -12,8 +12,9 @@
 
 #include "File.h"
 
-#include <string>
 #include <vector>
+#include <string>
+#include <string_view>
 
 
 namespace NAS2D
@@ -66,8 +67,8 @@ namespace NAS2D
 		void makeDirectory(const std::string& path) const;
 
 		std::string dirSeparator() const;
-		std::string parentPath(const std::string& filePath) const;
-		std::string extension(const std::string& filePath) const;
+		std::string parentPath(std::string_view filePath) const;
+		std::string extension(std::string_view filePath) const;
 
 	private:
 		std::string mAppName;

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -66,8 +66,8 @@ namespace NAS2D
 		void makeDirectory(const std::string& path) const;
 
 		std::string dirSeparator() const;
-		std::string workingPath(const std::string& filename) const;
-		std::string extension(const std::string& path) const;
+		std::string workingPath(const std::string& filePath) const;
+		std::string extension(const std::string& filePath) const;
 
 	private:
 		std::string mAppName;

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -78,7 +78,7 @@ namespace
 		try
 		{
 			auto& filesystem = Utility<Filesystem>::get();
-			const auto basePath = filesystem.workingPath(filePath);
+			const auto basePath = filesystem.parentPath(filePath);
 
 			Xml::XmlDocument xmlDoc;
 			xmlDoc.parse(filesystem.read(filePath).c_str());

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -37,26 +37,6 @@ TEST_F(FilesystemTest, prefPath) {
 	EXPECT_THAT(fs.prefPath(), testing::HasSubstr(AppName));
 }
 
-TEST_F(FilesystemTest, extension) {
-	EXPECT_EQ(".txt", fs.extension("subdir/file.txt"));
-	EXPECT_EQ(".txt", fs.extension("file.txt"));
-	EXPECT_EQ(".reallyLongExtensionName", fs.extension("file.reallyLongExtensionName"));
-	EXPECT_EQ(".a", fs.extension("file.a"));
-	EXPECT_EQ(".file", fs.extension(".file"));
-	EXPECT_EQ(".", fs.extension("file."));
-	EXPECT_EQ("", fs.extension("file"));
-}
-
-TEST_F(FilesystemTest, parentPath) {
-	EXPECT_EQ("", fs.parentPath(""));
-	EXPECT_EQ("", fs.parentPath("file.extension"));
-	EXPECT_EQ("/", fs.parentPath("/"));
-	EXPECT_EQ("data/", fs.parentPath("data/"));
-	EXPECT_EQ("data/", fs.parentPath("data/file.extension"));
-	EXPECT_EQ("data/subfolder/", fs.parentPath("data/subfolder/file.extension"));
-	EXPECT_EQ("anotherFolder/", fs.parentPath("anotherFolder/file.extension"));
-}
-
 TEST_F(FilesystemTest, searchPath) {
 	auto pathList = fs.searchPath();
 	EXPECT_EQ(3u, pathList.size());
@@ -140,4 +120,24 @@ TEST_F(FilesystemTest, dirSeparator) {
 	// New platforms may choose a new unique value
 	// Some platforms may not even have a hierarchal filesystem ("")
 	EXPECT_NO_THROW(fs.dirSeparator());
+}
+
+TEST_F(FilesystemTest, parentPath) {
+	EXPECT_EQ("", fs.parentPath(""));
+	EXPECT_EQ("", fs.parentPath("file.extension"));
+	EXPECT_EQ("/", fs.parentPath("/"));
+	EXPECT_EQ("data/", fs.parentPath("data/"));
+	EXPECT_EQ("data/", fs.parentPath("data/file.extension"));
+	EXPECT_EQ("data/subfolder/", fs.parentPath("data/subfolder/file.extension"));
+	EXPECT_EQ("anotherFolder/", fs.parentPath("anotherFolder/file.extension"));
+}
+
+TEST_F(FilesystemTest, extension) {
+	EXPECT_EQ(".txt", fs.extension("subdir/file.txt"));
+	EXPECT_EQ(".txt", fs.extension("file.txt"));
+	EXPECT_EQ(".reallyLongExtensionName", fs.extension("file.reallyLongExtensionName"));
+	EXPECT_EQ(".a", fs.extension("file.a"));
+	EXPECT_EQ(".file", fs.extension(".file"));
+	EXPECT_EQ(".", fs.extension("file."));
+	EXPECT_EQ("", fs.extension("file"));
 }

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -133,11 +133,12 @@ TEST_F(FilesystemTest, parentPath) {
 }
 
 TEST_F(FilesystemTest, extension) {
-	EXPECT_EQ(".txt", fs.extension("subdir/file.txt"));
-	EXPECT_EQ(".txt", fs.extension("file.txt"));
-	EXPECT_EQ(".reallyLongExtensionName", fs.extension("file.reallyLongExtensionName"));
-	EXPECT_EQ(".a", fs.extension("file.a"));
-	EXPECT_EQ(".file", fs.extension(".file"));
-	EXPECT_EQ(".", fs.extension("file."));
 	EXPECT_EQ("", fs.extension("file"));
+	EXPECT_EQ(".", fs.extension("file."));
+	EXPECT_EQ(".file", fs.extension(".file"));
+
+	EXPECT_EQ(".a", fs.extension("file.a"));
+	EXPECT_EQ(".txt", fs.extension("file.txt"));
+	EXPECT_EQ(".txt", fs.extension("subdir/file.txt"));
+	EXPECT_EQ(".reallyLongExtensionName", fs.extension("file.reallyLongExtensionName"));
 }

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -48,10 +48,13 @@ TEST_F(FilesystemTest, extension) {
 }
 
 TEST_F(FilesystemTest, workingPath) {
+	EXPECT_EQ("", fs.workingPath(""));
+	EXPECT_EQ("", fs.workingPath("file.extension"));
+	EXPECT_EQ("/", fs.workingPath("/"));
+	EXPECT_EQ("data/", fs.workingPath("data/"));
 	EXPECT_EQ("data/", fs.workingPath("data/file.extension"));
 	EXPECT_EQ("data/subfolder/", fs.workingPath("data/subfolder/file.extension"));
 	EXPECT_EQ("anotherFolder/", fs.workingPath("anotherFolder/file.extension"));
-	EXPECT_EQ("", fs.workingPath("file.extension"));
 }
 
 TEST_F(FilesystemTest, searchPath) {

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -133,7 +133,9 @@ TEST_F(FilesystemTest, parentPath) {
 }
 
 TEST_F(FilesystemTest, extension) {
+	EXPECT_EQ("", fs.extension(""));
 	EXPECT_EQ("", fs.extension("file"));
+	EXPECT_EQ("", fs.extension("subdir/file"));
 	EXPECT_EQ(".", fs.extension("file."));
 	EXPECT_EQ(".file", fs.extension(".file"));
 

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -136,6 +136,7 @@ TEST_F(FilesystemTest, extension) {
 	EXPECT_EQ("", fs.extension(""));
 	EXPECT_EQ("", fs.extension("file"));
 	EXPECT_EQ("", fs.extension("subdir/file"));
+	EXPECT_EQ("", fs.extension("subdir.ext/file"));
 	EXPECT_EQ(".", fs.extension("file."));
 	EXPECT_EQ(".file", fs.extension(".file"));
 

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -47,14 +47,14 @@ TEST_F(FilesystemTest, extension) {
 	EXPECT_EQ("", fs.extension("file"));
 }
 
-TEST_F(FilesystemTest, workingPath) {
-	EXPECT_EQ("", fs.workingPath(""));
-	EXPECT_EQ("", fs.workingPath("file.extension"));
-	EXPECT_EQ("/", fs.workingPath("/"));
-	EXPECT_EQ("data/", fs.workingPath("data/"));
-	EXPECT_EQ("data/", fs.workingPath("data/file.extension"));
-	EXPECT_EQ("data/subfolder/", fs.workingPath("data/subfolder/file.extension"));
-	EXPECT_EQ("anotherFolder/", fs.workingPath("anotherFolder/file.extension"));
+TEST_F(FilesystemTest, parentPath) {
+	EXPECT_EQ("", fs.parentPath(""));
+	EXPECT_EQ("", fs.parentPath("file.extension"));
+	EXPECT_EQ("/", fs.parentPath("/"));
+	EXPECT_EQ("data/", fs.parentPath("data/"));
+	EXPECT_EQ("data/", fs.parentPath("data/file.extension"));
+	EXPECT_EQ("data/subfolder/", fs.parentPath("data/subfolder/file.extension"));
+	EXPECT_EQ("anotherFolder/", fs.parentPath("anotherFolder/file.extension"));
 }
 
 TEST_F(FilesystemTest, searchPath) {


### PR DESCRIPTION
Reference: #321

Refactor and organize `Filesystem`'s lexical methods:
- `dirSeparator`
- `parentPath` (formerly `workingPath`)
- `extension`
