### PR TITLE
Fix zero as nullptr in Delegate code

### DIFF
--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -435,7 +435,7 @@ namespace NAS2D
 		using unspecified_bool_type = StaticFunctionPtr SafeBoolStruct::*;
 
 	public:
-		operator unspecified_bool_type() const { return empty() ? 0 : &SafeBoolStruct::m_nonzero; }
+		operator unspecified_bool_type() const { return empty() ? nullptr : &SafeBoolStruct::m_nonzero; }
 
 		inline bool operator==(StaticFunctionPtr funcptr) { return m_Closure.IsEqualToStaticFuncPtr(funcptr); }
 		inline bool operator!=(StaticFunctionPtr funcptr) { return !m_Closure.IsEqualToStaticFuncPtr(funcptr); }


### PR DESCRIPTION
This was recently flagged as an error on MacOS:
https://app.circleci.com/pipelines/github/lairworks/nas2d-core/1702/workflows/64055bf4-340c-4805-a68f-13a80afc716b/jobs/6868

Not sure why it was suddenly flagged now. That code does have platform dependent `#if` guards though, so not surprising it would affect just one platform.
