### PR TITLE
Remove outdated AnimationSet documentation on casing

### DIFF
--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -169,9 +169,6 @@ namespace
 	/**
 	 * Iterates through all elements of a Sprite XML definition looking
 	 * for 'action' elements and processes them.
-	 *
-	 * \note	Action names are not case sensitive. "Case", "caSe",
-	 *			"CASE", etc. will all be viewed as identical.
 	 */
 	std::map<std::string, std::vector<AnimationSet::Frame>> processActions(const std::map<std::string, std::string>& imageSheetMap, const Xml::XmlElement* element, ImageCache& imageCache)
 	{


### PR DESCRIPTION
The case independence was removed by a recent change to the `AnimationSet` code.

Reference commit:
10ec2d880dc45792fbd0a82d83f801884087e230
PR #902

----

Needed the fix from #918 for this to build.
