### PR TITLE
Remove static_cast in AnimationSet data loading

### DIFF
--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -218,7 +218,7 @@ namespace
 			reportMissingOrUnexpected(dictionary.keys(), {"sheetid", "delay", "x", "y", "width", "height", "anchorx", "anchory"}, {});
 
 			const auto sheetId = dictionary.get("sheetid");
-			const auto delay = dictionary.get<int>("delay");
+			const auto delay = dictionary.get<unsigned int>("delay");
 			const auto x = dictionary.get<int>("x");
 			const auto y = dictionary.get<int>("y");
 			const auto width = dictionary.get<int>("width");
@@ -260,7 +260,7 @@ namespace
 
 			const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
 			const auto anchorOffset = Vector{anchorx, anchory};
-			frameList.push_back(AnimationSet::Frame{image, bounds, anchorOffset, static_cast<unsigned int>(delay)});
+			frameList.push_back(AnimationSet::Frame{image, bounds, anchorOffset, delay});
 		}
 
 		if (frameList.empty())


### PR DESCRIPTION
Reference: #797

Use the proper type in the `Dictionary::get<>` method, and avoid the need for a `static_cast` later.
