### PR TITLE
Documentation pass on files in Mixer folder

### DIFF
--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -20,9 +20,10 @@ namespace NAS2D
 	class Music;
 
 	/**
-	 * @brief Mixer base class.
+	 * \brief Mixer base class.
 	 * 
-	 * Provides a standard Mixer interface. The base Mixer can be used but will act as a NULL interface.
+	 * Provides a standard Mixer interface.
+	 * The base Mixer can be used but will act as a NULL interface.
 	*/
 	class Mixer
 	{
@@ -61,14 +62,14 @@ namespace NAS2D
 		void resumeAllAudio();
 
 		/**
-		 * @brief Sets the sound volume.
-		 * @param level Volume level to set. Valid range is [0, 128].
+		 * \brief Sets the sound volume.
+		 * \param level Volume level to set. Valid range is [0, 128].
 		*/
 		virtual void soundVolume(int level) = 0;
 
 		/**
-		 * @brief Sets the music volume.
-		 * @param level Volume level to set. Valid range is [0, 128].
+		 * \brief Sets the music volume.
+		 * \param level Volume level to set. Valid range is [0, 128].
 		*/
 		virtual void musicVolume(int level) = 0;
 

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -21,7 +21,7 @@ namespace NAS2D
 
 	/**
 	 * \brief Mixer base class.
-	 * 
+	 *
 	 * Provides a standard Mixer interface.
 	 * The base Mixer can be used but will act as a NULL interface.
 	*/

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -20,10 +20,7 @@ namespace NAS2D
 	class Music;
 
 	/**
-	 * \brief Mixer base class.
-	 *
-	 * Provides a standard Mixer interface.
-	 * The base Mixer can be used but will act as a NULL interface.
+	Mixer base class.
 	*/
 	class Mixer
 	{

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -19,18 +19,16 @@ namespace NAS2D
 	class Sound;
 	class Music;
 
-
 	/**
-	 * Mixer base class.
-	 *
-	 * Provides a standard Mixer interface. The base Mixer can be used
-	 * but will act as a NULL interface.
-	 */
+	 * @brief Mixer base class.
+	 * 
+	 * Provides a standard Mixer interface. The base Mixer can be used but will act as a NULL interface.
+	*/
 	class Mixer
 	{
 	public:
-		static const int CONTINUOUS = -1; /**< Constant representing a continuous loop. */
-		static const int DEFAULT_FADE_TIME = 500; /**< Default fade time. */
+		static const int CONTINUOUS = -1;
+		static const int DEFAULT_FADE_TIME = 500;
 
 	public:
 		Mixer() = default;
@@ -41,121 +39,46 @@ namespace NAS2D
 		virtual ~Mixer() = default;
 
 	public:
-		/**
-		 * Plays a sound on the first available sound channel.
-		 *
-		 * \param	sound	A reference to a Sound Resource.
-		 */
 		virtual void playSound(const Sound& sound) = 0;
-
-		/**
-		 * Stops playing all sounds on all channels.
-		 */
 		virtual void stopSound() = 0;
-
-		/**
-		 * Pauses sound on all channels.
-		 */
 		virtual void pauseSound() = 0;
-
-		/**
-		 * Resumes sound on all channels.
-		 */
 		virtual void resumeSound() = 0;
-
-		/**
-		 * Starts playing a Music track.
-		 *
-		 * \param music	Reference to a Music Resource.
-		 * \param loops	Number of times to repeat the music.
-		 */
 		void playMusic(const Music& music, int loops = Mixer::CONTINUOUS);
-
-		/**
-		 * Stops all playing music.
-		 */
 		virtual void stopMusic() = 0;
-
-		/**
-		 * Pauses the currently playing Music.
-		 */
 		virtual void pauseMusic() = 0;
-
-		/**
-		 * Resumes the currently paused Music.
-		 *
-		 * \note	It is safe to call this function if the music is stopped or already playing.
-		 */
 		virtual void resumeMusic() = 0;
 
-		/**
-		 * Starts a Music track and fades it in to the current Music volume.
-		 *
-		 * \param	music	Reference to a Music Resource.
-		 * \param	loops	Number of times the Music should be repeated. -1 for continuous loop.
-		 * \param	time	Time, in miliseconds, for the fade to last. Default is 500.
-		 */
+		//TODO: Consider type-safety via std::chrono::milliseconds? or rename variable to fadeInMS
 		virtual void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) = 0;
 
-		/**
-		 * Fades out the currently playing Music track.
-		 *
-		 * \param	time	Time, in miliseconds, for the fade to last. Default is 500.
-		 */
+		//TODO: Consider type-safety via std::chrono::milliseconds? or rename variable to fadeOutMS
 		virtual void fadeOutMusic(int time = Mixer::DEFAULT_FADE_TIME) = 0;
 
-		/**
-		 * Gets whether or not music is currently playing.
-		 */
 		virtual bool musicPlaying() const = 0;
 
-		/**
-		 * Stops all music and sound.
-		 */
 		void stopAllAudio();
-
-		/**
-		 * Pauses all music and sound.
-		 */
 		void pauseAllAudio();
-
-		/**
-		 * Resumes all paused music and sound.
-		 */
 		void resumeAllAudio();
 
 		/**
-		 * Sets the sound volume.
-		 *
-		 * \param	level	Volume level to set. Valid values are 0 - 128.
-		 */
+		 * @brief Sets the sound volume.
+		 * @param level Volume level to set. Valid range is [0, 128].
+		*/
 		virtual void soundVolume(int level) = 0;
 
 		/**
-		 * Sets the music volume.
-		 *
-		 * \param	level	Volume level to set. Valid values are 0 - 128.
-		 */
+		 * @brief Sets the music volume.
+		 * @param level Volume level to set. Valid range is [0, 128].
+		*/
 		virtual void musicVolume(int level) = 0;
 
-		/**
-		 * Gets the sound volume.
-		 *
-		 * \return	Volume level. Valid values are 0 - 128.
-		 */
 		virtual int soundVolume() const = 0;
-
-		/**
-		 * Gets the music volume.
-		 *
-		 * \return	Volume level. Valid values are 0 - 128.
-		 */
 		virtual int musicVolume() const = 0;
 
 		SignalSource<>& musicCompleteSignalSource();
 
 	protected:
-		Signal<> mMusicComplete; /**< Signal used when music finished playing. */
+		Signal<> mMusicComplete;
 	};
 
 } // namespace

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -71,10 +71,15 @@ namespace NAS2D
 		void pauseAllAudio();
 		void resumeAllAudio();
 
-		//Returned values are in the closed range [0, 128].
+		/**
+		 * \param level Volume level, valid values are in the range [0, 128]
+		*/
 		virtual void soundVolume(int level) = 0;
 
-		//Returned values are in the closed range [0, 128].
+
+		/**
+		 * \param level Volume level, valid values are in the range [0, 128]
+		*/
 		virtual void musicVolume(int level) = 0;
 
 		virtual int soundVolume() const = 0;

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -48,8 +48,8 @@ namespace NAS2D
 		/**
 		 * Starts playing a Music track.
 		 *
-		 * \param music	Reference to a Music Resource.
-		 * \param loops	Number of times to repeat the music.
+		 * \param music: Reference to a Music Resource.
+		 * \param loops: Number of times to repeat the music.
 		 */
 		void playMusic(const Music& music, int loops = Mixer::CONTINUOUS);
 		virtual void stopMusic() = 0;
@@ -59,16 +59,16 @@ namespace NAS2D
 		/**
 		 * Starts a Music track and fades it in to the current Music volume.
 		 *
-		 * \param	music	Reference to a Music Resource.
-		 * \param	loops	Number of times the Music should be repeated. -1 for continuous loop.
-		 * \param	time	Time, in milliseconds, for the fade to last. Default is 500.
+		 * \param music: Reference to a Music Resource.
+		 * \param loops: Number of times the Music should be repeated. -1 for continuous loop.
+		 * \param time: Time, in milliseconds, for the fade to last. Default is 500.
 		 */
 		virtual void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) = 0;
 
 		/**
 		 * Fades out the currently playing Music track.
 		 *
-		 * \param	time	Time, in milliseconds, for the fade to last. Default is 500.
+		 * \param time: Time, in milliseconds, for the fade to last. Default is 500.
 		 */
 		virtual void fadeOutMusic(int time = Mixer::DEFAULT_FADE_TIME) = 0;
 
@@ -79,13 +79,13 @@ namespace NAS2D
 		void resumeAllAudio();
 
 		/**
-		 * \param level Volume level, valid values are in the range [0, 128]
+		 * \param level: Volume level, valid values are in the range [0, 128]
 		*/
 		virtual void soundVolume(int level) = 0;
 
 
 		/**
-		 * \param level Volume level, valid values are in the range [0, 128]
+		 * \param level: Volume level, valid values are in the range [0, 128]
 		*/
 		virtual void musicVolume(int level) = 0;
 

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -44,6 +44,13 @@ namespace NAS2D
 		virtual void stopSound() = 0;
 		virtual void pauseSound() = 0;
 		virtual void resumeSound() = 0;
+
+		/**
+		 * Starts playing a Music track.
+		 *
+		 * \param music	Reference to a Music Resource.
+		 * \param loops	Number of times to repeat the music.
+		 */
 		void playMusic(const Music& music, int loops = Mixer::CONTINUOUS);
 		virtual void stopMusic() = 0;
 		virtual void pauseMusic() = 0;

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -71,16 +71,10 @@ namespace NAS2D
 		void pauseAllAudio();
 		void resumeAllAudio();
 
-		/**
-		 * \brief Sets the sound volume.
-		 * \param level Volume level to set. Valid range is [0, 128].
-		*/
+		//Returned values are in the closed range [0, 128].
 		virtual void soundVolume(int level) = 0;
 
-		/**
-		 * \brief Sets the music volume.
-		 * \param level Volume level to set. Valid range is [0, 128].
-		*/
+		//Returned values are in the closed range [0, 128].
 		virtual void musicVolume(int level) = 0;
 
 		virtual int soundVolume() const = 0;

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -82,7 +82,15 @@ namespace NAS2D
 		*/
 		virtual void musicVolume(int level) = 0;
 
+
+		/**
+		 * \return The volume level in the range [0, 128]
+		*/
 		virtual int soundVolume() const = 0;
+
+		/**
+		 * \return The volume level in the range [0, 128]
+		*/
 		virtual int musicVolume() const = 0;
 
 		SignalSource<>& musicCompleteSignalSource();

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -19,9 +19,6 @@ namespace NAS2D
 	class Sound;
 	class Music;
 
-	/**
-	Mixer base class.
-	*/
 	class Mixer
 	{
 	public:

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -49,10 +49,20 @@ namespace NAS2D
 		virtual void pauseMusic() = 0;
 		virtual void resumeMusic() = 0;
 
-		//TODO: Consider type-safety via std::chrono::milliseconds? or rename variable to fadeInMS
+		/**
+		 * Starts a Music track and fades it in to the current Music volume.
+		 *
+		 * \param	music	Reference to a Music Resource.
+		 * \param	loops	Number of times the Music should be repeated. -1 for continuous loop.
+		 * \param	time	Time, in milliseconds, for the fade to last. Default is 500.
+		 */
 		virtual void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, int time = Mixer::DEFAULT_FADE_TIME) = 0;
 
-		//TODO: Consider type-safety via std::chrono::milliseconds? or rename variable to fadeOutMS
+		/**
+		 * Fades out the currently playing Music track.
+		 *
+		 * \param	time	Time, in milliseconds, for the fade to last. Default is 500.
+		 */
 		virtual void fadeOutMusic(int time = Mixer::DEFAULT_FADE_TIME) = 0;
 
 		virtual bool musicPlaying() const = 0;

--- a/NAS2D/Mixer/MixerSDL.h
+++ b/NAS2D/Mixer/MixerSDL.h
@@ -47,13 +47,11 @@ namespace NAS2D
 		MixerSDL& operator=(MixerSDL&&) = default;
 		~MixerSDL() override;
 
-		// Sound Functions
 		void playSound(const Sound& sound) override;
 		void stopSound() override;
 		void pauseSound() override;
 		void resumeSound() override;
 
-		// Music Functions
 		void stopMusic() override;
 		void pauseMusic() override;
 		void resumeMusic() override;
@@ -63,7 +61,6 @@ namespace NAS2D
 
 		bool musicPlaying() const override;
 
-		// Global Functions
 		void soundVolume(int level) override;
 		void musicVolume(int level) override;
 


### PR DESCRIPTION
Ref: #861

Smaller chunk of #899.

I plan on splitting the documentation fixes (re: deletions...) into smaller chunks by folder to avoid large-scale merge conflicts.