### PR TITLE
Convert copyright symbols to Unicode

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
- Copyright © 2008 - 2017 LairWorks Entertainment
+ Copyright Â© 2008 - 2017 LairWorks Entertainment
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages

--- a/NAS2D/ContainerUtils.h
+++ b/NAS2D/ContainerUtils.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Dictionary.cpp
+++ b/NAS2D/Dictionary.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Dictionary.h
+++ b/NAS2D/Dictionary.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Mixer/Mixer.cpp
+++ b/NAS2D/Mixer/Mixer.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Mixer/MixerNull.cpp
+++ b/NAS2D/Mixer/MixerNull.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Mixer/MixerNull.h
+++ b/NAS2D/Mixer/MixerNull.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/ParserHelper.cpp
+++ b/NAS2D/ParserHelper.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/ParserHelper.h
+++ b/NAS2D/ParserHelper.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Renderer/DisplayDesc.cpp
+++ b/NAS2D/Renderer/DisplayDesc.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Renderer/DisplayDesc.h
+++ b/NAS2D/Renderer/DisplayDesc.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Renderer/PointInRectangleRange.h
+++ b/NAS2D/Renderer/PointInRectangleRange.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Renderer/RectangleSkin.cpp
+++ b/NAS2D/Renderer/RectangleSkin.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Renderer/RectangleSkin.h
+++ b/NAS2D/Renderer/RectangleSkin.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Renderer/Vector.h
+++ b/NAS2D/Renderer/Vector.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Renderer/VectorSizeRange.h
+++ b/NAS2D/Renderer/VectorSizeRange.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Resource/AnimationSet.h
+++ b/NAS2D/Resource/AnimationSet.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Resource/ResourceCache.h
+++ b/NAS2D/Resource/ResourceCache.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Signal/SignalConnection.h
+++ b/NAS2D/Signal/SignalConnection.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/StringValue.h
+++ b/NAS2D/StringValue.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/NAS2D/Xml/XmlDocument.h
+++ b/NAS2D/Xml/XmlDocument.h
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D
-// = Copyright © 2008 - 2020 New Age Software
+// = Copyright Â© 2008 - 2020 New Age Software
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.


### PR DESCRIPTION
Related: #922

I noticed my editor wanted to auto correct the copyright symbols to a Unicode encoding. It makes it frustrating to edit files that aren't already converted, as the change either adds noise to commits, or needs to be manually skipped when adding changes.

Would be nice to get confirmation from people using Windows that Unicode copyright symbols display correctly in Visual Studio.
