### PR TITLE
Define parsing of negative values to unsigned

### DIFF
--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -71,11 +71,7 @@ namespace NAS2D
 			return static_cast<T>(integerValue);
 		} else if constexpr (std::is_integral_v<T> && std::is_unsigned_v<T>) {
 			const auto integerValue = std::stoul(value);
-			if constexpr (std::numeric_limits<unsigned long>::max() > std::numeric_limits<T>::max()) {
-				if (integerValue > std::numeric_limits<T>::max()) {
-					throw std::out_of_range("Value out of range: " + value);
-				}
-			}
+			// Out of range values have well defined wraparound for unsigned values
 			return static_cast<T>(integerValue);
 		} else {
 			static_assert(true, "Unsupported type");

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -93,12 +93,15 @@ TEST(String, stringTo) {
 	EXPECT_EQ(int{0}, NAS2D::stringTo<int>("0"));
 	using unsignedInt = unsigned int;
 	EXPECT_EQ(unsignedInt{0}, NAS2D::stringTo<unsignedInt>("0"));
+	// TODO: Fix problem case with unexpected exception
+	// EXPECT_EQ(unsignedInt{std::numeric_limits<unsignedInt>::max()}, NAS2D::stringTo<unsignedInt>("-1"));
 
 	EXPECT_THROW(NAS2D::stringTo<long>(""), std::invalid_argument);
 	EXPECT_EQ(long{-1}, NAS2D::stringTo<long>("-1"));
 	EXPECT_EQ(long{0}, NAS2D::stringTo<long>("0"));
 	using unsignedLong = unsigned long;
 	EXPECT_EQ(unsignedLong{0}, NAS2D::stringTo<unsignedLong>("0"));
+	EXPECT_EQ(unsignedLong{std::numeric_limits<unsignedLong>::max()}, NAS2D::stringTo<unsignedLong>("-1"));
 
 	using longLong = long long;
 	EXPECT_THROW(NAS2D::stringTo<longLong>(""), std::invalid_argument);
@@ -106,6 +109,7 @@ TEST(String, stringTo) {
 	EXPECT_EQ(longLong{0}, NAS2D::stringTo<longLong>("0"));
 	using unsignedLongLong = unsigned long long;
 	EXPECT_EQ(unsignedLongLong{0}, NAS2D::stringTo<unsignedLongLong>("0"));
+	EXPECT_EQ(unsignedLongLong{std::numeric_limits<unsignedLongLong>::max()}, NAS2D::stringTo<unsignedLongLong>("-1"));
 
 	EXPECT_THROW(NAS2D::stringTo<float>(""), std::invalid_argument);
 	EXPECT_THROW(NAS2D::stringTo<double>(""), std::invalid_argument);

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -93,8 +93,7 @@ TEST(String, stringTo) {
 	EXPECT_EQ(int{0}, NAS2D::stringTo<int>("0"));
 	using unsignedInt = unsigned int;
 	EXPECT_EQ(unsignedInt{0}, NAS2D::stringTo<unsignedInt>("0"));
-	// TODO: Fix problem case with unexpected exception
-	// EXPECT_EQ(unsignedInt{std::numeric_limits<unsignedInt>::max()}, NAS2D::stringTo<unsignedInt>("-1"));
+	EXPECT_EQ(unsignedInt{std::numeric_limits<unsignedInt>::max()}, NAS2D::stringTo<unsignedInt>("-1"));
 
 	EXPECT_THROW(NAS2D::stringTo<long>(""), std::invalid_argument);
 	EXPECT_EQ(long{-1}, NAS2D::stringTo<long>("-1"));


### PR DESCRIPTION
Define parsing of negative values to `unsigned` types for `stringTo`.

In particular, this allows `"-1"` to be parsed as the maximum possible unsigned integer value for the given `unsigned` type. It also allows wraparound of large positive values too. That may be expected for `unsigned` values, which have well define wraparound, as per the C++ standard.

Related, is the definition of [`std::stoul`](https://en.cppreference.com/w/cpp/string/basic_string/stoul), which is used for parsing the smaller `unsigned` values:

> If the minus sign was part of the input sequence, the numeric value calculated from the sequence of digits is negated as if by unary minus in the result type, which applies unsigned integer wraparound rules.

Fixes the bug found after merging PR #920.
