### PR TITLE
Fix whitespace errors

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -62,7 +62,7 @@ MaxEmptyLinesToKeep: 2
 NamespaceIndentation: All
 PointerAlignment: Left
 ReflowComments: false
-SortIncludes : false
+SortIncludes: false
 SortUsingDeclarations: true
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -60,9 +60,9 @@ namespace NAS2D
 		};
 
 
-			/**
-			* Keyboard scan codes.
-			*/
+		/**
+		* Keyboard scan codes.
+		*/
 		enum class KeyCode : uint32_t
 		{
 			KEY_UNKNOWN = 0,

--- a/NAS2D/MathUtils.h
+++ b/NAS2D/MathUtils.h
@@ -54,4 +54,3 @@ namespace NAS2D
 	}
 
 } // namespace NAS2D
-

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -47,7 +47,7 @@ namespace NAS2D
 		Renderer(Renderer&& rhs) = default;
 		Renderer& operator=(Renderer&& rhs) = default;
 		virtual ~Renderer();
-		
+
 		virtual std::vector<DisplayDesc> getDisplayModes() const = 0;
 		virtual DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const = 0;
 		virtual Vector<int> getWindowClientArea() const noexcept = 0;

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -20,7 +20,6 @@ struct SDL_Cursor;
 
 namespace NAS2D
 {
-
 	/**
 	 * OpenGL Renderer.
 	 *
@@ -111,5 +110,4 @@ namespace NAS2D
 		SDL_GLContext sdlOglContext; /**< Primary OpenGL render context. */
 		std::map<int, SDL_Cursor*> cursors;
 	};
-
 } // namespace

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -102,7 +102,6 @@ namespace NAS2D
 		void setOrthoProjection(const Rectangle<float>& orthoBounds) override;
 
 	private:
-
 		void initGL();
 		void initVideo(Vector<int> resolution, bool fullscreen, bool vsync);
 

--- a/NAS2D/Resource/Font.h
+++ b/NAS2D/Resource/Font.h
@@ -36,7 +36,6 @@ namespace NAS2D
 	class Font
 	{
 	public:
-
 		struct GlyphMetrics
 		{
 			Rectangle<float> uvRect{};

--- a/NAS2D/Resource/Font.h
+++ b/NAS2D/Resource/Font.h
@@ -19,7 +19,6 @@
 
 namespace NAS2D
 {
-
 	/**
 	 * Font resource.
 	 *
@@ -86,5 +85,4 @@ namespace NAS2D
 		std::string mResourceName; /**< File path */
 		FontInfo mFontInfo;
 	};
-
 } // namespace

--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -104,4 +104,3 @@ namespace NAS2D
 	using StringList = std::vector<std::string>;
 
 } // namespace NAS2D
-


### PR DESCRIPTION
Reference: #893

Somewhat ironically there was a whitespace error in the `.clang-format` file. It was not able to detect nor correct the error in it's own config file. :wink: 
