### PR TITLE
Update data return style

### DIFF
--- a/NAS2D/Renderer/Point.h
+++ b/NAS2D/Renderer/Point.h
@@ -77,10 +77,7 @@ namespace NAS2D
 		template <typename NewBaseType>
 		constexpr operator Point<NewBaseType>() const
 		{
-			return {
-				static_cast<NewBaseType>(x),
-				static_cast<NewBaseType>(y)
-			};
+			return {static_cast<NewBaseType>(x), static_cast<NewBaseType>(y)};
 		}
 
 		template <typename NewBaseType>

--- a/NAS2D/Renderer/Rectangle.h
+++ b/NAS2D/Renderer/Rectangle.h
@@ -38,12 +38,7 @@ namespace NAS2D
 		// Factory method
 		constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Point<BaseType> endPoint)
 		{
-			return {
-				startPoint.x,
-				startPoint.y,
-				endPoint.x - startPoint.x,
-				endPoint.y - startPoint.y
-			};
+			return Create(startPoint, endPoint - startPoint);
 		}
 
 		constexpr bool operator==(const Rectangle& rect) const

--- a/NAS2D/Renderer/Rectangle.h
+++ b/NAS2D/Renderer/Rectangle.h
@@ -27,12 +27,7 @@ namespace NAS2D
 		// Factory method
 		constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Vector<BaseType> size)
 		{
-			return {
-				startPoint.x,
-				startPoint.y,
-				size.x,
-				size.y
-			};
+			return {startPoint.x, startPoint.y, size.x, size.y};
 		}
 
 		// Factory method

--- a/NAS2D/Renderer/Vector.h
+++ b/NAS2D/Renderer/Vector.h
@@ -37,6 +37,7 @@ namespace NAS2D
 			y += vector.y;
 			return *this;
 		}
+
 		Vector& operator-=(const Vector& vector)
 		{
 			x -= vector.x;
@@ -48,6 +49,7 @@ namespace NAS2D
 		{
 			return {x + vector.x, y + vector.y};
 		}
+
 		constexpr Vector operator-(const Vector& vector) const
 		{
 			return {x - vector.x, y - vector.y};

--- a/NAS2D/Renderer/Vector.h
+++ b/NAS2D/Renderer/Vector.h
@@ -46,17 +46,11 @@ namespace NAS2D
 
 		constexpr Vector operator+(const Vector& vector) const
 		{
-			return {
-				x + vector.x,
-				y + vector.y
-			};
+			return {x + vector.x, y + vector.y};
 		}
 		constexpr Vector operator-(const Vector& vector) const
 		{
-			return {
-				x - vector.x,
-				y - vector.y
-			};
+			return {x - vector.x, y - vector.y};
 		}
 
 		Vector& operator*=(BaseType scalar)
@@ -130,10 +124,7 @@ namespace NAS2D
 		template <typename NewBaseType>
 		constexpr operator Vector<NewBaseType>() const
 		{
-			return {
-				static_cast<NewBaseType>(x),
-				static_cast<NewBaseType>(y)
-			};
+			return {static_cast<NewBaseType>(x), static_cast<NewBaseType>(y)};
 		}
 
 		template <typename NewBaseType>


### PR DESCRIPTION
Reference: #893

Removes most of the `.clang-format` problem areas with data return style by making them one line.
