### PR TITLE
Update clang-format style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,7 +32,7 @@ BreakConstructorInitializers: AfterColon
 ColumnLimit: 0
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
-FixNamespaceComments: true
+FixNamespaceComments: false
 IncludeBlocks: Preserve
 IncludeCategories:
 # Prefer project-specific includes first

--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,7 @@ AllowShortCaseLabelsOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: true
 
 AllowShortLambdasOnASingleLine: All
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: true
 BinPackParameters: false
 #BreakBeforeBraces: Allman

--- a/makefile
+++ b/makefile
@@ -154,6 +154,7 @@ cppclean:
 
 .PHONY: format
 format:
+	clang-format --version
 	find NAS2D/ -path NAS2D/Xml -prune -name '*.cpp' -o -name '*.h' | xargs clang-format -i
 
 ### Linux development package dependencies ###


### PR DESCRIPTION
Reference: #893

Update `.clang-format` rules to reduce number of reformatted files down to 4.

The worst offender is Delegate.h, and a lot of that is the pre-processor macros.
