### PR TITLE
Refactor Delegate

### DIFF
--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -288,7 +288,7 @@ namespace NAS2D
 			m_pthis(nullptr),
 			m_pFunction(nullptr),
 			m_pStaticFunction(nullptr),
-		{};
+		{}
 
 		void clear()
 		{

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -228,7 +228,7 @@ namespace NAS2D
 				int virtual_delta = 0;
 				if (u.s.vtable_index)
 				{
-					const int* vtable = *reinterpret_cast<const int* const*>(reinterpret_cast<const char*>(pthis) + u.s.vtordisp );
+					const int* vtable = *reinterpret_cast<const int* const*>(reinterpret_cast<const char*>(pthis) + u.s.vtordisp);
 					virtual_delta = u.s.vtordisp + *reinterpret_cast<const int*>(reinterpret_cast<const char*>(vtable) + u.s.vtable_index);
 				}
 				return reinterpret_cast<GenericClass*>(reinterpret_cast<char*>(pthis) + u.s.delta + virtual_delta);

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -44,7 +44,7 @@
 #endif
 
 // Gcc(2.95+), and versions of Digital Mars, Intel and Comeau in common use.
-#if defined (__DMC__) || defined(__GNUC__) || defined(__ICL) || defined(__COMO__)
+#if defined(__DMC__) || defined(__GNUC__) || defined(__ICL) || defined(__COMO__)
 #define FASTDELEGATE_ALLOW_FUNCTION_TYPE_SYNTAX
 #endif
 

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -284,7 +284,11 @@ namespace NAS2D
 
 	public:
 	#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-		DelegateMemento() : m_pthis(nullptr), m_pFunction(nullptr), m_pStaticFunction(nullptr) {};
+		DelegateMemento() :
+			m_pthis(nullptr),
+			m_pFunction(nullptr),
+			m_pStaticFunction(nullptr),
+		{};
 
 		void clear()
 		{
@@ -293,7 +297,10 @@ namespace NAS2D
 			m_pStaticFunction = nullptr;
 		}
 	#else
-		DelegateMemento() : m_pthis(nullptr), m_pFunction(nullptr) {}
+		DelegateMemento() :
+			m_pthis(nullptr),
+			m_pFunction(nullptr)
+		{}
 
 		void clear()
 		{
@@ -345,7 +352,9 @@ namespace NAS2D
 		inline bool operator<(const DelegateMemento& right) { return IsLess(right); }
 		inline bool operator>(const DelegateMemento& right) { return right.IsLess(*this); }
 
-		DelegateMemento(const DelegateMemento& right) : m_pthis(right.m_pthis), m_pFunction(right.m_pFunction)
+		DelegateMemento(const DelegateMemento& right) :
+			m_pthis(right.m_pthis),
+			m_pFunction(right.m_pFunction)
 			#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
 			, m_pStaticFunction(right.m_pStaticFunction)
 			#endif
@@ -594,12 +603,18 @@ namespace NAS2D
 		Delegate() = default;
 
 		template <typename X, typename Y>
-		Delegate(Y* pthis, RetType (X::*function_to_bind)(Params...)) : BaseType(pthis, function_to_bind) {}
+		Delegate(Y* pthis, RetType (X::*function_to_bind)(Params...)) :
+			BaseType(pthis, function_to_bind)
+		{}
 
 		template <typename X, typename Y>
-		Delegate(const Y* pthis, RetType (X::*function_to_bind)(Params...) const) : BaseType(pthis, function_to_bind) {}
+		Delegate(const Y* pthis, RetType (X::*function_to_bind)(Params...) const) :
+			BaseType(pthis, function_to_bind)
+		{}
 
-		Delegate(RetType (*function_to_bind)(Params...)) : BaseType(function_to_bind) {}
+		Delegate(RetType (*function_to_bind)(Params...)) :
+			BaseType(function_to_bind)
+		{}
 
 		Delegate& operator=(const BaseType& x)
 		{

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -546,7 +546,7 @@ namespace NAS2D
 			m_Closure.bindstaticfunc(this, &DelegateX::InvokeStaticFunction, function_to_bind);
 		}
 
-		RetType operator() (Params... params) const
+		RetType operator()(Params... params) const
 		{
 			return (m_Closure.GetClosureThis()->*(m_Closure.GetClosureMemPtr()))(params...);
 		}

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -247,7 +247,7 @@ namespace NAS2D
 		GenericMemFuncType m_pFunction;
 
 	#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-		using GenericFuncPtr = void(*)();
+		using GenericFuncPtr = void (*)();
 		GenericFuncPtr m_pStaticFunction;
 	#endif
 
@@ -398,8 +398,8 @@ namespace NAS2D
 	{
 	private:
 		using DesiredRetType = typename detail::DefaultVoidToVoid<RetType>::type;
-		using StaticFunctionPtr = DesiredRetType(*)(Params...);
-		using UnvoidStaticFunctionPtr = RetType(*)(Params...);
+		using StaticFunctionPtr = DesiredRetType (*)(Params...);
+		using UnvoidStaticFunctionPtr = RetType (*)(Params...);
 		using GenericMemFn = RetType(detail::GenericClass::*)(Params...);
 		using ClosureType = detail::ClosurePtr<GenericMemFn, StaticFunctionPtr, UnvoidStaticFunctionPtr>;
 		ClosureType m_Closure;
@@ -425,9 +425,9 @@ namespace NAS2D
 		template <typename X, typename Y>
 		inline void Bind(const Y* pthis, DesiredRetType(X::*function_to_bind)(Params...) const) { m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind); }
 
-		DelegateX(DesiredRetType(*function_to_bind)(Params...)) { Bind(function_to_bind); }
-		DelegateX& operator = (DesiredRetType(*function_to_bind)(Params...)) { Bind(function_to_bind); return *this; }
-		inline void Bind(DesiredRetType(*function_to_bind)(Params...)) { m_Closure.bindstaticfunc(this, &DelegateX::InvokeStaticFunction, function_to_bind); }
+		DelegateX(DesiredRetType (*function_to_bind)(Params...)) { Bind(function_to_bind); }
+		DelegateX& operator = (DesiredRetType (*function_to_bind)(Params...)) { Bind(function_to_bind); return *this; }
+		inline void Bind(DesiredRetType (*function_to_bind)(Params...)) { m_Closure.bindstaticfunc(this, &DelegateX::InvokeStaticFunction, function_to_bind); }
 		RetType operator() (Params...params) const { return (m_Closure.GetClosureThis()->*(m_Closure.GetClosureMemPtr()))(params...); }
 
 	private:
@@ -471,7 +471,7 @@ namespace NAS2D
 		template <typename X, typename Y>
 		Delegate(const Y* pthis, RetType(X::*function_to_bind)(Params...) const) : BaseType(pthis, function_to_bind) {}
 
-		Delegate(RetType(*function_to_bind)(Params...)) : BaseType(function_to_bind) {}
+		Delegate(RetType (*function_to_bind)(Params...)) : BaseType(function_to_bind) {}
 		Delegate& operator = (const BaseType& x) { *static_cast<BaseType*>(this) = x; return *this; }
 	};
 

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -281,13 +281,13 @@ namespace NAS2D
 			return memcmp(&m_pFunction, &right.m_pFunction, sizeof(m_pFunction)) < 0;
 		}
 
-		inline bool operator ! () const { return !m_pthis && !m_pFunction; }
+		inline bool operator!() const { return !m_pthis && !m_pFunction; }
 		inline bool empty() const { return !m_pthis && !m_pFunction; }
 
 	public:
-		DelegateMemento& operator = (const DelegateMemento& right) { SetMementoFrom(right); return *this; }
-		inline bool operator <(const DelegateMemento& right) { return IsLess(right); }
-		inline bool operator >(const DelegateMemento& right) { return right.IsLess(*this); }
+		DelegateMemento& operator=(const DelegateMemento& right) { SetMementoFrom(right); return *this; }
+		inline bool operator<(const DelegateMemento& right) { return IsLess(right); }
+		inline bool operator>(const DelegateMemento& right) { return right.IsLess(*this); }
 		DelegateMemento(const DelegateMemento& right) : m_pthis(right.m_pthis), m_pFunction(right.m_pFunction)
 			#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
 			, m_pStaticFunction(right.m_pStaticFunction)
@@ -409,11 +409,11 @@ namespace NAS2D
 
 		DelegateX() { clear(); }
 		DelegateX(const DelegateX& x) { m_Closure.CopyFrom(this, x.m_Closure); }
-		DelegateX& operator = (const DelegateX& x) { m_Closure.CopyFrom(this, x.m_Closure); return *this; }
-		bool operator ==(const DelegateX& x) const { return m_Closure.IsEqual(x.m_Closure); }
-		bool operator !=(const DelegateX& x) const { return !m_Closure.IsEqual(x.m_Closure); }
-		bool operator <(const DelegateX& x) const { return m_Closure.IsLess(x.m_Closure); }
-		bool operator >(const DelegateX& x) const { return x.m_Closure.IsLess(m_Closure); }
+		DelegateX& operator=(const DelegateX& x) { m_Closure.CopyFrom(this, x.m_Closure); return *this; }
+		bool operator==(const DelegateX& x) const { return m_Closure.IsEqual(x.m_Closure); }
+		bool operator!=(const DelegateX& x) const { return !m_Closure.IsEqual(x.m_Closure); }
+		bool operator<(const DelegateX& x) const { return m_Closure.IsLess(x.m_Closure); }
+		bool operator>(const DelegateX& x) const { return x.m_Closure.IsLess(m_Closure); }
 
 		template <typename X, typename Y>
 		DelegateX(Y* pthis, DesiredRetType(X::*function_to_bind)(Params...)) { m_Closure.bindmemfunc(static_cast<X*>(pthis), function_to_bind); }
@@ -426,7 +426,7 @@ namespace NAS2D
 		inline void Bind(const Y* pthis, DesiredRetType(X::*function_to_bind)(Params...) const) { m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind); }
 
 		DelegateX(DesiredRetType (*function_to_bind)(Params...)) { Bind(function_to_bind); }
-		DelegateX& operator = (DesiredRetType (*function_to_bind)(Params...)) { Bind(function_to_bind); return *this; }
+		DelegateX& operator=(DesiredRetType (*function_to_bind)(Params...)) { Bind(function_to_bind); return *this; }
 		inline void Bind(DesiredRetType (*function_to_bind)(Params...)) { m_Closure.bindstaticfunc(this, &DelegateX::InvokeStaticFunction, function_to_bind); }
 		RetType operator() (Params...params) const { return (m_Closure.GetClosureThis()->*(m_Closure.GetClosureMemPtr()))(params...); }
 
@@ -472,7 +472,7 @@ namespace NAS2D
 		Delegate(const Y* pthis, RetType(X::*function_to_bind)(Params...) const) : BaseType(pthis, function_to_bind) {}
 
 		Delegate(RetType (*function_to_bind)(Params...)) : BaseType(function_to_bind) {}
-		Delegate& operator = (const BaseType& x) { *static_cast<BaseType*>(this) = x; return *this; }
+		Delegate& operator=(const BaseType& x) { *static_cast<BaseType*>(this) = x; return *this; }
 	};
 
 	#endif

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -254,10 +254,21 @@ namespace NAS2D
 	public:
 	#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
 		DelegateMemento() : m_pthis(nullptr), m_pFunction(nullptr), m_pStaticFunction(nullptr) {};
-		void clear() { m_pthis = nullptr; m_pFunction = nullptr; m_pStaticFunction = nullptr; }
+
+		void clear()
+		{
+			m_pthis = nullptr;
+			m_pFunction = nullptr;
+			m_pStaticFunction = nullptr;
+		}
 	#else
 		DelegateMemento() : m_pthis(nullptr), m_pFunction(nullptr) {}
-		void clear() { m_pthis = nullptr; m_pFunction = nullptr; }
+
+		void clear()
+		{
+			m_pthis = nullptr;
+			m_pFunction = nullptr;
+		}
 	#endif
 	public:
 	#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
@@ -269,7 +280,10 @@ namespace NAS2D
 			else return true;
 		}
 	#else
-		inline bool IsEqual(const DelegateMemento& x) const { return m_pthis == x.m_pthis && m_pFunction == x.m_pFunction; }
+		inline bool IsEqual(const DelegateMemento& x) const
+		{
+			return m_pthis == x.m_pthis && m_pFunction == x.m_pFunction;
+		}
 	#endif
 		inline bool IsLess(const DelegateMemento& right) const
 		{
@@ -285,9 +299,15 @@ namespace NAS2D
 		inline bool empty() const { return !m_pthis && !m_pFunction; }
 
 	public:
-		DelegateMemento& operator=(const DelegateMemento& right) { SetMementoFrom(right); return *this; }
+		DelegateMemento& operator=(const DelegateMemento& right)
+		{
+			SetMementoFrom(right);
+			return *this;
+		}
+
 		inline bool operator<(const DelegateMemento& right) { return IsLess(right); }
 		inline bool operator>(const DelegateMemento& right) { return right.IsLess(*this); }
+
 		DelegateMemento(const DelegateMemento& right) : m_pthis(right.m_pthis), m_pFunction(right.m_pFunction)
 			#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
 			, m_pStaticFunction(right.m_pStaticFunction)
@@ -341,8 +361,15 @@ namespace NAS2D
 			}
 		#endif
 
-			inline GenericClass* GetClosureThis() const { return m_pthis; }
-			inline GenericMemFunc GetClosureMemPtr() const { return CastMemFuncPtr<GenericMemFunc>(m_pFunction); }
+			inline GenericClass* GetClosureThis() const
+			{
+				return m_pthis;
+			}
+
+			inline GenericMemFunc GetClosureMemPtr() const
+			{
+				return CastMemFuncPtr<GenericMemFunc>(m_pFunction);
+			}
 
 		#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
 
@@ -365,7 +392,10 @@ namespace NAS2D
 		#else
 
 			template <typename DerivedClass>
-			inline void CopyFrom(DerivedClass*, const DelegateMemento& right) { SetMementoFrom(right); }
+			inline void CopyFrom(DerivedClass*, const DelegateMemento& right)
+			{
+				SetMementoFrom(right);
+			}
 
 			template <typename DerivedClass, typename ParentInvokerSig>
 			inline void bindstaticfunc(DerivedClass* pParent, ParentInvokerSig static_function_invoker, StaticFuncPtr function_to_bind)
@@ -409,26 +439,62 @@ namespace NAS2D
 
 		DelegateX() { clear(); }
 		DelegateX(const DelegateX& x) { m_Closure.CopyFrom(this, x.m_Closure); }
-		DelegateX& operator=(const DelegateX& x) { m_Closure.CopyFrom(this, x.m_Closure); return *this; }
+
+		DelegateX& operator=(const DelegateX& x)
+		{
+			m_Closure.CopyFrom(this, x.m_Closure);
+			return *this;
+		}
+
 		bool operator==(const DelegateX& x) const { return m_Closure.IsEqual(x.m_Closure); }
 		bool operator!=(const DelegateX& x) const { return !m_Closure.IsEqual(x.m_Closure); }
 		bool operator<(const DelegateX& x) const { return m_Closure.IsLess(x.m_Closure); }
 		bool operator>(const DelegateX& x) const { return x.m_Closure.IsLess(m_Closure); }
 
 		template <typename X, typename Y>
-		DelegateX(Y* pthis, DesiredRetType (X::*function_to_bind)(Params...)) { m_Closure.bindmemfunc(static_cast<X*>(pthis), function_to_bind); }
-		template <typename X, typename Y>
-		inline void Bind(Y* pthis, DesiredRetType (X::*function_to_bind)(Params...)) { m_Closure.bindmemfunc(static_cast<X*>(pthis), function_to_bind); }
+		DelegateX(Y* pthis, DesiredRetType (X::*function_to_bind)(Params...))
+		{
+			m_Closure.bindmemfunc(static_cast<X*>(pthis), function_to_bind);
+		}
 
 		template <typename X, typename Y>
-		DelegateX(const Y* pthis, DesiredRetType (X::*function_to_bind)(Params...) const) { m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind); }
-		template <typename X, typename Y>
-		inline void Bind(const Y* pthis, DesiredRetType (X::*function_to_bind)(Params...) const) { m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind); }
+		inline void Bind(Y* pthis, DesiredRetType (X::*function_to_bind)(Params...))
+		{
+			m_Closure.bindmemfunc(static_cast<X*>(pthis), function_to_bind);
+		}
 
-		DelegateX(DesiredRetType (*function_to_bind)(Params...)) { Bind(function_to_bind); }
-		DelegateX& operator=(DesiredRetType (*function_to_bind)(Params...)) { Bind(function_to_bind); return *this; }
-		inline void Bind(DesiredRetType (*function_to_bind)(Params...)) { m_Closure.bindstaticfunc(this, &DelegateX::InvokeStaticFunction, function_to_bind); }
-		RetType operator() (Params...params) const { return (m_Closure.GetClosureThis()->*(m_Closure.GetClosureMemPtr()))(params...); }
+		template <typename X, typename Y>
+		DelegateX(const Y* pthis, DesiredRetType (X::*function_to_bind)(Params...) const)
+		{
+			m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind);
+		}
+
+		template <typename X, typename Y>
+		inline void Bind(const Y* pthis, DesiredRetType (X::*function_to_bind)(Params...) const)
+		{
+			m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind);
+		}
+
+		DelegateX(DesiredRetType (*function_to_bind)(Params...))
+		{
+			Bind(function_to_bind);
+		}
+
+		DelegateX& operator=(DesiredRetType (*function_to_bind)(Params...))
+		{
+			Bind(function_to_bind);
+			return *this;
+		}
+
+		inline void Bind(DesiredRetType (*function_to_bind)(Params...))
+		{
+			m_Closure.bindstaticfunc(this, &DelegateX::InvokeStaticFunction, function_to_bind);
+		}
+
+		RetType operator() (Params...params) const
+		{
+			return (m_Closure.GetClosureThis()->*(m_Closure.GetClosureMemPtr()))(params...);
+		}
 
 	private:
 		using UselessTypedef = struct SafeBoolStruct { int a_data_pointer_to_this_is_0_on_buggy_compilers; StaticFunctionPtr m_nonzero; };
@@ -447,7 +513,10 @@ namespace NAS2D
 		void SetMemento(const DelegateMemento& any) { m_Closure.CopyFrom(this, any); }
 
 	private:
-		RetType InvokeStaticFunction(Params...params) const { return (*(m_Closure.GetStaticFunction()))(params...); }
+		RetType InvokeStaticFunction(Params...params) const
+		{
+			return (*(m_Closure.GetStaticFunction()))(params...);
+		}
 	};
 
 
@@ -472,14 +541,26 @@ namespace NAS2D
 		Delegate(const Y* pthis, RetType (X::*function_to_bind)(Params...) const) : BaseType(pthis, function_to_bind) {}
 
 		Delegate(RetType (*function_to_bind)(Params...)) : BaseType(function_to_bind) {}
-		Delegate& operator=(const BaseType& x) { *static_cast<BaseType*>(this) = x; return *this; }
+
+		Delegate& operator=(const BaseType& x)
+		{
+			*static_cast<BaseType*>(this) = x;
+			return *this;
+		}
 	};
 
 	#endif
 
 	template <typename X, typename Y, typename RetType, typename... Params>
-	DelegateX<RetType, Params...> MakeDelegate(Y* x, RetType (X::*func)(Params...)) { return DelegateX<RetType, Params...>(x, func); }
+	DelegateX<RetType, Params...> MakeDelegate(Y* x, RetType (X::*func)(Params...))
+	{
+		return DelegateX<RetType, Params...>(x, func);
+	}
+
 	template <typename X, typename Y, typename RetType, typename... Params>
-	DelegateX<RetType, Params...> MakeDelegate(Y* x, RetType (X::*func)(Params...) const) { return DelegateX<RetType, Params...>(x, func); }
+	DelegateX<RetType, Params...> MakeDelegate(Y* x, RetType (X::*func)(Params...) const)
+	{
+		return DelegateX<RetType, Params...>(x, func);
+	}
 
 }

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -400,7 +400,7 @@ namespace NAS2D
 		using DesiredRetType = typename detail::DefaultVoidToVoid<RetType>::type;
 		using StaticFunctionPtr = DesiredRetType (*)(Params...);
 		using UnvoidStaticFunctionPtr = RetType (*)(Params...);
-		using GenericMemFn = RetType(detail::GenericClass::*)(Params...);
+		using GenericMemFn = RetType (detail::GenericClass::*)(Params...);
 		using ClosureType = detail::ClosurePtr<GenericMemFn, StaticFunctionPtr, UnvoidStaticFunctionPtr>;
 		ClosureType m_Closure;
 
@@ -416,14 +416,14 @@ namespace NAS2D
 		bool operator>(const DelegateX& x) const { return x.m_Closure.IsLess(m_Closure); }
 
 		template <typename X, typename Y>
-		DelegateX(Y* pthis, DesiredRetType(X::*function_to_bind)(Params...)) { m_Closure.bindmemfunc(static_cast<X*>(pthis), function_to_bind); }
+		DelegateX(Y* pthis, DesiredRetType (X::*function_to_bind)(Params...)) { m_Closure.bindmemfunc(static_cast<X*>(pthis), function_to_bind); }
 		template <typename X, typename Y>
-		inline void Bind(Y* pthis, DesiredRetType(X::*function_to_bind)(Params...)) { m_Closure.bindmemfunc(static_cast<X*>(pthis), function_to_bind); }
+		inline void Bind(Y* pthis, DesiredRetType (X::*function_to_bind)(Params...)) { m_Closure.bindmemfunc(static_cast<X*>(pthis), function_to_bind); }
 
 		template <typename X, typename Y>
-		DelegateX(const Y* pthis, DesiredRetType(X::*function_to_bind)(Params...) const) { m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind); }
+		DelegateX(const Y* pthis, DesiredRetType (X::*function_to_bind)(Params...) const) { m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind); }
 		template <typename X, typename Y>
-		inline void Bind(const Y* pthis, DesiredRetType(X::*function_to_bind)(Params...) const) { m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind); }
+		inline void Bind(const Y* pthis, DesiredRetType (X::*function_to_bind)(Params...) const) { m_Closure.bindconstmemfunc(static_cast<const X*>(pthis), function_to_bind); }
 
 		DelegateX(DesiredRetType (*function_to_bind)(Params...)) { Bind(function_to_bind); }
 		DelegateX& operator=(DesiredRetType (*function_to_bind)(Params...)) { Bind(function_to_bind); return *this; }
@@ -466,10 +466,10 @@ namespace NAS2D
 		Delegate() = default;
 
 		template <typename X, typename Y>
-		Delegate(Y* pthis, RetType(X::*function_to_bind)(Params...)) : BaseType(pthis, function_to_bind) {}
+		Delegate(Y* pthis, RetType (X::*function_to_bind)(Params...)) : BaseType(pthis, function_to_bind) {}
 
 		template <typename X, typename Y>
-		Delegate(const Y* pthis, RetType(X::*function_to_bind)(Params...) const) : BaseType(pthis, function_to_bind) {}
+		Delegate(const Y* pthis, RetType (X::*function_to_bind)(Params...) const) : BaseType(pthis, function_to_bind) {}
 
 		Delegate(RetType (*function_to_bind)(Params...)) : BaseType(function_to_bind) {}
 		Delegate& operator=(const BaseType& x) { *static_cast<BaseType*>(this) = x; return *this; }
@@ -478,8 +478,8 @@ namespace NAS2D
 	#endif
 
 	template <typename X, typename Y, typename RetType, typename... Params>
-	DelegateX<RetType, Params...> MakeDelegate(Y* x, RetType(X::*func)(Params...)) { return DelegateX<RetType, Params...>(x, func); }
+	DelegateX<RetType, Params...> MakeDelegate(Y* x, RetType (X::*func)(Params...)) { return DelegateX<RetType, Params...>(x, func); }
 	template <typename X, typename Y, typename RetType, typename... Params>
-	DelegateX<RetType, Params...> MakeDelegate(Y* x, RetType(X::*func)(Params...) const) { return DelegateX<RetType, Params...>(x, func); }
+	DelegateX<RetType, Params...> MakeDelegate(Y* x, RetType (X::*func)(Params...) const) { return DelegateX<RetType, Params...>(x, func); }
 
 }

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -59,7 +59,11 @@ namespace NAS2D
 	{
 
 		template <typename OutputClass, typename InputClass>
-		union horrible_union { OutputClass out; InputClass in; };
+		union horrible_union
+		{
+			OutputClass out;
+			InputClass in;
+		};
 
 		template <typename OutputClass, typename InputClass>
 		inline OutputClass horrible_cast(const InputClass input)
@@ -78,17 +82,29 @@ namespace NAS2D
 
 		// Translate from 'DefaultVoid' to 'void'.
 		template <typename T>
-		struct DefaultVoidToVoid { using type = T; };
+		struct DefaultVoidToVoid
+		{
+			using type = T;
+		};
 
 		template <>
-		struct DefaultVoidToVoid<DefaultVoid> { using type = void; };
+		struct DefaultVoidToVoid<DefaultVoid>
+		{
+			using type = void;
+		};
 
 		// Translate from 'void' into 'DefaultVoid'
 		template <typename T>
-		struct VoidToDefaultVoid { using type = T; };
+		struct VoidToDefaultVoid
+		{
+			using type = T;
+		};
 
 		template <>
-		struct VoidToDefaultVoid<void> { using type = DefaultVoid; };
+		struct VoidToDefaultVoid<void>
+		{
+			using type = DefaultVoid;
+		};
 
 
 		template <typename GenericMemFuncType, typename XFuncType>
@@ -155,7 +171,11 @@ namespace NAS2D
 				union
 				{
 					XFuncType func;
-					struct { GenericMemFuncType funcaddress; int delta; } s;
+					struct
+					{
+						GenericMemFuncType funcaddress;
+						int delta;
+					} s;
 				} u;
 
 				static_assert(sizeof(function_to_bind) == sizeof(u.s), "Can't use horrible cast");
@@ -187,10 +207,21 @@ namespace NAS2D
 			template <typename X, typename XFuncType, typename GenericMemFuncType>
 			inline static GenericClass* Convert(X* pthis, XFuncType function_to_bind, GenericMemFuncType& bound_func)
 			{
-				union { XFuncType func; GenericClass* (X::*ProbeFunc)(); MicrosoftVirtualMFP s; } u;
+				union
+				{
+					XFuncType func;
+					GenericClass* (X::*ProbeFunc)();
+					MicrosoftVirtualMFP s;
+				} u;
+
 				u.func = function_to_bind;
 				bound_func = CastMemFuncPtr<GenericMemFuncType>(u.s.codeptr);
-				union { GenericVirtualClass::ProbePtrType virtfunc; MicrosoftVirtualMFP s; } u2;
+
+				union
+				{
+					GenericVirtualClass::ProbePtrType virtfunc;
+					MicrosoftVirtualMFP s;
+				} u2;
 
 				static_assert(sizeof(function_to_bind) == sizeof(u.s) && sizeof(function_to_bind) == sizeof(u.ProbeFunc) && sizeof(u2.virtfunc) == sizeof(u2.s), "Can't use horrible cast");
 
@@ -521,7 +552,11 @@ namespace NAS2D
 		}
 
 	private:
-		using UselessTypedef = struct SafeBoolStruct { int a_data_pointer_to_this_is_0_on_buggy_compilers; StaticFunctionPtr m_nonzero; };
+		using UselessTypedef = struct SafeBoolStruct
+		{
+			int a_data_pointer_to_this_is_0_on_buggy_compilers;
+			StaticFunctionPtr m_nonzero;
+		};
 		using unspecified_bool_type = StaticFunctionPtr SafeBoolStruct::*;
 
 	public:

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -515,7 +515,7 @@ namespace NAS2D
 			m_Closure.bindstaticfunc(this, &DelegateX::InvokeStaticFunction, function_to_bind);
 		}
 
-		RetType operator() (Params...params) const
+		RetType operator() (Params... params) const
 		{
 			return (m_Closure.GetClosureThis()->*(m_Closure.GetClosureMemPtr()))(params...);
 		}
@@ -537,7 +537,7 @@ namespace NAS2D
 		void SetMemento(const DelegateMemento& any) { m_Closure.CopyFrom(this, any); }
 
 	private:
-		RetType InvokeStaticFunction(Params...params) const
+		RetType InvokeStaticFunction(Params... params) const
 		{
 			return (*(m_Closure.GetStaticFunction()))(params...);
 		}

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -276,8 +276,14 @@ namespace NAS2D
 		{
 			if (m_pFunction != x.m_pFunction) return false;
 			if (m_pStaticFunction != x.m_pStaticFunction) return false;
-			if (m_pStaticFunction) return m_pthis == x.m_pthis;
-			else return true;
+			if (m_pStaticFunction)
+			{
+				return m_pthis == x.m_pthis;
+			}
+			else
+			{
+				return true;
+			}
 		}
 	#else
 		inline bool IsEqual(const DelegateMemento& x) const
@@ -384,8 +390,14 @@ namespace NAS2D
 			template <typename DerivedClass, typename ParentInvokerSig>
 			inline void bindstaticfunc(DerivedClass* pParent, ParentInvokerSig static_function_invoker, StaticFuncPtr function_to_bind)
 			{
-				if (!function_to_bind) m_pFunction = nullptr;
-				else bindmemfunc(pParent, static_function_invoker);
+				if (!function_to_bind)
+				{
+					m_pFunction = nullptr;
+				}
+				else
+				{
+					bindmemfunc(pParent, static_function_invoker);
+				}
 				m_pStaticFunction = reinterpret_cast<GenericFuncPtr>(function_to_bind);
 			}
 			inline UnvoidStaticFuncPtr GetStaticFunction() const { return reinterpret_cast<UnvoidStaticFuncPtr>(m_pStaticFunction); }
@@ -400,8 +412,14 @@ namespace NAS2D
 			template <typename DerivedClass, typename ParentInvokerSig>
 			inline void bindstaticfunc(DerivedClass* pParent, ParentInvokerSig static_function_invoker, StaticFuncPtr function_to_bind)
 			{
-				if (!function_to_bind) m_pFunction = nullptr;
-				else bindmemfunc(pParent, static_function_invoker);
+				if (!function_to_bind)
+				{
+					m_pFunction = nullptr;
+				}
+				else
+				{
+					bindmemfunc(pParent, static_function_invoker);
+				}
 				static_assert(sizeof(GenericClass*) != sizeof(function_to_bind), "Can't use evil method");
 				m_pthis = horrible_cast<GenericClass*>(function_to_bind);
 			}
@@ -415,8 +433,14 @@ namespace NAS2D
 
 			inline bool IsEqualToStaticFuncPtr(StaticFuncPtr funcptr)
 			{
-				if (!funcptr) return empty();
-				else return funcptr == reinterpret_cast<StaticFuncPtr>(GetStaticFunction());
+				if (!funcptr)
+				{
+					return empty();
+				}
+				else
+				{
+					return funcptr == reinterpret_cast<StaticFuncPtr>(GetStaticFunction());
+				}
 			}
 		};
 

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -463,7 +463,7 @@ namespace NAS2D
 		using BaseType = DelegateX<RetType, Params...>;
 		using SelfType = Delegate;
 
-		Delegate() : BaseType() {}
+		Delegate() = default;
 
 		template <typename X, typename Y>
 		Delegate(Y* pthis, RetType(X::*function_to_bind)(Params...)) : BaseType(pthis, function_to_bind) {}


### PR DESCRIPTION
Reference: #893

Refactor `Delegate` class to make it more consistent with project code style.

The pre-processor code still doesn't conform to the `.clang-format` rules. Though much of that code is to deal with ancient compilers, which definitely don't support the C++17 standard we are targeting. Perhaps a lot of that old compatibility code can be removed.
