### PR TITLE
Redefine stop frame sentinel

### DIFF
--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -45,6 +45,16 @@ namespace
 }
 
 
+bool AnimationSet::Frame::isStopFrame() const
+{
+	// We want to redefine the sentinel value for stop frames from -1 to 0
+	// Neither value makes sense as a delay, though the field is unsigned
+	// Using 0 would also help simplify some code, so makes the most sense
+	// Temporarily handle -1 for backwards compatibility during transition
+	return (frameDelay == 0) || (frameDelay == unsigned(-1));
+}
+
+
 AnimationSet::AnimationSet(std::string fileName) : AnimationSet{processXml(std::move(fileName), animationImageCache)}
 {
 }

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -229,10 +229,10 @@ namespace
 			int currentRow = frame->row();
 
 			const auto dictionary = attributesToDictionary(*frame);
-			reportMissingOrUnexpected(dictionary.keys(), {"sheetid", "delay", "x", "y", "width", "height", "anchorx", "anchory"}, {});
+			reportMissingOrUnexpected(dictionary.keys(), {"sheetid", "x", "y", "width", "height", "anchorx", "anchory"}, {"delay"});
 
 			const auto sheetId = dictionary.get("sheetid");
-			const auto delay = dictionary.get<int>("delay");
+			const auto delay = dictionary.get<int>("delay", 0);
 			const auto x = dictionary.get<int>("x");
 			const auto y = dictionary.get<int>("y");
 			const auto width = dictionary.get<int>("width");

--- a/NAS2D/Resource/AnimationSet.h
+++ b/NAS2D/Resource/AnimationSet.h
@@ -31,6 +31,8 @@ namespace NAS2D
 			Rectangle<int> bounds;
 			Vector<int> anchorOffset;
 			unsigned int frameDelay;
+
+			bool isStopFrame() const;
 		};
 
 		AnimationSet(std::string fileName);

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -23,8 +23,6 @@ using namespace NAS2D;
 
 namespace
 {
-	const auto FRAME_PAUSE = unsigned(-1);
-
 	using AnimationCache = ResourceCache<AnimationSet, std::string>;
 	AnimationCache animationCache;
 }
@@ -136,7 +134,7 @@ void Sprite::update(Point<float> position)
 {
 	const auto& frame = (*mCurrentAction)[mCurrentFrame];
 
-	if (!mPaused && (frame.frameDelay != FRAME_PAUSE))
+	if (!mPaused && !frame.isStopFrame())
 	{
 		while (frame.frameDelay > 0 && mTimer.accumulator() >= frame.frameDelay)
 		{
@@ -150,7 +148,7 @@ void Sprite::update(Point<float> position)
 			mAnimationCompleteSignal();
 		}
 	}
-	else if (frame.frameDelay == FRAME_PAUSE)
+	else if (frame.isStopFrame())
 	{
 		mAnimationCompleteSignal();
 	}

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -136,7 +136,7 @@ void Sprite::update(Point<float> position)
 
 	if (!mPaused && !frame.isStopFrame())
 	{
-		while (frame.frameDelay > 0 && mTimer.accumulator() >= frame.frameDelay)
+		while (mTimer.accumulator() >= frame.frameDelay)
 		{
 			mTimer.adjust_accumulator(frame.frameDelay);
 			mCurrentFrame++;


### PR DESCRIPTION
Reference: #935, #920, #925, #797

Redefine the stop frame sentinel value from `-1` to `0`. Add backwards compatibility for `-1`, which can be removed later after data is updated. Make the `"delay"` field in XML files optional, with a default value of `0`, equivalent to the new stop frame sentinel value.
