### PR TITLE
Re-apply change for static_cast removal

### DIFF
--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -232,7 +232,7 @@ namespace
 			reportMissingOrUnexpected(dictionary.keys(), {"sheetid", "x", "y", "width", "height", "anchorx", "anchory"}, {"delay"});
 
 			const auto sheetId = dictionary.get("sheetid");
-			const auto delay = dictionary.get<int>("delay", 0);
+			const auto delay = dictionary.get<unsigned int>("delay", 0);
 			const auto x = dictionary.get<int>("x");
 			const auto y = dictionary.get<int>("y");
 			const auto width = dictionary.get<int>("width");
@@ -274,7 +274,7 @@ namespace
 
 			const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});
 			const auto anchorOffset = Vector{anchorx, anchory};
-			frameList.push_back(AnimationSet::Frame{image, bounds, anchorOffset, static_cast<unsigned int>(delay)});
+			frameList.push_back(AnimationSet::Frame{image, bounds, anchorOffset, delay});
 		}
 
 		return frameList;


### PR DESCRIPTION
Reference: #797, #920, #935, #936, https://github.com/OutpostUniverse/OPHD/pull/1047, https://github.com/OutpostUniverse/OPHD/pull/1048, https://github.com/OutpostUniverse/ophd-assets/pull/3

We can now safely parse the `"delay"` field as an `unsigned int`, now that downstream project OPHD has updated data assets to not use "-1" to indicate stop frames.

----

Revert "Revert "Remove static_cast in AnimationSet data loading""

This reverts commit fa80d575f1bca979df7f75c8a0daf1c4e66ca50d. (#935)

This restores commit 23745702140209d65aa5cb0c14ad2e6330e2344c. (#920)
