### PR TITLE
Image delay creation of texture

### DIFF
--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -140,6 +140,10 @@ Color Image::pixelColor(Point<int> point) const
 
 unsigned int Image::textureId() const
 {
+	if (mTextureId == 0)
+	{
+		mTextureId = generateTexture(mSurface);
+	}
 	return mTextureId;
 }
 

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -47,7 +47,7 @@ namespace
 Image::Image(const std::string& filePath) :
 	mResourceName{filePath}
 {
-	auto data = Utility<Filesystem>::get().read(mResourceName);
+	const auto& data = Utility<Filesystem>::get().read(mResourceName);
 	if (data.size() == 0)
 	{
 		throw std::runtime_error("Image file is empty: " + mResourceName);

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -91,8 +91,15 @@ Image::Image(void* buffer, int bytesPerPixel, Vector<int> size) :
 
 Image::~Image()
 {
-	glDeleteFramebuffers(1, &mFrameBufferObjectId);
-	glDeleteTextures(1, &mTextureId);
+	if (mFrameBufferObjectId != 0)
+	{
+		glDeleteFramebuffers(1, &mFrameBufferObjectId);
+	}
+	if (mTextureId != 0)
+	{
+		glDeleteTextures(1, &mTextureId);
+	}
+
 	SDL_FreeSurface(mSurface);
 }
 

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -58,7 +58,6 @@ Image::Image(const std::string& filePath) :
 	{
 		throw std::runtime_error("Image failed to load: " + std::string{SDL_GetError()});
 	}
-	mTextureId = generateTexture(mSurface);
 	mSize = Vector{mSurface->w, mSurface->h};
 }
 
@@ -87,7 +86,6 @@ Image::Image(void* buffer, int bytesPerPixel, Vector<int> size) :
 	++IMAGE_ARBITRARY;
 
 	mSurface = SDL_CreateRGBSurfaceFrom(buffer, size.x, size.y, bytesPerPixel * 8, 0, 0, 0, 0, SDL_BYTEORDER == SDL_BIG_ENDIAN ? 0x000000FF : 0xFF000000);
-	mTextureId = generateTexture(mSurface);
 }
 
 

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -91,8 +91,8 @@ Image::Image(void* buffer, int bytesPerPixel, Vector<int> size) :
 
 Image::~Image()
 {
-	glDeleteTextures(1, &mTextureId);
 	glDeleteFramebuffers(1, &mFrameBufferObjectId);
+	glDeleteTextures(1, &mTextureId);
 	SDL_FreeSurface(mSurface);
 }
 

--- a/NAS2D/Resource/Image.h
+++ b/NAS2D/Resource/Image.h
@@ -61,7 +61,7 @@ namespace NAS2D
 	private:
 		std::string mResourceName; /**< File path or internal identifier. */
 		SDL_Surface* mSurface{nullptr};
-		unsigned int mTextureId{0u};
+		mutable unsigned int mTextureId{0u};
 		mutable unsigned int mFrameBufferObjectId{0u};
 		Vector<int> mSize{0, 0};
 	};

--- a/test/Resource/Image.test.cpp
+++ b/test/Resource/Image.test.cpp
@@ -1,2 +1,21 @@
 #include "NAS2D/Resource/Image.h"
 #include <gtest/gtest.h>
+
+
+TEST(Image, size) {
+	{
+		uint32_t buffer[1 * 1]{};
+		const auto image = NAS2D::Image{&buffer, 4, {1, 1}};
+		EXPECT_EQ((NAS2D::Vector{1, 1}), image.size());
+	}
+	{
+		uint32_t buffer[2 * 1]{};
+		const auto image = NAS2D::Image{&buffer, 4, {2, 1}};
+		EXPECT_EQ((NAS2D::Vector{2, 1}), image.size());
+	}
+	{
+		uint32_t buffer[1 * 2]{};
+		const auto image = NAS2D::Image{&buffer, 4, {1, 2}};
+		EXPECT_EQ((NAS2D::Vector{1, 2}), image.size());
+	}
+}


### PR DESCRIPTION
Delay creation of OpenGL texture ID until it is actually used. Guard OpenGL free calls in `Image` destructor.

By avoiding OpenGL calls for basic functionality, this allows an `Image` object to be safely created and destroyed before a valid OpenGL context is set. This enables basic unit testing of the `Image` class in a headless environment, such as a Continuous Integration server. In particular, no window needs to be created, which would be a prerequisite for an OpenGL context.

Closes #938
