### PR TITLE
Add Sprite data constructor

### DIFF
--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -28,10 +28,6 @@ namespace
 }
 
 
-/**
- * \param filePath	File path of the Sprite definition file.
- * \param initialAction	Name of initial action animation
- */
 Sprite::Sprite(const std::string& filePath, const std::string& initialAction) :
 	mAnimationSet{animationCache.load(filePath)},
 	mCurrentAction{&mAnimationSet.frames(initialAction)}

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -33,7 +33,6 @@ namespace
  * \param initialAction	Name of initial action animation
  */
 Sprite::Sprite(const std::string& filePath, const std::string& initialAction) :
-	mSpriteName{filePath},
 	mAnimationSet{&animationCache.load(filePath)},
 	mCurrentAction{&mAnimationSet->frames(initialAction)}
 {

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -35,6 +35,13 @@ Sprite::Sprite(const std::string& filePath, const std::string& initialAction) :
 }
 
 
+Sprite::Sprite(const AnimationSet& animationSet, const std::string& initialAction) :
+	mAnimationSet{animationSet},
+	mCurrentAction{&mAnimationSet.frames(initialAction)}
+{
+}
+
+
 Vector<int> Sprite::size() const
 {
 	return (*mCurrentAction)[mCurrentFrame].bounds.size();

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -33,8 +33,8 @@ namespace
  * \param initialAction	Name of initial action animation
  */
 Sprite::Sprite(const std::string& filePath, const std::string& initialAction) :
-	mAnimationSet{&animationCache.load(filePath)},
-	mCurrentAction{&mAnimationSet->frames(initialAction)}
+	mAnimationSet{animationCache.load(filePath)},
+	mCurrentAction{&mAnimationSet.frames(initialAction)}
 {
 }
 
@@ -58,7 +58,7 @@ Point<int> Sprite::origin(Point<int> point) const
  */
 std::vector<std::string> Sprite::actions() const
 {
-	return mAnimationSet->actionNames();
+	return mAnimationSet.actionNames();
 }
 
 
@@ -75,7 +75,7 @@ std::vector<std::string> Sprite::actions() const
  */
 void Sprite::play(const std::string& action)
 {
-	mCurrentAction = &mAnimationSet->frames(action);
+	mCurrentAction = &mAnimationSet.frames(action);
 	mCurrentFrame = 0;
 	mTimer.reset();
 	resume();

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -21,7 +21,6 @@
 
 namespace NAS2D
 {
-
 	/**
 	 * Sprite resource.
 	 *
@@ -74,5 +73,4 @@ namespace NAS2D
 		Color mColor{Color::Normal}; /**< Color tint to use for drawing the sprite. */
 		float mRotationAngle{0.0f}; /**< Angle of rotation in degrees. */
 	};
-
 } // namespace

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -60,8 +60,6 @@ namespace NAS2D
 		AnimationCompleteSignal::Source& animationCompleteSignalSource();
 
 	private:
-		std::string mSpriteName;
-
 		const AnimationSet* mAnimationSet;
 		const std::vector<AnimationSet::Frame>* mCurrentAction{nullptr};
 		std::size_t mCurrentFrame{0};

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -60,7 +60,7 @@ namespace NAS2D
 		AnimationCompleteSignal::Source& animationCompleteSignalSource();
 
 	private:
-		const AnimationSet* mAnimationSet;
+		const AnimationSet& mAnimationSet;
 		const std::vector<AnimationSet::Frame>* mCurrentAction{nullptr};
 		std::size_t mCurrentFrame{0};
 

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -33,6 +33,7 @@ namespace NAS2D
 		using AnimationCompleteSignal = Signal<>; /**< Signal used when action animations complete. */
 
 		Sprite(const std::string& filePath, const std::string& initialAction);
+		Sprite(const AnimationSet& animationSet, const std::string& initialAction);
 
 		Vector<int> size() const;
 		Point<int> origin(Point<int> point) const;

--- a/test/Resource/Sprite.test.cpp
+++ b/test/Resource/Sprite.test.cpp
@@ -1,0 +1,13 @@
+#include "NAS2D/Resource/Sprite.h"
+#include <gtest/gtest.h>
+
+
+TEST(Sprite, size) {
+	uint32_t imageBuffer[1 * 1];
+	NAS2D::Image image{&imageBuffer, 4, {1, 1}};
+	NAS2D::AnimationSet::Frame frame{image, {0, 0, 1, 1}, {0, 0}, 0};
+	NAS2D::AnimationSet animationSet{"", {}, {{"defaultAction", {frame}}}};
+	NAS2D::Sprite sprite{animationSet, "defaultAction"};
+
+	EXPECT_EQ((NAS2D::Vector{1, 1}), sprite.size());
+}


### PR DESCRIPTION
A bit of cleanup to make #939 easier to work on.

Adds unit tests for a new data based `Sprite` constructor taking an `AnimationSet` object. This allows `Sprite` to be constructed without having to read a file from disk.
