### PR TITLE
Reduce Filesystem includes

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -12,6 +12,7 @@
 
 #include <physfs.h>
 
+#include <cstddef>
 #include <cstring>
 #include <string>
 #include <utility>

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -271,16 +271,16 @@ std::string Filesystem::read(const std::string& filename) const
 		throw std::runtime_error("Error opening file for reading: " + filename + " : " + getLastPhysfsError());
 	}
 
-	// Ensure that the file size is greater than zero and can fit in a std::size_t
+	// Ensure that the file size is greater than zero and can fit in a std::string::size_type
 	auto fileLength = PHYSFS_fileLength(myFile);
-	if (fileLength < 0 || static_cast<PHYSFS_uint64>(fileLength) > std::numeric_limits<std::size_t>::max())
+	if (fileLength < 0 || static_cast<PHYSFS_uint64>(fileLength) > std::numeric_limits<std::string::size_type>::max())
 	{
 		closeFile(myFile);
 		throw std::runtime_error("Error determining length of file or file too large: " + filename + " : Length = " + std::to_string(fileLength));
 	}
 
 	// Create buffer large enough to hold entire file
-	const auto bufferSize = static_cast<std::size_t>(fileLength);
+	const auto bufferSize = static_cast<std::string::size_type>(fileLength);
 	std::string fileBuffer;
 	fileBuffer.resize(bufferSize);
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -13,9 +13,7 @@
 #include <physfs.h>
 
 #include <cstddef>
-#include <cstring>
 #include <string>
-#include <utility>
 #include <limits>
 #include <stdexcept>
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -12,7 +12,6 @@
 
 #include <physfs.h>
 
-#include <cstddef>
 #include <limits>
 #include <stdexcept>
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -13,7 +13,6 @@
 #include <physfs.h>
 
 #include <cstddef>
-#include <string>
 #include <limits>
 #include <stdexcept>
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -197,7 +197,7 @@ std::vector<std::string> Filesystem::directoryList(const std::string& dir, const
 	}
 	else
 	{
-		std::size_t filterLen = filter.size();
+		const auto filterLen = filter.size();
 		for (auto i = rc; *i != nullptr; i++)
 		{
 			std::string tmpStr = *i;

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -12,11 +12,8 @@
 
 #include <physfs.h>
 
-#include <climits>
 #include <cstring>
 #include <string>
-#include <iostream>
-#include <sstream>
 #include <utility>
 #include <limits>
 #include <stdexcept>


### PR DESCRIPTION
Remove a number of header includes the `Filesystem` implementation no longer needs.
