### PR TITLE
Removes comments for time argument for Mixer Fade functions

### DIFF
--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -56,15 +56,9 @@ namespace NAS2D
 		 *
 		 * \param music Reference to a Music Resource.
 		 * \param loops Repeat count. -1 for continuous loop.
-		 * \param time Length of the fade in milliseconds. Default is 500.
 		 */
 		virtual void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, std::chrono::milliseconds time = Mixer::DEFAULT_FADE_TIME) = 0;
 
-		/**
-		 * Fades out the currently playing Music track.
-		 *
-		 * \param time Length of the fade in milliseconds. Default is 500.
-		 */
 		virtual void fadeOutMusic(std::chrono::milliseconds time = Mixer::DEFAULT_FADE_TIME) = 0;
 
 		virtual bool musicPlaying() const = 0;

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -57,9 +57,9 @@ namespace NAS2D
 		 * \param music Reference to a Music Resource.
 		 * \param loops Repeat count. -1 for continuous loop.
 		 */
-		virtual void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, std::chrono::milliseconds time = Mixer::DEFAULT_FADE_TIME) = 0;
+		virtual void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, std::chrono::milliseconds fadeInTime = Mixer::DEFAULT_FADE_TIME) = 0;
 
-		virtual void fadeOutMusic(std::chrono::milliseconds time = Mixer::DEFAULT_FADE_TIME) = 0;
+		virtual void fadeOutMusic(std::chrono::milliseconds fadeOutTime = Mixer::DEFAULT_FADE_TIME) = 0;
 
 		virtual bool musicPlaying() const = 0;
 

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -51,12 +51,6 @@ namespace NAS2D
 		virtual void pauseMusic() = 0;
 		virtual void resumeMusic() = 0;
 
-		/**
-		 * Starts a Music track and fades it in to the current Music volume.
-		 *
-		 * \param music Reference to a Music Resource.
-		 * \param loops Repeat count. -1 for continuous loop.
-		 */
 		virtual void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, std::chrono::milliseconds fadeInTime = Mixer::DEFAULT_FADE_TIME) = 0;
 
 		virtual void fadeOutMusic(std::chrono::milliseconds fadeOutTime = Mixer::DEFAULT_FADE_TIME) = 0;

--- a/NAS2D/Mixer/MixerNull.cpp
+++ b/NAS2D/Mixer/MixerNull.cpp
@@ -34,10 +34,10 @@ namespace NAS2D
 	void MixerNull::resumeMusic()
 	{}
 
-	void MixerNull::fadeInMusic(const Music& /*music*/, int /*loops*/ /*= Mixer::CONTINUOUS*/, std::chrono::milliseconds /*time*/ /*= Mixer::DEFAULT_FADE_TIME*/)
+	void MixerNull::fadeInMusic(const Music& /*music*/, int /*loops*/ /*= Mixer::CONTINUOUS*/, std::chrono::milliseconds /*fadeInTime*/ /*= Mixer::DEFAULT_FADE_TIME*/)
 	{}
 
-	void MixerNull::fadeOutMusic(std::chrono::milliseconds /*time*/ /*= Mixer::DEFAULT_FADE_TIME*/)
+	void MixerNull::fadeOutMusic(std::chrono::milliseconds /*fadeOutTime*/ /*= Mixer::DEFAULT_FADE_TIME*/)
 	{}
 
 	bool MixerNull::musicPlaying() const

--- a/NAS2D/Mixer/MixerNull.h
+++ b/NAS2D/Mixer/MixerNull.h
@@ -27,8 +27,8 @@ namespace NAS2D
 		void pauseMusic() override;
 		void resumeMusic() override;
 
-		void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, std::chrono::milliseconds time = Mixer::DEFAULT_FADE_TIME) override;
-		void fadeOutMusic(std::chrono::milliseconds time = Mixer::DEFAULT_FADE_TIME) override;
+		void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, std::chrono::milliseconds fadeInTime = Mixer::DEFAULT_FADE_TIME) override;
+		void fadeOutMusic(std::chrono::milliseconds fadeOutTime = Mixer::DEFAULT_FADE_TIME) override;
 
 		bool musicPlaying() const override;
 

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -177,15 +177,15 @@ void MixerSDL::resumeMusic()
 }
 
 
-void MixerSDL::fadeInMusic(const Music& music, int loops, std::chrono::milliseconds time)
+void MixerSDL::fadeInMusic(const Music& music, int loops, std::chrono::milliseconds fadeInTime)
 {
-	Mix_FadeInMusic(music.music(), loops, static_cast<int>(time.count()));
+	Mix_FadeInMusic(music.music(), loops, static_cast<int>(fadeInTime.count()));
 }
 
 
-void MixerSDL::fadeOutMusic(std::chrono::milliseconds time)
+void MixerSDL::fadeOutMusic(std::chrono::milliseconds fadeOutTime)
 {
-	Mix_FadeOutMusic(static_cast<int>(time.count()));
+	Mix_FadeOutMusic(static_cast<int>(fadeOutTime.count()));
 }
 
 

--- a/NAS2D/Mixer/MixerSDL.h
+++ b/NAS2D/Mixer/MixerSDL.h
@@ -56,8 +56,8 @@ namespace NAS2D
 		void pauseMusic() override;
 		void resumeMusic() override;
 
-		void fadeInMusic(const Music& music, int loops, std::chrono::milliseconds time) override;
-		void fadeOutMusic(std::chrono::milliseconds time) override;
+		void fadeInMusic(const Music& music, int loops, std::chrono::milliseconds fadeInTime) override;
+		void fadeOutMusic(std::chrono::milliseconds fadeOutTime) override;
 
 		bool musicPlaying() const override;
 


### PR DESCRIPTION
Removes low-value comments for time argument for Fade functions due to explicit type for milliseconds.