### PR TITLE
Sprite pause on stop frame

### DIFF
--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -226,6 +226,7 @@ unsigned int Sprite::advanceByTimeDelta(unsigned int timeDelta)
 		if (frame.isStopFrame())
 		{
 			mAnimationCompleteSignal();
+			mPaused = true;
 			return accumulator;
 		}
 

--- a/test/Resource/Sprite.test.cpp
+++ b/test/Resource/Sprite.test.cpp
@@ -24,7 +24,8 @@ protected:
 	uint32_t imageBuffer[1 * 1];
 	NAS2D::Image image{&imageBuffer, 4, {1, 1}};
 	NAS2D::AnimationSet::Frame frame{image, {0, 0, 1, 1}, {0, 0}, 2};
-	NAS2D::AnimationSet animationSet{"", {}, {{"defaultAction", {frame}}}};
+	NAS2D::AnimationSet::Frame frameStop{image, {0, 0, 1, 1}, {0, 0}, 0};
+	NAS2D::AnimationSet animationSet{"", {}, {{"defaultAction", {frame}}, {"frameStopAction", {frameStop}}}};
 	SpriteDerived sprite{animationSet, "defaultAction"};
 };
 

--- a/test/Resource/Sprite.test.cpp
+++ b/test/Resource/Sprite.test.cpp
@@ -62,20 +62,30 @@ TEST_F(Sprite, animationCompleteSignal) {
 	sprite.play("frameStopAction");
 	EXPECT_CALL(handler, MockMethod());
 	sprite.advanceByTimeDelta(0u);
+	EXPECT_CALL(handler, MockMethod()).Times(0);
+	sprite.advanceByTimeDelta(0u);
 
 	sprite.play("frameStopAction");
 	EXPECT_CALL(handler, MockMethod());
+	sprite.advanceByTimeDelta(1u);
+	EXPECT_CALL(handler, MockMethod()).Times(0);
 	sprite.advanceByTimeDelta(1u);
 
 	sprite.play("frameStopAction");
 	EXPECT_CALL(handler, MockMethod());
 	sprite.advanceByTimeDelta(2u);
+	EXPECT_CALL(handler, MockMethod()).Times(0);
+	sprite.advanceByTimeDelta(2u);
 
 	sprite.play("frameStopAction");
 	EXPECT_CALL(handler, MockMethod());
 	sprite.advanceByTimeDelta(3u);
+	EXPECT_CALL(handler, MockMethod()).Times(0);
+	sprite.advanceByTimeDelta(3u);
 
 	sprite.play("frameStopAction");
 	EXPECT_CALL(handler, MockMethod());
+	sprite.advanceByTimeDelta(4u);
+	EXPECT_CALL(handler, MockMethod()).Times(0);
 	sprite.advanceByTimeDelta(4u);
 }

--- a/test/Resource/Sprite.test.cpp
+++ b/test/Resource/Sprite.test.cpp
@@ -58,4 +58,24 @@ TEST_F(Sprite, animationCompleteSignal) {
 
 	EXPECT_CALL(handler, MockMethod()).Times(2);
 	sprite.advanceByTimeDelta(4u);
+
+	sprite.play("frameStopAction");
+	EXPECT_CALL(handler, MockMethod());
+	sprite.advanceByTimeDelta(0u);
+
+	sprite.play("frameStopAction");
+	EXPECT_CALL(handler, MockMethod());
+	sprite.advanceByTimeDelta(1u);
+
+	sprite.play("frameStopAction");
+	EXPECT_CALL(handler, MockMethod());
+	sprite.advanceByTimeDelta(2u);
+
+	sprite.play("frameStopAction");
+	EXPECT_CALL(handler, MockMethod());
+	sprite.advanceByTimeDelta(3u);
+
+	sprite.play("frameStopAction");
+	EXPECT_CALL(handler, MockMethod());
+	sprite.advanceByTimeDelta(4u);
 }

--- a/test/Resource/Sprite.test.cpp
+++ b/test/Resource/Sprite.test.cpp
@@ -59,33 +59,11 @@ TEST_F(Sprite, animationCompleteSignal) {
 	EXPECT_CALL(handler, MockMethod()).Times(2);
 	sprite.advanceByTimeDelta(4u);
 
-	sprite.play("frameStopAction");
-	EXPECT_CALL(handler, MockMethod());
-	sprite.advanceByTimeDelta(0u);
-	EXPECT_CALL(handler, MockMethod()).Times(0);
-	sprite.advanceByTimeDelta(0u);
-
-	sprite.play("frameStopAction");
-	EXPECT_CALL(handler, MockMethod());
-	sprite.advanceByTimeDelta(1u);
-	EXPECT_CALL(handler, MockMethod()).Times(0);
-	sprite.advanceByTimeDelta(1u);
-
-	sprite.play("frameStopAction");
-	EXPECT_CALL(handler, MockMethod());
-	sprite.advanceByTimeDelta(2u);
-	EXPECT_CALL(handler, MockMethod()).Times(0);
-	sprite.advanceByTimeDelta(2u);
-
-	sprite.play("frameStopAction");
-	EXPECT_CALL(handler, MockMethod());
-	sprite.advanceByTimeDelta(3u);
-	EXPECT_CALL(handler, MockMethod()).Times(0);
-	sprite.advanceByTimeDelta(3u);
-
-	sprite.play("frameStopAction");
-	EXPECT_CALL(handler, MockMethod());
-	sprite.advanceByTimeDelta(4u);
-	EXPECT_CALL(handler, MockMethod()).Times(0);
-	sprite.advanceByTimeDelta(4u);
+	for (auto i = 0u; i <= 4u; ++i) {
+		sprite.play("frameStopAction");
+		EXPECT_CALL(handler, MockMethod());
+		sprite.advanceByTimeDelta(i);
+		EXPECT_CALL(handler, MockMethod()).Times(0);
+		sprite.advanceByTimeDelta(i);
+	}
 }


### PR DESCRIPTION
Noticed this while working on #949. Somewhat related to #936, and #797.

> We may want to revisit when the animationComplete signal is raised, but for now at least keep them all in one place.

This prevents the `mAnimationCompleteSignal` from being raised repeatedly after hitting a stop frame.