### PR TITLE
Fixes Sprite C26820 warning

### DIFF
--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -221,7 +221,7 @@ unsigned int Sprite::advanceByTimeDelta(unsigned int timeDelta)
 	const auto& frames = *mCurrentAction;
 	for (;;)
 	{
-		const auto frame = frames[mCurrentFrame];
+		const auto& frame = frames[mCurrentFrame];
 
 		if (frame.isStopFrame())
 		{


### PR DESCRIPTION
Fixes `Sprite.cpp(224): warning C26820: Assigning by value when a const-reference would suffice, use const auto& instead (p.9).`

See: https://docs.microsoft.com/en-us/cpp/code-quality/c26820?view=msvc-160