### PR TITLE
Update vector tests with floating point

### DIFF
--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -58,11 +58,20 @@ TEST(Vector, SelfMultiplyScalar) {
 }
 
 TEST(Vector, SelfDivideScalar) {
-	auto vector = NAS2D::Vector{2, 4};
-	EXPECT_EQ(&vector, &(vector /= 2));
-	EXPECT_EQ((NAS2D::Vector{1, 2}), vector);
+	{
+		NAS2D::Vector<int> vector{2, 4};
+		EXPECT_EQ(&vector, &(vector /= 2));
+		EXPECT_EQ((NAS2D::Vector{1, 2}), vector);
 
-	EXPECT_THROW(vector /= 0, std::domain_error);
+		EXPECT_THROW(vector /= 0, std::domain_error);
+	}
+	{
+		auto vector = NAS2D::Vector{2.0, 4.0};
+		EXPECT_EQ(&vector, &(vector /= 2.0));
+		EXPECT_EQ((NAS2D::Vector{1.0, 2.0}), vector);
+
+		EXPECT_THROW(vector /= 0.0, std::domain_error);
+	}
 }
 
 TEST(Vector, MultiplyScalar) {
@@ -71,8 +80,10 @@ TEST(Vector, MultiplyScalar) {
 
 TEST(Vector, DivideScalar) {
 	EXPECT_EQ((NAS2D::Vector{1, 2}), (NAS2D::Vector{2, 4} / 2));
-
 	EXPECT_THROW((NAS2D::Vector{2, 4} /= 0), std::domain_error);
+
+	EXPECT_EQ((NAS2D::Vector{1.0, 2.0}), (NAS2D::Vector{2.0, 4.0} / 2.0));
+	EXPECT_THROW((NAS2D::Vector{2.0, 4.0} /= 0.0), std::domain_error);
 }
 
 TEST(Vector, skewBy) {

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -32,13 +32,13 @@ TEST(Vector, Conversion) {
 }
 
 TEST(Vector, SelfAdd) {
-	NAS2D::Vector<int> vector{1, 1};
+	auto vector = NAS2D::Vector{1, 1};
 	EXPECT_EQ(&vector, &(vector += NAS2D::Vector{1, 2}));
 	EXPECT_EQ((NAS2D::Vector{2, 3}), vector);
 }
 
 TEST(Vector, SelfSubtract) {
-	NAS2D::Vector<int> vector{2, 3};
+	auto vector = NAS2D::Vector{2, 3};
 	EXPECT_EQ(&vector, &(vector -= NAS2D::Vector{1, 2}));
 	EXPECT_EQ((NAS2D::Vector{1, 1}), vector);
 }
@@ -52,13 +52,13 @@ TEST(Vector, Subtract) {
 }
 
 TEST(Vector, SelfMultiplyScalar) {
-	NAS2D::Vector<int> vector{1, 2};
+	auto vector = NAS2D::Vector{1, 2};
 	EXPECT_EQ(&vector, &(vector *= 2));
 	EXPECT_EQ((NAS2D::Vector{2, 4}), vector);
 }
 
 TEST(Vector, SelfDivideScalar) {
-	NAS2D::Vector<int> vector{2, 4};
+	auto vector = NAS2D::Vector{2, 4};
 	EXPECT_EQ(&vector, &(vector /= 2));
 	EXPECT_EQ((NAS2D::Vector{1, 2}), vector);
 

--- a/test/Renderer/Vector.test.cpp
+++ b/test/Renderer/Vector.test.cpp
@@ -101,6 +101,10 @@ TEST(Vector, skewBy) {
 }
 
 TEST(Vector, skewInverseBy) {
+	EXPECT_THROW((NAS2D::Vector{1.0, 1.0}.skewInverseBy(NAS2D::Vector{0.0, 0.0})), std::domain_error);
+	EXPECT_THROW((NAS2D::Vector{1.0, 1.0}.skewInverseBy(NAS2D::Vector{0.0, 1.0})), std::domain_error);
+	EXPECT_THROW((NAS2D::Vector{1.0, 1.0}.skewInverseBy(NAS2D::Vector{1.0, 0.0})), std::domain_error);
+
 	EXPECT_THROW((NAS2D::Vector{1, 1}.skewInverseBy(NAS2D::Vector{0, 0})), std::domain_error);
 	EXPECT_THROW((NAS2D::Vector{1, 1}.skewInverseBy(NAS2D::Vector{0, 1})), std::domain_error);
 	EXPECT_THROW((NAS2D::Vector{1, 1}.skewInverseBy(NAS2D::Vector{1, 0})), std::domain_error);


### PR DESCRIPTION
Reference: #978, PR #977 (in particular, commit https://github.com/lairworks/nas2d-core/commit/70724d54176c571fa33f1734af1dba5d84636aad appears to show some fixes for floating point)

Adds floating test cases for certain `Vector` operations that may produce warnings for floating pointer `BaseType`s.
