### PR TITLE
Fix Color.test.cpp spacing in header

### DIFF
--- a/test/Renderer/Color.test.cpp
+++ b/test/Renderer/Color.test.cpp
@@ -1,4 +1,5 @@
 #include "NAS2D/Renderer/Color.h"
+
 #include <gtest/gtest.h>
 
 


### PR DESCRIPTION
Missed the header spacing in one file from #980. I hadn't saved that one file, so got a warning when trying to close it.
