### PR TITLE
Fix includes for MathUtils.h and Trig.h from full project header

### DIFF
--- a/NAS2D/NAS2D.h
+++ b/NAS2D/NAS2D.h
@@ -15,15 +15,16 @@
 #include "Filesystem.h"
 #include "FpsCounter.h"
 #include "Game.h"
-#include "MathUtils.h"
 #include "State.h"
 #include "StateManager.h"
 #include "StringUtils.h"
 #include "StringValue.h"
 #include "Timer.h"
-#include "Trig.h"
 #include "Utility.h"
 #include "Version.h"
+
+#include "Math/MathUtils.h"
+#include "Math/Trig.h"
 
 #include "Mixer/Mixer.h"
 


### PR DESCRIPTION
Missed change from #980. Noticed while updating OP2-Landlord, which still uses the old full project include `NAS2D.h`.
