### PR TITLE
Add CTAD guide for range types

### DIFF
--- a/NAS2D/Math/PointInRectangleRange.h
+++ b/NAS2D/Math/PointInRectangleRange.h
@@ -83,4 +83,9 @@ namespace NAS2D
 	private:
 		const Rectangle<BaseType> mRect;
 	};
+
+
+	template <typename BaseType>
+	PointInRectangleRange(Rectangle<BaseType>) -> PointInRectangleRange<BaseType>;
+
 } // namespace NAS2D

--- a/NAS2D/Math/VectorSizeRange.h
+++ b/NAS2D/Math/VectorSizeRange.h
@@ -90,4 +90,9 @@ namespace NAS2D
 	private:
 		const Vector<BaseType> mSize;
 	};
+
+
+	template <typename BaseType>
+	VectorSizeRange(Vector<BaseType>) -> VectorSizeRange<BaseType>;
+
 } // namespace NAS2D


### PR DESCRIPTION
Reference: #528

Add CTAD guide for `PointInRectangleRange` and `VectorSizeRange`.

Eliminates Clang warnings when compiling with `-Wctad-maybe-unsupported`.
