### PR TITLE
Use separate texture internal format

### DIFF
--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -245,13 +245,16 @@ unsigned int generateTexture(SDL_Surface* surface)
 
 unsigned int generateTexture(void* buffer, int bytesPerPixel, int width, int height)
 {
+	GLint internalFormat = 0;
 	GLenum textureFormat = 0;
 	switch (bytesPerPixel)
 	{
 	case 4:
+		internalFormat = GL_RGBA;
 		textureFormat = SDL_BYTEORDER == SDL_BIG_ENDIAN ? GL_BGRA : GL_RGBA;
 		break;
 	case 3:
+		internalFormat = GL_RGB;
 		textureFormat = SDL_BYTEORDER == SDL_BIG_ENDIAN ? GL_BGR : GL_RGB;
 		break;
 
@@ -270,7 +273,7 @@ unsigned int generateTexture(void* buffer, int bytesPerPixel, int width, int hei
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-	glTexImage2D(GL_TEXTURE_2D, 0, textureFormat, width, height, 0, textureFormat, GL_UNSIGNED_BYTE, buffer);
+	glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, textureFormat, GL_UNSIGNED_BYTE, buffer);
 
 	return textureId;
 }


### PR DESCRIPTION
Previously we may have been potentially passing in values for the internal format that were not explicitly listed as allowed by the documentation.

Documentation for `glTexImage2D`:
https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml

```cpp
void glTexImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void * data);
```

> `internalformat`
> Specifies the number of color components in the texture. Must be one of base internal formats given in Table 1, one of the sized internal formats given in Table 2, or one of the compressed internal formats given in Table 3, below.

Those tables contains `GL_RGB` and `GL_RGBA`, but not `GL_BGR` nor `GL_BGRA`. Those values are instead permitted for the `format` paramter.

> `format`
> Specifies the format of the pixel data. The following symbolic values are accepted: GL_RED, GL_RG, GL_RGB, GL_BGR, GL_RGBA, GL_BGRA, GL_RED_INTEGER, GL_RG_INTEGER, GL_RGB_INTEGER, GL_BGR_INTEGER, GL_RGBA_INTEGER, GL_BGRA_INTEGER, GL_STENCIL_INDEX, GL_DEPTH_COMPONENT, GL_DEPTH_STENCIL.

----

Reference: #528
Noticed this using Clang warning `-Wsign-conversion`.
