### PR TITLE
Avoid implicit sign conversion in Font

### DIFF
--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -349,9 +349,9 @@ namespace
 	void fillInTextureCoordinates(std::vector<Font::GlyphMetrics>& glyphMetricsList)
 	{
 		const auto uvSize = Vector<float>{1, 1} / 16.0f;
-		for (const auto glyphPosition : PointInRectangleRange(Rectangle{0, 0, GLYPH_MATRIX_SIZE, GLYPH_MATRIX_SIZE}))
+		for (const auto glyphPosition : PointInRectangleRange(Rectangle<std::size_t>{0, 0, GLYPH_MATRIX_SIZE, GLYPH_MATRIX_SIZE}))
 		{
-			const std::size_t glyph = static_cast<std::size_t>(glyphPosition.y) * GLYPH_MATRIX_SIZE + glyphPosition.x;
+			const std::size_t glyph = glyphPosition.y * GLYPH_MATRIX_SIZE + glyphPosition.x;
 			const auto uvStart = glyphPosition.to<float>().skewBy(uvSize);
 			glyphMetricsList[glyph].uvRect = Rectangle<float>::Create(uvStart, uvSize);
 		}

--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -286,9 +286,9 @@ namespace
 		SDL_Surface* fontSurface = SDL_CreateRGBSurface(SDL_SWSURFACE, matrixSize.x, matrixSize.y, BITS_32, MasksDefault.red, MasksDefault.green, MasksDefault.blue, MasksDefault.alpha);
 
 		SDL_Color white = { 255, 255, 255, 255 };
-		for (const auto glyphPosition : PointInRectangleRange(Rectangle{0, 0, GLYPH_MATRIX_SIZE, GLYPH_MATRIX_SIZE}))
+		for (const auto glyphPosition : PointInRectangleRange(Rectangle<std::size_t>{0, 0, GLYPH_MATRIX_SIZE, GLYPH_MATRIX_SIZE}))
 		{
-			const std::size_t glyph = static_cast<std::size_t>(glyphPosition.y) * GLYPH_MATRIX_SIZE + glyphPosition.x;
+			const std::size_t glyph = glyphPosition.y * GLYPH_MATRIX_SIZE + glyphPosition.x;
 
 			// Avoid glyph 0, which has size 0 for some fonts
 			// SDL_TTF will produce errors for a glyph of size 0
@@ -302,7 +302,7 @@ namespace
 			}
 
 			SDL_SetSurfaceBlendMode(characterSurface, SDL_BLENDMODE_NONE);
-			const auto pixelPosition = glyphPosition.skewBy(characterSize);
+			const auto pixelPosition = glyphPosition.to<int>().skewBy(characterSize);
 			SDL_Rect rect = { pixelPosition.x, pixelPosition.y, 0, 0 };
 			SDL_BlitSurface(characterSurface, nullptr, fontSurface, &rect);
 			SDL_FreeSurface(characterSurface);


### PR DESCRIPTION
Reference: #528

Fix warnings in `Font` seen using Clang `-Wsign-conversion`.
