### PR TITLE
Fix Image pixel read implicit sign conversion

### DIFF
--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -180,9 +180,10 @@ namespace
 			case 3:
 			{
 				auto p = reinterpret_cast<const uint8_t*>(pixelAddress);
+				uint32_t p0 = p[0], p1 = p[1], p2 = p[2];
 				return (SDL_BYTEORDER == SDL_BIG_ENDIAN) ?
-					(uint32_t{p[0]} << 16 | uint32_t{p[1]} << 8 | uint32_t{p[2]}) :
-					(uint32_t{p[0]} | uint32_t{p[1]} << 8 | uint32_t{p[2]} << 16);
+					(p0 << 16 | p1 << 8 | p2) :
+					(p0 | p1 << 8 | p2 << 16);
 			}
 			case 4:
 			{

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -181,8 +181,8 @@ namespace
 			{
 				auto p = reinterpret_cast<const uint8_t*>(pixelAddress);
 				return (SDL_BYTEORDER == SDL_BIG_ENDIAN) ?
-					(p[0] << 16 | p[1] << 8 | p[2]) :
-					(p[0] | p[1] << 8 | p[2] << 16);
+					(uint32_t{p[0]} << 16 | uint32_t{p[1]} << 8 | uint32_t{p[2]}) :
+					(uint32_t{p[0]} | uint32_t{p[1]} << 8 | uint32_t{p[2]} << 16);
 			}
 			case 4:
 			{


### PR DESCRIPTION
Reference: #528 (`-Wsign-conversion`)

Fix sign conversion warning when reading 24-bit pixel values.

Documentation:
https://en.cppreference.com/w/cpp/language/operator_arithmetic

> **Bitwise shift operators**
> ...
> The return type is the type of the left operand after integral promotions.

https://en.cppreference.com/w/cpp/language/implicit_conversion#Integral_promotion

> **Integral promotion**
>
> prvalues of small integral types (such as char) may be converted to prvalues of larger integral types (such as int). In particular, arithmetic operators do not accept types smaller than int as arguments, and integral promotions are automatically applied after lvalue-to-rvalue conversion, if applicable. This conversion always preserves the value.
