### PR TITLE
Add CTAD guide for SignalConnection

### DIFF
--- a/NAS2D/Signal/SignalConnection.h
+++ b/NAS2D/Signal/SignalConnection.h
@@ -52,4 +52,9 @@ namespace NAS2D
 		DelegateType mDelegate;
 	};
 
+
+	template <typename... Params>
+	SignalConnection(SignalSource<Params...>&, typename SignalSource<Params...>::DelegateType)
+		-> SignalConnection<Params...>;
+
 }


### PR DESCRIPTION
Reference: #528 (Clang flag `-Wctad-maybe-unsupported`)

Fix warning generated by unit test code for `SignalConnection` when extra warning flag is passed.
