### PR TITLE
Reduce warnings from `-Weffc++`

### DIFF
--- a/NAS2D/Dictionary.h
+++ b/NAS2D/Dictionary.h
@@ -61,7 +61,7 @@ namespace NAS2D
 		std::vector<std::string> keys() const;
 
 	private:
-		std::map<std::string, StringValue> mDictionary;
+		std::map<std::string, StringValue> mDictionary{};
 	};
 
 

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -333,35 +333,35 @@ namespace NAS2D
 		void disconnectAll();
 
 	private:
-		Signal<bool> mActivateEvent;
+		Signal<bool> mActivateEvent{};
 
-		Signal<bool> mWindowHiddenEvent;
-		Signal<> mWindowExposedEvent;
-		Signal<> mWindowMinimizedEvent;
-		Signal<> mWindowMaximizedEvent;
-		Signal<> mWindowRestoredEvent;
-		Signal<Vector<int>> mWindowResizedEvent;
-		Signal<> mWindowMouseEnterEvent;
-		Signal<> mWindowMouseLeaveEvent;
+		Signal<bool> mWindowHiddenEvent{};
+		Signal<> mWindowExposedEvent{};
+		Signal<> mWindowMinimizedEvent{};
+		Signal<> mWindowMaximizedEvent{};
+		Signal<> mWindowRestoredEvent{};
+		Signal<Vector<int>> mWindowResizedEvent{};
+		Signal<> mWindowMouseEnterEvent{};
+		Signal<> mWindowMouseLeaveEvent{};
 
-		Signal<int, int, int> mJoystickAxisMotionEvent;
-		Signal<int, int, int, int> mJoystickBallMotionEvent;
-		Signal<int, int> mJoystickButtonUpEvent;
-		Signal<int, int> mJoystickButtonDownEvent;
-		Signal<int, int, int> mJoystickHatMotionEvent;
+		Signal<int, int, int> mJoystickAxisMotionEvent{};
+		Signal<int, int, int, int> mJoystickBallMotionEvent{};
+		Signal<int, int> mJoystickButtonUpEvent{};
+		Signal<int, int> mJoystickButtonDownEvent{};
+		Signal<int, int, int> mJoystickHatMotionEvent{};
 
-		Signal<KeyCode, KeyModifier, bool> mKeyDownEvent;
-		Signal<KeyCode, KeyModifier> mKeyUpEvent;
+		Signal<KeyCode, KeyModifier, bool> mKeyDownEvent{};
+		Signal<KeyCode, KeyModifier> mKeyUpEvent{};
 
-		Signal<const std::string&> mTextInput;
+		Signal<const std::string&> mTextInput{};
 
-		Signal<MouseButton, int, int> mMouseButtonDownEvent;
-		Signal<MouseButton, int, int> mMouseButtonUpEvent;
-		Signal<MouseButton, int, int> mMouseDoubleClick;
-		Signal<int, int, int, int> mMouseMotionEvent;
-		Signal<int, int> mMouseWheelEvent;
+		Signal<MouseButton, int, int> mMouseButtonDownEvent{};
+		Signal<MouseButton, int, int> mMouseButtonUpEvent{};
+		Signal<MouseButton, int, int> mMouseDoubleClick{};
+		Signal<int, int, int, int> mMouseMotionEvent{};
+		Signal<int, int> mMouseWheelEvent{};
 
-		Signal<> mQuitEvent;
+		Signal<> mQuitEvent{};
 	};
 
 	void postQuitEvent();

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -86,7 +86,7 @@ namespace NAS2D
 		SignalSource<>& musicCompleteSignalSource();
 
 	protected:
-		Signal<> mMusicComplete;
+		Signal<> mMusicComplete{};
 	};
 
 } // namespace

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -51,8 +51,8 @@ namespace NAS2D
 		Color mFadeColor{Color::Black};
 		FadeDirection mDirection{FadeDirection::None};
 		std::chrono::milliseconds mDuration{};
-		Timer mFadeTimer;
-		Signal<> mFadeComplete;
+		Timer mFadeTimer{};
+		Signal<> mFadeComplete{};
 	};
 
 }

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -133,8 +133,8 @@ namespace NAS2D
 		float mCurrentFade{0.0f};
 
 		FadeType mCurrentFadeType{FadeType::None};
-		Timer fadeTimer;
-		Signal<> fadeCompleteSignal;
+		Timer fadeTimer{};
+		Signal<> fadeCompleteSignal{};
 	};
 
 } // namespace

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -106,7 +106,7 @@ namespace NAS2D
 		void onResize(Vector<int> newSize);
 
 
-		SDL_GLContext sdlOglContext;
-		std::map<int, SDL_Cursor*> cursors;
+		SDL_GLContext sdlOglContext{};
+		std::map<int, SDL_Cursor*> cursors{};
 	};
 } // namespace NAS2D

--- a/NAS2D/Resource/Font.h
+++ b/NAS2D/Resource/Font.h
@@ -55,8 +55,8 @@ namespace NAS2D
 			unsigned int pointSize{0u};
 			int height{0};
 			int ascent{0};
-			Vector<int> glyphSize;
-			std::vector<GlyphMetrics> metrics;
+			Vector<int> glyphSize{};
+			std::vector<GlyphMetrics> metrics{};
 		};
 
 

--- a/NAS2D/Resource/ResourceCache.h
+++ b/NAS2D/Resource/ResourceCache.h
@@ -61,7 +61,7 @@ namespace NAS2D
 		}
 
 	private:
-		std::map<Key, Resource> cache;
+		std::map<Key, Resource> cache{};
 	};
 
 } // namespace

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -69,8 +69,8 @@ namespace NAS2D
 		std::size_t mCurrentFrame{0};
 
 		bool mPaused{false};
-		Timer mTimer;
-		AnimationCompleteSignal mAnimationCompleteSignal;
+		Timer mTimer{};
+		AnimationCompleteSignal mAnimationCompleteSignal{};
 
 		Color mColor{Color::Normal}; /**< Color tint to use for drawing the sprite. */
 		float mRotationAngle{0.0f}; /**< Angle of rotation in degrees. */

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -496,7 +496,7 @@ namespace NAS2D
 		using UnvoidStaticFunctionPtr = RetType (*)(Params...);
 		using GenericMemFn = RetType (detail::GenericClass::*)(Params...);
 		using ClosureType = detail::ClosurePtr<GenericMemFn, StaticFunctionPtr, UnvoidStaticFunctionPtr>;
-		ClosureType m_Closure;
+		ClosureType m_Closure{};
 
 	public:
 		using type = DelegateX;

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -45,6 +45,6 @@ namespace NAS2D
 		void disconnect(Y* obj, void (X::*func)(Params...) const) { delegateList.erase(MakeDelegate(obj, func)); }
 
 	protected:
-		std::set<DelegateType> delegateList;
+		std::set<DelegateType> delegateList{};
 	};
 } // namespace

--- a/NAS2D/StringValue.h
+++ b/NAS2D/StringValue.h
@@ -17,7 +17,7 @@ namespace NAS2D
 {
 	struct StringValue
 	{
-		std::string value;
+		std::string value{};
 
 
 		StringValue() = default;

--- a/test/Resource/Sprite.test.cpp
+++ b/test/Resource/Sprite.test.cpp
@@ -43,7 +43,7 @@ TEST_F(Sprite, advanceByTimeDelta) {
 }
 
 TEST_F(Sprite, animationCompleteSignal) {
-	MockHandler handler;
+	MockHandler handler{};
 	auto delegate = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
 	sprite.animationCompleteSignalSource().connect(delegate);
 

--- a/test/Signal/Delegate.test.cpp
+++ b/test/Signal/Delegate.test.cpp
@@ -14,7 +14,7 @@ namespace {
 
 
 TEST(Delegate, DelegateCall) {
-	MockHandler handler;
+	MockHandler handler{};
 	auto delegate = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
 	EXPECT_CALL(handler, MockMethod(0));
 	EXPECT_CALL(handler, MockMethod(1));
@@ -23,7 +23,7 @@ TEST(Delegate, DelegateCall) {
 }
 
 TEST(Delegate, DelegateCallConst) {
-	const MockHandler handler;
+	const MockHandler handler{};
 	auto delegate = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
 	EXPECT_CALL(handler, MockMethod(0));
 	EXPECT_CALL(handler, MockMethod(1));
@@ -32,7 +32,7 @@ TEST(Delegate, DelegateCallConst) {
 }
 
 TEST(Delegate, CopyDelegate) {
-	const MockHandler handler;
+	const MockHandler handler{};
 	// Copy delegate (value copy, with value equal compare)
 	auto delegate1 = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
 	auto delegate2 = delegate1;
@@ -40,7 +40,7 @@ TEST(Delegate, CopyDelegate) {
 }
 
 TEST(Delegate, MakeDelegateEqual) {
-	const MockHandler handler;
+	const MockHandler handler{};
 	// Make identical delegates, which should compare equal
 	auto delegate1 = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
 	auto delegate2 = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
@@ -48,7 +48,7 @@ TEST(Delegate, MakeDelegateEqual) {
 }
 
 TEST(Delegate, MakeDelegateNotEqualMethods) {
-	const MockHandler handler;
+	const MockHandler handler{};
 	// Different handler methods should compare not equal
 	auto delegate1 = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
 	auto delegate2 = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod2);
@@ -56,8 +56,8 @@ TEST(Delegate, MakeDelegateNotEqualMethods) {
 }
 
 TEST(Delegate, MakeDelegateNotEqualObjects) {
-	const MockHandler handler1;
-	const MockHandler handler2;
+	const MockHandler handler1{};
+	const MockHandler handler2{};
 	// Different handler objects should compare not equal
 	auto delegate1 = NAS2D::MakeDelegate(&handler1, &MockHandler::MockMethod);
 	auto delegate2 = NAS2D::MakeDelegate(&handler2, &MockHandler::MockMethod);

--- a/test/Signal/Signal.test.cpp
+++ b/test/Signal/Signal.test.cpp
@@ -13,7 +13,7 @@ namespace {
 
 
 TEST(Signal, ConnectEmitDisconnect) {
-	MockHandler handler;
+	MockHandler handler{};
 	auto delegate = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
 	NAS2D::Signal<> signal;
 

--- a/test/Signal/SignalConnection.test.cpp
+++ b/test/Signal/SignalConnection.test.cpp
@@ -14,7 +14,7 @@ namespace {
 
 
 TEST(SignalConnection, Scope) {
-	MockHandler handler;
+	MockHandler handler{};
 	auto delegate = NAS2D::MakeDelegate(&handler, &MockHandler::MockMethod);
 	NAS2D::Signal<> signal;
 


### PR DESCRIPTION
Reference: #528 (`-Weffc++`)

Add explicit default initialization for fields that must be default initialized. This is either because the field type has only a default constructor, or the containing type does not have any constructors taking parameters that could be used to initialize the field to anything other than the default.

This does not attempt to default initialize every field. In particular, some fields may be set by constructor parameters, or might be inappropriate to default initialize. In particular, we don't want to silence warnings for a field that is not properly initialized by a constructor, when that field is required to be explicitly initialized by all constructors.
