### PR TITLE
Fix warnings for `-Weffc++` in Xml code

### DIFF
--- a/NAS2D/Xml/XmlAttribute.cpp
+++ b/NAS2D/Xml/XmlAttribute.cpp
@@ -19,6 +19,8 @@ using namespace NAS2D::Xml;
 XmlAttribute::XmlAttribute() :
 	XmlBase(),
 	_document(nullptr),
+	_name(),
+	_value(),
 	_prev(nullptr),
 	_next(nullptr)
 {}

--- a/NAS2D/Xml/XmlAttributeSet.h
+++ b/NAS2D/Xml/XmlAttributeSet.h
@@ -47,7 +47,7 @@ public:
 	XmlAttribute* findOrCreate(const std::string& _name);
 
 private:
-	XmlAttribute sentinel; /**< Comment me. */
+	XmlAttribute sentinel{}; /**< Comment me. */
 };
 
 } // namespace Xml

--- a/NAS2D/Xml/XmlBase.h
+++ b/NAS2D/Xml/XmlBase.h
@@ -124,7 +124,7 @@ protected:
 
 	inline static int toLower(int v) { return tolower(v); }
 
-	ParseLocation location;
+	ParseLocation location{};
 
 private:
 	struct Entity

--- a/NAS2D/Xml/XmlDocument.h
+++ b/NAS2D/Xml/XmlDocument.h
@@ -58,13 +58,13 @@ private:
 	void copyTo(XmlDocument* target) const;
 
 private:
-	XmlErrorCode _errorId;
+	XmlErrorCode _errorId{};
 
-	bool _error;
+	bool _error{};
 
-	std::string _errorDesc;
+	std::string _errorDesc{};
 
-	XmlBase::ParseLocation _errorLocation;
+	XmlBase::ParseLocation _errorLocation{};
 };
 
 } // namespace Xml

--- a/NAS2D/Xml/XmlElement.h
+++ b/NAS2D/Xml/XmlElement.h
@@ -68,7 +68,7 @@ protected:
 	const char* readValue(const char* in, void* prevData);
 
 private:
-	XmlAttributeSet attributeSet;
+	XmlAttributeSet attributeSet{};
 };
 
 } // namespace Xml

--- a/NAS2D/Xml/XmlMemoryBuffer.h
+++ b/NAS2D/Xml/XmlMemoryBuffer.h
@@ -55,7 +55,7 @@ public:
 private:
 	int depth;
 
-	std::string _buffer;
+	std::string _buffer{};
 	std::string _indent;
 	std::string _lineBreak;
 };

--- a/NAS2D/Xml/XmlNode.h
+++ b/NAS2D/Xml/XmlNode.h
@@ -158,7 +158,7 @@ protected:
 	XmlNode* _firstChild; /**< First child of the XmlNode. */
 	XmlNode* _lastChild; /**< Last child of the XmlNode. */
 
-	std::string _value; /**< Value of the XmlNode. */
+	std::string _value{}; /**< Value of the XmlNode. */
 
 	XmlNode* _prev; /**< Previous XmlNode. */
 	XmlNode* _next; /**< Next XmlNode. */

--- a/NAS2D/Xml/XmlText.h
+++ b/NAS2D/Xml/XmlText.h
@@ -63,7 +63,7 @@ protected:
 	void streamIn(std::istream& in, std::string& tag) override;
 
 private:
-	bool cdata; // true if this should be input and output as a CDATA style text element
+	bool cdata{}; // true if this should be input and output as a CDATA style text element
 };
 
 } // namespace Xml


### PR DESCRIPTION
Reference: #528 (`-Weffc++`)

Reduce warnings in Xml code by adding explicit default initialization.
