### PR TITLE
Remove vcpkg hack for yasm

### DIFF
--- a/InstallVcpkgDeps.bat
+++ b/InstallVcpkgDeps.bat
@@ -16,7 +16,5 @@ if not defined PLATFORM (
 )
 
 :Install
-REM Work around problem where yasm tool (recursive dependency) needs x86 version installed before x64 version
-if "%PLATFORM%" == "x64" vcpkg install --recurse  yasm-tool:x86-windows
 REM Install dependencies (recursively)
 vcpkg install --recurse --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[dynamic-load,libflac,libmodplug,libvorbis,mpg123,nativemidi,opusfile] gtest


### PR DESCRIPTION
Remove vcpkg hack for yasm transitive dependency. It looks like this hack is no longer required, and may actually get in the way now.

https://ci.appveyor.com/project/OPU/ophd/builds/41422593/job/8rd7bwvwlp37kuv7
> Computing installation plan...
> Error: yasm-tool[core] is only supported on 'native & !uwp'

----

Reference: commit 1ae0e161e674c080f4b8f03c568ebec504884733 from PR #848
