### PR TITLE
Decouple Sprite::update and Sprite::draw

### DIFF
--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -114,24 +114,6 @@ void Sprite::setFrame(std::size_t frameIndex)
 }
 
 
-/**
- * Increments the frame counter.
- */
-void Sprite::incrementFrame()
-{
-	setFrame(mCurrentFrame + 1);
-}
-
-
-/**
- * Decrements the frame counter.
- */
-void Sprite::decrementFrame()
-{
-	setFrame(mCurrentFrame - 1);
-}
-
-
 void Sprite::update(Point<float> position)
 {
 	mTimer.adjust_accumulator(advanceByTimeDelta(mTimer.accumulator()));

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -117,7 +117,12 @@ void Sprite::setFrame(std::size_t frameIndex)
 void Sprite::update(Point<float> position)
 {
 	mTimer.adjust_accumulator(advanceByTimeDelta(mTimer.accumulator()));
+	draw(position);
+}
 
+
+void Sprite::draw(Point<float> position) const
+{
 	const auto& frame = (*mCurrentAction)[mCurrentFrame];
 	const auto drawPosition = position - frame.anchorOffset.to<float>();
 	const auto frameBounds = frame.bounds.to<float>();

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -114,10 +114,9 @@ void Sprite::setFrame(std::size_t frameIndex)
 }
 
 
-void Sprite::update(Point<float> position)
+void Sprite::update()
 {
 	mTimer.adjust_accumulator(advanceByTimeDelta(mTimer.accumulator()));
-	draw(position);
 }
 
 

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -45,8 +45,6 @@ namespace NAS2D
 		void resume();
 
 		void setFrame(std::size_t frameIndex);
-		void incrementFrame();
-		void decrementFrame();
 
 		void update(Point<float> position);
 

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -46,7 +46,7 @@ namespace NAS2D
 
 		void setFrame(std::size_t frameIndex);
 
-		void update(Point<float> position);
+		void update();
 		void draw(Point<float> position) const;
 
 		void rotation(float angle);

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -47,6 +47,7 @@ namespace NAS2D
 		void setFrame(std::size_t frameIndex);
 
 		void update(Point<float> position);
+		void draw(Point<float> position) const;
 
 		void rotation(float angle);
 		float rotation() const;


### PR DESCRIPTION
Split draw code from `Sprite::update` into `Sprite::draw`, and then decouple `update` and `draw`.

This allows `draw` to be called on `const` objects, assuming the `update` has already been done.
