### PR TITLE
Add Rectangle::offset

### DIFF
--- a/NAS2D/Math/Rectangle.h
+++ b/NAS2D/Math/Rectangle.h
@@ -86,6 +86,11 @@ namespace NAS2D
 			y = newStartPoint.y;
 		}
 
+		constexpr Rectangle offset(Vector<BaseType> offsetAmount) const
+		{
+			return Create(startPoint() + offsetAmount, size());
+		}
+
 		constexpr Rectangle inset(BaseType amount) const
 		{
 			return {x + amount, y + amount, width - 2 * amount, height - 2 * amount};

--- a/test/Math/Rectangle.test.cpp
+++ b/test/Math/Rectangle.test.cpp
@@ -55,6 +55,12 @@ TEST(Rectangle, startPointSet) {
 	EXPECT_EQ((NAS2D::Rectangle{5, 6, 3, 4}), rect);
 }
 
+TEST(Rectangle, offset) {
+	EXPECT_EQ((NAS2D::Rectangle{1, 1, 1, 1}), (NAS2D::Rectangle{0, 0, 1, 1}).offset({1, 1}));
+	EXPECT_EQ((NAS2D::Rectangle{2, 2, 1, 1}), (NAS2D::Rectangle{1, 1, 1, 1}).offset({1, 1}));
+	EXPECT_EQ((NAS2D::Rectangle{4, 6, 5, 6}), (NAS2D::Rectangle{3, 4, 5, 6}).offset({1, 2}));
+}
+
 TEST(Rectangle, inset) {
 	// Intuitive test is for start and end point adjustments
 	EXPECT_EQ((NAS2D::Point{1, 1}), (NAS2D::Rectangle{0, 0, 10, 10}.inset(1).startPoint()));


### PR DESCRIPTION
Add method to offset a `Rectangle` by some `Vector`. This affects the `startPoint()`, but not the `size()`.
