### PR TITLE
Renames offset to translate

### DIFF
--- a/NAS2D/Math/Rectangle.h
+++ b/NAS2D/Math/Rectangle.h
@@ -86,9 +86,9 @@ namespace NAS2D
 			y = newStartPoint.y;
 		}
 
-		constexpr Rectangle offset(Vector<BaseType> offsetAmount) const
+		constexpr Rectangle translate(Vector<BaseType> offset) const
 		{
-			return Create(startPoint() + offsetAmount, size());
+			return Create(startPoint() + offset, size());
 		}
 
 		constexpr Rectangle inset(BaseType amount) const

--- a/test/Math/Rectangle.test.cpp
+++ b/test/Math/Rectangle.test.cpp
@@ -55,10 +55,10 @@ TEST(Rectangle, startPointSet) {
 	EXPECT_EQ((NAS2D::Rectangle{5, 6, 3, 4}), rect);
 }
 
-TEST(Rectangle, offset) {
-	EXPECT_EQ((NAS2D::Rectangle{1, 1, 1, 1}), (NAS2D::Rectangle{0, 0, 1, 1}).offset({1, 1}));
-	EXPECT_EQ((NAS2D::Rectangle{2, 2, 1, 1}), (NAS2D::Rectangle{1, 1, 1, 1}).offset({1, 1}));
-	EXPECT_EQ((NAS2D::Rectangle{4, 6, 5, 6}), (NAS2D::Rectangle{3, 4, 5, 6}).offset({1, 2}));
+TEST(Rectangle, translate) {
+	EXPECT_EQ((NAS2D::Rectangle{1, 1, 1, 1}), (NAS2D::Rectangle{0, 0, 1, 1}).translate({1, 1}));
+	EXPECT_EQ((NAS2D::Rectangle{2, 2, 1, 1}), (NAS2D::Rectangle{1, 1, 1, 1}).translate({1, 1}));
+	EXPECT_EQ((NAS2D::Rectangle{4, 6, 5, 6}), (NAS2D::Rectangle{3, 4, 5, 6}).translate({1, 2}));
 }
 
 TEST(Rectangle, inset) {


### PR DESCRIPTION
The verb translate better communicates what the function does.