### PR TITLE
Add GitHub actions config for windows

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,47 @@
+name: MSBuild
+
+on: [push]
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: .
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [x86, x64]
+    runs-on: windows-latest
+    env:
+      PLATFORM: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore vcpkg dependency cache
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: C:\vcpkg\installed\
+        key: ${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('InstallVcpkgDeps.bat') }}
+
+    - name: Install vcpkg dependencies
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: ./InstallVcpkgDeps.bat
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: |
+        vcpkg integrate install
+        msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}


### PR DESCRIPTION
Reference: https://github.com/OutpostUniverse/OPHD/pull/1184

With the parallelism offered by GitHub Actions, it looks like the two Windows builds can now complete in about half the total time.

It may also be reasonable to enable Debug builds too, as they would all run in parallel.

----

I still need to look into saving artifacts and release packaging.
