### PR TITLE
Enable warnings as errors on Windows CI builds

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -44,4 +44,4 @@ jobs:
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: |
         vcpkg integrate install
-        msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+        msbuild /warnAsError /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -44,4 +44,4 @@ jobs:
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: |
         vcpkg integrate install
-        msbuild /warnAsError /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+        msbuild /warnAsError /warnAsMessage:C26812 /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}


### PR DESCRIPTION
Reference: #723, https://github.com/OutpostUniverse/OPHD/issues/459

This change is for CI builds only. Local builds will still continue to treat warnings as warnings.

----

The option `/warnAsMessage:C26812` does indeed suppress the warning/error that would have been generated, though I didn't see any messages either. This is maybe disabling the check more than I would like.

We may wish to revisit this at some point.

----

Documentation:
[MSBuild command-line reference](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022)
- `-warnAsError`
- `-warnAsMessage`
