### PR TITLE
Update mingw build image for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - build-and-test
   build-linux-mingw:
     docker:
-      - image: outpostuniverse/nas2d-mingw:1.6
+      - image: outpostuniverse/nas2d-mingw:1.7
     environment:
       - WARN_EXTRA: "-Wno-redundant-decls"
     steps:

--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     gzip=1.10-* \
     bzip2=1.0.8-* \
     gnupg=2.2.19-* \
-    software-properties-common=0.98.9.3 \
+    software-properties-common=0.99.9.8 \
     ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -92,9 +92,9 @@ RUN \
 # Install NAS2D specific dependencies
 WORKDIR /tmp/
 # Install SDL libraries from binary packages
-RUN curl https://libsdl.org/release/SDL2-devel-2.0.12-mingw.tar.gz | tar -xz && \
-  make -C SDL2-2.0.12/ cross && \
-  rm -rf SDL2-2.0.12/
+RUN curl https://libsdl.org/release/SDL2-devel-2.0.16-mingw.tar.gz | tar -xz && \
+  make -C SDL2-2.0.16/ cross && \
+  rm -rf SDL2-2.0.16/
 RUN curl https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.5-mingw.tar.gz | tar -xz && \
   make -C SDL2_image-2.0.5/ cross && \
   rm -rf SDL2_image-2.0.5/

--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -60,10 +60,10 @@ RUN mkdir --parents "${INSTALL64}" "${INSTALL32}"
 # Download, compile, and install Google Test source package
 WORKDIR /tmp/gtest/
 RUN \
-  cmake -H/usr/src/googletest/ -B"${ARCH64}" -DCMAKE_CXX_COMPILER="${CXX64}" -DCMAKE_C_COMPILER="${CC64}" -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" -Dgtest_disable_pthreads=ON && make -C "${ARCH64}" && \
-  cmake -H/usr/src/googletest/ -B"${ARCH64}" -DCMAKE_CXX_COMPILER="${CXX64}" -DCMAKE_C_COMPILER="${CC64}" -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" -Dgtest_disable_pthreads=ON -DBUILD_SHARED_LIBS=ON && make -C "${ARCH64}" && \
-  cmake -H/usr/src/googletest/ -B"${ARCH32}" -DCMAKE_CXX_COMPILER="${CXX32}" -DCMAKE_C_COMPILER="${CC32}" -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" -Dgtest_disable_pthreads=ON && make -C "${ARCH32}" && \
-  cmake -H/usr/src/googletest/ -B"${ARCH32}" -DCMAKE_CXX_COMPILER="${CXX32}" -DCMAKE_C_COMPILER="${CC32}" -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" -Dgtest_disable_pthreads=ON -DBUILD_SHARED_LIBS=ON && make -C "${ARCH32}" && \
+  cmake -H/usr/src/googletest/ -B"${ARCH64}" -DCMAKE_CXX_COMPILER="${CXX64}" -DCMAKE_C_COMPILER="${CC64}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" -Dgtest_disable_pthreads=ON && make -C "${ARCH64}" && \
+  cmake -H/usr/src/googletest/ -B"${ARCH64}" -DCMAKE_CXX_COMPILER="${CXX64}" -DCMAKE_C_COMPILER="${CC64}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" -Dgtest_disable_pthreads=ON -DBUILD_SHARED_LIBS=ON && make -C "${ARCH64}" && \
+  cmake -H/usr/src/googletest/ -B"${ARCH32}" -DCMAKE_CXX_COMPILER="${CXX32}" -DCMAKE_C_COMPILER="${CC32}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" -Dgtest_disable_pthreads=ON && make -C "${ARCH32}" && \
+  cmake -H/usr/src/googletest/ -B"${ARCH32}" -DCMAKE_CXX_COMPILER="${CXX32}" -DCMAKE_C_COMPILER="${CC32}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" -Dgtest_disable_pthreads=ON -DBUILD_SHARED_LIBS=ON && make -C "${ARCH32}" && \
   cp --parents -r \
     "${ARCH64}/bin/" \
     "${ARCH64}/lib/" \

--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -43,10 +43,10 @@ RUN curl -L https://dl.winehq.org/wine-builds/winehq.key | apt-key add - && \
   add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' && \
   dpkg --add-architecture i386 && \
   apt-get update && apt-get install -y --no-install-recommends \
-    wine-stable-amd64=5.0.2~focal \
-    wine-stable-i386=5.0.2~focal \
-    wine-stable=5.0.2~focal \
-    winehq-stable=5.0.2~focal \
+    wine-stable-amd64=6.0.2~focal-1 \
+    wine-stable-i386=6.0.2~focal-1 \
+    wine-stable=6.0.2~focal-1 \
+    winehq-stable=6.0.2~focal-1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Set default install location for custom packages

--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -1,6 +1,6 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages
@@ -8,19 +8,19 @@ FROM ubuntu:20.04
 # The software-properties-common package is needed for add-apt-repository, used to install wine
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    mingw-w64=7.0.0-2 \
-    cmake=3.16.3-* \
-    make=4.2.1-* \
-    binutils=2.34-* \
-    git=1:2.25.1-* \
-    ssh=1:8.2p1-* \
-    googletest=1.10.0-2 \
-    curl=7.68.0-* \
-    tar=1.30+* \
+    mingw-w64=8.0.0-1 \
+    cmake=3.18.4-* \
+    make=4.3-* \
+    binutils=2.37-* \
+    git=1:2.32.0-* \
+    ssh=1:8.7p1-2 \
+    googletest=1.11.0-3 \
+    curl=7.74.0-* \
+    tar=1.34+* \
     gzip=1.10-* \
     bzip2=1.0.8-* \
-    gnupg=2.2.19-* \
-    software-properties-common=0.99.9.8 \
+    gnupg=2.2.27-* \
+    software-properties-common=0.99.16 \
     ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
 
@@ -40,13 +40,13 @@ ENV  LD32=${ARCH32}-ld
 
 # Install wine so resulting unit test binaries can be run
 RUN curl -L https://dl.winehq.org/wine-builds/winehq.key | apt-key add - && \
-  add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' && \
+  add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ impish main' && \
   dpkg --add-architecture i386 && \
   apt-get update && apt-get install -y --no-install-recommends \
-    wine-stable-amd64=6.0.2~focal-1 \
-    wine-stable-i386=6.0.2~focal-1 \
-    wine-stable=6.0.2~focal-1 \
-    winehq-stable=6.0.2~focal-1 \
+    wine-stable-amd64=6.0.2~impish-1 \
+    wine-stable-i386=6.0.2~impish-1 \
+    wine-stable=6.0.2~impish-1 \
+    winehq-stable=6.0.2~impish-1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Set default install location for custom packages
@@ -126,8 +126,8 @@ ENV BIN64=${INSTALL64}bin/
 ENV BIN32=${INSTALL32}bin/
 ENV PATH64="${PATH}:${BIN64}"
 ENV PATH32="${PATH}:${BIN32}"
-ENV WINEPATH64=${BIN64};/usr/lib/gcc/${ARCH64}/9.3-win32/
-ENV WINEPATH32=${BIN32};/usr/lib/gcc/${ARCH32}/9.3-win32/
+ENV WINEPATH64=${BIN64};/usr/lib/gcc/${ARCH64}/10-win32/
+ENV WINEPATH32=${BIN32};/usr/lib/gcc/${ARCH32}/10-win32/
 
 # Setup compiler and tooling default folders
 ENV CPLUS_INCLUDE_PATH="${INCLUDE64}"

--- a/makefile
+++ b/makefile
@@ -221,7 +221,7 @@ ImageName_clang := nas2d-clang
 ImageVersion_clang := 1.2
 
 ImageName_mingw := nas2d-mingw
-ImageVersion_mingw := 1.6
+ImageVersion_mingw := 1.7
 
 .PHONY: build-image
 build-image:


### PR DESCRIPTION
Reference: #826, #682

This uses an updated based image for `ubuntu:22.04` (preview). The updated version of Ubuntu comes with a version of mingw-w64 based on GCC 10, which includes support for C++20.

We'll probably want to update the image again once Ubuntu 22.04 is officially released.
