### PR TITLE
Add unit test runs to GitHub Actions build pipeline

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -45,3 +45,7 @@ jobs:
       run: |
         vcpkg integrate install
         msbuild /warnAsError /warnAsMessage:C26812 /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Test
+      working-directory: ./test/
+      run: .\${{env.PLATFORM}}\${{env.BUILD_CONFIGURATION}}\test.exe

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -48,4 +48,4 @@ jobs:
 
     - name: Test
       working-directory: ./test/
-      run: .\${{env.PLATFORM}}\${{env.BUILD_CONFIGURATION}}\test.exe
+      run: ./${{env.PLATFORM}}/${{env.BUILD_CONFIGURATION}}/test.exe

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -51,7 +51,7 @@ TEST_F(Filesystem, exists) {
 
 TEST_F(Filesystem, read) {
 	const auto data = fs.read("file.txt");
-	EXPECT_EQ("Test data\n", data);
+	EXPECT_THAT(data, testing::StartsWith("Test data"));
 }
 
 // Test a few related methods. Some don't test well standalone.


### PR DESCRIPTION
Reference: https://github.com/lairworks/nas2d-core/pull/1002

----

This needed an update to a brittle unit test for `Filesystem::read` involving a newline character `\n`. The test was failing on Windows on GitHub Actions, even though it was passing on Windows on AppVeyor, as well as passing on Linux and MacOS.

I think the difference between the two Windows builds may have been caused by the `git` checkout, which can perform line ending conversions to text files, depending on checkout settings. The `Filesystem::read` method uses binary mode, so shouldn't modify the data it reads. Whatever was on disk should be what's in memory. Depending on `git` checkout settings, this may have not matched the platform specific expansion of the `\n` used in the unit test code.

The platform dependence mess of `\n` can be avoided by ignoring the line ending character in the unit test.
