### PR TITLE
Use `makefile` pattern rules for Docker image targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -222,11 +222,13 @@ ImageVersion_mingw := 1.7
 
 .PHONY: build-image run-image debug-image root-debug-image push-image
 
-.PHONY: build-image-gcc build-image-clang build-image-mingw
-.PHONY: run-image-gcc run-image-clang run-image-mingw
-.PHONY: debug-image-gcc debug-image-clang debug-image-mingw
-.PHONY: root-debug-image-gcc root-debug-image-clang root-debug-image-mingw
-.PHONY: push-image-gcc push-image-clang push-image-mingw
+DockerBuildRules := build-image-gcc build-image-clang build-image-mingw
+DockerRunRules := run-image-gcc run-image-clang run-image-mingw
+DockerDebugRules := debug-image-gcc debug-image-clang debug-image-mingw
+DockerDebugRootRules := root-debug-image-gcc root-debug-image-clang root-debug-image-mingw
+DockerPushRules := push-image-gcc push-image-clang push-image-mingw
+
+.PHONY: ${DockerBuildRules} ${DockerRunRules} ${DockerDebugRules} ${DockerDebugRootRules} ${DockerPushRules}
 
 build-image:
 	docker build ${DockerFolder}/ --file ${DockerFolder}/${ImageName}.Dockerfile --tag ${DockerRepository}/${ImageName}:latest --tag ${DockerRepository}/${ImageName}:${ImageVersion}

--- a/makefile
+++ b/makefile
@@ -211,13 +211,8 @@ DockerFolder := ${TopLevelFolder}/docker
 DockerRunFlags := --volume ${TopLevelFolder}:/code
 DockerRepository := outpostuniverse
 
-ImageName_gcc := nas2d-gcc
 ImageVersion_gcc := 1.3
-
-ImageName_clang := nas2d-clang
 ImageVersion_clang := 1.2
-
-ImageName_mingw := nas2d-mingw
 ImageVersion_mingw := 1.7
 
 DockerBuildRules := build-image-gcc build-image-clang build-image-mingw

--- a/makefile
+++ b/makefile
@@ -241,6 +241,8 @@ push-image:
 	docker push ${DockerRepository}/${ImageName}
 
 .PHONY: build-image-gcc run-image-gcc debug-image-gcc root-debug-image-gcc push-image-gcc
+.PHONY: build-image-clang run-image-clang debug-image-clang root-debug-image-clang push-image-clang
+.PHONY: build-image-mingw run-image-mingw debug-image-mingw root-debug-image-mingw push-image-mingw
 
 build-image-gcc: ImageName := ${ImageName_gcc}
 build-image-gcc: ImageVersion := ${ImageVersion_gcc}
@@ -254,8 +256,6 @@ root-debug-image-gcc: | root-debug-image
 push-image-gcc: ImageName := ${ImageName_gcc}
 push-image-gcc: | push-image
 
-.PHONY: build-image-clang run-image-clang debug-image-clang root-debug-image-clang push-image-clang
-
 build-image-clang: ImageName := ${ImageName_clang}
 build-image-clang: ImageVersion := ${ImageVersion_clang}
 build-image-clang: | build-image
@@ -267,8 +267,6 @@ root-debug-image-clang: ImageName := ${ImageName_clang}
 root-debug-image-clang: | root-debug-image
 push-image-clang: ImageName := ${ImageName_clang}
 push-image-clang: | push-image
-
-.PHONY: build-image-mingw run-image-mingw debug-image-mingw root-debug-image-mingw push-image-mingw
 
 build-image-mingw: ImageName := ${ImageName_mingw}
 build-image-mingw: ImageVersion := ${ImageVersion_mingw}

--- a/makefile
+++ b/makefile
@@ -221,6 +221,9 @@ ImageName_mingw := nas2d-mingw
 ImageVersion_mingw := 1.7
 
 .PHONY: build-image run-image debug-image root-debug-image push-image
+.PHONY: build-image-gcc run-image-gcc debug-image-gcc root-debug-image-gcc push-image-gcc
+.PHONY: build-image-clang run-image-clang debug-image-clang root-debug-image-clang push-image-clang
+.PHONY: build-image-mingw run-image-mingw debug-image-mingw root-debug-image-mingw push-image-mingw
 
 build-image:
 	docker build ${DockerFolder}/ --file ${DockerFolder}/${ImageName}.Dockerfile --tag ${DockerRepository}/${ImageName}:latest --tag ${DockerRepository}/${ImageName}:${ImageVersion}
@@ -236,10 +239,6 @@ root-debug-image:
 
 push-image:
 	docker push ${DockerRepository}/${ImageName}
-
-.PHONY: build-image-gcc run-image-gcc debug-image-gcc root-debug-image-gcc push-image-gcc
-.PHONY: build-image-clang run-image-clang debug-image-clang root-debug-image-clang push-image-clang
-.PHONY: build-image-mingw run-image-mingw debug-image-mingw root-debug-image-mingw push-image-mingw
 
 build-image-gcc: ImageName := ${ImageName_gcc}
 build-image-gcc: ImageVersion := ${ImageVersion_gcc}

--- a/makefile
+++ b/makefile
@@ -220,11 +220,7 @@ ImageVersion_clang := 1.2
 ImageName_mingw := nas2d-mingw
 ImageVersion_mingw := 1.7
 
-.PHONY: build-image
-.PHONY: run-image
-.PHONY: debug-image
-.PHONY: root-debug-image
-.PHONY: push-image
+.PHONY: build-image run-image debug-image root-debug-image push-image
 
 build-image:
 	docker build ${DockerFolder}/ --file ${DockerFolder}/${ImageName}.Dockerfile --tag ${DockerRepository}/${ImageName}:latest --tag ${DockerRepository}/${ImageName}:${ImageVersion}

--- a/makefile
+++ b/makefile
@@ -224,7 +224,7 @@ DockerPushRules := push-image-gcc push-image-clang push-image-mingw
 .PHONY: ${DockerBuildRules} ${DockerRunRules} ${DockerDebugRules} ${DockerDebugRootRules} ${DockerPushRules}
 
 ${DockerBuildRules}: build-image-%:
-	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d-$*.Dockerfile --tag ${DockerRepository}/nas2d-$*:latest --tag ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
+	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d-$*.Dockerfile --tag ${DockerRepository}/nas2d-$*:${ImageVersion_$*} --tag ${DockerRepository}/nas2d-$*:latest
 
 ${DockerRunRules}: run-image-%:
 	docker run ${DockerRunFlags} --rm --tty ${DockerRepository}/nas2d-$*

--- a/makefile
+++ b/makefile
@@ -221,22 +221,23 @@ ImageName_mingw := nas2d-mingw
 ImageVersion_mingw := 1.7
 
 .PHONY: build-image
+.PHONY: run-image
+.PHONY: debug-image
+.PHONY: root-debug-image
+.PHONY: push-image
+
 build-image:
 	docker build ${DockerFolder}/ --file ${DockerFolder}/${ImageName}.Dockerfile --tag ${DockerRepository}/${ImageName}:latest --tag ${DockerRepository}/${ImageName}:${ImageVersion}
 
-.PHONY: run-image
 run-image:
 	docker run ${DockerRunFlags} --rm --tty ${DockerRepository}/${ImageName}
 
-.PHONY: debug-image
 debug-image:
 	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerRepository}/${ImageName} bash
 
-.PHONY: root-debug-image
 root-debug-image:
 	docker run ${DockerRunFlags} --rm --tty --interactive --user=0 ${DockerRepository}/${ImageName} bash
 
-.PHONY: push-image
 push-image:
 	docker push ${DockerRepository}/${ImageName}
 

--- a/makefile
+++ b/makefile
@@ -240,11 +240,7 @@ root-debug-image:
 push-image:
 	docker push ${DockerRepository}/${ImageName}
 
-.PHONY: build-image-gcc
-.PHONY: run-image-gcc
-.PHONY: debug-image-gcc
-.PHONY: root-debug-image-gcc
-.PHONY: push-image-gcc
+.PHONY: build-image-gcc run-image-gcc debug-image-gcc root-debug-image-gcc push-image-gcc
 
 build-image-gcc: ImageName := ${ImageName_gcc}
 build-image-gcc: ImageVersion := ${ImageVersion_gcc}
@@ -258,11 +254,7 @@ root-debug-image-gcc: | root-debug-image
 push-image-gcc: ImageName := ${ImageName_gcc}
 push-image-gcc: | push-image
 
-.PHONY: build-image-clang
-.PHONY: run-image-clang
-.PHONY: debug-image-clang
-.PHONY: root-debug-image-clang
-.PHONY: push-image-clang
+.PHONY: build-image-clang run-image-clang debug-image-clang root-debug-image-clang push-image-clang
 
 build-image-clang: ImageName := ${ImageName_clang}
 build-image-clang: ImageVersion := ${ImageVersion_clang}
@@ -276,11 +268,7 @@ root-debug-image-clang: | root-debug-image
 push-image-clang: ImageName := ${ImageName_clang}
 push-image-clang: | push-image
 
-.PHONY: build-image-mingw
-.PHONY: run-image-mingw
-.PHONY: debug-image-mingw
-.PHONY: root-debug-image-mingw
-.PHONY: push-image-mingw
+.PHONY: build-image-mingw run-image-mingw debug-image-mingw root-debug-image-mingw push-image-mingw
 
 build-image-mingw: ImageName := ${ImageName_mingw}
 build-image-mingw: ImageVersion := ${ImageVersion_mingw}

--- a/makefile
+++ b/makefile
@@ -221,9 +221,12 @@ ImageName_mingw := nas2d-mingw
 ImageVersion_mingw := 1.7
 
 .PHONY: build-image run-image debug-image root-debug-image push-image
-.PHONY: build-image-gcc run-image-gcc debug-image-gcc root-debug-image-gcc push-image-gcc
-.PHONY: build-image-clang run-image-clang debug-image-clang root-debug-image-clang push-image-clang
-.PHONY: build-image-mingw run-image-mingw debug-image-mingw root-debug-image-mingw push-image-mingw
+
+.PHONY: build-image-gcc build-image-clang build-image-mingw
+.PHONY: run-image-gcc run-image-clang run-image-mingw
+.PHONY: debug-image-gcc debug-image-clang debug-image-mingw
+.PHONY: root-debug-image-gcc root-debug-image-clang root-debug-image-mingw
+.PHONY: push-image-gcc push-image-clang push-image-mingw
 
 build-image:
 	docker build ${DockerFolder}/ --file ${DockerFolder}/${ImageName}.Dockerfile --tag ${DockerRepository}/${ImageName}:latest --tag ${DockerRepository}/${ImageName}:${ImageVersion}

--- a/makefile
+++ b/makefile
@@ -232,54 +232,28 @@ DockerPushRules := push-image-gcc push-image-clang push-image-mingw
 
 build-image:
 	docker build ${DockerFolder}/ --file ${DockerFolder}/${ImageName}.Dockerfile --tag ${DockerRepository}/${ImageName}:latest --tag ${DockerRepository}/${ImageName}:${ImageVersion}
+${DockerBuildRules}: build-image-%:
+	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d-$*.Dockerfile --tag ${DockerRepository}/nas2d-$*:latest --tag ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
 
 run-image:
 	docker run ${DockerRunFlags} --rm --tty ${DockerRepository}/${ImageName}
+${DockerRunRules}: run-image-%:
+	docker run ${DockerRunFlags} --rm --tty ${DockerRepository}/nas2d-$*
 
 debug-image:
 	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerRepository}/${ImageName} bash
+${DockerDebugRules}: debug-image-%:
+	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerRepository}/nas2d-$* bash
 
 root-debug-image:
 	docker run ${DockerRunFlags} --rm --tty --interactive --user=0 ${DockerRepository}/${ImageName} bash
+${DockerDebugRootRules}: root-debug-image-%:
+	docker run ${DockerRunFlags} --rm --tty --interactive --user=0 ${DockerRepository}/nas2d-$* bash
 
 push-image:
 	docker push ${DockerRepository}/${ImageName}
-
-build-image-gcc: ImageName := ${ImageName_gcc}
-build-image-gcc: ImageVersion := ${ImageVersion_gcc}
-build-image-gcc: | build-image
-run-image-gcc: ImageName := ${ImageName_gcc}
-run-image-gcc: | run-image
-debug-image-gcc: ImageName := ${ImageName_gcc}
-debug-image-gcc: | debug-image
-root-debug-image-gcc: ImageName := ${ImageName_gcc}
-root-debug-image-gcc: | root-debug-image
-push-image-gcc: ImageName := ${ImageName_gcc}
-push-image-gcc: | push-image
-
-build-image-clang: ImageName := ${ImageName_clang}
-build-image-clang: ImageVersion := ${ImageVersion_clang}
-build-image-clang: | build-image
-run-image-clang: ImageName := ${ImageName_clang}
-run-image-clang: | run-image
-debug-image-clang: ImageName := ${ImageName_clang}
-debug-image-clang: | debug-image
-root-debug-image-clang: ImageName := ${ImageName_clang}
-root-debug-image-clang: | root-debug-image
-push-image-clang: ImageName := ${ImageName_clang}
-push-image-clang: | push-image
-
-build-image-mingw: ImageName := ${ImageName_mingw}
-build-image-mingw: ImageVersion := ${ImageVersion_mingw}
-build-image-mingw: | build-image
-run-image-mingw: ImageName := ${ImageName_mingw}
-run-image-mingw: | run-image
-debug-image-mingw: ImageName := ${ImageName_mingw}
-debug-image-mingw: | debug-image
-root-debug-image-mingw: ImageName := ${ImageName_mingw}
-root-debug-image-mingw: | root-debug-image
-push-image-mingw: ImageName := ${ImageName_mingw}
-push-image-mingw: | push-image
+${DockerPushRules}: push-image-%:
+	docker push ${DockerRepository}/nas2d-$*
 
 #### CircleCI related build rules ####
 

--- a/makefile
+++ b/makefile
@@ -220,8 +220,6 @@ ImageVersion_clang := 1.2
 ImageName_mingw := nas2d-mingw
 ImageVersion_mingw := 1.7
 
-.PHONY: build-image run-image debug-image root-debug-image push-image
-
 DockerBuildRules := build-image-gcc build-image-clang build-image-mingw
 DockerRunRules := run-image-gcc run-image-clang run-image-mingw
 DockerDebugRules := debug-image-gcc debug-image-clang debug-image-mingw
@@ -230,28 +228,18 @@ DockerPushRules := push-image-gcc push-image-clang push-image-mingw
 
 .PHONY: ${DockerBuildRules} ${DockerRunRules} ${DockerDebugRules} ${DockerDebugRootRules} ${DockerPushRules}
 
-build-image:
-	docker build ${DockerFolder}/ --file ${DockerFolder}/${ImageName}.Dockerfile --tag ${DockerRepository}/${ImageName}:latest --tag ${DockerRepository}/${ImageName}:${ImageVersion}
 ${DockerBuildRules}: build-image-%:
 	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d-$*.Dockerfile --tag ${DockerRepository}/nas2d-$*:latest --tag ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
 
-run-image:
-	docker run ${DockerRunFlags} --rm --tty ${DockerRepository}/${ImageName}
 ${DockerRunRules}: run-image-%:
 	docker run ${DockerRunFlags} --rm --tty ${DockerRepository}/nas2d-$*
 
-debug-image:
-	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerRepository}/${ImageName} bash
 ${DockerDebugRules}: debug-image-%:
 	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerRepository}/nas2d-$* bash
 
-root-debug-image:
-	docker run ${DockerRunFlags} --rm --tty --interactive --user=0 ${DockerRepository}/${ImageName} bash
 ${DockerDebugRootRules}: root-debug-image-%:
 	docker run ${DockerRunFlags} --rm --tty --interactive --user=0 ${DockerRepository}/nas2d-$* bash
 
-push-image:
-	docker push ${DockerRepository}/${ImageName}
 ${DockerPushRules}: push-image-%:
 	docker push ${DockerRepository}/nas2d-$*
 

--- a/makefile
+++ b/makefile
@@ -241,53 +241,56 @@ push-image:
 	docker push ${DockerRepository}/${ImageName}
 
 .PHONY: build-image-gcc
+.PHONY: run-image-gcc
+.PHONY: debug-image-gcc
+.PHONY: root-debug-image-gcc
+.PHONY: push-image-gcc
+
 build-image-gcc: ImageName := ${ImageName_gcc}
 build-image-gcc: ImageVersion := ${ImageVersion_gcc}
 build-image-gcc: | build-image
-.PHONY: run-image-gcc
 run-image-gcc: ImageName := ${ImageName_gcc}
 run-image-gcc: | run-image
-.PHONY: debug-image-gcc
 debug-image-gcc: ImageName := ${ImageName_gcc}
 debug-image-gcc: | debug-image
-.PHONY: root-debug-image-gcc
 root-debug-image-gcc: ImageName := ${ImageName_gcc}
 root-debug-image-gcc: | root-debug-image
-.PHONY: push-image-gcc
 push-image-gcc: ImageName := ${ImageName_gcc}
 push-image-gcc: | push-image
 
 .PHONY: build-image-clang
+.PHONY: run-image-clang
+.PHONY: debug-image-clang
+.PHONY: root-debug-image-clang
+.PHONY: push-image-clang
+
 build-image-clang: ImageName := ${ImageName_clang}
 build-image-clang: ImageVersion := ${ImageVersion_clang}
 build-image-clang: | build-image
-.PHONY: run-image-clang
 run-image-clang: ImageName := ${ImageName_clang}
 run-image-clang: | run-image
-.PHONY: debug-image-clang
 debug-image-clang: ImageName := ${ImageName_clang}
 debug-image-clang: | debug-image
-.PHONY: root-debug-image-clang
 root-debug-image-clang: ImageName := ${ImageName_clang}
 root-debug-image-clang: | root-debug-image
-.PHONY: push-image-clang
 push-image-clang: ImageName := ${ImageName_clang}
 push-image-clang: | push-image
 
 .PHONY: build-image-mingw
+.PHONY: run-image-mingw
+.PHONY: debug-image-mingw
+.PHONY: root-debug-image-mingw
+.PHONY: push-image-mingw
+
 build-image-mingw: ImageName := ${ImageName_mingw}
 build-image-mingw: ImageVersion := ${ImageVersion_mingw}
 build-image-mingw: | build-image
-.PHONY: run-image-mingw
 run-image-mingw: ImageName := ${ImageName_mingw}
 run-image-mingw: | run-image
-.PHONY: debug-image-mingw
 debug-image-mingw: ImageName := ${ImageName_mingw}
 debug-image-mingw: | debug-image
-.PHONY: root-debug-image-mingw
 root-debug-image-mingw: ImageName := ${ImageName_mingw}
 root-debug-image-mingw: | root-debug-image
-.PHONY: push-image-mingw
 push-image-mingw: ImageName := ${ImageName_mingw}
 push-image-mingw: | push-image
 


### PR DESCRIPTION
Reference:
- https://github.com/lairworks/nas2d-core/pull/1006

The concept of a default Docker image name was dropped when support for the Ubuntu 18.04 image was dropped. The rules persisted due to the way other rules delegated to the default rules with updated variable values. That has been re-worked to instead use pattern rules. The now defunct default image rules have now been dropped.

The pattern rules are likely to be much more maintainable than the previous mess.
