### PR TITLE
Use `foreach` to generate Docker `makefile` rules

### DIFF
--- a/makefile
+++ b/makefile
@@ -215,7 +215,7 @@ ImageVersion_gcc := 1.3
 ImageVersion_clang := 1.2
 ImageVersion_mingw := 1.7
 
-DockerImageNames := gcc clang mingw
+DockerImageNames := $(patsubst docker/nas2d-%.Dockerfile,%,$(wildcard docker/nas2d-*.Dockerfile))
 
 DockerBuildRules := $(foreach ImageName,${DockerImageNames},build-image-${ImageName})
 DockerRunRules := $(foreach ImageName,${DockerImageNames},run-image-${ImageName})

--- a/makefile
+++ b/makefile
@@ -215,11 +215,13 @@ ImageVersion_gcc := 1.3
 ImageVersion_clang := 1.2
 ImageVersion_mingw := 1.7
 
-DockerBuildRules := build-image-gcc build-image-clang build-image-mingw
-DockerRunRules := run-image-gcc run-image-clang run-image-mingw
-DockerDebugRules := debug-image-gcc debug-image-clang debug-image-mingw
-DockerDebugRootRules := root-debug-image-gcc root-debug-image-clang root-debug-image-mingw
-DockerPushRules := push-image-gcc push-image-clang push-image-mingw
+DockerImageNames := gcc clang mingw
+
+DockerBuildRules := $(foreach ImageName,${DockerImageNames},build-image-${ImageName})
+DockerRunRules := $(foreach ImageName,${DockerImageNames},run-image-${ImageName})
+DockerDebugRules := $(foreach ImageName,${DockerImageNames},debug-image-${ImageName})
+DockerDebugRootRules := $(foreach ImageName,${DockerImageNames},root-debug-image-${ImageName})
+DockerPushRules := $(foreach ImageName,${DockerImageNames},push-image-${ImageName})
 
 .PHONY: ${DockerBuildRules} ${DockerRunRules} ${DockerDebugRules} ${DockerDebugRootRules} ${DockerPushRules}
 


### PR DESCRIPTION
Reference: #1010

----

This was a test, and I don't think I'll merge it. The code uses GNU Make specific features, so I'd like to avoid using it, at least for now. I wanted to record the effort somewhere though, rather than just throw it away. I would prefer sticking to features that are common to both GNU Make and Posix Make. We have the MacOS build, and MacOS derives from BSD, where Posix Make may be used.

In particular, it's not clear if the Docker related `makefile` commands would still be usable from a MacOS system if these changes were merged. Interestingly though, there are no errors or warnings generated by the `make` calls for the MacOS build. Though that may just mean variables are empty and not generating parse errors, rather than indicating they work.

----

The main idea was to scan the `docker/` folder for suitable NAS2D Dockerfiles, and generate the image names from that, then generate the list of rules. This is done using [`foreach`](https://www.gnu.org/software/make/manual/html_node/Foreach-Function.html), which seems to be GNU Make specific:
```makefile
DockerImageNames := $(patsubst docker/nas2d-%.Dockerfile,%,$(wildcard docker/nas2d-*.Dockerfile))

DockerBuildRules := $(foreach ImageName,${DockerImageNames},build-image-${ImageName})
DockerRunRules := $(foreach ImageName,${DockerImageNames},run-image-${ImageName})
DockerDebugRules := $(foreach ImageName,${DockerImageNames},debug-image-${ImageName})
DockerDebugRootRules := $(foreach ImageName,${DockerImageNames},root-debug-image-${ImageName})
DockerPushRules := $(foreach ImageName,${DockerImageNames},push-image-${ImageName})
```

Other possible functions of interest are [`subst`](https://www.gnu.org/software/make/manual/html_node/Text-Functions.html) and [`addprefix`](https://www.gnu.org/software/make/manual/html_node/File-Name-Functions.html). These also appear to be GNU Make specific though.

----

Another experiment was to use a list of Docker commands, and generate a 2D product of commands and images.
```makefile
DockerRuleNames := build-image run-image debug-image root-debug-image push-image

.PHONY: $(foreach ImageName,${DockerImageNames},$(foreach RuleName,${DockerRuleNames},${RuleName}-${ImageName}))
```

This leads to some complications when defining the pattern rules. The pattern must match every target, or a warning is generated, so you really need to break out the targets to be rule specific. For example, the following would generate a warning, since `run-image-gcc` doesn't match the pattern:
```makefile
build-image-gcc run-image-gcc: build-image-%:
```

Potentially you could `filter` the rules for ones matching the pattern, but that duplicates the pattern.
```makefile
$(filter build-image-%,${DockerRules}): build-image-%:
```

It doesn't appear there is an easy non-repetitive way to generate all pattern rules without specifically naming variables for the rules matching a given pattern.
