### PR TITLE
Be explicit with Docker image tags

### DIFF
--- a/makefile
+++ b/makefile
@@ -215,6 +215,8 @@ ImageVersion_gcc := 1.3
 ImageVersion_clang := 1.2
 ImageVersion_mingw := 1.7
 
+DockerImageName = ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
+
 DockerBuildRules := build-image-gcc build-image-clang build-image-mingw
 DockerRunRules := run-image-gcc run-image-clang run-image-mingw
 DockerDebugRules := debug-image-gcc debug-image-clang debug-image-mingw
@@ -224,19 +226,19 @@ DockerPushRules := push-image-gcc push-image-clang push-image-mingw
 .PHONY: ${DockerBuildRules} ${DockerRunRules} ${DockerDebugRules} ${DockerDebugRootRules} ${DockerPushRules}
 
 ${DockerBuildRules}: build-image-%:
-	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d-$*.Dockerfile --tag ${DockerRepository}/nas2d-$*:${ImageVersion_$*} --tag ${DockerRepository}/nas2d-$*:latest
+	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d-$*.Dockerfile --tag ${DockerImageName} --tag ${DockerRepository}/nas2d-$*:latest
 
 ${DockerRunRules}: run-image-%:
-	docker run ${DockerRunFlags} --rm --tty ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
+	docker run ${DockerRunFlags} --rm --tty ${DockerImageName}
 
 ${DockerDebugRules}: debug-image-%:
-	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerRepository}/nas2d-$*:${ImageVersion_$*} bash
+	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerImageName} bash
 
 ${DockerDebugRootRules}: root-debug-image-%:
-	docker run ${DockerRunFlags} --rm --tty --interactive --user=0 ${DockerRepository}/nas2d-$*:${ImageVersion_$*} bash
+	docker run ${DockerRunFlags} --rm --tty --interactive --user=0 ${DockerImageName} bash
 
 ${DockerPushRules}: push-image-%:
-	docker push ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
+	docker push ${DockerImageName}
 
 #### CircleCI related build rules ####
 

--- a/makefile
+++ b/makefile
@@ -239,6 +239,7 @@ ${DockerDebugRootRules}: root-debug-image-%:
 
 ${DockerPushRules}: push-image-%:
 	docker push ${DockerImageName}
+	docker push ${DockerRepository}/nas2d-$*:latest
 
 #### CircleCI related build rules ####
 

--- a/makefile
+++ b/makefile
@@ -227,16 +227,16 @@ ${DockerBuildRules}: build-image-%:
 	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d-$*.Dockerfile --tag ${DockerRepository}/nas2d-$*:${ImageVersion_$*} --tag ${DockerRepository}/nas2d-$*:latest
 
 ${DockerRunRules}: run-image-%:
-	docker run ${DockerRunFlags} --rm --tty ${DockerRepository}/nas2d-$*
+	docker run ${DockerRunFlags} --rm --tty ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
 
 ${DockerDebugRules}: debug-image-%:
-	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerRepository}/nas2d-$* bash
+	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerRepository}/nas2d-$*:${ImageVersion_$*} bash
 
 ${DockerDebugRootRules}: root-debug-image-%:
-	docker run ${DockerRunFlags} --rm --tty --interactive --user=0 ${DockerRepository}/nas2d-$* bash
+	docker run ${DockerRunFlags} --rm --tty --interactive --user=0 ${DockerRepository}/nas2d-$*:${ImageVersion_$*} bash
 
 ${DockerPushRules}: push-image-%:
-	docker push ${DockerRepository}/nas2d-$*
+	docker push ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
 
 #### CircleCI related build rules ####
 


### PR DESCRIPTION
Reference: #1010

When updating the `nas2d-mingw` image, I noticed the scripted command only pushed the `latest` tag, and not the `1.7` version tag. I had to manually push the version tag. This fixes the code to push both versions.

The other Docker related rules are now also more explicit about what tags to use, such as `run-image-%` and `debug-image-%`.
