### PR TITLE
Add `AnimationSet` constructor taking external `imageCache`

### DIFF
--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -62,9 +62,15 @@ bool AnimationSet::Frame::isStopFrame() const
 
 
 AnimationSet::AnimationSet(std::string fileName) :
+	AnimationSet{std::move(fileName), animationImageCache}
+{
+}
+
+
+AnimationSet::AnimationSet(std::string fileName, ImageCache& imageCache) :
 	mFileName{std::move(fileName)}
 {
-	auto [imageSheetMap, actions] = processXml(mFileName, animationImageCache);
+	auto [imageSheetMap, actions] = processXml(mFileName, imageCache);
 	mImageSheetMap = std::move(imageSheetMap);
 	mActions = std::move(actions);
 }

--- a/NAS2D/Resource/AnimationSet.h
+++ b/NAS2D/Resource/AnimationSet.h
@@ -21,6 +21,8 @@
 
 namespace NAS2D
 {
+	template <typename Resource, typename ... Params> class ResourceCache;
+
 
 	class AnimationSet
 	{
@@ -40,6 +42,7 @@ namespace NAS2D
 
 
 		AnimationSet(std::string fileName);
+		AnimationSet(std::string fileName, ResourceCache<Image, std::string>& imageCache);
 		AnimationSet(std::string fileName, ImageSheetMap imageSheetMap, ActionsMap actions);
 
 		std::vector<std::string> actionNames() const;


### PR DESCRIPTION
This allows for external control of the `Image` cache used by `AnimationSet`. By default an internally managed cached would have been used, which isn't exposed for direct access.
