### PR TITLE
Use `std::vector` in `Signal`

### DIFF
--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "Delegate.h"
-#include <set>
+#include <vector>
 #include <algorithm>
 
 
@@ -34,7 +34,7 @@ namespace NAS2D
 			const auto iterator = std::find(delegateList.begin(), delegateList.end(), delegate);
 			if (iterator == delegateList.end())
 			{
-				delegateList.insert(delegate);
+				delegateList.push_back(delegate);
 			}
 		}
 
@@ -49,7 +49,7 @@ namespace NAS2D
 			const auto iterator = std::find(delegateList.begin(), delegateList.end(), delegate);
 			if (iterator != delegateList.end())
 			{
-				delegateList.erase(delegate);
+				delegateList.erase(iterator);
 			}
 		}
 
@@ -60,6 +60,6 @@ namespace NAS2D
 		void disconnect(Y* obj, void (X::*func)(Params...) const) { disconnect(MakeDelegate(obj, func)); }
 
 	protected:
-		std::set<DelegateType> delegateList{};
+		std::vector<DelegateType> delegateList{};
 	};
 } // namespace

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -31,18 +31,18 @@ namespace NAS2D
 		void connect(DelegateType delegate) { delegateList.insert(delegate); }
 
 		template <typename X, typename Y>
-		void connect(Y* obj, void (X::*func)(Params...)) { delegateList.insert(MakeDelegate(obj, func)); }
+		void connect(Y* obj, void (X::*func)(Params...)) { connect(MakeDelegate(obj, func)); }
 
 		template <typename X, typename Y>
-		void connect(Y* obj, void (X::*func)(Params...) const) { delegateList.insert(MakeDelegate(obj, func)); }
+		void connect(Y* obj, void (X::*func)(Params...) const) { connect(MakeDelegate(obj, func)); }
 
 		void disconnect(DelegateType delegate) { delegateList.erase(delegate); }
 
 		template <typename X, typename Y>
-		void disconnect(Y* obj, void (X::*func)(Params...)) { delegateList.erase(MakeDelegate(obj, func)); }
+		void disconnect(Y* obj, void (X::*func)(Params...)) { disconnect(MakeDelegate(obj, func)); }
 
 		template <typename X, typename Y>
-		void disconnect(Y* obj, void (X::*func)(Params...) const) { delegateList.erase(MakeDelegate(obj, func)); }
+		void disconnect(Y* obj, void (X::*func)(Params...) const) { disconnect(MakeDelegate(obj, func)); }
 
 	protected:
 		std::set<DelegateType> delegateList{};

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -28,7 +28,10 @@ namespace NAS2D
 
 		void clear() { delegateList.clear(); }
 
-		void connect(DelegateType delegate) { delegateList.insert(delegate); }
+		void connect(DelegateType delegate)
+		{
+			delegateList.insert(delegate);
+		}
 
 		template <typename X, typename Y>
 		void connect(Y* obj, void (X::*func)(Params...)) { connect(MakeDelegate(obj, func)); }
@@ -36,7 +39,10 @@ namespace NAS2D
 		template <typename X, typename Y>
 		void connect(Y* obj, void (X::*func)(Params...) const) { connect(MakeDelegate(obj, func)); }
 
-		void disconnect(DelegateType delegate) { delegateList.erase(delegate); }
+		void disconnect(DelegateType delegate)
+		{
+			delegateList.erase(delegate);
+		}
 
 		template <typename X, typename Y>
 		void disconnect(Y* obj, void (X::*func)(Params...)) { disconnect(MakeDelegate(obj, func)); }

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -60,6 +60,6 @@ namespace NAS2D
 		void disconnect(Y* obj, void (X::*func)(Params...) const) { disconnect(MakeDelegate(obj, func)); }
 
 	protected:
-		std::vector<DelegateType> delegateList{};
+		std::vector<DelegateType> delegateList;
 	};
 } // namespace

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -12,6 +12,7 @@
 
 #include "Delegate.h"
 #include <set>
+#include <algorithm>
 
 
 namespace NAS2D
@@ -30,7 +31,11 @@ namespace NAS2D
 
 		void connect(DelegateType delegate)
 		{
-			delegateList.insert(delegate);
+			const auto iterator = std::find(delegateList.begin(), delegateList.end(), delegate);
+			if (iterator == delegateList.end())
+			{
+				delegateList.insert(delegate);
+			}
 		}
 
 		template <typename X, typename Y>
@@ -41,7 +46,11 @@ namespace NAS2D
 
 		void disconnect(DelegateType delegate)
 		{
-			delegateList.erase(delegate);
+			const auto iterator = std::find(delegateList.begin(), delegateList.end(), delegate);
+			if (iterator != delegateList.end())
+			{
+				delegateList.erase(delegate);
+			}
 		}
 
 		template <typename X, typename Y>


### PR DESCRIPTION
Reference: #1015

There are two main reasons for this change:
1. To make it easier to use `std::function` internally rather than the custom `Delegate` class
2. Speed (for the typical use case)

Using a `std::set` requires the stored object to be "less than" comparable. The custom `Delegate` class has an `operator<`. That being a bit odd aside, the `std::function` class does not have `operator<`. That means switching to `std::function` would either require a custom `operator<` function, or we could change to a different collection class that doesn't require `operator<` for the stored elements.

In terms of speed, a `std::vector` is about the fastest collection class you can likely get for small amounts of data. It's simple, and caches well, so pretty much all operations will be fast for small collections. Things like `std::set` may have `insert` and `delete` speed advantages for larger collections, due to better asymptotic complexity, but the more complex algorithms and lower cache locality mean it'll be slower for small collections. Most `Signal` objects only have a single listener. That far favours using a simpler collection, such as `std::vector`. Further, the main operation will generally be `emit`, rather than `connect` or `disconnect`. That means collection traversal speed matters more than `insert` and `delete` speed. In that case, the `std::vector` will definitely perform better, due to simpler iteration and better cache locality.
