### PR TITLE
Remove old `#if` hacks for older compilers from `Delegate`

### DIFF
--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -37,12 +37,11 @@
 #define FASTDLGT_HASINHERITANCE_KEYWORDS
 #endif
 
+
 namespace NAS2D
 {
-
 	namespace detail
 	{
-
 		template <typename OutputClass, typename InputClass>
 		union horrible_union
 		{
@@ -457,7 +456,6 @@ namespace NAS2D
 				}
 			}
 		};
-
 	}
 
 

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -48,10 +48,6 @@
 #define FASTDELEGATE_ALLOW_FUNCTION_TYPE_SYNTAX
 #endif
 
-#ifdef __GNUC__ // Workaround GCC bug #8271
-#define FASTDELEGATE_GCC_BUG_8271
-#endif
-
 namespace NAS2D
 {
 
@@ -395,17 +391,6 @@ namespace NAS2D
 				m_pStaticFunction = nullptr;
 				#endif
 			}
-
-		#ifdef FASTDELEGATE_GCC_BUG_8271 // At present, GCC doesn't recognize constness of MFPs in templates
-			template <typename X, typename XMemFunc>
-			inline void bindmemfunc(const X* pthis, XMemFunc function_to_bind)
-			{
-				bindconstmemfunc(pthis, function_to_bind);
-				#if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
-				m_pStaticFunction = nullptr;
-				#endif
-			}
-		#endif
 
 			inline GenericClass* GetClosureThis() const
 			{

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -214,9 +214,6 @@ namespace NAS2D
 		};
 
 
-		#if (_MSC_VER <1300)
-		#error Support for this compiler is no longer provided. Please upgrade.
-		#else
 		template <>
 		struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE + 3 * sizeof(int)>
 		{
@@ -247,7 +244,6 @@ namespace NAS2D
 				return reinterpret_cast<GenericClass*>(reinterpret_cast<char*>(pthis) + u.s.delta + virtual_delta);
 			};
 		};
-		#endif
 		#endif
 	}
 

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -33,7 +33,6 @@
 // Compiler identification. It's not easy to identify Visual C++ because many vendors
 // fraudulently define Microsoft's identifiers.
 #if defined(_MSC_VER) && !defined(__MWERKS__) && !defined(__VECTOR_C) && !defined(__ICL) && !defined(__BORLANDC__)
-#define FASTDLGT_ISMSVC
 #define FASTDLGT_MICROSOFT_MFP
 #define FASTDLGT_HASINHERITANCE_KEYWORDS
 #endif

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -32,7 +32,6 @@
 // fraudulently define Microsoft's identifiers.
 #if defined(_MSC_VER) && !defined(__MWERKS__) && !defined(__VECTOR_C) && !defined(__ICL) && !defined(__BORLANDC__)
 #define FASTDLGT_MICROSOFT_MFP
-#define FASTDLGT_HASINHERITANCE_KEYWORDS
 #endif
 
 
@@ -105,10 +104,7 @@ namespace NAS2D
 		// GenericClass is a fake class, ONLY used to provide a type. It is vitally important
 		// that it is never defined.
 		#ifdef FASTDLGT_MICROSOFT_MFP
-
-		#ifdef FASTDLGT_HASINHERITANCE_KEYWORDS
 			class __single_inheritance GenericClass;
-		#endif
 			class GenericClass {};
 		#else
 			class GenericClass;

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -38,16 +38,6 @@
 #define FASTDLGT_HASINHERITANCE_KEYWORDS
 #endif
 
-// Does it allow function declarator syntax? The following compilers are known to work:
-#if defined(FASTDLGT_ISMSVC) && (_MSC_VER >= 1310) // VC 7.1
-#define FASTDELEGATE_ALLOW_FUNCTION_TYPE_SYNTAX
-#endif
-
-// Gcc(2.95+), and versions of Digital Mars, Intel and Comeau in common use.
-#if defined(__DMC__) || defined(__GNUC__) || defined(__ICL) || defined(__COMO__)
-#define FASTDELEGATE_ALLOW_FUNCTION_TYPE_SYNTAX
-#endif
-
 namespace NAS2D
 {
 
@@ -573,8 +563,6 @@ namespace NAS2D
 	};
 
 
-	#ifdef FASTDELEGATE_ALLOW_FUNCTION_TYPE_SYNTAX
-
 	template <typename Signature>
 	class Delegate;
 
@@ -607,8 +595,6 @@ namespace NAS2D
 			return *this;
 		}
 	};
-
-	#endif
 
 	template <typename X, typename Y, typename RetType, typename... Params>
 	DelegateX<RetType, Params...> MakeDelegate(Y* x, RetType (X::*func)(Params...))


### PR DESCRIPTION
Reference: #1015

The code requires at least C++17 support, so any special hacks for compilers too old to support C++17 aren't needed.

Might be good if a Windows developer tested OPHD still compiles and works with this change, since the removed hacks are compiler and platform specific.
