### PR TITLE
Add Arch Linux build support

### DIFF
--- a/docker/nas2d-arch.Dockerfile
+++ b/docker/nas2d-arch.Dockerfile
@@ -1,0 +1,34 @@
+# See Docker section of makefile in root project folder for usage commands.
+
+FROM archlinux:base-20220130.0.46058
+
+# Install base development tools
+# Includes tools to build download, unpack, and build source packages
+# Includes tools needed for primary CircleCI containers
+RUN pacman --sync --refresh --noconfirm \
+    gcc \
+    make \
+    gtest \
+    git \
+    openssh \
+    tar \
+    gzip \
+    ca-certificates \
+  && rm -rf /var/cache/pacman/pkg
+
+RUN pacman --sync --refresh --noconfirm \
+    glew \
+    physfs \
+    sdl2 \
+    sdl2_image \
+    sdl2_mixer \
+    sdl2_ttf \
+  && rm -rf /var/cache/pacman/pkg
+
+RUN useradd -m -s /bin/bash user
+USER user
+
+VOLUME /code
+WORKDIR /code
+
+CMD ["make", "--keep-going", "check"]

--- a/makefile
+++ b/makefile
@@ -214,14 +214,15 @@ DockerRepository := outpostuniverse
 ImageVersion_gcc := 1.3
 ImageVersion_clang := 1.2
 ImageVersion_mingw := 1.7
+ImageVersion_arch := 1.0
 
 DockerImageName = ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
 
-DockerBuildRules := build-image-gcc build-image-clang build-image-mingw
-DockerRunRules := run-image-gcc run-image-clang run-image-mingw
-DockerDebugRules := debug-image-gcc debug-image-clang debug-image-mingw
-DockerDebugRootRules := root-debug-image-gcc root-debug-image-clang root-debug-image-mingw
-DockerPushRules := push-image-gcc push-image-clang push-image-mingw
+DockerBuildRules := build-image-gcc build-image-clang build-image-mingw build-image-arch
+DockerRunRules := run-image-gcc run-image-clang run-image-mingw run-image-arch
+DockerDebugRules := debug-image-gcc debug-image-clang debug-image-mingw debug-image-arch
+DockerDebugRootRules := root-debug-image-gcc root-debug-image-clang root-debug-image-mingw root-debug-image-arch
+DockerPushRules := push-image-gcc push-image-clang push-image-mingw push-image-arch
 
 .PHONY: ${DockerBuildRules} ${DockerRunRules} ${DockerDebugRules} ${DockerDebugRootRules} ${DockerPushRules}
 


### PR DESCRIPTION
Reference: #1019 

Add a Dockerfile and makefile support rules for an Arch Linux compile environment. This helps reproduce the bug noted in issue #1019.

To build the Docker image:
`make build-image-arch`

To run a build using the new Docker image:
`make run-image-arch`
