### PR TITLE
Ignore zero width glyph

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -208,6 +208,12 @@
     <ClCompile Include="Mixer\Mixer.cpp" />
     <ClCompile Include="Mixer\MixerSDL.cpp" />
     <ClCompile Include="Mixer\MixerNull.cpp" />
+    <ClCompile Include="Parsing\XmlFile.cpp" />
+    <ClCompile Include="Parsing\XmlNamedSubSectionIterator.cpp" />
+    <ClCompile Include="Parsing\XmlNamedSubSectionRange.cpp" />
+    <ClCompile Include="Parsing\XmlSection.cpp" />
+    <ClCompile Include="Parsing\XmlSubSectionIterator.cpp" />
+    <ClCompile Include="Parsing\XmlSubSectionRange.cpp" />
     <ClCompile Include="Renderer\Color.cpp" />
     <ClCompile Include="Renderer\DisplayDesc.cpp" />
     <ClCompile Include="Renderer\Fade.cpp" />
@@ -258,6 +264,12 @@
     <ClInclude Include="Mixer\MixerNull.h" />
     <ClInclude Include="NAS2D.h" />
     <ClInclude Include="ParserHelper.h" />
+    <ClInclude Include="Parsing\XmlFile.h" />
+    <ClInclude Include="Parsing\XmlNamedSubSectionIterator.h" />
+    <ClInclude Include="Parsing\XmlNamedSubSectionRange.h" />
+    <ClInclude Include="Parsing\XmlSection.h" />
+    <ClInclude Include="Parsing\XmlSubSectionIterator.h" />
+    <ClInclude Include="Parsing\XmlSubSectionRange.h" />
     <ClInclude Include="Renderer\DisplayDesc.h" />
     <ClInclude Include="Renderer\RendererNull.h" />
     <ClInclude Include="Renderer\Color.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -37,6 +37,12 @@
     <Filter Include="Header Files\Xml">
       <UniqueIdentifier>{f77ff9a8-6639-4ae0-8705-c016859865d9}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\Parsing">
+      <UniqueIdentifier>{cd643ee8-ed26-43fa-ab3e-012a00b17a74}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Parsing">
+      <UniqueIdentifier>{064e1bf7-5414-4749-bc5b-73bcd2d9c04f}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Configuration.cpp">
@@ -164,6 +170,24 @@
     </ClCompile>
     <ClCompile Include="Dictionary.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Parsing\XmlFile.cpp">
+      <Filter>Source Files\Parsing</Filter>
+    </ClCompile>
+    <ClCompile Include="Parsing\XmlNamedSubSectionIterator.cpp">
+      <Filter>Source Files\Parsing</Filter>
+    </ClCompile>
+    <ClCompile Include="Parsing\XmlNamedSubSectionRange.cpp">
+      <Filter>Source Files\Parsing</Filter>
+    </ClCompile>
+    <ClCompile Include="Parsing\XmlSection.cpp">
+      <Filter>Source Files\Parsing</Filter>
+    </ClCompile>
+    <ClCompile Include="Parsing\XmlSubSectionIterator.cpp">
+      <Filter>Source Files\Parsing</Filter>
+    </ClCompile>
+    <ClCompile Include="Parsing\XmlSubSectionRange.cpp">
+      <Filter>Source Files\Parsing</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -340,6 +364,24 @@
     </ClInclude>
     <ClInclude Include="Dictionary.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Parsing\XmlFile.h">
+      <Filter>Header Files\Parsing</Filter>
+    </ClInclude>
+    <ClInclude Include="Parsing\XmlNamedSubSectionIterator.h">
+      <Filter>Header Files\Parsing</Filter>
+    </ClInclude>
+    <ClInclude Include="Parsing\XmlNamedSubSectionRange.h">
+      <Filter>Header Files\Parsing</Filter>
+    </ClInclude>
+    <ClInclude Include="Parsing\XmlSection.h">
+      <Filter>Header Files\Parsing</Filter>
+    </ClInclude>
+    <ClInclude Include="Parsing\XmlSubSectionIterator.h">
+      <Filter>Header Files\Parsing</Filter>
+    </ClInclude>
+    <ClInclude Include="Parsing\XmlSubSectionRange.h">
+      <Filter>Header Files\Parsing</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/NAS2D/Parsing/XmlFile.cpp
+++ b/NAS2D/Parsing/XmlFile.cpp
@@ -1,0 +1,40 @@
+#include "XmlFile.h"
+
+#include "../Xml/XmlElement.h"
+
+#include <stdexcept>
+
+
+using namespace NAS2D;
+
+
+XmlFile::XmlFile(const std::string& fileData)
+{
+	mDocument.parse(fileData.c_str());
+	if (mDocument.error())
+	{
+		const auto positionString = " at (line " + std::to_string(mDocument.errorRow()) + ", column " + std::to_string(mDocument.errorCol()) + ")";
+		throw std::runtime_error(mDocument.errorDesc() + positionString);
+	}
+}
+
+
+XmlSection XmlFile::root() const
+{
+	const auto* rootElement = mDocument.rootElement();
+	if (!rootElement){
+		throw std::runtime_error("No root element found in XML data");
+	}
+	return XmlSection{*rootElement};
+}
+
+
+XmlSection XmlFile::root(const std::string& name) const
+{
+	const auto rootElement = root();
+	if (rootElement.name() != name)
+	{
+		rootElement.throwError("Unexpected XML root tag. Expected: '" + name + "', Found: '" + rootElement.name() + "'");
+	}
+	return rootElement;
+}

--- a/NAS2D/Parsing/XmlFile.cpp
+++ b/NAS2D/Parsing/XmlFile.cpp
@@ -1,11 +1,19 @@
 #include "XmlFile.h"
 
 #include "../Xml/XmlElement.h"
+#include "../Utility.h"
+#include "../Filesystem.h"
 
 #include <stdexcept>
 
 
 using namespace NAS2D;
+
+
+XmlFile XmlFile::Open(const std::string& fileName)
+{
+	return XmlFile{Utility<Filesystem>::get().read(fileName)};
+}
 
 
 XmlFile::XmlFile(const std::string& fileData)

--- a/NAS2D/Parsing/XmlFile.h
+++ b/NAS2D/Parsing/XmlFile.h
@@ -12,6 +12,8 @@ namespace NAS2D
 	class XmlFile
 	{
 	public:
+		static XmlFile Open(const std::string& fileName);
+
 		explicit XmlFile(const std::string& fileData);
 
 		XmlSection root() const;

--- a/NAS2D/Parsing/XmlFile.h
+++ b/NAS2D/Parsing/XmlFile.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "XmlSection.h"
+
+#include "../Xml/XmlDocument.h"
+
+#include <string>
+
+
+namespace NAS2D
+{
+	class XmlFile
+	{
+	public:
+		explicit XmlFile(const std::string& fileData);
+
+		XmlSection root() const;
+		XmlSection root(const std::string& name) const;
+
+	protected:
+		NAS2D::Xml::XmlDocument mDocument;
+	};
+}

--- a/NAS2D/Parsing/XmlNamedSubSectionIterator.cpp
+++ b/NAS2D/Parsing/XmlNamedSubSectionIterator.cpp
@@ -9,8 +9,8 @@
 using namespace NAS2D;
 
 
-XmlNamedSubSectionIterator::XmlNamedSubSectionIterator(const Xml::XmlElement& currentElement, std::string name) :
-	mXmlElement{&currentElement},
+XmlNamedSubSectionIterator::XmlNamedSubSectionIterator(const Xml::XmlElement* currentElement, std::string name) :
+	mXmlElement{currentElement},
 	mName{std::move(name)}
 {
 }

--- a/NAS2D/Parsing/XmlNamedSubSectionIterator.cpp
+++ b/NAS2D/Parsing/XmlNamedSubSectionIterator.cpp
@@ -1,0 +1,35 @@
+#include "XmlNamedSubSectionIterator.h"
+
+#include "XmlSection.h"
+#include "../Xml/XmlElement.h"
+
+#include <utility>
+
+
+using namespace NAS2D;
+
+
+XmlNamedSubSectionIterator::XmlNamedSubSectionIterator(const Xml::XmlElement& currentElement, std::string name) :
+	mXmlElement{&currentElement},
+	mName{std::move(name)}
+{
+}
+
+
+XmlNamedSubSectionIterator& XmlNamedSubSectionIterator::operator++()
+{
+	mXmlElement = mXmlElement->nextSiblingElement(mName);
+	return *this;
+}
+
+
+bool XmlNamedSubSectionIterator::operator!=(std::nullptr_t)
+{
+	return mXmlElement != nullptr;
+}
+
+
+XmlSection XmlNamedSubSectionIterator::operator*() const
+{
+	return XmlSection{*mXmlElement};
+}

--- a/NAS2D/Parsing/XmlNamedSubSectionIterator.cpp
+++ b/NAS2D/Parsing/XmlNamedSubSectionIterator.cpp
@@ -23,9 +23,9 @@ XmlNamedSubSectionIterator& XmlNamedSubSectionIterator::operator++()
 }
 
 
-bool XmlNamedSubSectionIterator::operator!=(std::nullptr_t)
+bool XmlNamedSubSectionIterator::operator!=(const XmlNamedSubSectionIterator& other)
 {
-	return mXmlElement != nullptr;
+	return mXmlElement != other.mXmlElement;
 }
 
 

--- a/NAS2D/Parsing/XmlNamedSubSectionIterator.h
+++ b/NAS2D/Parsing/XmlNamedSubSectionIterator.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iterator>
 #include <string>
 
 
@@ -16,6 +17,12 @@ namespace NAS2D
 	class XmlNamedSubSectionIterator
 	{
 	public:
+		using value_type = XmlSection;
+		using reference = XmlSection&;
+		using pointer = XmlSection*;
+		using difference_type = std::ptrdiff_t;
+		using iterator_category = std::forward_iterator_tag;
+
 		explicit XmlNamedSubSectionIterator(const Xml::XmlElement* currentElement, std::string name);
 
 		XmlNamedSubSectionIterator& operator++();

--- a/NAS2D/Parsing/XmlNamedSubSectionIterator.h
+++ b/NAS2D/Parsing/XmlNamedSubSectionIterator.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <cstddef>
 
 
 namespace NAS2D
@@ -20,7 +19,7 @@ namespace NAS2D
 		explicit XmlNamedSubSectionIterator(const Xml::XmlElement* currentElement, std::string name);
 
 		XmlNamedSubSectionIterator& operator++();
-		bool operator!=(std::nullptr_t);
+		bool operator!=(const XmlNamedSubSectionIterator& other);
 		XmlSection operator*() const;
 
 	protected:

--- a/NAS2D/Parsing/XmlNamedSubSectionIterator.h
+++ b/NAS2D/Parsing/XmlNamedSubSectionIterator.h
@@ -17,7 +17,7 @@ namespace NAS2D
 	class XmlNamedSubSectionIterator
 	{
 	public:
-		explicit XmlNamedSubSectionIterator(const Xml::XmlElement& currentElement, std::string name);
+		explicit XmlNamedSubSectionIterator(const Xml::XmlElement* currentElement, std::string name);
 
 		XmlNamedSubSectionIterator& operator++();
 		bool operator!=(std::nullptr_t);

--- a/NAS2D/Parsing/XmlNamedSubSectionIterator.h
+++ b/NAS2D/Parsing/XmlNamedSubSectionIterator.h
@@ -11,7 +11,6 @@ namespace NAS2D
 		class XmlElement;
 	}
 
-	class XmlSubSectionRange;
 	class XmlSection;
 
 

--- a/NAS2D/Parsing/XmlNamedSubSectionIterator.h
+++ b/NAS2D/Parsing/XmlNamedSubSectionIterator.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+#include <cstddef>
+
+
+namespace NAS2D
+{
+	namespace Xml
+	{
+		class XmlElement;
+	}
+
+	class XmlSubSectionRange;
+	class XmlSection;
+
+
+	class XmlNamedSubSectionIterator
+	{
+	public:
+		explicit XmlNamedSubSectionIterator(const Xml::XmlElement& currentElement, std::string name);
+
+		XmlNamedSubSectionIterator& operator++();
+		bool operator!=(std::nullptr_t);
+		XmlSection operator*() const;
+
+	protected:
+		const Xml::XmlElement* mXmlElement;
+		const std::string mName;
+	};
+}

--- a/NAS2D/Parsing/XmlNamedSubSectionRange.cpp
+++ b/NAS2D/Parsing/XmlNamedSubSectionRange.cpp
@@ -21,7 +21,7 @@ XmlNamedSubSectionIterator XmlNamedSubSectionRange::begin() const
 }
 
 
-std::nullptr_t XmlNamedSubSectionRange::end() const
+XmlNamedSubSectionIterator XmlNamedSubSectionRange::end() const
 {
-	return nullptr;
+	return XmlNamedSubSectionIterator{nullptr, ""};
 }

--- a/NAS2D/Parsing/XmlNamedSubSectionRange.cpp
+++ b/NAS2D/Parsing/XmlNamedSubSectionRange.cpp
@@ -3,6 +3,7 @@
 #include "../Xml/XmlElement.h"
 
 #include <utility>
+#include <iterator>
 
 
 using namespace NAS2D;
@@ -24,4 +25,10 @@ XmlNamedSubSectionIterator XmlNamedSubSectionRange::begin() const
 XmlNamedSubSectionIterator XmlNamedSubSectionRange::end() const
 {
 	return XmlNamedSubSectionIterator{nullptr, ""};
+}
+
+
+XmlNamedSubSectionIterator::difference_type XmlNamedSubSectionRange::size() const
+{
+	return std::distance(begin(), end());
 }

--- a/NAS2D/Parsing/XmlNamedSubSectionRange.cpp
+++ b/NAS2D/Parsing/XmlNamedSubSectionRange.cpp
@@ -1,0 +1,28 @@
+#include "XmlNamedSubSectionRange.h"
+
+#include "XmlNamedSubSectionIterator.h"
+#include "../Xml/XmlElement.h"
+
+#include <utility>
+
+
+using namespace NAS2D;
+
+
+XmlNamedSubSectionRange::XmlNamedSubSectionRange(const Xml::XmlElement& parentElement, std::string name) :
+	mParentElement{parentElement},
+	mName{std::move(name)}
+{
+}
+
+
+XmlNamedSubSectionIterator XmlNamedSubSectionRange::begin() const
+{
+	return XmlNamedSubSectionIterator{*mParentElement.firstChildElement(mName), mName};
+}
+
+
+std::nullptr_t XmlNamedSubSectionRange::end() const
+{
+	return nullptr;
+}

--- a/NAS2D/Parsing/XmlNamedSubSectionRange.cpp
+++ b/NAS2D/Parsing/XmlNamedSubSectionRange.cpp
@@ -1,6 +1,5 @@
 #include "XmlNamedSubSectionRange.h"
 
-#include "XmlNamedSubSectionIterator.h"
 #include "../Xml/XmlElement.h"
 
 #include <utility>

--- a/NAS2D/Parsing/XmlNamedSubSectionRange.cpp
+++ b/NAS2D/Parsing/XmlNamedSubSectionRange.cpp
@@ -17,7 +17,7 @@ XmlNamedSubSectionRange::XmlNamedSubSectionRange(const Xml::XmlElement& parentEl
 
 XmlNamedSubSectionIterator XmlNamedSubSectionRange::begin() const
 {
-	return XmlNamedSubSectionIterator{*mParentElement.firstChildElement(mName), mName};
+	return XmlNamedSubSectionIterator{mParentElement.firstChildElement(mName), mName};
 }
 
 

--- a/NAS2D/Parsing/XmlNamedSubSectionRange.h
+++ b/NAS2D/Parsing/XmlNamedSubSectionRange.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+#include <cstddef>
+
+
+namespace NAS2D
+{
+	namespace Xml
+	{
+		class XmlElement;
+	}
+
+	class XmlSection;
+	class XmlNamedSubSectionIterator;
+
+
+	class XmlNamedSubSectionRange
+	{
+	public:
+		explicit XmlNamedSubSectionRange(const Xml::XmlElement& parentElement, std::string name);
+
+		XmlNamedSubSectionIterator begin() const;
+		std::nullptr_t end() const;
+
+	protected:
+		const Xml::XmlElement& mParentElement;
+		std::string mName;
+	};
+}

--- a/NAS2D/Parsing/XmlNamedSubSectionRange.h
+++ b/NAS2D/Parsing/XmlNamedSubSectionRange.h
@@ -3,7 +3,6 @@
 #include "XmlNamedSubSectionIterator.h"
 
 #include <string>
-#include <cstddef>
 
 
 namespace NAS2D
@@ -20,7 +19,7 @@ namespace NAS2D
 		explicit XmlNamedSubSectionRange(const Xml::XmlElement& parentElement, std::string name);
 
 		XmlNamedSubSectionIterator begin() const;
-		std::nullptr_t end() const;
+		XmlNamedSubSectionIterator end() const;
 
 	protected:
 		const Xml::XmlElement& mParentElement;

--- a/NAS2D/Parsing/XmlNamedSubSectionRange.h
+++ b/NAS2D/Parsing/XmlNamedSubSectionRange.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "XmlNamedSubSectionIterator.h"
+
 #include <string>
 #include <cstddef>
 
@@ -10,8 +12,6 @@ namespace NAS2D
 	{
 		class XmlElement;
 	}
-
-	class XmlNamedSubSectionIterator;
 
 
 	class XmlNamedSubSectionRange

--- a/NAS2D/Parsing/XmlNamedSubSectionRange.h
+++ b/NAS2D/Parsing/XmlNamedSubSectionRange.h
@@ -11,7 +11,6 @@ namespace NAS2D
 		class XmlElement;
 	}
 
-	class XmlSection;
 	class XmlNamedSubSectionIterator;
 
 

--- a/NAS2D/Parsing/XmlNamedSubSectionRange.h
+++ b/NAS2D/Parsing/XmlNamedSubSectionRange.h
@@ -21,6 +21,8 @@ namespace NAS2D
 		XmlNamedSubSectionIterator begin() const;
 		XmlNamedSubSectionIterator end() const;
 
+		XmlNamedSubSectionIterator::difference_type size() const;
+
 	protected:
 		const Xml::XmlElement& mParentElement;
 		std::string mName;

--- a/NAS2D/Parsing/XmlSection.cpp
+++ b/NAS2D/Parsing/XmlSection.cpp
@@ -1,9 +1,13 @@
 #include "XmlSection.h"
 
+#include "XmlSubSectionRange.h"
+#include "XmlNamedSubSectionRange.h"
+
 #include "../Xml/XmlElement.h"
 #include "../ContainerUtils.h"
 
 #include <stdexcept>
+#include <utility>
 
 
 using namespace NAS2D;
@@ -107,6 +111,18 @@ XmlSection XmlSection::subSection(const std::string& name) const
 		throwError("Required sub-section name not found: " + name);
 	}
 	return XmlSection{*subElement};
+}
+
+
+XmlSubSectionRange XmlSection::subSections() const
+{
+	return XmlSubSectionRange{mXmlElement};
+}
+
+
+XmlNamedSubSectionRange XmlSection::subSections(std::string name) const
+{
+	return XmlNamedSubSectionRange{mXmlElement, std::move(name)};
 }
 
 

--- a/NAS2D/Parsing/XmlSection.cpp
+++ b/NAS2D/Parsing/XmlSection.cpp
@@ -1,0 +1,116 @@
+#include "XmlSection.h"
+
+#include "../Xml/XmlElement.h"
+#include "../ContainerUtils.h"
+
+#include <stdexcept>
+
+
+using namespace NAS2D;
+
+
+namespace
+{
+	void throwErrorMissingUnexpected(const XmlSection& xmlSection, const std::string& context, const std::vector<std::string>& missing, const std::vector<std::string>& unexpected)
+	{
+		const auto missingString = !missing.empty() ? "Missing names: {" + join(missing, ", ") + "}" : "";
+		const auto unexpectedString = !unexpected.empty() ? "Unexpected names: {" + join(unexpected, ", ") + "}" : "";
+		const auto joinString = (!missingString.empty() && !unexpectedString.empty()) ? "\n" : "";
+		xmlSection.throwError(context + missingString + joinString + unexpectedString);
+	}
+
+
+	void verifyNames(const XmlSection& xmlSection, const std::string& context, const std::vector<std::string>& names, const std::vector<std::string>&required, const std::vector<std::string>& optional)
+	{
+		const auto missing = missingValues(names, required);
+		const auto unexpected = unexpectedValues(names, required, optional);
+		if (!missing.empty() || !unexpected.empty())
+		{
+			throwErrorMissingUnexpected(xmlSection, "Failed to validate " + context, missing, unexpected);
+		}
+	}
+}
+
+
+XmlSection::XmlSection(const NAS2D::Xml::XmlElement& xmlElement) :
+	mXmlElement{xmlElement}
+{
+}
+
+
+const std::string& XmlSection::name() const
+{
+	return mXmlElement.value();
+}
+
+
+void XmlSection::throwError(const std::string& errorMessage) const
+{
+	const auto positionString = " at (line " + std::to_string(mXmlElement.row()) + ", column " + std::to_string(mXmlElement.column()) + ")";
+	throw std::runtime_error(errorMessage + positionString);
+}
+
+
+void XmlSection::verifySubSections(const std::vector<std::string>& required, const std::vector<std::string>& optional) const
+{
+	verifyNames(*this, "Sub-sections", subSectionNames(), required, optional);
+}
+
+
+void XmlSection::verifyKeys(const std::vector<std::string>& required, const std::vector<std::string>& optional) const
+{
+	verifyNames(*this, "Keys", keys(), required, optional);
+}
+
+
+std::vector<std::string> XmlSection::subSectionNames() const
+{
+	std::vector<std::string> results;
+	for (const auto* subElement = mXmlElement.firstChildElement(); subElement; subElement = subElement->nextSiblingElement())
+	{
+		results.push_back(subElement->value());
+	}
+	return results;
+}
+
+
+std::vector<std::string> XmlSection::keys() const
+{
+	std::vector<std::string> results;
+	for (const auto* attribute = mXmlElement.firstAttribute(); attribute; attribute = attribute->next())
+	{
+		results.push_back(attribute->name());
+	}
+	return results;
+}
+
+
+bool XmlSection::hasSubSection(const std::string& name) const
+{
+	const auto names = subSectionNames();
+	return std::find(names.begin(), names.end(), name) != names.end();
+}
+
+
+bool XmlSection::hasKey(const std::string& key) const
+{
+	const auto names = keys();
+	return std::find(names.begin(), names.end(), key) != names.end();
+}
+
+
+XmlSection XmlSection::subSection(const std::string& name) const
+{
+	const auto* subElement = mXmlElement.firstChildElement(name);
+	if (!subElement)
+	{
+		throwError("Required sub-section name not found: " + name);
+	}
+	return XmlSection{*subElement};
+}
+
+
+NAS2D::StringValue XmlSection::valueOrEmpty(const std::string& key) const
+{
+	return NAS2D::StringValue{mXmlElement.attribute(key)};
+}

--- a/NAS2D/Parsing/XmlSection.cpp
+++ b/NAS2D/Parsing/XmlSection.cpp
@@ -1,8 +1,5 @@
 #include "XmlSection.h"
 
-#include "XmlSubSectionRange.h"
-#include "XmlNamedSubSectionRange.h"
-
 #include "../Xml/XmlElement.h"
 #include "../ContainerUtils.h"
 

--- a/NAS2D/Parsing/XmlSection.cpp
+++ b/NAS2D/Parsing/XmlSection.cpp
@@ -92,6 +92,11 @@ std::vector<std::string> XmlSection::keys() const
 			results.push_back(subElement->value());
 		}
 	}
+	// Add current element name as key if there is a value
+	if (!mXmlElement.getText().empty())
+	{
+		results.push_back(mXmlElement.value());
+	}
 	return results;
 }
 
@@ -142,6 +147,10 @@ NAS2D::StringValue XmlSection::valueOrEmpty(const std::string& key) const
 		if (subElement)
 		{
 			value = subElement->getText();
+		}
+		else if (key == mXmlElement.value())
+		{
+			value = mXmlElement.getText();
 		}
 	}
 	return NAS2D::StringValue{value};

--- a/NAS2D/Parsing/XmlSection.cpp
+++ b/NAS2D/Parsing/XmlSection.cpp
@@ -82,6 +82,16 @@ std::vector<std::string> XmlSection::keys() const
 	{
 		results.push_back(attribute->name());
 	}
+	// Add in attribute like sub elements that contain only values
+	for (const auto* subElement = mXmlElement.firstChildElement(); subElement; subElement = subElement->nextSiblingElement())
+	{
+		// Ignore anything with attributes or sub-elements of their own
+		// Such elements would be object like, rather than attribute like
+		if (subElement->firstAttribute() == nullptr && subElement->firstChildElement() == nullptr)
+		{
+			results.push_back(subElement->value());
+		}
+	}
 	return results;
 }
 
@@ -125,5 +135,14 @@ XmlNamedSubSectionRange XmlSection::subSections(std::string name) const
 
 NAS2D::StringValue XmlSection::valueOrEmpty(const std::string& key) const
 {
-	return NAS2D::StringValue{mXmlElement.attribute(key)};
+	auto value = mXmlElement.attribute(key);
+	if (value.empty())
+	{
+		const auto subElement = mXmlElement.firstChildElement(key);
+		if (subElement)
+		{
+			value = subElement->getText();
+		}
+	}
+	return NAS2D::StringValue{value};
 }

--- a/NAS2D/Parsing/XmlSection.h
+++ b/NAS2D/Parsing/XmlSection.h
@@ -13,7 +13,6 @@ namespace NAS2D
 		class XmlElement;
 	}
 
-	class XmlFile;
 	class XmlSubSectionRange;
 	class XmlNamedSubSectionRange;
 

--- a/NAS2D/Parsing/XmlSection.h
+++ b/NAS2D/Parsing/XmlSection.h
@@ -14,6 +14,8 @@ namespace NAS2D
 	}
 
 	class XmlFile;
+	class XmlSubSectionRange;
+	class XmlNamedSubSectionRange;
 
 
 	class XmlSection
@@ -34,6 +36,9 @@ namespace NAS2D
 		bool hasKey(const std::string& key) const;
 
 		XmlSection subSection(const std::string& name) const;
+		XmlSubSectionRange subSections() const;
+		XmlNamedSubSectionRange subSections(std::string name) const;
+
 		NAS2D::StringValue valueOrEmpty(const std::string& key) const;
 
 		template <typename T = std::string>

--- a/NAS2D/Parsing/XmlSection.h
+++ b/NAS2D/Parsing/XmlSection.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "XmlSubSectionRange.h"
+#include "XmlNamedSubSectionRange.h"
+
 #include "../StringValue.h"
 
 #include <string>
@@ -12,9 +15,6 @@ namespace NAS2D
 	{
 		class XmlElement;
 	}
-
-	class XmlSubSectionRange;
-	class XmlNamedSubSectionRange;
 
 
 	class XmlSection

--- a/NAS2D/Parsing/XmlSection.h
+++ b/NAS2D/Parsing/XmlSection.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "../StringValue.h"
+
+#include <string>
+#include <vector>
+
+
+namespace NAS2D
+{
+	namespace Xml
+	{
+		class XmlElement;
+	}
+
+	class XmlFile;
+
+
+	class XmlSection
+	{
+	public:
+		explicit XmlSection(const NAS2D::Xml::XmlElement& xmlElement);
+
+		const std::string& name() const;
+
+		void throwError(const std::string& errorMessage) const;
+		void verifySubSections(const std::vector<std::string>& required, const std::vector<std::string>& optional = {}) const;
+		void verifyKeys(const std::vector<std::string>& required, const std::vector<std::string>& optional = {}) const;
+
+		std::vector<std::string> subSectionNames() const;
+		std::vector<std::string> keys() const;
+
+		bool hasSubSection(const std::string& name) const;
+		bool hasKey(const std::string& key) const;
+
+		XmlSection subSection(const std::string& name) const;
+		NAS2D::StringValue valueOrEmpty(const std::string& key) const;
+
+		template <typename T = std::string>
+		T value(const std::string& key) const
+		{
+			if (!hasKey(key))
+			{
+				throwError("Required key name not found: " + key);
+			}
+			return valueOrEmpty(key).to<T>();
+		}
+
+		template <typename T = std::string>
+		T value(const std::string& key, T defaultValue) const
+		{
+			return hasKey(key) ? valueOrEmpty(key).to<T>() : defaultValue;
+		}
+
+	protected:
+		const NAS2D::Xml::XmlElement& mXmlElement;
+	};
+}

--- a/NAS2D/Parsing/XmlSubSectionIterator.cpp
+++ b/NAS2D/Parsing/XmlSubSectionIterator.cpp
@@ -7,8 +7,8 @@
 using namespace NAS2D;
 
 
-XmlSubSectionIterator::XmlSubSectionIterator(const Xml::XmlElement& currentElement) :
-	mXmlElement{&currentElement}
+XmlSubSectionIterator::XmlSubSectionIterator(const Xml::XmlElement* currentElement) :
+	mXmlElement{currentElement}
 {
 }
 

--- a/NAS2D/Parsing/XmlSubSectionIterator.cpp
+++ b/NAS2D/Parsing/XmlSubSectionIterator.cpp
@@ -1,0 +1,32 @@
+#include "XmlSubSectionIterator.h"
+
+#include "XmlSection.h"
+#include "../Xml/XmlElement.h"
+
+
+using namespace NAS2D;
+
+
+XmlSubSectionIterator::XmlSubSectionIterator(const Xml::XmlElement& currentElement) :
+	mXmlElement{&currentElement}
+{
+}
+
+
+XmlSubSectionIterator& XmlSubSectionIterator::operator++()
+{
+	mXmlElement = mXmlElement->nextSiblingElement();
+	return *this;
+}
+
+
+bool XmlSubSectionIterator::operator!=(std::nullptr_t)
+{
+	return mXmlElement != nullptr;
+}
+
+
+XmlSection XmlSubSectionIterator::operator*() const
+{
+	return XmlSection{*mXmlElement};
+}

--- a/NAS2D/Parsing/XmlSubSectionIterator.cpp
+++ b/NAS2D/Parsing/XmlSubSectionIterator.cpp
@@ -20,9 +20,9 @@ XmlSubSectionIterator& XmlSubSectionIterator::operator++()
 }
 
 
-bool XmlSubSectionIterator::operator!=(std::nullptr_t)
+bool XmlSubSectionIterator::operator!=(const XmlSubSectionIterator& other)
 {
-	return mXmlElement != nullptr;
+	return mXmlElement != other.mXmlElement;
 }
 
 

--- a/NAS2D/Parsing/XmlSubSectionIterator.h
+++ b/NAS2D/Parsing/XmlSubSectionIterator.h
@@ -16,7 +16,7 @@ namespace NAS2D
 	class XmlSubSectionIterator
 	{
 	public:
-		explicit XmlSubSectionIterator(const Xml::XmlElement& currentElement);
+		explicit XmlSubSectionIterator(const Xml::XmlElement* currentElement);
 
 		XmlSubSectionIterator& operator++();
 		bool operator!=(std::nullptr_t);

--- a/NAS2D/Parsing/XmlSubSectionIterator.h
+++ b/NAS2D/Parsing/XmlSubSectionIterator.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <cstddef>
-
 
 namespace NAS2D
 {
@@ -19,7 +17,7 @@ namespace NAS2D
 		explicit XmlSubSectionIterator(const Xml::XmlElement* currentElement);
 
 		XmlSubSectionIterator& operator++();
-		bool operator!=(std::nullptr_t);
+		bool operator!=(const XmlSubSectionIterator& other);
 		XmlSection operator*() const;
 
 	protected:

--- a/NAS2D/Parsing/XmlSubSectionIterator.h
+++ b/NAS2D/Parsing/XmlSubSectionIterator.h
@@ -10,7 +10,6 @@ namespace NAS2D
 		class XmlElement;
 	}
 
-	class XmlSubSectionRange;
 	class XmlSection;
 
 

--- a/NAS2D/Parsing/XmlSubSectionIterator.h
+++ b/NAS2D/Parsing/XmlSubSectionIterator.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstddef>
+
+
+namespace NAS2D
+{
+	namespace Xml
+	{
+		class XmlElement;
+	}
+
+	class XmlSubSectionRange;
+	class XmlSection;
+
+
+	class XmlSubSectionIterator
+	{
+	public:
+		explicit XmlSubSectionIterator(const Xml::XmlElement& currentElement);
+
+		XmlSubSectionIterator& operator++();
+		bool operator!=(std::nullptr_t);
+		XmlSection operator*() const;
+
+	protected:
+		const Xml::XmlElement* mXmlElement;
+	};
+}

--- a/NAS2D/Parsing/XmlSubSectionIterator.h
+++ b/NAS2D/Parsing/XmlSubSectionIterator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <iterator>
+
 
 namespace NAS2D
 {
@@ -14,6 +16,12 @@ namespace NAS2D
 	class XmlSubSectionIterator
 	{
 	public:
+		using value_type = XmlSection;
+		using reference = XmlSection&;
+		using pointer = XmlSection*;
+		using difference_type = std::ptrdiff_t;
+		using iterator_category = std::forward_iterator_tag;
+
 		explicit XmlSubSectionIterator(const Xml::XmlElement* currentElement);
 
 		XmlSubSectionIterator& operator++();

--- a/NAS2D/Parsing/XmlSubSectionRange.cpp
+++ b/NAS2D/Parsing/XmlSubSectionRange.cpp
@@ -1,0 +1,25 @@
+#include "XmlSubSectionRange.h"
+
+#include "XmlSubSectionIterator.h"
+#include "../Xml/XmlElement.h"
+
+
+using namespace NAS2D;
+
+
+XmlSubSectionRange::XmlSubSectionRange(const Xml::XmlElement& parentElement) :
+	mParentElement{parentElement}
+{
+}
+
+
+XmlSubSectionIterator XmlSubSectionRange::begin() const
+{
+	return XmlSubSectionIterator{*mParentElement.firstChildElement()};
+}
+
+
+std::nullptr_t XmlSubSectionRange::end() const
+{
+	return nullptr;
+}

--- a/NAS2D/Parsing/XmlSubSectionRange.cpp
+++ b/NAS2D/Parsing/XmlSubSectionRange.cpp
@@ -2,6 +2,8 @@
 
 #include "../Xml/XmlElement.h"
 
+#include <iterator>
+
 
 using namespace NAS2D;
 
@@ -21,4 +23,10 @@ XmlSubSectionIterator XmlSubSectionRange::begin() const
 XmlSubSectionIterator XmlSubSectionRange::end() const
 {
 	return XmlSubSectionIterator{nullptr};
+}
+
+
+XmlSubSectionIterator::difference_type XmlSubSectionRange::size() const
+{
+	return std::distance(begin(), end());
 }

--- a/NAS2D/Parsing/XmlSubSectionRange.cpp
+++ b/NAS2D/Parsing/XmlSubSectionRange.cpp
@@ -18,7 +18,7 @@ XmlSubSectionIterator XmlSubSectionRange::begin() const
 }
 
 
-std::nullptr_t XmlSubSectionRange::end() const
+XmlSubSectionIterator XmlSubSectionRange::end() const
 {
-	return nullptr;
+	return XmlSubSectionIterator{nullptr};
 }

--- a/NAS2D/Parsing/XmlSubSectionRange.cpp
+++ b/NAS2D/Parsing/XmlSubSectionRange.cpp
@@ -1,6 +1,5 @@
 #include "XmlSubSectionRange.h"
 
-#include "XmlSubSectionIterator.h"
 #include "../Xml/XmlElement.h"
 
 

--- a/NAS2D/Parsing/XmlSubSectionRange.cpp
+++ b/NAS2D/Parsing/XmlSubSectionRange.cpp
@@ -14,7 +14,7 @@ XmlSubSectionRange::XmlSubSectionRange(const Xml::XmlElement& parentElement) :
 
 XmlSubSectionIterator XmlSubSectionRange::begin() const
 {
-	return XmlSubSectionIterator{*mParentElement.firstChildElement()};
+	return XmlSubSectionIterator{mParentElement.firstChildElement()};
 }
 
 

--- a/NAS2D/Parsing/XmlSubSectionRange.h
+++ b/NAS2D/Parsing/XmlSubSectionRange.h
@@ -10,7 +10,6 @@ namespace NAS2D
 		class XmlElement;
 	}
 
-	class XmlSection;
 	class XmlSubSectionIterator;
 
 

--- a/NAS2D/Parsing/XmlSubSectionRange.h
+++ b/NAS2D/Parsing/XmlSubSectionRange.h
@@ -19,6 +19,8 @@ namespace NAS2D
 		XmlSubSectionIterator begin() const;
 		XmlSubSectionIterator end() const;
 
+		XmlSubSectionIterator::difference_type size() const;
+
 	protected:
 		const Xml::XmlElement& mParentElement;
 	};

--- a/NAS2D/Parsing/XmlSubSectionRange.h
+++ b/NAS2D/Parsing/XmlSubSectionRange.h
@@ -2,8 +2,6 @@
 
 #include "XmlSubSectionIterator.h"
 
-#include <cstddef>
-
 
 namespace NAS2D
 {
@@ -19,7 +17,7 @@ namespace NAS2D
 		explicit XmlSubSectionRange(const Xml::XmlElement& parentElement);
 
 		XmlSubSectionIterator begin() const;
-		std::nullptr_t end() const;
+		XmlSubSectionIterator end() const;
 
 	protected:
 		const Xml::XmlElement& mParentElement;

--- a/NAS2D/Parsing/XmlSubSectionRange.h
+++ b/NAS2D/Parsing/XmlSubSectionRange.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstddef>
+
+
+namespace NAS2D
+{
+	namespace Xml
+	{
+		class XmlElement;
+	}
+
+	class XmlSection;
+	class XmlSubSectionIterator;
+
+
+	class XmlSubSectionRange
+	{
+	public:
+		explicit XmlSubSectionRange(const Xml::XmlElement& parentElement);
+
+		XmlSubSectionIterator begin() const;
+		std::nullptr_t end() const;
+
+	protected:
+		const Xml::XmlElement& mParentElement;
+	};
+}

--- a/NAS2D/Parsing/XmlSubSectionRange.h
+++ b/NAS2D/Parsing/XmlSubSectionRange.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "XmlSubSectionIterator.h"
+
 #include <cstddef>
 
 
@@ -9,8 +11,6 @@ namespace NAS2D
 	{
 		class XmlElement;
 	}
-
-	class XmlSubSectionIterator;
 
 
 	class XmlSubSectionRange

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -19,6 +19,9 @@
 #include "../ParserHelper.h"
 #include "../Version.h"
 #include "../Xml/Xml.h"
+#include "../Parsing/XmlFile.h"
+#include "../Parsing/XmlNamedSubSectionRange.h"
+#include "../Parsing/XmlNamedSubSectionIterator.h"
 
 #include <tuple>
 
@@ -33,21 +36,14 @@ namespace
 	using ImageCache = ResourceCache<Image, std::string>;
 	ImageCache animationImageCache;
 
-
-	// Adds a row tag to the end of messages.
-	std::string endTag(int row)
-	{
-		return " (Row: " + std::to_string(row) + ")";
-	}
-
 	using ImageSheetMap = AnimationSet::ImageSheetMap;
 	using ActionsMap = AnimationSet::ActionsMap;
 
 
 	std::tuple<ImageSheetMap, ActionsMap> processXml(const std::string& filePath, ImageCache& imageCache);
-	ImageSheetMap processImageSheets(const std::string& basePath, const Xml::XmlElement* element, ImageCache& imageCache);
-	ActionsMap processActions(const ImageSheetMap& imageSheetMap, const Xml::XmlElement* element, ImageCache& imageCache);
-	std::vector<AnimationSet::Frame> processFrames(const ImageSheetMap& imageSheetMap, const Xml::XmlElement* element, ImageCache& imageCache);
+	ImageSheetMap processImageSheets(const std::string& basePath, const XmlSection& spriteSection, ImageCache& imageCache);
+	ActionsMap processActions(const ImageSheetMap& imageSheetMap, const XmlSection& spriteSection, ImageCache& imageCache);
+	std::vector<AnimationSet::Frame> processFrames(const ImageSheetMap& imageSheetMap, const XmlSection& actionSection, ImageCache& imageCache);
 }
 
 
@@ -116,23 +112,10 @@ namespace
 			auto& filesystem = Utility<Filesystem>::get();
 			const auto basePath = filesystem.parentPath(filePath);
 
-			Xml::XmlDocument xmlDoc;
-			xmlDoc.parse(filesystem.read(filePath).c_str());
+			const auto xmlFile = XmlFile{filesystem.read(filePath)};
+			const auto spriteSection = xmlFile.root("sprite");
 
-			if (xmlDoc.error())
-			{
-				throw std::runtime_error("Sprite file has malformed XML: Row: " + std::to_string(xmlDoc.errorRow()) + " Column: " + std::to_string(xmlDoc.errorCol()) + " : " + xmlDoc.errorDesc());
-			}
-
-			// Find the Sprite node.
-			const auto* xmlRootElement = xmlDoc.firstChildElement("sprite");
-			if (!xmlRootElement)
-			{
-				throw std::runtime_error("Sprite file does not contain required <sprite> tag");
-			}
-
-			// Get the Sprite version.
-			const auto version = xmlRootElement->attribute("version");
+			const auto version = spriteSection.value("version", std::string{""});
 			if (version.empty())
 			{
 				throw std::runtime_error("Sprite file's root element does not specify a version");
@@ -146,8 +129,8 @@ namespace
 			// Here instead of going through each element and calling a processing function to handle
 			// it, we just iterate through all nodes to find sprite sheets. This allows us to define
 			// image sheets anywhere in the sprite file.
-			auto imageSheetMap = processImageSheets(basePath, xmlRootElement, imageCache);
-			auto actions = processActions(imageSheetMap, xmlRootElement, imageCache);
+			auto imageSheetMap = processImageSheets(basePath, spriteSection, imageCache);
+			auto actions = processActions(imageSheetMap, spriteSection, imageCache);
 			return std::tuple{std::move(imageSheetMap), std::move(actions)};
 		}
 		catch(const std::runtime_error& error)
@@ -165,29 +148,28 @@ namespace
 	 *			element in a sprite definition, these elements can appear
 	 *			anywhere in a Sprite XML definition.
 	 */
-	ImageSheetMap processImageSheets(const std::string& basePath, const Xml::XmlElement* element, ImageCache& imageCache)
+	ImageSheetMap processImageSheets(const std::string& basePath, const XmlSection& spriteSection, ImageCache& imageCache)
 	{
 		ImageSheetMap imageSheetMap;
 
-		for (const auto* node = element->firstChildElement("imagesheet"); node; node = node->nextSiblingElement("imagesheet"))
+		for (const auto& section : spriteSection.subSections("imagesheet"))
 		{
-			const auto dictionary = attributesToDictionary(*node);
-			const auto id = dictionary.get("id");
-			const auto src = dictionary.get("src");
+			const auto id = section.value("id");
+			const auto src = section.value("src");
 
 			if (id.empty())
 			{
-				throw std::runtime_error("Sprite imagesheet definition has `id` of length zero: " + endTag(node->row()));
+				section.throwError("Sprite imagesheet definition has `id` of length zero");
 			}
 
 			if (src.empty())
 			{
-				throw std::runtime_error("Sprite imagesheet definition has `src` of length zero: " + endTag(node->row()));
+				section.throwError("Sprite imagesheet definition has `src` of length zero");
 			}
 
 			if (imageSheetMap.find(id) != imageSheetMap.end())
 			{
-				throw std::runtime_error("Sprite image sheet redefinition: id: '" + id + "' " + endTag(node->row()));
+				section.throwError("Sprite image sheet redefinition: id: '" + id + "'");
 			}
 
 			const auto imagePath = basePath + src;
@@ -203,29 +185,28 @@ namespace
 	 * Iterates through all elements of a Sprite XML definition looking
 	 * for 'action' elements and processes them.
 	 */
-	ActionsMap processActions(const ImageSheetMap& imageSheetMap, const Xml::XmlElement* element, ImageCache& imageCache)
+	ActionsMap processActions(const ImageSheetMap& imageSheetMap, const XmlSection& spriteSection, ImageCache& imageCache)
 	{
 		ActionsMap actions;
 
-		for (const auto* action = element->firstChildElement("action"); action; action = action->nextSiblingElement("action"))
+		for (const auto& section : spriteSection.subSections("action"))
 		{
-			const auto dictionary = attributesToDictionary(*action);
-			const auto actionName = dictionary.get("name");
+			const auto actionName = section.value("name");
 
 			if (actionName.empty())
 			{
-				throw std::runtime_error("Sprite Action definition has 'name' of length zero: " + endTag(action->row()));
+				section.throwError("Sprite Action definition has 'name' of length zero");
 			}
 			if (actions.find(actionName) != actions.end())
 			{
-				throw std::runtime_error("Sprite Action redefinition: '" + actionName + "' " + endTag(action->row()));
+				section.throwError("Sprite Action redefinition: '" + actionName + "'");
 			}
 
-			actions[actionName] = processFrames(imageSheetMap, action, imageCache);
+			actions[actionName] = processFrames(imageSheetMap, section, imageCache);
 
 			if (actions[actionName].empty())
 			{
-				throw std::runtime_error("Sprite Action contains no valid frames: " + actionName);
+				section.throwError("Sprite Action contains no valid frames: " + actionName);
 			}
 		}
 
@@ -236,56 +217,53 @@ namespace
 	/**
 	 * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
 	 */
-	std::vector<AnimationSet::Frame> processFrames(const ImageSheetMap& imageSheetMap, const Xml::XmlElement* element, ImageCache& imageCache)
+	std::vector<AnimationSet::Frame> processFrames(const ImageSheetMap& imageSheetMap, const XmlSection& actionSection, ImageCache& imageCache)
 	{
 		std::vector<AnimationSet::Frame> frameList;
 
-		for (const auto* frame = element->firstChildElement("frame"); frame; frame = frame->nextSiblingElement("frame"))
+		for (const auto& section : actionSection.subSections("frame"))
 		{
-			int currentRow = frame->row();
+			section.verifyKeys({"sheetid", "x", "y", "width", "height", "anchorx", "anchory"}, {"delay"});
 
-			const auto dictionary = attributesToDictionary(*frame);
-			reportMissingOrUnexpected(dictionary.keys(), {"sheetid", "x", "y", "width", "height", "anchorx", "anchory"}, {"delay"});
-
-			const auto sheetId = dictionary.get("sheetid");
-			const auto delay = dictionary.get<unsigned int>("delay", 0);
-			const auto x = dictionary.get<int>("x");
-			const auto y = dictionary.get<int>("y");
-			const auto width = dictionary.get<int>("width");
-			const auto height = dictionary.get<int>("height");
-			const auto anchorx = dictionary.get<int>("anchorx");
-			const auto anchory = dictionary.get<int>("anchory");
+			const auto sheetId = section.value("sheetid");
+			const auto delay = section.value<unsigned int>("delay", 0);
+			const auto x = section.value<int>("x");
+			const auto y = section.value<int>("y");
+			const auto width = section.value<int>("width");
+			const auto height = section.value<int>("height");
+			const auto anchorx = section.value<int>("anchorx");
+			const auto anchory = section.value<int>("anchory");
 
 			if (sheetId.empty())
 			{
-				throw std::runtime_error("Sprite Frame definition has 'sheetid' of length zero: " + endTag(currentRow));
+				section.throwError("Sprite Frame definition has 'sheetid' of length zero");
 			}
 			const auto iterator = imageSheetMap.find(sheetId);
 			if (iterator == imageSheetMap.end())
 			{
-				throw std::runtime_error("Sprite Frame definition references undefined imagesheet: '" + sheetId + "' " + endTag(currentRow));
+				section.throwError("Sprite Frame definition references undefined imagesheet: '" + sheetId + "'");
 			}
 
 			const auto& image = imageCache.load(iterator->second);
 			// X-Coordinate
 			if (x < 0 || x > image.size().x)
 			{
-				throw std::runtime_error("Sprite frame attribute 'x' is out of bounds: " + endTag(currentRow));
+				section.throwError("Sprite frame attribute 'x' is out of bounds");
 			}
 			// Y-Coordinate
 			if (y < 0 || y > image.size().y)
 			{
-				throw std::runtime_error("Sprite frame attribute 'y' is out of bounds: " + endTag(currentRow));
+				section.throwError("Sprite frame attribute 'y' is out of bounds");
 			}
 			// Width
 			if (width <= 0 || width > image.size().x - x)
 			{
-				throw std::runtime_error("Sprite frame attribute 'width' is out of bounds: " + endTag(currentRow));
+				section.throwError("Sprite frame attribute 'width' is out of bounds");
 			}
 			// Height
 			if (height <= 0 || height > image.size().y - y)
 			{
-				throw std::runtime_error("Sprite frame attribute 'height' is out of bounds: " + endTag(currentRow));
+				section.throwError("Sprite frame attribute 'height' is out of bounds");
 			}
 
 			const auto bounds = Rectangle<int>::Create(Point<int>{x, y}, Vector{width, height});

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -20,8 +20,6 @@
 #include "../Version.h"
 #include "../Xml/Xml.h"
 #include "../Parsing/XmlFile.h"
-#include "../Parsing/XmlNamedSubSectionRange.h"
-#include "../Parsing/XmlNamedSubSectionIterator.h"
 
 #include <tuple>
 

--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -292,7 +292,7 @@ namespace
 
 			// Avoid glyph 0, which has size 0 for some fonts
 			// SDL_TTF will produce errors for a glyph of size 0
-			if (glyph == 0) { continue; }
+			if (glyph == 0 || glyph == 173) { continue; }
 
 			SDL_Surface* characterSurface = TTF_RenderGlyph_Blended(font, static_cast<uint16_t>(glyph), white);
 			if (!characterSurface)

--- a/test/Parsing/XmlSection.test.cpp
+++ b/test/Parsing/XmlSection.test.cpp
@@ -40,10 +40,10 @@ TEST_F(XmlSection, verifySubSections) {
 }
 
 TEST_F(XmlSection, verifyKeys) {
-	EXPECT_NO_THROW(root.verifyKeys({"attributeName"}));
-	EXPECT_NO_THROW(root.verifyKeys({"attributeName"}, {"optionalNotFound"}));
-	EXPECT_NO_THROW(root.verifyKeys({}, {"attributeName"}));
-	EXPECT_NO_THROW(root.verifyKeys({}, {"attributeName", "optionalNotFound"}));
+	EXPECT_NO_THROW(root.verifyKeys({"attributeName", "subElementValue"}));
+	EXPECT_NO_THROW(root.verifyKeys({"attributeName", "subElementValue"}, {"optionalNotFound"}));
+	EXPECT_NO_THROW(root.verifyKeys({}, {"attributeName", "subElementValue"}));
+	EXPECT_NO_THROW(root.verifyKeys({}, {"attributeName", "subElementValue", "optionalNotFound"}));
 
 	EXPECT_THROW(root.verifyKeys({"attributeNotFound"}), std::runtime_error);
 	EXPECT_THROW(root.verifyKeys({}), std::runtime_error);
@@ -55,7 +55,7 @@ TEST_F(XmlSection, subSectionNames) {
 }
 
 TEST_F(XmlSection, keys) {
-	EXPECT_EQ(std::vector<std::string>{"attributeName"}, root.keys());
+	EXPECT_EQ((std::vector<std::string>{"attributeName", "subElementValue"}), root.keys());
 }
 
 TEST_F(XmlSection, hasSubSection) {
@@ -91,15 +91,18 @@ TEST_F(XmlSection, subSectionsNamed) {
 
 TEST_F(XmlSection, valueOrEmpty) {
 	EXPECT_EQ(std::string{"attributeValue"}, root.valueOrEmpty("attributeName"));
+	EXPECT_EQ(std::string{"Value"}, root.valueOrEmpty("subElementValue"));
 	EXPECT_EQ(std::string{""}, root.valueOrEmpty("attributeNameNotFound"));
 }
 
 TEST_F(XmlSection, value) {
 	EXPECT_EQ("attributeValue", root.value("attributeName"));
+	EXPECT_EQ("Value", root.value("subElementValue"));
 	EXPECT_THROW(root.value("attributeNameNotFound"), std::runtime_error);
 }
 
 TEST_F(XmlSection, valueWithDefault) {
 	EXPECT_EQ("attributeValue", root.value("attributeName", std::string{""}));
+	EXPECT_EQ("Value", root.value("subElementValue", std::string{""}));
 	EXPECT_EQ("", root.value("attributeNameNotFound", std::string{""}));
 }

--- a/test/Parsing/XmlSection.test.cpp
+++ b/test/Parsing/XmlSection.test.cpp
@@ -13,6 +13,7 @@ protected:
 		"<rootElement attributeName=\"attributeValue\">"
 			"<subElement subElementAttributeName=\"subElementAttributeValue\">Value</subElement>"
 			"<subElementValue>Value</subElementValue>"
+			"<dualUse attribute=\"dualAttribute\">dualValue</dualUse>"
 		"</rootElement>";
 	NAS2D::XmlFile xmlFile{fileData};
 	NAS2D::XmlSection root = xmlFile.root();
@@ -28,11 +29,11 @@ TEST_F(XmlSection, throwError) {
 }
 
 TEST_F(XmlSection, verifySubSections) {
-	EXPECT_NO_THROW(root.verifySubSections({"subElement", "subElementValue"}));
-	EXPECT_NO_THROW(root.verifySubSections({"subElement", "subElementValue"}, {"optionalNotFound"}));
-	EXPECT_NO_THROW(root.verifySubSections({"subElement"}, {"subElementValue"}));
-	EXPECT_NO_THROW(root.verifySubSections({}, {"subElement", "subElementValue"}));
-	EXPECT_NO_THROW(root.verifySubSections({}, {"subElement", "subElementValue", "optionalNotFound"}));
+	EXPECT_NO_THROW(root.verifySubSections({"subElement", "subElementValue", "dualUse"}));
+	EXPECT_NO_THROW(root.verifySubSections({"subElement", "subElementValue", "dualUse"}, {"optionalNotFound"}));
+	EXPECT_NO_THROW(root.verifySubSections({"subElement"}, {"subElementValue", "dualUse"}));
+	EXPECT_NO_THROW(root.verifySubSections({}, {"subElement", "subElementValue", "dualUse"}));
+	EXPECT_NO_THROW(root.verifySubSections({}, {"subElement", "subElementValue", "dualUse", "optionalNotFound"}));
 
 	EXPECT_THROW(root.verifySubSections({"subElementNotFound"}), std::runtime_error);
 	EXPECT_THROW(root.verifySubSections({}), std::runtime_error);
@@ -51,7 +52,7 @@ TEST_F(XmlSection, verifyKeys) {
 }
 
 TEST_F(XmlSection, subSectionNames) {
-	EXPECT_EQ((std::vector<std::string>{"subElement", "subElementValue"}), root.subSectionNames());
+	EXPECT_EQ((std::vector<std::string>{"subElement", "subElementValue", "dualUse"}), root.subSectionNames());
 }
 
 TEST_F(XmlSection, keys) {

--- a/test/Parsing/XmlSection.test.cpp
+++ b/test/Parsing/XmlSection.test.cpp
@@ -106,6 +106,10 @@ TEST_F(XmlSection, value) {
 	EXPECT_EQ("attributeValue", root.value("attributeName"));
 	EXPECT_EQ("Value", root.value("subElementValue"));
 	EXPECT_THROW(root.value("attributeNameNotFound"), std::runtime_error);
+
+	const auto& dualUse = root.subSection("dualUse");
+	EXPECT_EQ("dualValue", dualUse.value("dualUse"));
+	EXPECT_EQ("dualAttribute", dualUse.value("attribute"));
 }
 
 TEST_F(XmlSection, valueWithDefault) {

--- a/test/Parsing/XmlSection.test.cpp
+++ b/test/Parsing/XmlSection.test.cpp
@@ -82,11 +82,17 @@ TEST_F(XmlSection, subSection) {
 TEST_F(XmlSection, subSections) {
 	const auto sectionsRange = root.subSections();
 	EXPECT_EQ("subElement", (*sectionsRange.begin()).name());
+
+	const auto sections = std::vector<NAS2D::XmlSection>{sectionsRange.begin(), sectionsRange.end()};
+	EXPECT_GE(sections.size(), 1);
 }
 
 TEST_F(XmlSection, subSectionsNamed) {
 	const auto sectionsRange = root.subSections("subElement");
 	EXPECT_EQ("subElement", (*sectionsRange.begin()).name());
+
+	const auto sections = std::vector<NAS2D::XmlSection>{sectionsRange.begin(), sectionsRange.end()};
+	EXPECT_GE(sections.size(), 1);
 }
 
 TEST_F(XmlSection, valueOrEmpty) {

--- a/test/Parsing/XmlSection.test.cpp
+++ b/test/Parsing/XmlSection.test.cpp
@@ -1,0 +1,105 @@
+#include "NAS2D/Parsing/XmlSection.h"
+#include "NAS2D/Parsing/XmlFile.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+
+class XmlSection : public ::testing::Test {
+protected:
+	const std::string fileData =
+		"<rootElement attributeName=\"attributeValue\">"
+			"<subElement subElementAttributeName=\"subElementAttributeValue\">Value</subElement>"
+			"<subElementValue>Value</subElementValue>"
+		"</rootElement>";
+	NAS2D::XmlFile xmlFile{fileData};
+	NAS2D::XmlSection root = xmlFile.root();
+};
+
+
+TEST_F(XmlSection, name) {
+	EXPECT_EQ("rootElement", root.name());
+}
+
+TEST_F(XmlSection, throwError) {
+	EXPECT_THROW(root.throwError("Some error string"), std::runtime_error);
+}
+
+TEST_F(XmlSection, verifySubSections) {
+	EXPECT_NO_THROW(root.verifySubSections({"subElement", "subElementValue"}));
+	EXPECT_NO_THROW(root.verifySubSections({"subElement", "subElementValue"}, {"optionalNotFound"}));
+	EXPECT_NO_THROW(root.verifySubSections({"subElement"}, {"subElementValue"}));
+	EXPECT_NO_THROW(root.verifySubSections({}, {"subElement", "subElementValue"}));
+	EXPECT_NO_THROW(root.verifySubSections({}, {"subElement", "subElementValue", "optionalNotFound"}));
+
+	EXPECT_THROW(root.verifySubSections({"subElementNotFound"}), std::runtime_error);
+	EXPECT_THROW(root.verifySubSections({}), std::runtime_error);
+	EXPECT_THROW(root.verifySubSections({}, {"subElementNotFound"}), std::runtime_error);
+}
+
+TEST_F(XmlSection, verifyKeys) {
+	EXPECT_NO_THROW(root.verifyKeys({"attributeName"}));
+	EXPECT_NO_THROW(root.verifyKeys({"attributeName"}, {"optionalNotFound"}));
+	EXPECT_NO_THROW(root.verifyKeys({}, {"attributeName"}));
+	EXPECT_NO_THROW(root.verifyKeys({}, {"attributeName", "optionalNotFound"}));
+
+	EXPECT_THROW(root.verifyKeys({"attributeNotFound"}), std::runtime_error);
+	EXPECT_THROW(root.verifyKeys({}), std::runtime_error);
+	EXPECT_THROW(root.verifyKeys({}, {"attributeNotFound"}), std::runtime_error);
+}
+
+TEST_F(XmlSection, subSectionNames) {
+	EXPECT_EQ((std::vector<std::string>{"subElement", "subElementValue"}), root.subSectionNames());
+}
+
+TEST_F(XmlSection, keys) {
+	EXPECT_EQ(std::vector<std::string>{"attributeName"}, root.keys());
+}
+
+TEST_F(XmlSection, hasSubSection) {
+	EXPECT_TRUE(root.hasSubSection("subElement"));
+	EXPECT_TRUE(root.hasSubSection("subElementValue"));
+
+	EXPECT_FALSE(root.hasSubSection("elementNotFound"));
+	EXPECT_FALSE(root.hasSubSection("attributeName"));
+}
+
+TEST_F(XmlSection, hasKey) {
+	EXPECT_TRUE(root.hasKey("attributeName"));
+
+	EXPECT_FALSE(root.hasKey("attributeNotFound"));
+}
+
+TEST_F(XmlSection, subSection) {
+	const auto subElement = root.subSection("subElement");
+	EXPECT_EQ("subElement", subElement.name());
+
+	EXPECT_THROW(root.subSection("sectionNameNotFound"), std::runtime_error);
+}
+
+TEST_F(XmlSection, subSections) {
+	const auto sectionsRange = root.subSections();
+	EXPECT_EQ("subElement", (*sectionsRange.begin()).name());
+}
+
+TEST_F(XmlSection, subSectionsNamed) {
+	const auto sectionsRange = root.subSections("subElement");
+	EXPECT_EQ("subElement", (*sectionsRange.begin()).name());
+}
+
+TEST_F(XmlSection, valueOrEmpty) {
+	EXPECT_EQ(std::string{"attributeValue"}, root.valueOrEmpty("attributeName"));
+	EXPECT_EQ(std::string{""}, root.valueOrEmpty("attributeNameNotFound"));
+}
+
+TEST_F(XmlSection, value) {
+	EXPECT_EQ("attributeValue", root.value("attributeName"));
+	EXPECT_THROW(root.value("attributeNameNotFound"), std::runtime_error);
+}
+
+TEST_F(XmlSection, valueWithDefault) {
+	EXPECT_EQ("attributeValue", root.value("attributeName", std::string{""}));
+	EXPECT_EQ("", root.value("attributeNameNotFound", std::string{""}));
+}

--- a/test/Parsing/XmlSection.test.cpp
+++ b/test/Parsing/XmlSection.test.cpp
@@ -86,6 +86,7 @@ TEST_F(XmlSection, subSections) {
 
 	const auto sections = std::vector<NAS2D::XmlSection>{sectionsRange.begin(), sectionsRange.end()};
 	EXPECT_GE(sections.size(), 1);
+	EXPECT_EQ(sections.size(), sectionsRange.size());
 }
 
 TEST_F(XmlSection, subSectionsNamed) {
@@ -94,6 +95,7 @@ TEST_F(XmlSection, subSectionsNamed) {
 
 	const auto sections = std::vector<NAS2D::XmlSection>{sectionsRange.begin(), sectionsRange.end()};
 	EXPECT_GE(sections.size(), 1);
+	EXPECT_EQ(sections.size(), sectionsRange.size());
 }
 
 TEST_F(XmlSection, valueOrEmpty) {


### PR DESCRIPTION
Fixes an issue on Arch linux when rendering the only other zero-width glyph, ASCII character 173 in the extended set. Not thrilled with special case code but there are only two characters in the table that behave like this. 160 is another one that doesn't have any appearance but it's not zero width so... eh.