### PR TITLE
Use SDL for `prefPath`

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -12,6 +12,7 @@
 
 #include <physfs.h>
 
+#include <filesystem>
 #include <limits>
 #include <stdexcept>
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -11,16 +11,30 @@
 #include "Filesystem.h"
 
 #include <physfs.h>
+#include <SDL2/SDL_filesystem.h>
 
 #include <filesystem>
 #include <limits>
 #include <stdexcept>
+#include <memory>
 
 
 using namespace NAS2D;
 
 
 namespace {
+	struct SdlStringDeleter
+	{
+		void operator()(char* string)
+		{
+			SDL_free(string);
+		}
+	};
+
+
+	using SdlString = std::unique_ptr<char, SdlStringDeleter>;
+
+
 	std::string getLastPhysfsError()
 	{
 		return PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -330,7 +330,7 @@ void Filesystem::write(const std::string& filename, const std::string& data, Wri
  */
 std::string Filesystem::dirSeparator() const
 {
-	return PHYSFS_getDirSeparator();
+	return {std::filesystem::path::preferred_separator};
 }
 
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -60,8 +60,8 @@ enum MountPosition
 
 
 Filesystem::Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName) :
-	mAppName{appName},
-	mOrganizationName{organizationName}
+	mBasePath{SdlString{SDL_GetBasePath()}.get()},
+	mPrefPath{SdlString{SDL_GetPrefPath(organizationName.c_str(), appName.c_str())}.get()}
 {
 	if (PHYSFS_isInit()) { throw std::runtime_error("Filesystem is already initialized"); }
 
@@ -88,7 +88,7 @@ Filesystem::~Filesystem()
  */
 std::string Filesystem::basePath() const
 {
-	return PHYSFS_getBaseDir();
+	return mBasePath;
 }
 
 
@@ -98,12 +98,10 @@ std::string Filesystem::basePath() const
  * The user should have write access to the preferences folder, which is generally under their user folder.
  *
  * \note This path is dependent on the Operating System (OS).
- * \note Path may be empty if the folder could not be created.
  */
 std::string Filesystem::prefPath() const
 {
-	auto prefDir = PHYSFS_getPrefDir(mOrganizationName.c_str(), mAppName.c_str());
-	return (prefDir != nullptr) ? prefDir : "";
+	return mPrefPath;
 }
 
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -45,8 +45,8 @@ enum MountPosition
 
 
 Filesystem::Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName) :
-	mAppName(appName),
-	mOrganizationName(organizationName)
+	mAppName{appName},
+	mOrganizationName{organizationName}
 {
 	if (PHYSFS_isInit()) { throw std::runtime_error("Filesystem is already initialized"); }
 

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -64,7 +64,7 @@ namespace NAS2D
 		std::string extension(std::string_view filePath) const;
 
 	private:
-		std::string mAppName;
-		std::string mOrganizationName;
+		std::string mBasePath;
+		std::string mPrefPath;
 	};
 }


### PR DESCRIPTION
Use SDL for `basePath` and `prefPath`.

This changes the directory layout slightly on Linux. PhysFS ignored the `organizationName` parameter when forming the `prefPath`, while the SDL functions include it. People may need to move config files and saved games for them to be found at the updated path.

Closes #212
Related #967, #973
