### PR TITLE
Disable Brew caching for MacOS builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,15 +4,7 @@ commands:
   brew-install:
     description: "Brew install MacOS dependencies (or restore from cache)"
     steps:
-      - restore_cache:
-          name: Restoring brew dependencies
-          key: deps-NAS2D-{{ arch }}-v1-{{ checksum "BrewDeps.txt" }}
       - run: make install-dependencies
-      - save_cache:
-          name: Caching brew dependencies
-          key: deps-NAS2D-{{ arch }}-v1-{{ checksum "BrewDeps.txt" }}
-          paths:
-            - /usr/local/Cellar
   build-and-test:
     steps:
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"


### PR DESCRIPTION
Recently there have been permission errors attempting to restore the cache. This is causing the failed cache restore to take longer than just re-installing dependencies would take. Better to disable the cache for now until the problem can be resolved.

Reference: https://github.com/OutpostUniverse/OPHD/pull/1210
