### PR TITLE
Update AppVeyor image to VS2022

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration:
   - Release
 platform:

--- a/InstallVcpkgDeps.bat
+++ b/InstallVcpkgDeps.bat
@@ -17,4 +17,4 @@ if not defined PLATFORM (
 
 :Install
 REM Install dependencies (recursively)
-vcpkg install --recurse --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[dynamic-load,libflac,libmodplug,libvorbis,mpg123,nativemidi,opusfile] gtest
+vcpkg install --recurse --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[libflac,libmodplug,libvorbis,mpg123,nativemidi,opusfile] gtest


### PR DESCRIPTION
Related: Issue #999

The GitHub Actions workflow for the Windows build has been failing recently due to a `vcpkg` issue. Removing the `dynamic-load` feature for the `SDL2-mixer` package fixes the build with the newer version of `vcpkg` on GitHub Actions, but breaks the build for the older version used on AppVeyor. By updating both build systems to `Visual Studio 2022`, we can remove the `dynamic-load` flag for `SDL2-mixer` and have both build systems work.

Example of problem:
https://github.com/lairworks/nas2d-core/runs/7703423429?check_suite_focus=true
> Package sdl2-mixer does not have a dynamic-load feature
note: updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.
