### PR TITLE
Rename `Filesystem` methods to `readFile` and `writeFile`

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -87,7 +87,7 @@ void Configuration::save(const std::string& filePath) const
 {
 	try
 	{
-		Utility<Filesystem>::get().write(filePath, saveData());
+		Utility<Filesystem>::get().writeFile(filePath, saveData());
 	}
 	catch (const std::runtime_error& e)
 	{

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -59,7 +59,7 @@ void Configuration::load(const std::string& filePath)
 		try
 		{
 			// Read in the Config File.
-			auto xmlData = Utility<Filesystem>::get().read(filePath);
+			auto xmlData = Utility<Filesystem>::get().readFile(filePath);
 			loadData(xmlData.c_str());
 			std::cout << "done." << std::endl;
 		}

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -310,7 +310,7 @@ std::string Filesystem::readFile(const std::string& filename) const
 }
 
 
-void Filesystem::write(const std::string& filename, const std::string& data, WriteFlags flags) const
+void Filesystem::writeFile(const std::string& filename, const std::string& data, WriteFlags flags) const
 {
 	if (flags != WriteFlags::Overwrite && exists(filename))
 	{

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -274,7 +274,7 @@ void Filesystem::del(const std::string& filename) const
 }
 
 
-std::string Filesystem::read(const std::string& filename) const
+std::string Filesystem::readFile(const std::string& filename) const
 {
 	PHYSFS_file* myFile = PHYSFS_openRead(filename.c_str());
 	if (!myFile)

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -56,7 +56,7 @@ namespace NAS2D
 		bool exists(const std::string& filename) const;
 		void del(const std::string& path) const;
 
-		std::string read(const std::string& filename) const;
+		std::string readFile(const std::string& filename) const;
 		void write(const std::string& filename, const std::string& data, WriteFlags flags = WriteFlags::Overwrite) const;
 
 		std::string dirSeparator() const;

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -57,7 +57,7 @@ namespace NAS2D
 		void del(const std::string& path) const;
 
 		std::string readFile(const std::string& filename) const;
-		void write(const std::string& filename, const std::string& data, WriteFlags flags = WriteFlags::Overwrite) const;
+		void writeFile(const std::string& filename, const std::string& data, WriteFlags flags = WriteFlags::Overwrite) const;
 
 		std::string dirSeparator() const;
 		std::string parentPath(std::string_view filePath) const;

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -182,7 +182,7 @@ DisplayDesc RendererOpenGL::getClosestMatchingDisplayMode(const DisplayDesc& pre
 
 void RendererOpenGL::window_icon(const std::string& path)
 {
-	auto iconData = Utility<Filesystem>::get().read(path);
+	auto iconData = Utility<Filesystem>::get().readFile(path);
 	SDL_Surface* icon = IMG_Load_RW(SDL_RWFromConstMem(iconData.c_str(), static_cast<int>(iconData.size())), 1);
 	if (!icon)
 	{
@@ -202,7 +202,7 @@ void RendererOpenGL::showSystemPointer(bool _b)
 
 void RendererOpenGL::addCursor(const std::string& filePath, int cursorId, int offx, int offy)
 {
-	auto imageData = Utility<Filesystem>::get().read(filePath);
+	auto imageData = Utility<Filesystem>::get().readFile(filePath);
 	if (imageData.size() == 0)
 	{
 		throw std::runtime_error("Cursor file is empty: " + filePath);

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -117,7 +117,7 @@ namespace
 			const auto basePath = filesystem.parentPath(filePath);
 
 			Xml::XmlDocument xmlDoc;
-			xmlDoc.parse(filesystem.read(filePath).c_str());
+			xmlDoc.parse(filesystem.readFile(filePath).c_str());
 
 			if (xmlDoc.error())
 			{

--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -185,7 +185,7 @@ namespace
 			}
 		}
 
-		auto fontBuffer = Utility<Filesystem>::get().read(path);
+		auto fontBuffer = Utility<Filesystem>::get().readFile(path);
 		if (fontBuffer.empty())
 		{
 			throw std::runtime_error("Font file is empty: " + path);
@@ -223,7 +223,7 @@ namespace
 	 */
 	Font::FontInfo loadBitmap(const std::string& path)
 	{
-		auto fontBuffer = Utility<Filesystem>::get().read(path);
+		auto fontBuffer = Utility<Filesystem>::get().readFile(path);
 		if (fontBuffer.empty())
 		{
 			throw std::runtime_error("Font file is empty: " + path);

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -47,7 +47,7 @@ namespace
 Image::Image(const std::string& filePath) :
 	Image{
 		filePath,
-		Utility<Filesystem>::get().read(filePath)
+		Utility<Filesystem>::get().readFile(filePath)
 	}
 {
 }

--- a/NAS2D/Resource/Music.cpp
+++ b/NAS2D/Resource/Music.cpp
@@ -25,7 +25,7 @@ using namespace NAS2D;
 
 Music::Music(const std::string& filePath) :
 	mResourceName{filePath},
-	mBuffer{Utility<Filesystem>::get().read(mResourceName)}
+	mBuffer{Utility<Filesystem>::get().readFile(mResourceName)}
 {
 	if (mBuffer.empty())
 	{

--- a/NAS2D/Resource/Sound.cpp
+++ b/NAS2D/Resource/Sound.cpp
@@ -28,7 +28,7 @@ using namespace NAS2D;
 Sound::Sound(const std::string& filePath) :
 	mResourceName{filePath}
 {
-	auto data = Utility<Filesystem>::get().read(mResourceName);
+	auto data = Utility<Filesystem>::get().readFile(mResourceName);
 	if (data.empty())
 	{
 		throw std::runtime_error("Sound file is empty: " + mResourceName);

--- a/NAS2D/Xml/XmlMemoryBuffer.h
+++ b/NAS2D/Xml/XmlMemoryBuffer.h
@@ -30,7 +30,7 @@ namespace Xml {
  * XmlMemoryBuffer buff;
  * doc.Accept(&buff);
  *
- * Utility<Filesystem>::get().write(filePath, buff.buffer());
+ * Utility<Filesystem>::get().writeFile(filePath, buff.buffer());
  * \endcode
  */
 class XmlMemoryBuffer : public XmlVisitor

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -59,12 +59,12 @@ TEST_F(Filesystem, writeReadDeleteExists) {
 	const std::string testFilename = "TestFile.txt";
 	const std::string testData = "Test file contents";
 
-	EXPECT_NO_THROW(fs.write(testFilename, testData));
+	EXPECT_NO_THROW(fs.writeFile(testFilename, testData));
 	EXPECT_TRUE(fs.exists(testFilename));
 
 	// Try to overwrite file, with and without permission
-	EXPECT_NO_THROW(fs.write(testFilename, testData));
-	EXPECT_THROW(fs.write(testFilename, testData, NAS2D::Filesystem::WriteFlags::NoOverwrite), std::runtime_error);
+	EXPECT_NO_THROW(fs.writeFile(testFilename, testData));
+	EXPECT_THROW(fs.writeFile(testFilename, testData, NAS2D::Filesystem::WriteFlags::NoOverwrite), std::runtime_error);
 
 	const auto data = fs.readFile(testFilename);
 	EXPECT_EQ(testData, data);

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -50,7 +50,7 @@ TEST_F(Filesystem, exists) {
 }
 
 TEST_F(Filesystem, read) {
-	const auto data = fs.read("file.txt");
+	const auto data = fs.readFile("file.txt");
 	EXPECT_THAT(data, testing::StartsWith("Test data"));
 }
 
@@ -66,7 +66,7 @@ TEST_F(Filesystem, writeReadDeleteExists) {
 	EXPECT_NO_THROW(fs.write(testFilename, testData));
 	EXPECT_THROW(fs.write(testFilename, testData, NAS2D::Filesystem::WriteFlags::NoOverwrite), std::runtime_error);
 
-	const auto data = fs.read(testFilename);
+	const auto data = fs.readFile(testFilename);
 	EXPECT_EQ(testData, data);
 
 	EXPECT_NO_THROW(fs.del(testFilename));


### PR DESCRIPTION
Partly this is to emphasize these methods do full file read and writes. Partly this is to avoid false errors with Codacy, which seems to be confusing the custom `read` method with a standard library method that is subject to unsafe usage.

Example of Codacy errors:
https://app.codacy.com/gh/lairworks/nas2d-core/issues?categoryType=Security&bid=29267938
> Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20).

I suspect the error might actually apply to a standard library [`read`](https://en.cppreference.com/w/cpp/io/basic_istream/read) method.
