### PR TITLE
Re-implement `Filesystem` to not use PhysFS

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -242,8 +242,8 @@ std::vector<std::string> Filesystem::directoryList(const std::string& dir, const
  */
 bool Filesystem::isDirectory(const std::string& path) const
 {
-	PHYSFS_Stat stat;
-	return (PHYSFS_stat(path.c_str(), &stat) != 0) && (stat.filetype == PHYSFS_FILETYPE_DIRECTORY);
+	const auto& filePath = findFirstPath(path, mSearchPaths);
+	return std::filesystem::is_directory(filePath);
 }
 
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -281,9 +281,10 @@ bool Filesystem::exists(const std::string& path) const
  */
 void Filesystem::del(const std::string& filename)
 {
-	if (PHYSFS_delete(filename.c_str()) == 0)
+	const auto& filePath = std::filesystem::path{mWritePath} / filename;
+	if (!std::filesystem::remove(filePath))
 	{
-		throw std::runtime_error("Error deleting file: " + filename + " : " + getLastPhysfsError());
+		throw std::runtime_error("Error deleting file: " + filename + " : " + errorDescription());
 	}
 }
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -41,6 +41,20 @@ namespace {
 	}
 
 
+	std::string findFirstPath(const std::string& path, const std::vector<std::string>& searchPaths)
+	{
+		for (const auto& searchPath : searchPaths)
+		{
+			const auto& filePath = std::filesystem::path{searchPath} / path;
+			if (std::filesystem::exists(filePath))
+			{
+				return filePath.string();
+			}
+		}
+		return {};
+	}
+
+
 	std::string getLastPhysfsError()
 	{
 		return PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -270,7 +270,8 @@ void Filesystem::makeDirectory(const std::string& path)
  */
 bool Filesystem::exists(const std::string& path) const
 {
-	return PHYSFS_exists(path.c_str()) != 0;
+	const auto& filePath = findFirstPath(path, mSearchPaths);
+	return !filePath.empty();
 }
 
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -138,7 +138,7 @@ void Filesystem::mountReadWrite(const std::string& path)
 
 
 /**
- * Removes a directory or supported archive from the Search Path.
+ * Removes a directory from the Search Path.
  *
  * \param path	File path to remove.
  */

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -17,6 +17,7 @@
 #include <limits>
 #include <stdexcept>
 #include <memory>
+#include <system_error>
 
 
 using namespace NAS2D;
@@ -52,6 +53,12 @@ namespace {
 			}
 		}
 		return {};
+	}
+
+
+	std::string errorDescription()
+	{
+		return std::error_code{errno, std::generic_category()}.message();
 	}
 
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -192,28 +192,23 @@ std::vector<std::string> Filesystem::searchPath() const
  */
 std::vector<std::string> Filesystem::directoryList(const std::string& dir, const std::string& filter) const
 {
-	auto rc = PHYSFS_enumerateFiles(dir.c_str());
-
 	std::vector<std::string> fileList;
-	if (filter.empty())
+
+	for (const auto& searchPath : mSearchPaths)
 	{
-		for (auto i = rc; *i != nullptr; i++)
+		const auto dirPath = std::filesystem::path{searchPath} / dir;
+		if (std::filesystem::is_directory(dirPath))
 		{
-			fileList.push_back(*i);
-		}
-	}
-	else
-	{
-		for (auto i = rc; *i != nullptr; i++)
-		{
-			if (hasFileSuffix(*i, filter))
+			for (const auto& dirEntry : std::filesystem::directory_iterator(dirPath))
 			{
-				fileList.push_back(*i);
+				const auto& filePath = dirEntry.path().filename().generic_string();
+				if (hasFileSuffix(filePath, filter))
+				{
+					fileList.push_back(filePath);
+				}
 			}
 		}
 	}
-
-	PHYSFS_freeList(rc);
 
 	return fileList;
 }

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -70,11 +70,6 @@ Filesystem::Filesystem(const std::string& /*argv_0*/, const std::string& appName
 }
 
 
-Filesystem::~Filesystem()
-{
-}
-
-
 /**
  * Determines the path to the folder where the executable is located
  *

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -120,6 +120,7 @@ std::string Filesystem::prefPath() const
  */
 int Filesystem::mountSoftFail(const std::string& path)
 {
+	mSearchPaths.push_back(path);
 	return PHYSFS_mount(path.c_str(), "/", MountPosition::MOUNT_APPEND);
 }
 
@@ -153,6 +154,7 @@ void Filesystem::mountReadWrite(const std::string& path)
 	{
 		throw std::runtime_error("Error setting write folder: " + path + " : " + getLastPhysfsError());
 	}
+	mWritePath = path;
 }
 
 
@@ -167,6 +169,7 @@ void Filesystem::unmount(const std::string& path)
 	{
 		throw std::runtime_error("Error unmounting search path: " + path + " : " + getLastPhysfsError());
 	}
+	mSearchPaths.erase(std::remove(mSearchPaths.begin(), mSearchPaths.end(), path), mSearchPaths.end());
 }
 
 
@@ -175,16 +178,7 @@ void Filesystem::unmount(const std::string& path)
  */
 std::vector<std::string> Filesystem::searchPath() const
 {
-	std::vector<std::string> searchPath;
-
-	auto searchPathList = PHYSFS_getSearchPath();
-	for (auto i = searchPathList; *i != nullptr; ++i)
-	{
-		searchPath.push_back(*i);
-	}
-	PHYSFS_freeList(searchPathList);
-
-	return searchPath;
+	return mSearchPaths;
 }
 
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -255,10 +255,8 @@ bool Filesystem::isDirectory(const std::string& path) const
  */
 void Filesystem::makeDirectory(const std::string& path)
 {
-	if (PHYSFS_mkdir(path.c_str()) == 0)
-	{
-		throw std::runtime_error("Error creating directory: " + path + " : " + getLastPhysfsError());
-	}
+	const auto& filePath = std::filesystem::path{mWritePath} / path;
+	std::filesystem::create_directories(filePath);
 }
 
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -63,13 +63,6 @@ namespace {
 }
 
 
-enum MountPosition
-{
-	MOUNT_PREPEND = 0,
-	MOUNT_APPEND = 1,
-};
-
-
 Filesystem::Filesystem(const std::string& /*argv_0*/, const std::string& appName, const std::string& organizationName) :
 	mBasePath{SdlString{SDL_GetBasePath()}.get()},
 	mPrefPath{SdlString{SDL_GetPrefPath(organizationName.c_str(), appName.c_str())}.get()}

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -17,11 +17,6 @@
 
 namespace NAS2D
 {
-	/**
-	 * Implements a virtual file system.
-	 *
-	 * Provides cross-platform and transparent archive Filesystem functions.
-	 */
 	class Filesystem
 	{
 	public:

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -66,5 +66,7 @@ namespace NAS2D
 	private:
 		std::string mBasePath;
 		std::string mPrefPath;
+		std::string mWritePath;
+		std::vector<std::string> mSearchPaths;
 	};
 }

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -36,7 +36,7 @@ namespace NAS2D
 		Filesystem& operator=(const Filesystem&) = delete;
 		Filesystem(Filesystem&&) = delete;
 		Filesystem& operator=(Filesystem&&) = delete;
-		~Filesystem();
+		~Filesystem() = default;
 
 		std::string basePath() const;
 		std::string prefPath() const;


### PR DESCRIPTION
Related issues: #967, #973
Related PRs: #1024

Re-implement `Filesystem` so it no longer depends on PhysFS. Instead, it uses `std::filesystem` and standard library streams internally.
