### PR TITLE
Remove template parameter when deleting `Utility` constructors

### DIFF
--- a/NAS2D/Utility.h
+++ b/NAS2D/Utility.h
@@ -55,10 +55,10 @@ namespace NAS2D
 	class Utility
 	{
 	public:
-		Utility<T>() = delete;
+		Utility() = delete;
 		~Utility() = delete;
-		Utility<T>(const Utility& s) = delete;
-		Utility<T>& operator=(const Utility& s) = delete;
+		Utility(const Utility& s) = delete;
+		Utility& operator=(const Utility& s) = delete;
 
 		/**
 		 * Gets a reference to a global instance of the specified type


### PR DESCRIPTION
Closes #1019

The template parameter is not needed in this place. It is effectively already implied by the template parameter being on the class itself.

Including a template parameter here leads to compile errors with `g++` versions 11 and newer, which is found on Ubuntu 22.04 and Arch Linux.
