### PR TITLE
Update Docker build environments (Ubuntu 22.04, PhysFS)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - build-and-test
   build-linux-gcc:
     docker:
-      - image: outpostuniverse/nas2d-gcc:1.3
+      - image: outpostuniverse/nas2d-gcc:1.4
     environment:
       - WARN_EXTRA: "-Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast"
     steps:
@@ -36,7 +36,7 @@ jobs:
       - build-and-test
   build-linux-clang:
     docker:
-      - image: outpostuniverse/nas2d-clang:1.2
+      - image: outpostuniverse/nas2d-clang:1.3
     environment:
       - WARN_EXTRA: "-Wdocumentation -Wdocumentation-unknown-command -Wcomma -Winconsistent-missing-destructor-override -Wmissing-prototypes -Wctad-maybe-unsupported"
     steps:
@@ -44,7 +44,7 @@ jobs:
       - build-and-test
   build-linux-mingw:
     docker:
-      - image: outpostuniverse/nas2d-mingw:1.7
+      - image: outpostuniverse/nas2d-mingw:1.8
     environment:
       - WARN_EXTRA: "-Wno-redundant-decls"
     steps:

--- a/BrewDeps.txt
+++ b/BrewDeps.txt
@@ -1,4 +1,3 @@
-physfs
 sdl2
 sdl2_image
 sdl2_mixer

--- a/InstallVcpkgDeps.bat
+++ b/InstallVcpkgDeps.bat
@@ -17,4 +17,4 @@ if not defined PLATFORM (
 
 :Install
 REM Install dependencies (recursively)
-vcpkg install --recurse --triplet %PLATFORM%-windows  physfs glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[libflac,libmodplug,libvorbis,mpg123,nativemidi,opusfile] gtest
+vcpkg install --recurse --triplet %PLATFORM%-windows  glew SDL2 SDL2-image SDL2-ttf SDL2-mixer[libflac,libmodplug,libvorbis,mpg123,nativemidi,opusfile] gtest

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -12,8 +12,8 @@
 .PHONY: download-sdl2-modules compile-sdl2-modules install-sdl2-modules
 .PHONY: clean-sdl2-modules clean-all-sdl2-modules
 
-all: install-sdl2 install-sdl2-modules install-glew install-physfs
-download-all: download-sdl2 download-sdl2-modules download-glew download-physfs
+all: install-sdl2 install-sdl2-modules install-glew
+download-all: download-sdl2 download-sdl2-modules download-glew
 download-sdl2-modules: download-sdl2-image download-sdl2-mixer download-sdl2-ttf
 compile-sdl2-modules: compile-sdl2-image compile-sdl2-mixer compile-sdl2-ttf
 install-sdl2-modules: install-sdl2-image install-sdl2-mixer install-sdl2-ttf
@@ -25,7 +25,6 @@ Sdl2PackageUrl := https://www.libsdl.org/release/SDL2-2.0.8.tar.gz
 Sdl2ImagePackageUrl := https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.3.tar.gz
 Sdl2MixerPackageUrl := https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2.tar.gz
 Sdl2TtfPackageUrl := https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14.tar.gz
-PhysfsPackageUrl := https://icculus.org/physfs/downloads/physfs-3.0.1.tar.bz2
 GlewPackageUrl := https://github.com/nigels-com/glew/releases/download/glew-2.1.0/glew-2.1.0.tgz
 
 # Note: This variable can be overridden from the command line
@@ -89,5 +88,4 @@ $(eval $(call SourcePackageInstallRules,sdl2,${Sdl2PackageUrl}))
 $(eval $(call SourcePackageInstallRules,sdl2-image,${Sdl2ImagePackageUrl}))
 $(eval $(call SourcePackageInstallRules,sdl2-mixer,${Sdl2MixerPackageUrl}))
 $(eval $(call SourcePackageInstallRules,sdl2-ttf,${Sdl2TtfPackageUrl}))
-$(eval $(call SourcePackageInstallRules,physfs,${PhysfsPackageUrl}))
 $(eval $(call SourcePackageInstallRules,glew,${GlewPackageUrl}))

--- a/docker/nas2d-arch.Dockerfile
+++ b/docker/nas2d-arch.Dockerfile
@@ -1,6 +1,6 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM archlinux:base-20220130.0.46058
+FROM archlinux:base-20220731.0.71623
 
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages

--- a/docker/nas2d-arch.Dockerfile
+++ b/docker/nas2d-arch.Dockerfile
@@ -18,7 +18,6 @@ RUN pacman --sync --refresh --noconfirm \
 
 RUN pacman --sync --refresh --noconfirm \
     glew \
-    physfs \
     sdl2 \
     sdl2_image \
     sdl2_mixer \

--- a/docker/nas2d-clang.Dockerfile
+++ b/docker/nas2d-clang.Dockerfile
@@ -25,7 +25,6 @@ ENV  CC=clang
 # Install NAS2D specific dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libglew-dev=2.2.0-* \
-    libphysfs-dev=3.0.2-* \
     libsdl2-dev=2.0.20+* \
     libsdl2-image-dev=2.0.5+* \
     libsdl2-mixer-dev=2.0.4+* \

--- a/docker/nas2d-clang.Dockerfile
+++ b/docker/nas2d-clang.Dockerfile
@@ -1,20 +1,20 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages
 # Includes tools needed for primary CircleCI containers
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    build-essential=12.8* \
-    clang=1:10.0-* \
-    cmake=3.16.3-* \
-    libgtest-dev=1.10.0-* \
-    libgmock-dev=1.10.0-* \
-    git=1:2.25.1-* \
-    ssh=1:8.2p1-* \
-    tar=1.30* \
+    build-essential=12.9* \
+    clang=1:14.0-* \
+    cmake=3.22.1-* \
+    libgtest-dev=1.11.0-* \
+    libgmock-dev=1.11.0-* \
+    git=1:2.34.1-* \
+    ssh=1:8.9p1-* \
+    tar=1.34* \
     gzip=1.10-* \
     ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
@@ -24,12 +24,12 @@ ENV  CC=clang
 
 # Install NAS2D specific dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libglew-dev=2.1.0-* \
+    libglew-dev=2.2.0-* \
     libphysfs-dev=3.0.2-* \
-    libsdl2-dev=2.0.10+* \
+    libsdl2-dev=2.0.20+* \
     libsdl2-image-dev=2.0.5+* \
     libsdl2-mixer-dev=2.0.4+* \
-    libsdl2-ttf-dev=2.0.15+* \
+    libsdl2-ttf-dev=2.0.18+* \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash user

--- a/docker/nas2d-gcc.Dockerfile
+++ b/docker/nas2d-gcc.Dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:22.04
 # Install latest available GCC compiler (which may not be the default)
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    g++-10=10.3.0-* \
+    g++=4:11.2.0-* \
     make=4.3-* \
     cmake=3.22.1-* \
     libgtest-dev=1.11.0-* \
@@ -20,8 +20,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
 
-ENV CXX=g++-10
-ENV  CC=gcc-10
+ENV CXX=g++
+ENV  CC=gcc
 
 # Install NAS2D specific dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/nas2d-gcc.Dockerfile
+++ b/docker/nas2d-gcc.Dockerfile
@@ -26,7 +26,6 @@ ENV  CC=gcc-10
 # Install NAS2D specific dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libglew-dev=2.2.0-* \
-    libphysfs-dev=3.0.2-* \
     libsdl2-dev=2.0.20+* \
     libsdl2-image-dev=2.0.5+* \
     libsdl2-mixer-dev=2.0.4+* \

--- a/docker/nas2d-gcc.Dockerfile
+++ b/docker/nas2d-gcc.Dockerfile
@@ -1,6 +1,6 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages
@@ -9,13 +9,13 @@ FROM ubuntu:20.04
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     g++-10=10.3.0-* \
-    make=4.2.1-* \
-    cmake=3.16.3-* \
-    libgtest-dev=1.10.0-* \
-    libgmock-dev=1.10.0-* \
-    git=1:2.25.1-* \
-    ssh=1:8.2p1-* \
-    tar=1.30+* \
+    make=4.3-* \
+    cmake=3.22.1-* \
+    libgtest-dev=1.11.0-* \
+    libgmock-dev=1.11.0-* \
+    git=1:2.34.1-* \
+    ssh=1:8.9p1-* \
+    tar=1.34+* \
     gzip=1.10-* \
     ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
@@ -25,12 +25,12 @@ ENV  CC=gcc-10
 
 # Install NAS2D specific dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libglew-dev=2.1.0-* \
+    libglew-dev=2.2.0-* \
     libphysfs-dev=3.0.2-* \
-    libsdl2-dev=2.0.10+* \
+    libsdl2-dev=2.0.20+* \
     libsdl2-image-dev=2.0.5+* \
     libsdl2-mixer-dev=2.0.4+* \
-    libsdl2-ttf-dev=2.0.15+* \
+    libsdl2-ttf-dev=2.0.18+* \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash user

--- a/docker/nas2d-gcc.Dockerfile
+++ b/docker/nas2d-gcc.Dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:20.04
 # Install latest available GCC compiler (which may not be the default)
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    g++-10=10.2.0-* \
+    g++-10=10.3.0-* \
     make=4.2.1-* \
     cmake=3.16.3-* \
     libgtest-dev=1.10.0-* \

--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -110,12 +110,6 @@ RUN curl --location https://github.com/nigels-com/glew/releases/download/glew-2.
   make -C glew-2.1.0/ distclean && \
   make -C glew-2.1.0/ SYSTEM=linux-mingw-w64 CC="${CC32}" LD="${LD32}" LDFLAGS.EXTRA=-L"/usr/${ARCH32}/lib/" GLEW_DEST="${INSTALL32}" install && \
   rm -rf glew-2.1.0/ glew.*
-RUN curl https://icculus.org/physfs/downloads/physfs-3.0.2.tar.bz2 | tar -xj && \
-  cmake -H"physfs-3.0.2/" -B"${ARCH64}" -DCMAKE_INSTALL_PREFIX="${INSTALL64}" -DCMAKE_CXX_COMPILER="${CXX64}" -DCMAKE_C_COMPILER="${CC64}" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" && \
-  make -C "${ARCH64}" install && \
-  cmake -H"physfs-3.0.2/" -B"${ARCH32}" -DCMAKE_INSTALL_PREFIX="${INSTALL32}" -DCMAKE_CXX_COMPILER="${CXX32}" -DCMAKE_C_COMPILER="${CC32}" -DCMAKE_SYSTEM_NAME="${TARGET_OS}" && \
-  make -C "${ARCH32}" install && \
-  rm -rf physfs-3.0.2/ "${ARCH64}" "${ARCH32}"
 
 # Custom variables for install locations
 ENV INCLUDE64=${INSTALL64}include/

--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -9,18 +9,18 @@ FROM ubuntu:22.04
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     mingw-w64=8.0.0-1 \
-    cmake=3.18.4-* \
+    cmake=3.22.1-* \
     make=4.3-* \
-    binutils=2.37-* \
-    git=1:2.32.0-* \
-    ssh=1:8.7p1-2 \
+    binutils=2.38-* \
+    git=1:2.34.1-* \
+    ssh=1:8.9p1-3 \
     googletest=1.11.0-3 \
-    curl=7.74.0-* \
+    curl=7.81.0-* \
     tar=1.34+* \
     gzip=1.10-* \
     bzip2=1.0.8-* \
     gnupg=2.2.27-* \
-    software-properties-common=0.99.16 \
+    software-properties-common=0.99.22.2 \
     ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
 

--- a/makefile
+++ b/makefile
@@ -211,10 +211,10 @@ DockerFolder := ${TopLevelFolder}/docker
 DockerRunFlags := --volume ${TopLevelFolder}:/code
 DockerRepository := outpostuniverse
 
-ImageVersion_gcc := 1.3
-ImageVersion_clang := 1.2
-ImageVersion_mingw := 1.7
-ImageVersion_arch := 1.0
+ImageVersion_gcc := 1.4
+ImageVersion_clang := 1.3
+ImageVersion_mingw := 1.8
+ImageVersion_arch := 1.1
 
 DockerImageName = ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
 

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ CPPFLAGS := $(CPPFLAGS_EXTRA)
 CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute -Wredundant-decls -Wformat=2 $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) $(CONFIG_CXX_FLAGS) -std=c++20 $(CXXFLAGS_WARN) $(SDL_CONFIG_CFLAGS)
 LDFLAGS := $(LDFLAGS_EXTRA)
-LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lphysfs -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(SDL_CONFIG_LIBS) $(OpenGL_LIBS)
+LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(SDL_CONFIG_LIBS) $(OpenGL_LIBS)
 
 Windows_RUN_PREFIX := wine
 RUN_PREFIX := $($(TARGET_OS)_RUN_PREFIX)
@@ -178,13 +178,13 @@ install-dependencies:
 ## Ubuntu ##
 .PHONY: install-dependencies-ubuntu
 install-dependencies-ubuntu:
-	apt --yes install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev libphysfs-dev
+	apt --yes install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev
 
 ## CentOS ##
 .PHONY: install-dependencies-centos
 install-dependencies-centos: | install-dependencies-repository-centos
 	# Install development packages (-y answers "yes" to prompts)
-	yum --assumeyes install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel physfs-devel
+	yum --assumeyes install SDL2-devel SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel glew-devel
 .PHONY: install-dependencies-repository-centos
 install-dependencies-repository-centos:
 	# Default CentOS repositories only contain SDL1
@@ -194,7 +194,7 @@ install-dependencies-repository-centos:
 ## Arch Linux ##
 .PHONY: install-dependencies-arch
 install-dependencies-arch:
-	pacman --sync --refresh sdl2 sdl2_mixer sdl2_image sdl2_ttf glew physfs
+	pacman --sync --refresh sdl2 sdl2_mixer sdl2_image sdl2_ttf glew
 
 ## MacOS ##
 .PHONY: install-dependencies-darwin


### PR DESCRIPTION
Update to use Ubuntu 22.04 for the base image. Update installed package versions. Remove PhysFS dependency.

Related: PR #1027, Issue #682
