### PR TITLE
Add `Filesystem` constructor without `argv_0` argument

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -64,6 +64,12 @@ namespace {
 
 
 Filesystem::Filesystem(const std::string& /*argv_0*/, const std::string& appName, const std::string& organizationName) :
+	Filesystem(appName, organizationName)
+{
+}
+
+
+Filesystem::Filesystem(const std::string& appName, const std::string& organizationName) :
 	mBasePath{SdlString{SDL_GetBasePath()}.get()},
 	mPrefPath{SdlString{SDL_GetPrefPath(organizationName.c_str(), appName.c_str())}.get()}
 {

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -27,6 +27,7 @@ namespace NAS2D
 		};
 
 		Filesystem(const std::string& argv_0, const std::string& appName, const std::string& organizationName);
+		Filesystem(const std::string& appName, const std::string& organizationName);
 		Filesystem(const Filesystem&) = delete;
 		Filesystem& operator=(const Filesystem&) = delete;
 		Filesystem(Filesystem&&) = delete;


### PR DESCRIPTION
The `argv_0` argument is no longer needed and will be removed. For now, we can use overloaded constructors and constructor delegation to allow callers to drop passing this argument, without requiring them to do so. That will open up a transition period where users of the library can be adjusted without breaking code.

Reference: #1028
