### PR TITLE
Update MacOS CircleCI image to 12.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
 jobs:
   build-macos:
     macos:
-      xcode: "12.5.0"
+      xcode: "12.5.1"
     environment:
       - HOMEBREW_NO_AUTO_UPDATE: 1
       - WARN_EXTRA: "-Wno-double-promotion"


### PR DESCRIPTION
It seems the previous image 12.5.0 is no longer supported.

----
Available MacOS images:
https://circleci.com/docs/using-macos#supported-xcode-versions

There is a stable version 13.4.1 available, though builds with that version fail in some SDL code due to a warning flag we are using.

Example of failure:
https://app.circleci.com/pipelines/github/lairworks/nas2d-core/1986/workflows/f4e7c376-605c-4b7b-beb4-f10ed6a235f0/jobs/8179
