### PR TITLE
Skip caching of problem glyphs

### DIFF
--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -290,22 +290,16 @@ namespace
 		{
 			const std::size_t glyph = glyphPosition.y * GLYPH_MATRIX_SIZE + glyphPosition.x;
 
-			// Avoid glyph 0, which has size 0 for some fonts
-			// SDL_TTF will produce errors for a glyph of size 0
-			if (glyph == 0) { continue; }
-
 			SDL_Surface* characterSurface = TTF_RenderGlyph_Blended(font, static_cast<uint16_t>(glyph), white);
-			if (!characterSurface)
+			// A character surface can fail to be created for glyphs of size 0
+			if (characterSurface)
 			{
-				SDL_FreeSurface(fontSurface);
-				throw std::runtime_error("Font failed to generate surface for character : " + std::to_string(glyph) + " : " + std::string(TTF_GetError()));
+				SDL_SetSurfaceBlendMode(characterSurface, SDL_BLENDMODE_NONE);
+				const auto pixelPosition = glyphPosition.to<int>().skewBy(characterSize);
+				SDL_Rect rect = { pixelPosition.x, pixelPosition.y, 0, 0 };
+				SDL_BlitSurface(characterSurface, nullptr, fontSurface, &rect);
+				SDL_FreeSurface(characterSurface);
 			}
-
-			SDL_SetSurfaceBlendMode(characterSurface, SDL_BLENDMODE_NONE);
-			const auto pixelPosition = glyphPosition.to<int>().skewBy(characterSize);
-			SDL_Rect rect = { pixelPosition.x, pixelPosition.y, 0, 0 };
-			SDL_BlitSurface(characterSurface, nullptr, fontSurface, &rect);
-			SDL_FreeSurface(characterSurface);
 		}
 
 		return fontSurface;


### PR DESCRIPTION
Glyphs of size 0 fail to create a character surface when pre-rendering characters to a bitmap image cache. We don't actually care about the reason why the pre-rendering fails. We just want to skip over glyphs that can be printed. Effectively we will print an empty glyph in their place, which will likely also have a size of 0.

This is an alternate solution to PR #1021.
