### PR TITLE
Ignore some files when running `cppclean`

### DIFF
--- a/makefile
+++ b/makefile
@@ -150,7 +150,7 @@ cppcheck:
 
 .PHONY: cppclean
 cppclean:
-	cppclean "$(SRCDIR)" --exclude="NAS2D.h"
+	cppclean "$(SRCDIR)" --exclude="NAS2D.h" --exclude="Xml"
 
 .PHONY: format
 format:

--- a/makefile
+++ b/makefile
@@ -150,7 +150,7 @@ cppcheck:
 
 .PHONY: cppclean
 cppclean:
-	cppclean "$(SRCDIR)"
+	cppclean "$(SRCDIR)" --exclude="NAS2D.h"
 
 .PHONY: format
 format:


### PR DESCRIPTION
The warnings about unused includes in `NAS2D.h` are a bit silly, since the purpose of that file is to provide an easy include everything solution, and of course it doesn't use anything it includes.

Similarly, there are some warnings about the TinyXML code that we don't intend to fix. It's external code, and it's due to be eventually replaced by TinyXML2. No need to expend effort on minor warnings in external code which is going to be removed.

----

Somewhat related to Issue #528
