### PR TITLE
Fix `Sprite` copy/move specification

### DIFF
--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -34,7 +34,7 @@ namespace NAS2D
 
 		Sprite(const std::string& filePath, const std::string& initialAction);
 		Sprite(const AnimationSet& animationSet, const std::string& initialAction);
-		Sprite(const Sprite&) = delete;
+		Sprite(const Sprite&) = default;
 		const Sprite& operator=(const Sprite&) = delete;
 
 		Vector<int> size() const;

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -35,7 +35,9 @@ namespace NAS2D
 		Sprite(const std::string& filePath, const std::string& initialAction);
 		Sprite(const AnimationSet& animationSet, const std::string& initialAction);
 		Sprite(const Sprite&) = default;
+		Sprite(Sprite&&) = default;
 		const Sprite& operator=(const Sprite&) = delete;
+		Sprite& operator=(Sprite&&) = delete;
 
 		Vector<int> size() const;
 		Point<int> origin(Point<int> point) const;

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -34,8 +34,8 @@ namespace NAS2D
 
 		Sprite(const std::string& filePath, const std::string& initialAction);
 		Sprite(const AnimationSet& animationSet, const std::string& initialAction);
-		Sprite(Sprite&) = delete;
-		Sprite& operator=(Sprite&) = delete;
+		Sprite(const Sprite&) = delete;
+		const Sprite& operator=(const Sprite&) = delete;
 
 		Vector<int> size() const;
 		Point<int> origin(Point<int> point) const;


### PR DESCRIPTION
Fix for some sloppy work done in PR #1040, commit 078124b5851ba14ab4c808e71cc888bb1a988ca8, that was overly restrictive for `Sprite` copy construction.

The `Sprite` class has `const` and reference fields, and so can not be assigned to. That means the copy and move assignment operators are implicitly deleted. It doesn't however mean the copy/move constructors have any kind of problem. It's perfectly valid to initialize a `const` field, it just can't be changed later through assignment.
