### PR TITLE
Upgrade MacOS image to 13.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
 jobs:
   build-macos:
     macos:
-      xcode: "12.5.1"
+      xcode: "13.4.1"
     environment:
       - HOMEBREW_NO_AUTO_UPDATE: 1
       - WARN_EXTRA: "-isystem /usr/local/include"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       xcode: "12.5.1"
     environment:
       - HOMEBREW_NO_AUTO_UPDATE: 1
-      - WARN_EXTRA: "-Wno-double-promotion"
+      - WARN_EXTRA: "-isystem /usr/local/include"
     steps:
       - checkout
       - brew-install


### PR DESCRIPTION
Use the `-isystem` flag to mark certain folders as system folders, which suppresses warnings for code from those folders. This eliminates warnings generated from `brew` installed dependencies, without having to disable warnings for the main project itself.

Closes #1035
