### PR TITLE
Remove global constructors

### DIFF
--- a/NAS2D/Xml/XmlElement.cpp
+++ b/NAS2D/Xml/XmlElement.cpp
@@ -21,7 +21,6 @@
 
 using namespace NAS2D::Xml;
 
-const std::string NAS2D_EMPTY_STR = "";
 
 XmlElement::XmlElement(const std::string& value) :
 	XmlNode(XmlNode::NodeType::XML_ELEMENT)

--- a/NAS2D/Xml/XmlParser.cpp
+++ b/NAS2D/Xml/XmlParser.cpp
@@ -50,23 +50,26 @@
 #	endif
 #endif
 
-const std::vector<std::string> XML_ERROR_TABLE = {
-	"No error",
-	"Unspecified Error",
-	"Error parsing Element.",
-	"Failed to read Element name.",
-	"Error reading Element value.",
-	"Error reading Attributes.",
-	"Error: Empty tag.",
-	"Error reading end tag.",
-	"Error parsing Unknown.",
-	"Error parsing Comment.",
-	"Error parsing Declaration.",
-	"Error: Document empty.",
-	"Error: Unexpected EOF found in input stream.",
-	"Error parsing CDATA.",
-	"Error adding XmlDocument to document: XmlDocument can only be at the root.",
-};
+namespace
+{
+	const std::vector<std::string> XML_ERROR_TABLE = {
+		"No error",
+		"Unspecified Error",
+		"Error parsing Element.",
+		"Failed to read Element name.",
+		"Error reading Element value.",
+		"Error reading Attributes.",
+		"Error: Empty tag.",
+		"Error reading end tag.",
+		"Error parsing Unknown.",
+		"Error parsing Comment.",
+		"Error parsing Declaration.",
+		"Error: Document empty.",
+		"Error: Unexpected EOF found in input stream.",
+		"Error parsing CDATA.",
+		"Error adding XmlDocument to document: XmlDocument can only be at the root.",
+	};
+}
 
 
 namespace NAS2D

--- a/NAS2D/Xml/XmlParser.cpp
+++ b/NAS2D/Xml/XmlParser.cpp
@@ -38,6 +38,7 @@
 #include <fstream>
 #include <cstring>
 #include <string>
+#include <array>
 
 
 //#define DEBUG_PARSER
@@ -52,7 +53,7 @@
 
 namespace
 {
-	const std::vector<std::string> XML_ERROR_TABLE = {
+	const auto XML_ERROR_TABLE = std::array{
 		"No error",
 		"Unspecified Error",
 		"Error parsing Element.",


### PR DESCRIPTION
Reference: #528

Noticed a few easy improvements after running Clang with `-Wglobal-constructors`. There are more detected with that flag, but these were the easy ones.
