### PR TITLE
Explicit sign conversion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
     docker:
       - image: outpostuniverse/nas2d-clang:1.3
     environment:
-      - WARN_EXTRA: "-Wdocumentation -Wdocumentation-unknown-command -Wcomma -Winconsistent-missing-destructor-override -Wmissing-prototypes -Wctad-maybe-unsupported -Wimplicit-int-float-conversion"
+      - WARN_EXTRA: "-Wdocumentation -Wdocumentation-unknown-command -Wcomma -Winconsistent-missing-destructor-override -Wmissing-prototypes -Wctad-maybe-unsupported -Wimplicit-int-float-conversion -Wsign-conversion"
     steps:
       - checkout
       - build-and-test

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -271,7 +271,7 @@ std::string Filesystem::readFile(const std::string& filename) const
 	std::string fileBuffer;
 	fileBuffer.resize(bufferSize);
 
-	file.read(fileBuffer.data(), bufferSize);
+	file.read(fileBuffer.data(), static_cast<std::streamsize>(bufferSize));
 	if (!file)
 	{
 		throw std::runtime_error("Error reading file: " + filename + " : " + errorDescription());


### PR DESCRIPTION
Reference: #528

Fix warning and add Clang warning flag `-Wsign-conversion`.
