### PR TITLE
Add `Sprite` constructor overload taking `animationCache`

### DIFF
--- a/NAS2D/Resource/AnimationSet.h
+++ b/NAS2D/Resource/AnimationSet.h
@@ -41,7 +41,7 @@ namespace NAS2D
 		using ActionsMap = std::map<std::string, std::vector<Frame>>;
 
 
-		AnimationSet(std::string fileName);
+		explicit AnimationSet(std::string fileName);
 		AnimationSet(std::string fileName, ResourceCache<Image, std::string>& imageCache);
 		AnimationSet(std::string fileName, ImageSheetMap imageSheetMap, ActionsMap actions);
 

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -24,13 +24,19 @@ using namespace NAS2D;
 namespace
 {
 	using AnimationCache = ResourceCache<AnimationSet, std::string>;
-	AnimationCache animationCache;
+	AnimationCache defaultAnimationCache;
+}
+
+
+Sprite::Sprite(const std::string& filePath, const std::string& initialAction, AnimationCache& animationCache) :
+	mAnimationSet{animationCache.load(filePath)},
+	mCurrentAction{&mAnimationSet.frames(initialAction)}
+{
 }
 
 
 Sprite::Sprite(const std::string& filePath, const std::string& initialAction) :
-	mAnimationSet{animationCache.load(filePath)},
-	mCurrentAction{&mAnimationSet.frames(initialAction)}
+	Sprite{filePath, initialAction, defaultAnimationCache}
 {
 }
 

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -21,6 +21,9 @@
 
 namespace NAS2D
 {
+	template <typename Resource, typename... Params> class ResourceCache;
+
+
 	/**
 	 * Sprite resource.
 	 *
@@ -30,8 +33,10 @@ namespace NAS2D
 	class Sprite
 	{
 	public:
+		using AnimationCache = ResourceCache<AnimationSet, std::string>;
 		using AnimationCompleteSignal = Signal<>; /**< Signal used when action animations complete. */
 
+		Sprite(const std::string& filePath, const std::string& initialAction, AnimationCache& animationCache);
 		Sprite(const std::string& filePath, const std::string& initialAction);
 		Sprite(const AnimationSet& animationSet, const std::string& initialAction);
 		Sprite(const Sprite&) = default;


### PR DESCRIPTION
Add `Sprite` constructor overload taking an explicit `animationCache`. This allows projects to define and use their own `AnimationSet` cache, which they can control the lifetime and maintenance of. This eliminates much of the need for the library to define it's own `defaultAnimationCache`. This change also makes the API a bit more consistent, in that `AnimationSet` has a constructor overload that can accept a custom `imageCache`.

----

The `defaultAnimationCache` is flagged when compiling with the Clang warning flag `-Wglobal-constructors` and `-Wexit-time-destructors`.

Reference: #528
