### PR TITLE
Revert #1050 `Sprite` constructor overload taking `animationCache`

### DIFF
--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -24,19 +24,13 @@ using namespace NAS2D;
 namespace
 {
 	using AnimationCache = ResourceCache<AnimationSet, std::string>;
-	AnimationCache defaultAnimationCache;
-}
-
-
-Sprite::Sprite(const std::string& filePath, const std::string& initialAction, AnimationCache& animationCache) :
-	mAnimationSet{animationCache.load(filePath)},
-	mCurrentAction{&mAnimationSet.frames(initialAction)}
-{
+	AnimationCache animationCache;
 }
 
 
 Sprite::Sprite(const std::string& filePath, const std::string& initialAction) :
-	Sprite{filePath, initialAction, defaultAnimationCache}
+	mAnimationSet{animationCache.load(filePath)},
+	mCurrentAction{&mAnimationSet.frames(initialAction)}
 {
 }
 

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -21,9 +21,6 @@
 
 namespace NAS2D
 {
-	template <typename Resource, typename... Params> class ResourceCache;
-
-
 	/**
 	 * Sprite resource.
 	 *
@@ -33,10 +30,8 @@ namespace NAS2D
 	class Sprite
 	{
 	public:
-		using AnimationCache = ResourceCache<AnimationSet, std::string>;
 		using AnimationCompleteSignal = Signal<>; /**< Signal used when action animations complete. */
 
-		Sprite(const std::string& filePath, const std::string& initialAction, AnimationCache& animationCache);
 		Sprite(const std::string& filePath, const std::string& initialAction);
 		Sprite(const AnimationSet& animationSet, const std::string& initialAction);
 		Sprite(const Sprite&) = default;


### PR DESCRIPTION
Revert "Allow a custom `animationCache` to be passed to `Sprite` constructor"

This reverts commit 74233f4e258b5710e937447ad841b518be344792.

This feature is of questionable use until the second layer of caching of `Image` object used by `AnimationSet` objects is dealt with. Maybe best to remove it for now so it doesn't get used.

Reference: #1050
