### PR TITLE
Remove `FadeType` enum

### DIFF
--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -111,13 +111,6 @@ namespace NAS2D
 		Vector<int> mResolution{1600, 900};
 
 	private:
-		enum class FadeType
-		{
-			In = -1,
-			None = 0,
-			Out = 1
-		};
-
 		std::string mDriverName{"NULL Renderer"};
 		std::string mTitle{"Default Application"};
 	};


### PR DESCRIPTION
This was mistakenly left in when the other fade related items were removed.

Reference: PR #1053 