### PR TITLE
Preconstruct `DelegateX` before calling `connect`/`disconnect`

### DIFF
--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -76,7 +76,7 @@ EventHandler::~EventHandler()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -98,7 +98,7 @@ EventHandler::ActivateEventSource& EventHandler::activate()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -120,7 +120,7 @@ EventHandler::WindowHiddenEventSource& EventHandler::windowHidden()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -140,7 +140,7 @@ EventHandler::WindowExposedEventSource& EventHandler::windowExposed()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -160,7 +160,7 @@ EventHandler::WindowMinimizedEventSource& EventHandler::windowMinimized()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -180,7 +180,7 @@ EventHandler::WindowMaximizedEventSource& EventHandler::windowMaximized()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -200,7 +200,7 @@ EventHandler::WindowRestoredEventSource& EventHandler::windowRestored()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -220,7 +220,7 @@ EventHandler::WindowResizedEventSource& EventHandler::windowResized()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -240,7 +240,7 @@ EventHandler::WindowMouseEnterEventSource& EventHandler::windowMouseEnter()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -261,7 +261,7 @@ EventHandler::WindowMouseLeaveEventSource& EventHandler::windowMouseLeave()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -287,7 +287,7 @@ EventHandler::JoystickAxisMotionEventSource& EventHandler::joystickAxisMotion()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -313,7 +313,7 @@ EventHandler::JoystickBallMotionEventSource& EventHandler::joystickBallMotion()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -338,7 +338,7 @@ EventHandler::JoystickButtonEventSource& EventHandler::joystickButtonUp()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -362,7 +362,7 @@ EventHandler::JoystickButtonEventSource& EventHandler::joystickButtonDown()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -387,7 +387,7 @@ EventHandler::JoystickHatMotionEventSource& EventHandler::joystickHatMotion()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -412,7 +412,7 @@ EventHandler::KeyDownEventSource& EventHandler::keyDown()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -435,7 +435,7 @@ EventHandler::KeyUpEventSource& EventHandler::keyUp()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -456,7 +456,7 @@ EventHandler::TextInputEventSource& EventHandler::textInput()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -480,7 +480,7 @@ EventHandler::MouseButtonEventSource& EventHandler::mouseButtonDown()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -504,7 +504,7 @@ EventHandler::MouseButtonEventSource& EventHandler::mouseButtonUp()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -528,7 +528,7 @@ EventHandler::MouseButtonEventSource& EventHandler::mouseDoubleClick()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -552,7 +552,7 @@ EventHandler::MouseMotionEventSource& EventHandler::mouseMotion()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code
@@ -579,7 +579,7 @@ EventHandler::MouseWheelEventSource& EventHandler::mouseWheel()
  * function as follows:
  *
  * \code
- * connect(this, &Object::function);
+ * connect({this, &Object::function});
  * \endcode
  *
  * \code

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -112,7 +112,7 @@ MixerSDL::MixerSDL(const Options& options)
 	soundVolume(options.sfxVolume);
 	musicVolume(options.musicVolume);
 
-	musicFinished.connect(this, &MixerSDL::onMusicFinished);
+	musicFinished.connect({this, &MixerSDL::onMusicFinished});
 	Mix_HookMusicFinished([](){ musicFinished(); });
 }
 
@@ -124,7 +124,7 @@ MixerSDL::~MixerSDL()
 	Mix_CloseAudio();
 
 	Mix_HookMusicFinished(nullptr);
-	musicFinished.disconnect(this, &MixerSDL::onMusicFinished);
+	musicFinished.disconnect({this, &MixerSDL::onMusicFinished});
 
 	SDL_QuitSubSystem(SDL_INIT_AUDIO);
 }

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -131,7 +131,7 @@ RendererOpenGL::RendererOpenGL(const std::string& title, const Options& options)
 
 RendererOpenGL::~RendererOpenGL()
 {
-	Utility<EventHandler>::get().windowResized().disconnect(this, &RendererOpenGL::onResize);
+	Utility<EventHandler>::get().windowResized().disconnect({this, &RendererOpenGL::onResize});
 
 	SDL_GL_DeleteContext(sdlOglContext);
 	SDL_DestroyWindow(underlyingWindow);
@@ -780,7 +780,7 @@ void RendererOpenGL::initVideo(Vector<int> resolution, bool fullscreen, bool vsy
 	glewInit();
 	initGL();
 
-	Utility<EventHandler>::get().windowResized().connect(this, &RendererOpenGL::onResize);
+	Utility<EventHandler>::get().windowResized().connect({this, &RendererOpenGL::onResize});
 }
 
 // ==================================================================================

--- a/NAS2D/StateManager.cpp
+++ b/NAS2D/StateManager.cpp
@@ -24,7 +24,7 @@ StateManager::StateManager() :
 	mActive(true)
 {
 	// Ensure that all quit messages are handled in some way even if a State object doesn't.
-	Utility<EventHandler>::get().quit().connect(this, &StateManager::handleQuit);
+	Utility<EventHandler>::get().quit().connect({this, &StateManager::handleQuit});
 }
 
 

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -29,17 +29,17 @@ TestGraphics::TestGraphics() :
 
 TestGraphics::~TestGraphics()
 {
-	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().disconnect(this, &TestGraphics::onMouseMove);
-	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().disconnect(this, &TestGraphics::onMouseDown);
-	NAS2D::Utility<NAS2D::EventHandler>::get().keyDown().disconnect(this, &TestGraphics::onKeyDown);
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().disconnect({this, &TestGraphics::onMouseMove});
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().disconnect({this, &TestGraphics::onMouseDown});
+	NAS2D::Utility<NAS2D::EventHandler>::get().keyDown().disconnect({this, &TestGraphics::onKeyDown});
 
 }
 
 void TestGraphics::initialize()
 {
-	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().connect(this, &TestGraphics::onMouseMove);
-	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect(this, &TestGraphics::onMouseDown);
-	NAS2D::Utility<NAS2D::EventHandler>::get().keyDown().connect(this, &TestGraphics::onKeyDown);
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().connect({this, &TestGraphics::onMouseMove});
+	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect({this, &TestGraphics::onMouseDown});
+	NAS2D::Utility<NAS2D::EventHandler>::get().keyDown().connect({this, &TestGraphics::onKeyDown});
 
 	NAS2D::Utility<NAS2D::Renderer>::get().showSystemPointer(true);
 	NAS2D::Utility<NAS2D::Renderer>::get().minimumSize({1600, 900});


### PR DESCRIPTION
This means fewer overloaded methods will be needed on the `SignalSource` object. It also more tightly associates `this` pointers with member function pointers by composing them into an obvious compound object.

One reason to want to reduce `connect` overloads, is to add debugging capabilities to the `connect` method. This is easier when only a single overload needs to be updated.

Reference: https://github.com/OutpostUniverse/OPHD/pull/1271, https://github.com/OutpostUniverse/OPHD/issues/1269
