### PR TITLE
Remove unpacked `connect`/`disconnect` overloads from `SignalSource`

### DIFF
--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -38,12 +38,6 @@ namespace NAS2D
 			}
 		}
 
-		template <typename X, typename Y>
-		void connect(Y* obj, void (X::*func)(Params...)) { connect(MakeDelegate(obj, func)); }
-
-		template <typename X, typename Y>
-		void connect(Y* obj, void (X::*func)(Params...) const) { connect(MakeDelegate(obj, func)); }
-
 		void disconnect(DelegateType delegate)
 		{
 			const auto iterator = std::find(delegateList.begin(), delegateList.end(), delegate);
@@ -52,12 +46,6 @@ namespace NAS2D
 				delegateList.erase(iterator);
 			}
 		}
-
-		template <typename X, typename Y>
-		void disconnect(Y* obj, void (X::*func)(Params...)) { disconnect(MakeDelegate(obj, func)); }
-
-		template <typename X, typename Y>
-		void disconnect(Y* obj, void (X::*func)(Params...) const) { disconnect(MakeDelegate(obj, func)); }
 
 	protected:
 		std::vector<DelegateType> delegateList{};


### PR DESCRIPTION
These overloads are currently unused.

A `DelegateX` object can be preconstructed at the point of call by enclosing the two parameters with braces `{}`, which can then be passed to the remaining overload. That perhaps adds clarity as well, since the `this` pointer and the member function pointer are closely related, so it makes sense to pass them as a compound object.

Reducing the number of overloads makes it easier to add debug code to just a single overload, which should help with occasional event handling issues.

Reference: https://github.com/lairworks/nas2d-core/pull/1055, https://github.com/OutpostUniverse/OPHD/pull/1271, https://github.com/OutpostUniverse/OPHD/issues/1269