### PR TITLE
Extract window related functions to a `Window` base class

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -214,6 +214,7 @@
     <ClCompile Include="Renderer\RectangleSkin.cpp" />
     <ClCompile Include="Renderer\Renderer.cpp" />
     <ClCompile Include="Renderer\RendererOpenGL.cpp" />
+    <ClCompile Include="Renderer\Window.cpp" />
     <ClCompile Include="Resource\AnimationSet.cpp" />
     <ClCompile Include="Resource\Font.cpp" />
     <ClCompile Include="Resource\Image.cpp" />
@@ -265,6 +266,7 @@
     <ClInclude Include="Renderer\RectangleSkin.h" />
     <ClInclude Include="Renderer\Renderer.h" />
     <ClInclude Include="Renderer\RendererOpenGL.h" />
+    <ClInclude Include="Renderer\Window.h" />
     <ClInclude Include="Resource\ResourceCache.h" />
     <ClInclude Include="Resource\AnimationSet.h" />
     <ClInclude Include="Resource\Font.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -99,6 +99,9 @@
     <ClCompile Include="Renderer\RendererOpenGL.cpp">
       <Filter>Source Files\Renderer</Filter>
     </ClCompile>
+    <ClCompile Include="Renderer\Window.cpp">
+      <Filter>Source Files\Renderer</Filter>
+    </ClCompile>
     <ClCompile Include="Resource\AnimationSet.cpp">
       <Filter>Source Files\Resource</Filter>
     </ClCompile>
@@ -252,6 +255,9 @@
       <Filter>Header Files\Renderer</Filter>
     </ClInclude>
     <ClInclude Include="Renderer\RendererOpenGL.h">
+      <Filter>Header Files\Renderer</Filter>
+    </ClInclude>
+    <ClInclude Include="Renderer\Window.h">
       <Filter>Header Files\Renderer</Filter>
     </ClInclude>
     <ClInclude Include="Resource\ResourceCache.h">

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -18,7 +18,7 @@
 using namespace NAS2D;
 
 
-Renderer::Renderer(const std::string& appTitle) : mTitle(appTitle)
+Renderer::Renderer(const std::string& appTitle) : Window(appTitle)
 {}
 
 
@@ -34,30 +34,9 @@ void Renderer::driverName(const std::string& name)
 }
 
 
-const std::string& Renderer::title() const
-{
-	return mTitle;
-}
-
-
 const std::string& Renderer::driverName() const
 {
 	return mDriverName;
-}
-
-
-void Renderer::title(const std::string& title)
-{
-	mTitle = title;
-}
-
-
-void Renderer::setResolution(Vector<int> newResolution)
-{
-	if (!fullscreen())
-	{
-		mResolution = newResolution;
-	}
 }
 
 

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "Color.h"
-#include "DisplayDesc.h"
+#include "Window.h"
 #include "../Math/Point.h"
 #include "../Math/Vector.h"
 #include "../Timer.h"
@@ -33,7 +33,7 @@ namespace NAS2D
 	struct Rectangle;
 
 
-	class Renderer
+	class Renderer : public Window
 	{
 	public:
 		Renderer() = default;
@@ -44,31 +44,6 @@ namespace NAS2D
 		virtual ~Renderer();
 
 		const std::string& driverName() const;
-		virtual std::vector<DisplayDesc> getDisplayModes() const = 0;
-		virtual DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const = 0;
-
-		const std::string& title() const;
-		void title(const std::string& title);
-
-		virtual void window_icon(const std::string& path) = 0;
-
-		virtual void showSystemPointer(bool) = 0;
-		virtual void addCursor(const std::string& filePath, int cursorId, int offx, int offy) = 0;
-		virtual void setCursor(int cursorId) = 0;
-
-		virtual void fullscreen(bool fs, bool maintain = false) = 0;
-		virtual bool fullscreen() const = 0;
-
-		virtual void resizeable(bool _r) = 0;
-		virtual bool resizeable() const = 0;
-
-		virtual void minimumSize(Vector<int> newSize) = 0;
-
-		virtual Vector<int> size() const = 0;
-		virtual void size(Vector<int> newSize) = 0;
-		void setResolution(Vector<int> newResolution);
-
-		virtual Vector<int> getWindowClientArea() const noexcept = 0;
 
 		virtual void drawImage(const Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) = 0;
 		virtual void drawSubImage(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, Color color = Color::Normal) = 0;
@@ -108,11 +83,8 @@ namespace NAS2D
 
 		void driverName(const std::string& name);
 
-		Vector<int> mResolution{1600, 900};
-
 	private:
 		std::string mDriverName{"NULL Renderer"};
-		std::string mTitle{"Default Application"};
 	};
 
 } // namespace

--- a/NAS2D/Renderer/RendererNull.h
+++ b/NAS2D/Renderer/RendererNull.h
@@ -22,28 +22,6 @@ namespace NAS2D
 
 		~RendererNull() override {}
 
-		std::vector<DisplayDesc> getDisplayModes() const override { return {}; }
-		DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc&) const override { return {}; }
-
-		void window_icon(const std::string&) override {}
-
-		void showSystemPointer(bool) override {}
-		void addCursor(const std::string&, int, int, int) override {}
-		void setCursor(int) override {}
-
-		void fullscreen(bool, bool = false) override {}
-		bool fullscreen() const override { return false; }
-
-		void resizeable(bool) override {}
-		bool resizeable() const override { return false; }
-
-		void minimumSize(Vector<int>) override {}
-
-		Vector<int> size() const override { return {}; }
-		void size(Vector<int>) override {}
-
-		Vector<int> getWindowClientArea() const noexcept override { return {}; }
-
 		void drawImage(const Image&, Point<float>, float = 1.0, Color = Color::Normal) override {}
 
 		void drawSubImage(const Image&, Point<float>, const Rectangle<float>&, Color = Color::Normal) override {}

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -39,7 +39,7 @@ using namespace NAS2D;
 
 // UGLY ASS HACK!
 // This is required for mouse grabbing in the EventHandler class.
-SDL_Window* underlyingWindow = nullptr;
+extern SDL_Window* underlyingWindow;
 
 
 namespace
@@ -85,11 +85,6 @@ namespace
 		std::cout << "\tRenderer: " << glString(GL_RENDERER) << std::endl;
 		std::cout << "\tDriver Version: " << glString(GL_VERSION) << std::endl;
 		std::cout << "\tGLSL Version: " << glString(GL_SHADING_LANGUAGE_VERSION) << std::endl;
-	}
-
-	bool isAnyWindowFlagSet(Uint32 testFlags)
-	{
-		return (SDL_GetWindowFlags(underlyingWindow) & testFlags) != 0;
 	}
 }
 
@@ -139,194 +134,6 @@ RendererOpenGL::~RendererOpenGL()
 	SDL_QuitSubSystem(SDL_INIT_VIDEO);
 
 	std::cout << "OpenGL Renderer Terminated." << std::endl;
-}
-
-
-std::vector<DisplayDesc> RendererOpenGL::getDisplayModes() const
-{
-	const auto displayIndex = SDL_GetWindowDisplayIndex(underlyingWindow);
-	const auto numResolutions = SDL_GetNumDisplayModes(displayIndex);
-	if (numResolutions < 0)
-	{
-		throw std::runtime_error("Error getting number of display modes for display index: " + std::to_string(displayIndex) + " : " + SDL_GetError());
-	}
-
-	std::vector<DisplayDesc> result{};
-	result.reserve(static_cast<std::size_t>(numResolutions));
-	for (int i = 0; i < numResolutions; ++i)
-	{
-		SDL_DisplayMode currentMode{};
-		SDL_GetDisplayMode(displayIndex, i, &currentMode);
-		result.push_back({currentMode.w, currentMode.h, currentMode.refresh_rate});
-	}
-	return result;
-}
-
-
-DisplayDesc RendererOpenGL::getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const
-{
-	const auto displayIndex = SDL_GetWindowDisplayIndex(underlyingWindow);
-	SDL_DisplayMode preferredMode{};
-	preferredMode.w = preferredDisplayDesc.width;
-	preferredMode.h = preferredDisplayDesc.height;
-	preferredMode.refresh_rate = preferredDisplayDesc.refreshHz;
-
-	SDL_DisplayMode closestMode{};
-	if (SDL_GetClosestDisplayMode(displayIndex, &preferredMode, &closestMode))
-	{
-		return {closestMode.w, closestMode.h, closestMode.refresh_rate};
-	}
-	throw std::runtime_error("No matching display mode for " + std::string{preferredDisplayDesc});
-}
-
-
-void RendererOpenGL::window_icon(const std::string& path)
-{
-	auto iconData = Utility<Filesystem>::get().readFile(path);
-	SDL_Surface* icon = IMG_Load_RW(SDL_RWFromConstMem(iconData.c_str(), static_cast<int>(iconData.size())), 1);
-	if (!icon)
-	{
-		throw std::runtime_error("Failed to set window icon: " + path + " : " + SDL_GetError());
-	}
-
-	SDL_SetWindowIcon(underlyingWindow, icon);
-	SDL_FreeSurface(icon);
-}
-
-
-void RendererOpenGL::showSystemPointer(bool _b)
-{
-	SDL_ShowCursor(static_cast<int>(_b));
-}
-
-
-void RendererOpenGL::addCursor(const std::string& filePath, int cursorId, int offx, int offy)
-{
-	auto imageData = Utility<Filesystem>::get().readFile(filePath);
-	if (imageData.size() == 0)
-	{
-		throw std::runtime_error("Cursor file is empty: " + filePath);
-	}
-
-	SDL_Surface* surface = IMG_Load_RW(SDL_RWFromConstMem(imageData.c_str(), static_cast<int>(imageData.size())), 1);
-	if (!surface)
-	{
-		throw std::runtime_error("Failed to load cursor: " + filePath + " : " + SDL_GetError());
-	}
-
-	SDL_Cursor* cur = SDL_CreateColorCursor(surface, offx, offy);
-	SDL_FreeSurface(surface);
-	if (!cur)
-	{
-		throw std::runtime_error("Failed to create color cursor: " + filePath + " : " + SDL_GetError());
-	}
-
-	if (cursors.count(cursorId))
-	{
-		SDL_FreeCursor(cursors[cursorId]);
-	}
-
-	cursors[cursorId] = cur;
-
-	if (cursors.size() == 1)
-	{
-		setCursor(cursorId);
-	}
-}
-
-
-void RendererOpenGL::setCursor(int cursorId)
-{
-	SDL_SetCursor(cursors[cursorId]);
-}
-
-
-void RendererOpenGL::fullscreen(bool fullscreen, bool maintain)
-{
-	if (fullscreen)
-	{
-		const auto windowFlags = maintain ? SDL_WINDOW_FULLSCREEN : SDL_WINDOW_FULLSCREEN_DESKTOP;
-		SDL_SetWindowFullscreen(underlyingWindow, windowFlags);
-		SDL_SetWindowResizable(underlyingWindow, SDL_FALSE);
-	}
-	else
-	{
-		SDL_SetWindowFullscreen(underlyingWindow, 0);
-		const auto windowSize = size();
-		SDL_SetWindowSize(underlyingWindow, windowSize.x, windowSize.y);
-		onResize(windowSize);
-		SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-	}
-}
-
-
-bool RendererOpenGL::fullscreen() const
-{
-	return isAnyWindowFlagSet(SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP);
-}
-
-
-void RendererOpenGL::resizeable(bool resizable)
-{
-	if (fullscreen())
-	{
-		return;
-	}
-
-	#if defined(_MSC_VER)
-	#pragma warning(suppress: 26812) // C26812 Warns to use enum class (C++), but SDL is a C library
-	#endif
-	SDL_SetWindowResizable(underlyingWindow, resizable ? SDL_TRUE : SDL_FALSE);
-}
-
-
-bool RendererOpenGL::resizeable() const
-{
-	return isAnyWindowFlagSet(SDL_WINDOW_RESIZABLE);
-}
-
-
-void RendererOpenGL::minimumSize(Vector<int> newSize)
-{
-	SDL_SetWindowMinimumSize(underlyingWindow, newSize.x, newSize.y);
-
-	// Read back the window size, in case it was changed
-	// Window may need to have been enlarged to the minimum size
-	SDL_GetWindowSize(underlyingWindow, &newSize.x, &newSize.y);
-	onResize(newSize);
-}
-
-
-Vector<int> RendererOpenGL::size() const
-{
-	if (isAnyWindowFlagSet(SDL_WINDOW_FULLSCREEN_DESKTOP))
-	{
-		SDL_DisplayMode dm;
-		if (SDL_GetDesktopDisplayMode(0, &dm) != 0)
-		{
-			throw std::runtime_error("Unable to get desktop dislay mode: " + std::string{SDL_GetError()});
-		}
-
-		return {dm.w, dm.h};
-	}
-
-	return mResolution;
-}
-
-
-void RendererOpenGL::size(Vector<int> newSize)
-{
-	SDL_SetWindowSize(underlyingWindow, newSize.x, newSize.y);
-	onResize(newSize);
-	SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-}
-
-
-Vector<int> RendererOpenGL::getWindowClientArea() const noexcept
-{
-	Vector<int> size;
-	SDL_GetWindowSize(underlyingWindow, &size.x, &size.y);
-	return size;
 }
 
 

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -15,7 +15,6 @@
 
 
 using SDL_GLContext = void*;
-struct SDL_Cursor;
 
 
 namespace NAS2D
@@ -41,28 +40,6 @@ namespace NAS2D
 		RendererOpenGL& operator=(const RendererOpenGL& rhs) = delete;
 		RendererOpenGL& operator=(RendererOpenGL&& rhs) = delete;
 		virtual ~RendererOpenGL() override;
-
-		std::vector<DisplayDesc> getDisplayModes() const override;
-		DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const override;
-
-		void window_icon(const std::string& path) override;
-
-		void showSystemPointer(bool) override;
-		void addCursor(const std::string& filePath, int cursorId, int offx, int offy) override;
-		void setCursor(int cursorId) override;
-
-		void fullscreen(bool fs, bool maintain = false) override;
-		bool fullscreen() const override;
-
-		void resizeable(bool resizable) override;
-		bool resizeable() const override;
-
-		void minimumSize(Vector<int> newSize) override;
-
-		Vector<int> size() const override;
-		void size(Vector<int> newSize) override;
-
-		Vector<int> getWindowClientArea() const noexcept override;
 
 		void drawImage(const Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) override;
 
@@ -103,10 +80,9 @@ namespace NAS2D
 		void initSdlGL(bool vsync);
 		void initVideo(Vector<int> resolution, bool fullscreen, bool vsync);
 
-		void onResize(Vector<int> newSize);
+		void onResize(Vector<int> newSize) override;
 
 
 		SDL_GLContext sdlOglContext{};
-		std::map<int, SDL_Cursor*> cursors{};
 	};
 } // namespace NAS2D

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -1,0 +1,254 @@
+
+#include "Window.h"
+
+#include "DisplayDesc.h"
+#include "../Utility.h"
+#include "../Filesystem.h"
+#include "../EventHandler.h"
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
+
+
+using namespace NAS2D;
+
+
+// UGLY ASS HACK!
+// This is required for mouse grabbing in the EventHandler class.
+SDL_Window* underlyingWindow = nullptr;
+
+
+namespace
+{
+	bool isAnyWindowFlagSet(Uint32 testFlags)
+	{
+		return (SDL_GetWindowFlags(underlyingWindow) & testFlags) != 0;
+	}
+}
+
+
+Window::Window() :
+	Window{"Default Application"}
+{
+}
+
+
+Window::Window(const std::string& appTitle) :
+	mTitle{appTitle}
+{
+	Utility<EventHandler>::get().windowResized().connect({this, &Window::onResize});
+}
+
+
+const std::string& Window::title() const
+{
+	return mTitle;
+}
+
+
+void Window::title(const std::string& title)
+{
+	mTitle = title;
+}
+
+
+void Window::setResolution(Vector<int> newResolution)
+{
+	if (!fullscreen())
+	{
+		mResolution = newResolution;
+	}
+}
+
+
+std::vector<DisplayDesc> Window::getDisplayModes() const
+{
+	const auto displayIndex = SDL_GetWindowDisplayIndex(underlyingWindow);
+	const auto numResolutions = SDL_GetNumDisplayModes(displayIndex);
+	if (numResolutions < 0)
+	{
+		throw std::runtime_error("Error getting number of display modes for display index: " + std::to_string(displayIndex) + " : " + SDL_GetError());
+	}
+
+	std::vector<DisplayDesc> result{};
+	result.reserve(static_cast<std::size_t>(numResolutions));
+	for (int i = 0; i < numResolutions; ++i)
+	{
+		SDL_DisplayMode currentMode{};
+		SDL_GetDisplayMode(displayIndex, i, &currentMode);
+		result.push_back({currentMode.w, currentMode.h, currentMode.refresh_rate});
+	}
+	return result;
+}
+
+
+DisplayDesc Window::getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const
+{
+	const auto displayIndex = SDL_GetWindowDisplayIndex(underlyingWindow);
+	SDL_DisplayMode preferredMode{};
+	preferredMode.w = preferredDisplayDesc.width;
+	preferredMode.h = preferredDisplayDesc.height;
+	preferredMode.refresh_rate = preferredDisplayDesc.refreshHz;
+
+	SDL_DisplayMode closestMode{};
+	if (SDL_GetClosestDisplayMode(displayIndex, &preferredMode, &closestMode))
+	{
+		return {closestMode.w, closestMode.h, closestMode.refresh_rate};
+	}
+	throw std::runtime_error("No matching display mode for " + std::string{preferredDisplayDesc});
+}
+
+
+void Window::window_icon(const std::string& path)
+{
+	auto iconData = Utility<Filesystem>::get().readFile(path);
+	SDL_Surface* icon = IMG_Load_RW(SDL_RWFromConstMem(iconData.c_str(), static_cast<int>(iconData.size())), 1);
+	if (!icon)
+	{
+		throw std::runtime_error("Failed to set window icon: " + path + " : " + SDL_GetError());
+	}
+
+	SDL_SetWindowIcon(underlyingWindow, icon);
+	SDL_FreeSurface(icon);
+}
+
+
+void Window::showSystemPointer(bool _b)
+{
+	SDL_ShowCursor(static_cast<int>(_b));
+}
+
+
+void Window::addCursor(const std::string& filePath, int cursorId, int offx, int offy)
+{
+	auto imageData = Utility<Filesystem>::get().readFile(filePath);
+	if (imageData.size() == 0)
+	{
+		throw std::runtime_error("Cursor file is empty: " + filePath);
+	}
+
+	SDL_Surface* surface = IMG_Load_RW(SDL_RWFromConstMem(imageData.c_str(), static_cast<int>(imageData.size())), 1);
+	if (!surface)
+	{
+		throw std::runtime_error("Failed to load cursor: " + filePath + " : " + SDL_GetError());
+	}
+
+	SDL_Cursor* cur = SDL_CreateColorCursor(surface, offx, offy);
+	SDL_FreeSurface(surface);
+	if (!cur)
+	{
+		throw std::runtime_error("Failed to create color cursor: " + filePath + " : " + SDL_GetError());
+	}
+
+	if (cursors.count(cursorId))
+	{
+		SDL_FreeCursor(cursors[cursorId]);
+	}
+
+	cursors[cursorId] = cur;
+
+	if (cursors.size() == 1)
+	{
+		setCursor(cursorId);
+	}
+}
+
+
+void Window::setCursor(int cursorId)
+{
+	SDL_SetCursor(cursors[cursorId]);
+}
+
+
+void Window::fullscreen(bool fullscreen, bool maintain)
+{
+	if (fullscreen)
+	{
+		const auto windowFlags = maintain ? SDL_WINDOW_FULLSCREEN : SDL_WINDOW_FULLSCREEN_DESKTOP;
+		SDL_SetWindowFullscreen(underlyingWindow, windowFlags);
+		SDL_SetWindowResizable(underlyingWindow, SDL_FALSE);
+	}
+	else
+	{
+		SDL_SetWindowFullscreen(underlyingWindow, 0);
+		const auto windowSize = size();
+		SDL_SetWindowSize(underlyingWindow, windowSize.x, windowSize.y);
+		onResize(windowSize);
+		SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+	}
+}
+
+
+bool Window::fullscreen() const
+{
+	return isAnyWindowFlagSet(SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP);
+}
+
+
+void Window::resizeable(bool resizable)
+{
+	if (fullscreen())
+	{
+		return;
+	}
+
+	#if defined(_MSC_VER)
+	#pragma warning(suppress: 26812) // C26812 Warns to use enum class (C++), but SDL is a C library
+	#endif
+	SDL_SetWindowResizable(underlyingWindow, resizable ? SDL_TRUE : SDL_FALSE);
+}
+
+
+bool Window::resizeable() const
+{
+	return isAnyWindowFlagSet(SDL_WINDOW_RESIZABLE);
+}
+
+
+void Window::minimumSize(Vector<int> newSize)
+{
+	SDL_SetWindowMinimumSize(underlyingWindow, newSize.x, newSize.y);
+
+	// Read back the window size, in case it was changed
+	// Window may need to have been enlarged to the minimum size
+	SDL_GetWindowSize(underlyingWindow, &newSize.x, &newSize.y);
+	onResize(newSize);
+}
+
+
+Vector<int> Window::size() const
+{
+	if (isAnyWindowFlagSet(SDL_WINDOW_FULLSCREEN_DESKTOP))
+	{
+		SDL_DisplayMode dm;
+		if (SDL_GetDesktopDisplayMode(0, &dm) != 0)
+		{
+			throw std::runtime_error("Unable to get desktop dislay mode: " + std::string{SDL_GetError()});
+		}
+
+		return {dm.w, dm.h};
+	}
+
+	return mResolution;
+}
+
+
+void Window::size(Vector<int> newSize)
+{
+	SDL_SetWindowSize(underlyingWindow, newSize.x, newSize.y);
+	onResize(newSize);
+	SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+}
+
+
+void Window::onResize(Vector<int> /*newSize*/)
+{
+}
+
+
+Vector<int> Window::getWindowClientArea() const noexcept
+{
+	Vector<int> size;
+	SDL_GetWindowSize(underlyingWindow, &size.x, &size.y);
+	return size;
+}

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "../Math/Vector.h"
+
+#include <string>
+#include <vector>
+#include <map>
+
+
+struct SDL_Cursor;
+
+
+namespace NAS2D
+{
+	struct DisplayDesc;
+
+
+	class Window
+	{
+	public:
+		Window();
+		Window(const std::string& appTitle);
+		virtual ~Window() = default;
+
+		virtual std::vector<DisplayDesc> getDisplayModes() const;
+		virtual DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const;
+
+		const std::string& title() const;
+		void title(const std::string& title);
+
+		virtual void window_icon(const std::string& path);
+
+		virtual void showSystemPointer(bool);
+		virtual void addCursor(const std::string& filePath, int cursorId, int offx, int offy);
+		virtual void setCursor(int cursorId);
+
+		virtual void fullscreen(bool fs, bool maintain = false);
+		virtual bool fullscreen() const;
+
+		virtual void resizeable(bool _r);
+		virtual bool resizeable() const;
+
+		virtual void minimumSize(Vector<int> newSize);
+
+		virtual Vector<int> size() const;
+		virtual void size(Vector<int> newSize);
+		void setResolution(Vector<int> newResolution);
+
+		virtual Vector<int> getWindowClientArea() const noexcept;
+
+	protected:
+		virtual void onResize(Vector<int> newSize);
+
+	protected:
+		Vector<int> mResolution{1600, 900};
+		std::string mTitle;
+		std::map<int, SDL_Cursor*> cursors{};
+	};
+}


### PR DESCRIPTION
Long term, I would expect `Window` to be not directly related to the `Renderer` class, but instead allow creating a `Renderer` for a specific viewport within the `Window`, such as for the window client area.

For now though, we just want to move things in the right direction. Previously the window related methods were sorted together in the `Renderer` class. Now they are moved out to a `Window` base class, leaving the final `Renderer` interface basically still the same. Eventually the code may be updated so `Window` is no longer a base class, but instead creates or returns a `Renderer` for a specific viewport.

There may be some implications here, in that SDL related window code is now in the base `Window` class, which is inherited by `RendererNull`. This means more code has effectively found it's way into `RendererNull`. Mind you, we never actually use `RendererNull` anywhere, so perhaps this isn't much of a concern. It likely also won't matter much if `Window` is later split from `Renderer` so there is no inheritance.

Reference: #701
