### PR TITLE
Refactor `Timer`

### DIFF
--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -65,7 +65,7 @@ void Fade::update()
 		return;
 	}
 
-	const auto step = static_cast<uint8_t>(std::clamp(mFadeTimer.accumulator() * 255u / static_cast<unsigned int>(mDuration.count()), 0u, 255u));
+	const auto step = static_cast<uint8_t>(std::clamp(mFadeTimer.elapsedTicks() * 255u / static_cast<unsigned int>(mDuration.count()), 0u, 255u));
 	mFadeColor.alpha = (mDirection == FadeDirection::In) ? 255 - step : step;
 
 	if (step == 255)

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -14,7 +14,6 @@
 #include "Window.h"
 #include "../Math/Point.h"
 #include "../Math/Vector.h"
-#include "../Timer.h"
 #include "../Signal/Signal.h"
 
 #include <chrono>

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -116,7 +116,7 @@ void Sprite::setFrame(std::size_t frameIndex)
 
 void Sprite::update()
 {
-	mTimer.adjust_accumulator(advanceByTimeDelta(mTimer.accumulator()));
+	mTimer.adjustStartTick(advanceByTimeDelta(mTimer.elapsedTicks()));
 }
 
 

--- a/NAS2D/Timer.cpp
+++ b/NAS2D/Timer.cpp
@@ -32,15 +32,27 @@ Timer::Timer(unsigned int startTick) :
 {}
 
 
-unsigned int Timer::accumulator() const
+unsigned int Timer::elapsedTicks() const
 {
 	return tick() - mStartTick;
 }
 
 
-void Timer::adjust_accumulator(unsigned int ticksForward)
+void Timer::adjustStartTick(unsigned int ticksForward)
 {
 	mStartTick += ticksForward;
+}
+
+
+unsigned int Timer::accumulator() const
+{
+	return elapsedTicks();
+}
+
+
+void Timer::adjust_accumulator(unsigned int ticksForward)
+{
+	adjustStartTick(ticksForward);
 }
 
 

--- a/NAS2D/Timer.cpp
+++ b/NAS2D/Timer.cpp
@@ -12,58 +12,39 @@
 
 #include <SDL2/SDL.h>
 
+
 using namespace NAS2D;
 
-/**
- * Gets the current tick.
- */
-unsigned int Timer::tick() const
+
+unsigned int Timer::tick()
 {
 	return SDL_GetTicks();
 }
 
 
-/**
- * Gets the difference in time since the last call to delta().
- */
-unsigned int Timer::delta()
-{
-	unsigned int mLastTick = mCurrentTick;
-	mCurrentTick = SDL_GetTicks();
+Timer::Timer() :
+	Timer{Timer::tick()}
+{}
 
-	return mCurrentTick - mLastTick;
+
+Timer::Timer(unsigned int startTick) :
+	mStartTick{startTick}
+{}
+
+
+unsigned int Timer::accumulator() const
+{
+	return tick() - mStartTick;
 }
 
 
-/**
- * Updates the Accumulator value.
- *
- * \return	Returns an accumulator value.
- */
-unsigned int Timer::accumulator()
+void Timer::adjust_accumulator(unsigned int ticksForward)
 {
-	mAccumulator += delta();
-
-	return mAccumulator;
+	mStartTick += ticksForward;
 }
 
 
-/**
- * Adjusts the Accumulator value by a given amount.
- *
- * \param	a	Amount to adjust the Accumulator by.
- */
-void Timer::adjust_accumulator(unsigned int a)
-{
-	mAccumulator -= a;
-}
-
-
-/**
- * Resets the accumulator and updates the tick counter.
- */
 void Timer::reset()
 {
-	delta();
-	mAccumulator = 0;
+	mStartTick = tick();
 }

--- a/NAS2D/Timer.h
+++ b/NAS2D/Timer.h
@@ -16,59 +16,37 @@ namespace NAS2D
 	/**
 	 * A timing class that provides high-resolution, millisecond-precision timing services.
 	 *
-	 * The Timer class provides three different method for getting and managing timing.
+	 * The Timer class provides elapsed time from the Timer start/initialization time.
+	 *
+	 * The reference start time can be moved forward relative by a specified number of ticks
+	 * in case a new event needs to be measured relative to a previous event.
+	 * This relative adjustment can be used to avoid issues with jitter,
+	 * caused by the processing time for the old event before the new event is setup.
 	 *
 	 * \section Raw Tick
 	 *
-	 * By far the simplest method, raw ticks provide the current tick in milliseconds since the application
-	 * started. You can get this value by calling the function <tt>unsigned int tick() const</tt>.
+	 * A static method is provided for the raw time in ticks.
 	 *
-	 * As a note, according to SDL documentation, values will roll back over to 0 if the application runs
-	 * for more than 49 days. In practice this should cause no noticable side effects (as all values are
-	 * in <tt>unsigned int</tt>'s).
-	 *
-	 * \section Delta Change
-	 *
-	 * This is a basic method of getting delta times, or the difference in time from the last time <tt>delta()</tt>
-	 * was called to the current call.
-	 *
-	 * This is the simplest timing method in that physics simulations can use a raw delta value like this
-	 * to determine how far to advance the simulation, etc.
-	 *
-	 * \section Accumulators
-	 *
-	 * The third and final method for handling timing is through the use of an Accumulator. In essence, an accumulator
-	 * is just what it sounds like. It accumulates the elapsed time every time it is updated. The accumulator will continue
-	 * to report the current accumulated time in milliseconds since the Timer was created or since the last call to
-	 * <tt>void reset()</tt>.
-	 *
-	 * Additionally, the accumulator provides a method to adjust the accumulated time. Calling <tt>void adjust_accumulator(unsigned int a)</tt>
-	 * will adjust the accumulated time counter by the amount indicated by \c 'a'. E.g., a positive value will adjust the
-	 * accumulator forward vs. a negative value which will adjust it backward.
-	 *
-	 * Using accumulators are very useful when it comes to timing things like animation accurately to account for
-	 * jumps and gaps in time, for instance if the application stalls for a few seconds.
-	 *
-	 * Accumulators are used internally in the Sprite animation handling to account for time desynchs between frames. As
-	 * time passes the frame counter loses accuracy. Using an accumulator corrects for these inaccuracies by skipping
-	 * frames whenever needed.
+	 * With the current implementation, raw ticks are since app startup, and wrap back to 0 after about 49 days.
 	 */
 	class Timer
 	{
 	public:
-		Timer() = default;
+		static unsigned int tick();
 
-		unsigned int tick() const;
-		unsigned int delta();
+		Timer();
+		Timer(unsigned int startTick);
 
-		unsigned int accumulator();
-		void adjust_accumulator(unsigned int a);
+		Timer(const Timer&) = default;
+		Timer& operator=(const Timer&) = default;
+
+		unsigned int accumulator() const;
+		void adjust_accumulator(unsigned int ticksForward);
 
 		void reset();
 
 	private:
-		unsigned int mCurrentTick = 0;
-		unsigned int mAccumulator = 0;
+		unsigned int mStartTick;
 	};
 
 } // namespace

--- a/NAS2D/Timer.h
+++ b/NAS2D/Timer.h
@@ -40,6 +40,9 @@ namespace NAS2D
 		Timer(const Timer&) = default;
 		Timer& operator=(const Timer&) = default;
 
+		unsigned int elapsedTicks() const;
+		void adjustStartTick(unsigned int ticksForward);
+
 		unsigned int accumulator() const;
 		void adjust_accumulator(unsigned int ticksForward);
 

--- a/NAS2D/Timer.h
+++ b/NAS2D/Timer.h
@@ -43,7 +43,9 @@ namespace NAS2D
 		unsigned int elapsedTicks() const;
 		void adjustStartTick(unsigned int ticksForward);
 
+		[[deprecated("Replaced by `elapsedTicks`")]]
 		unsigned int accumulator() const;
+		[[deprecated("Replaced by `adjustStartTick`")]]
 		void adjust_accumulator(unsigned int ticksForward);
 
 		void reset();

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -22,7 +22,6 @@ namespace
 
 
 TestGraphics::TestGraphics() :
-	mTimer{},
 	mDxImage{"Test_DirectX.png"},
 	mOglImage{"Test_OpenGL.png"}
 {}

--- a/test-graphics/TestGraphics.h
+++ b/test-graphics/TestGraphics.h
@@ -2,7 +2,6 @@
 
 #include "NAS2D/State.h"
 #include "NAS2D/EventHandler.h"
-#include "NAS2D/Timer.h"
 #include "NAS2D/Resource/Image.h"
 
 
@@ -23,8 +22,6 @@ protected:
 	void onWindowResized(int w, int h);
 
 private:
-	NAS2D::Timer mTimer;
-
 	NAS2D::Image mDxImage;
 	NAS2D::Image mOglImage;
 };


### PR DESCRIPTION
Simplify the design of `Timer`. Update method names (and `deprecate` the old names). Decrease size of `Timer` to a single `unsigned int` field.

Methods:
- `unsigned int elapsedTicks() const;` - Elapsed ticks, relative to `Timer` initialization
- `void adjustStartTick(unsigned int ticksForward);` - Move `Timer` initialization time forward by delta
- `void reset();` - Reset `Timer` to now

Some discussion of jitter may be needed to address the processing time needed for handling a series of timed events. In some models, timer event processing time is not included in the interval between events, while in other models it is. Effectively, you are either measuring time to a second event relative to the start of a previous event, or the end of a previous event. In either case, `elapsedTicks` is used to measure time against some fixed reference point. If a second event should be relative to the start time of a previous event, you can use `adjustStartTick` to update that reference point without adding the processing time for that event. If the next event should be relative to the end of processing of the last event, so it does include the processing time, then use `reset` at the end of processing the previous event to update the reference point.

Example: Animation with frame skipping - use `adjustStartTick` (or just repeated calls to `elapsedTicks`, though there might be a jump at the wrap around point of 49 days). When an update is made, which may jump a few frames, `adjustStartTick` can be used to move the reference point forward by the time value of the number of frames moved.

Example: Batch jobs with fixed reset period between them - use `reset`. We don't care how long the batch job takes, and there may be some variation length and start times. We will never attempt to run concurrent jobs since the next job will only ever start at some fixed time after the previous one finished.

Note: `reset` is equivalent to re-initializing the `Timer` object (but never requires a namespace prefix):
- `mTimer.reset();`
- `mTimer = Timer{};`
- `mTimer = NAS2D::Timer{};`

Reference: #334
