### PR TITLE
Re-add `Timer::delta` method

### DIFF
--- a/NAS2D/Timer.cpp
+++ b/NAS2D/Timer.cpp
@@ -38,6 +38,14 @@ unsigned int Timer::elapsedTicks() const
 }
 
 
+unsigned int Timer::delta()
+{
+	const auto elapsed = elapsedTicks();
+	adjustStartTick(elapsed);
+	return elapsed;
+}
+
+
 void Timer::adjustStartTick(unsigned int ticksForward)
 {
 	mStartTick += ticksForward;

--- a/NAS2D/Timer.h
+++ b/NAS2D/Timer.h
@@ -41,6 +41,7 @@ namespace NAS2D
 		Timer& operator=(const Timer&) = default;
 
 		unsigned int elapsedTicks() const;
+		unsigned int delta();
 		void adjustStartTick(unsigned int ticksForward);
 
 		[[deprecated("Replaced by `elapsedTicks`")]]


### PR DESCRIPTION
This method is effectively a combination of `elapsedTicks` and `adjustStartTick`. It is perhaps rather convenient in some contexts to be able to easily call the combination of these two methods.

This method is not used within NAS2D, nor in OPHD, but is used by the NAS2D test project.

Reference: #1060, #334
