### PR TITLE
Remove deprecated `Timer` methods

### DIFF
--- a/NAS2D/Timer.cpp
+++ b/NAS2D/Timer.cpp
@@ -52,18 +52,6 @@ void Timer::adjustStartTick(unsigned int ticksForward)
 }
 
 
-unsigned int Timer::accumulator() const
-{
-	return elapsedTicks();
-}
-
-
-void Timer::adjust_accumulator(unsigned int ticksForward)
-{
-	adjustStartTick(ticksForward);
-}
-
-
 void Timer::reset()
 {
 	mStartTick = tick();

--- a/NAS2D/Timer.h
+++ b/NAS2D/Timer.h
@@ -43,12 +43,6 @@ namespace NAS2D
 		unsigned int elapsedTicks() const;
 		unsigned int delta();
 		void adjustStartTick(unsigned int ticksForward);
-
-		[[deprecated("Replaced by `elapsedTicks`")]]
-		unsigned int accumulator() const;
-		[[deprecated("Replaced by `adjustStartTick`")]]
-		void adjust_accumulator(unsigned int ticksForward);
-
 		void reset();
 
 	private:


### PR DESCRIPTION
All downstream projects have been updated.

Closes #334

Reference: #1060
