### PR TITLE
Free cursors in `Window` destructor

### DIFF
--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -127,6 +127,15 @@ Window::Window(const std::string& appTitle) :
 }
 
 
+Window::~Window()
+{
+	for(auto& [key, cursor] : cursors)
+	{
+		SDL_FreeCursor(cursor);
+	}
+}
+
+
 const std::string& Window::title() const
 {
 	return mTitle;

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -20,7 +20,7 @@ namespace NAS2D
 	public:
 		Window();
 		Window(const std::string& appTitle);
-		virtual ~Window() = default;
+		virtual ~Window();
 
 		virtual std::vector<DisplayDesc> getDisplayModes() const;
 		virtual DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const;


### PR DESCRIPTION
Reference: #810

We should probably be cleaning up the loaded cursors when we're done with them.
