### PR TITLE
Update Linux Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - build-and-test
   build-linux-gcc:
     docker:
-      - image: outpostuniverse/nas2d-gcc:1.4
+      - image: outpostuniverse/nas2d-gcc:1.5
     environment:
       - WARN_EXTRA: "-Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Weffc++"
     steps:
@@ -36,7 +36,7 @@ jobs:
       - build-and-test
   build-linux-clang:
     docker:
-      - image: outpostuniverse/nas2d-clang:1.3
+      - image: outpostuniverse/nas2d-clang:1.4
     environment:
       - WARN_EXTRA: "-Wdocumentation -Wdocumentation-unknown-command -Wcomma -Winconsistent-missing-destructor-override -Wmissing-prototypes -Wctad-maybe-unsupported -Wimplicit-int-float-conversion -Wsign-conversion"
     steps:
@@ -44,7 +44,7 @@ jobs:
       - build-and-test
   build-linux-mingw:
     docker:
-      - image: outpostuniverse/nas2d-mingw:1.8
+      - image: outpostuniverse/nas2d-mingw:1.9
     environment:
       - WARN_EXTRA: "-Wno-redundant-decls"
     steps:

--- a/docker/nas2d-arch.Dockerfile
+++ b/docker/nas2d-arch.Dockerfile
@@ -24,7 +24,4 @@ RUN pacman --sync --refresh --noconfirm \
     sdl2_ttf \
   && rm -rf /var/cache/pacman/pkg
 
-VOLUME /code
-WORKDIR /code
-
 CMD ["make", "--keep-going", "check"]

--- a/docker/nas2d-arch.Dockerfile
+++ b/docker/nas2d-arch.Dockerfile
@@ -24,9 +24,6 @@ RUN pacman --sync --refresh --noconfirm \
     sdl2_ttf \
   && rm -rf /var/cache/pacman/pkg
 
-RUN useradd -m -s /bin/bash user
-USER user
-
 VOLUME /code
 WORKDIR /code
 

--- a/docker/nas2d-clang.Dockerfile
+++ b/docker/nas2d-clang.Dockerfile
@@ -31,7 +31,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsdl2-ttf-dev=2.0.18+* \
   && rm -rf /var/lib/apt/lists/*
 
-VOLUME /code
-WORKDIR /code
-
 CMD ["make", "--keep-going", "check"]

--- a/docker/nas2d-clang.Dockerfile
+++ b/docker/nas2d-clang.Dockerfile
@@ -31,9 +31,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsdl2-ttf-dev=2.0.18+* \
   && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -m -s /bin/bash user
-USER user
-
 VOLUME /code
 WORKDIR /code
 

--- a/docker/nas2d-gcc.Dockerfile
+++ b/docker/nas2d-gcc.Dockerfile
@@ -32,7 +32,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsdl2-ttf-dev=2.0.18+* \
   && rm -rf /var/lib/apt/lists/*
 
-VOLUME /code
-WORKDIR /code
-
 CMD ["make", "--keep-going", "check"]

--- a/docker/nas2d-gcc.Dockerfile
+++ b/docker/nas2d-gcc.Dockerfile
@@ -32,9 +32,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsdl2-ttf-dev=2.0.18+* \
   && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -m -s /bin/bash user
-USER user
-
 VOLUME /code
 WORKDIR /code
 

--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -133,9 +133,6 @@ ENV WINEPATH="${WINEPATH64}"
 ENV CXX=${CXX64}
 ENV  CC=${CC64}
 
-RUN useradd -m -s /bin/bash user
-USER user
-
 VOLUME /code
 WORKDIR /code
 

--- a/docker/nas2d-mingw.Dockerfile
+++ b/docker/nas2d-mingw.Dockerfile
@@ -133,9 +133,6 @@ ENV WINEPATH="${WINEPATH64}"
 ENV CXX=${CXX64}
 ENV  CC=${CC64}
 
-VOLUME /code
-WORKDIR /code
-
 # Pre-setup Wine to save startup time later
 RUN wineboot
 

--- a/makefile
+++ b/makefile
@@ -209,6 +209,7 @@ install-dependencies-darwin:
 
 DockerFolder := ${TopLevelFolder}/docker
 DockerRunFlags := --volume ${TopLevelFolder}:/code
+DockerUserFlags = --user="$(shell id --user):$(shell id --group)"
 DockerRepository := outpostuniverse
 
 ImageVersion_gcc := 1.5
@@ -230,13 +231,13 @@ ${DockerBuildRules}: build-image-%:
 	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d-$*.Dockerfile --tag ${DockerImageName} --tag ${DockerRepository}/nas2d-$*:latest
 
 ${DockerRunRules}: run-image-%:
-	docker run ${DockerRunFlags} --rm --tty ${DockerImageName}
+	docker run ${DockerRunFlags} --rm --tty ${DockerUserFlags} ${DockerImageName}
 
 ${DockerDebugRules}: debug-image-%:
-	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerImageName} bash
+	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerUserFlags} ${DockerImageName} bash
 
 ${DockerDebugRootRules}: root-debug-image-%:
-	docker run ${DockerRunFlags} --rm --tty --interactive --user=0 ${DockerImageName} bash
+	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerImageName} bash
 
 ${DockerPushRules}: push-image-%:
 	docker push ${DockerImageName}

--- a/makefile
+++ b/makefile
@@ -208,7 +208,7 @@ install-dependencies-darwin:
 # Build rules relating to Docker images
 
 DockerFolder := ${TopLevelFolder}/docker
-DockerRunFlags := --volume ${TopLevelFolder}:/code --workdir=/code
+DockerRunFlags := --volume ${TopLevelFolder}:/code --workdir=/code --rm --tty
 DockerUserFlags = --user="$(shell id --user):$(shell id --group)"
 DockerRepository := outpostuniverse
 
@@ -231,13 +231,13 @@ ${DockerBuildRules}: build-image-%:
 	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d-$*.Dockerfile --tag ${DockerImageName} --tag ${DockerRepository}/nas2d-$*:latest
 
 ${DockerRunRules}: run-image-%:
-	docker run ${DockerRunFlags} --rm --tty ${DockerUserFlags} ${DockerImageName}
+	docker run ${DockerRunFlags} ${DockerUserFlags} ${DockerImageName}
 
 ${DockerDebugRules}: debug-image-%:
-	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerUserFlags} ${DockerImageName} bash
+	docker run ${DockerRunFlags} --interactive ${DockerUserFlags} ${DockerImageName} bash
 
 ${DockerDebugRootRules}: root-debug-image-%:
-	docker run ${DockerRunFlags} --rm --tty --interactive ${DockerImageName} bash
+	docker run ${DockerRunFlags} --interactive ${DockerImageName} bash
 
 ${DockerPushRules}: push-image-%:
 	docker push ${DockerImageName}

--- a/makefile
+++ b/makefile
@@ -211,10 +211,10 @@ DockerFolder := ${TopLevelFolder}/docker
 DockerRunFlags := --volume ${TopLevelFolder}:/code
 DockerRepository := outpostuniverse
 
-ImageVersion_gcc := 1.4
-ImageVersion_clang := 1.3
-ImageVersion_mingw := 1.8
-ImageVersion_arch := 1.2
+ImageVersion_gcc := 1.5
+ImageVersion_clang := 1.4
+ImageVersion_mingw := 1.9
+ImageVersion_arch := 1.3
 
 DockerImageName = ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
 

--- a/makefile
+++ b/makefile
@@ -208,7 +208,7 @@ install-dependencies-darwin:
 # Build rules relating to Docker images
 
 DockerFolder := ${TopLevelFolder}/docker
-DockerRunFlags := --volume ${TopLevelFolder}:/code
+DockerRunFlags := --volume ${TopLevelFolder}:/code --workdir=/code
 DockerUserFlags = --user="$(shell id --user):$(shell id --group)"
 DockerRepository := outpostuniverse
 


### PR DESCRIPTION
Update the Linux Docker images to make them more usable in different environments. In particular, make them compatible for use with GitHub Actions runners. This means not specifying `USER` or `WORKDIR` in the Dockerfile. Instead, pass those parameters on the command line at startup for local use with the `makefile`, or let the CircleCI and GitHub Actions environments specify their own values at startup.

It should be noted that passing in the `uid` and `gid` of the current user also makes the Docker images more broadly usable in local environments. Previously the images would always run with a `uid` of `1000`, which matched the first user on many Linux distributions, such as Ubuntu, but would not match any subsequent local users added to the system, nor distributions that started local user numbering at a different value. That used to cause files build in the Docker images to be owned by a different user in the build output folder. The new behavior of matching the `uid` and `gid` to the user running the `makefile` on the host system is much more convenient.

Reference: #682
