### PR TITLE
Update `clang-format` rules and formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 Language: Cpp
 AccessModifierOffset: -4
+AlignAfterOpenBracket: BlockIndent
 AlignTrailingComments: false
 AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true

--- a/NAS2D/Math/Rectangle.h
+++ b/NAS2D/Math/Rectangle.h
@@ -123,7 +123,7 @@ namespace NAS2D
 				static_cast<NewBaseType>(x),
 				static_cast<NewBaseType>(y),
 				static_cast<NewBaseType>(width),
-				static_cast<NewBaseType>(height)
+				static_cast<NewBaseType>(height),
 			};
 		}
 

--- a/NAS2D/Resource/AnimationSet.h
+++ b/NAS2D/Resource/AnimationSet.h
@@ -21,7 +21,8 @@
 
 namespace NAS2D
 {
-	template <typename Resource, typename ... Params> class ResourceCache;
+	template <typename Resource, typename... Params>
+	class ResourceCache;
 
 
 	class AnimationSet

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -472,8 +472,8 @@ namespace NAS2D
 	};
 
 	template <typename X, typename Y, typename RetType, typename... Params>
-	Delegate(Y*, RetType(X::*func)(Params...)) -> Delegate<RetType(Params...)>;
+	Delegate(Y*, RetType (X::*func)(Params...)) -> Delegate<RetType(Params...)>;
 
 	template <typename X, typename Y, typename RetType, typename... Params>
-	Delegate(Y*, RetType(X::*func)(Params...) const) -> Delegate<RetType(Params...)>;
+	Delegate(Y*, RetType (X::*func)(Params...) const) -> Delegate<RetType(Params...)>;
 }

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -78,7 +78,7 @@ namespace NAS2D
 			class GenericClass;
 		#endif
 
-		const int SINGLE_MEMFUNCPTR_SIZE = sizeof(void (GenericClass::*)());
+		const int SINGLE_MEMFUNCPTR_SIZE = sizeof(void(GenericClass::*)());
 
 		template <int N>
 		struct SimplifyMemFunc


### PR DESCRIPTION
Reference: #893

Note: The following requires `clang-format` version 14 or higher.
```
AlignAfterOpenBracket: BlockIndent
```
