### PR TITLE
Update format of headers

### DIFF
--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -31,7 +31,7 @@
 // Compiler identification. It's not easy to identify Visual C++ because many vendors
 // fraudulently define Microsoft's identifiers.
 #if defined(_MSC_VER) && !defined(__MWERKS__) && !defined(__VECTOR_C) && !defined(__ICL) && !defined(__BORLANDC__)
-#define FASTDLGT_MICROSOFT_MFP
+	#define FASTDLGT_MICROSOFT_MFP
 #endif
 
 
@@ -59,24 +59,25 @@ namespace NAS2D
 		template <typename GenericMemFuncType, typename XFuncType>
 		GenericMemFuncType CastMemFuncPtr(XFuncType function_to_bind)
 		{
-			#if __GNUC__ >= 8
-			#pragma GCC diagnostic push
-			#pragma GCC diagnostic ignored "-Wcast-function-type"
-			#endif
+#if __GNUC__ >= 8
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 			return reinterpret_cast<GenericMemFuncType>(function_to_bind);
-			#if __GNUC__ >= 8
-			#pragma GCC diagnostic pop
-			#endif
+#if __GNUC__ >= 8
+	#pragma GCC diagnostic pop
+#endif
 		}
 
-		// GenericClass is a fake class, ONLY used to provide a type. It is vitally important
-		// that it is never defined.
-		#ifdef FASTDLGT_MICROSOFT_MFP
-			class __single_inheritance GenericClass;
-			class GenericClass {};
-		#else
-			class GenericClass;
-		#endif
+// GenericClass is a fake class, ONLY used to provide a type. It is vitally important
+// that it is never defined.
+#ifdef FASTDLGT_MICROSOFT_MFP
+		class __single_inheritance GenericClass;
+		class GenericClass
+		{};
+#else
+		class GenericClass;
+#endif
 
 		const int SINGLE_MEMFUNCPTR_SIZE = sizeof(void(GenericClass::*)());
 
@@ -97,16 +98,16 @@ namespace NAS2D
 			template <typename X, typename XFuncType, typename GenericMemFuncType>
 			inline static GenericClass* Convert(X* pthis, XFuncType function_to_bind, GenericMemFuncType& bound_func)
 			{
-				#if defined __DMC__
+#if defined __DMC__
 				bound_func = horrible_cast<GenericMemFuncType>(function_to_bind);
-				#else
+#else
 				bound_func = CastMemFuncPtr<GenericMemFuncType>(function_to_bind);
-				#endif
+#endif
 				return reinterpret_cast<GenericClass*>(pthis);
 			}
 		};
 
-		#ifdef FASTDLGT_MICROSOFT_MFP
+#ifdef FASTDLGT_MICROSOFT_MFP
 
 		template <>
 		struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE + sizeof(int)>
@@ -208,7 +209,7 @@ namespace NAS2D
 				return reinterpret_cast<GenericClass*>(reinterpret_cast<char*>(pthis) + u.s.delta + virtual_delta);
 			};
 		};
-		#endif
+#endif
 	}
 
 

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -230,6 +230,7 @@ namespace NAS2D
 			m_pthis = nullptr;
 			m_pFunction = nullptr;
 		}
+
 	public:
 		inline bool IsEqual(const DelegateMemento& x) const
 		{

--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -24,60 +24,92 @@ namespace NAS2D
 	template <typename T>
 	std::string stringFrom(T value)
 	{
-		if constexpr (std::is_convertible<T, std::string>::value) {
+		if constexpr (std::is_convertible<T, std::string>::value)
+		{
 			return value;
-		} else if constexpr (std::is_same_v<T, bool>) {
+		}
+		else if constexpr (std::is_same_v<T, bool>)
+		{
 			return value ? "true" : "false";
-		} else {
+		}
+		else
+		{
 			return std::to_string(value);
 		}
 	}
 
 	template <typename T>
-	T stringTo(const std::string& value) {
-		if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, const char*>) {
+	T stringTo(const std::string& value)
+	{
+		if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, const char*>)
+		{
 			return value;
-		} else if constexpr (std::is_same_v<T, bool>) {
-			return
-				value == "true" || value == "1" ? true :
-				value == "false" || value == "0" ? false :
-				throw std::invalid_argument("Value must be 'true' or 'false': " + std::string{value});
-		} else if constexpr (std::is_same_v<T, long double>) {
+		}
+		else if constexpr (std::is_same_v<T, bool>)
+		{
+			return value == "true" || value == "1" ? true : value == "false" || value == "0" ? false
+																							 : throw std::invalid_argument("Value must be 'true' or 'false': " + std::string{value});
+		}
+		else if constexpr (std::is_same_v<T, long double>)
+		{
 			return std::stold(value);
-		} else if constexpr (std::is_same_v<T, double>) {
+		}
+		else if constexpr (std::is_same_v<T, double>)
+		{
 			return std::stod(value);
-		} else if constexpr (std::is_same_v<T, float>) {
+		}
+		else if constexpr (std::is_same_v<T, float>)
+		{
 			return std::stof(value);
-		} else if constexpr (std::is_same_v<T, long long>) {
+		}
+		else if constexpr (std::is_same_v<T, long long>)
+		{
 			return std::stoll(value);
-		} else if constexpr (std::is_same_v<T, long>) {
+		}
+		else if constexpr (std::is_same_v<T, long>)
+		{
 			return std::stol(value);
-		} else if constexpr (std::is_same_v<T, int>) {
+		}
+		else if constexpr (std::is_same_v<T, int>)
+		{
 			return std::stoi(value);
-		} else if constexpr (std::is_same_v<T, unsigned long long>) {
+		}
+		else if constexpr (std::is_same_v<T, unsigned long long>)
+		{
 			return std::stoull(value);
-		} else if constexpr (std::is_same_v<T, unsigned long>) {
+		}
+		else if constexpr (std::is_same_v<T, unsigned long>)
+		{
 			return std::stoul(value);
-		} else if constexpr (std::is_integral_v<T> && std::is_signed_v<T>) {
+		}
+		else if constexpr (std::is_integral_v<T> && std::is_signed_v<T>)
+		{
 			const auto integerValue = std::stoi(value);
 			if constexpr (
-				std::numeric_limits<int>::max() > std::numeric_limits<T>::max() ||
-				std::numeric_limits<int>::min() < std::numeric_limits<T>::min()
-			) {
-				if (integerValue > std::numeric_limits<T>::max() || integerValue < std::numeric_limits<T>::min()) {
+				std::numeric_limits<int>::max() > std::numeric_limits<T>::max() || std::numeric_limits<int>::min() < std::numeric_limits<T>::min()
+			)
+			{
+				if (integerValue > std::numeric_limits<T>::max() || integerValue < std::numeric_limits<T>::min())
+				{
 					throw std::out_of_range("Value out of range: " + value);
 				}
 			}
 			return static_cast<T>(integerValue);
-		} else if constexpr (std::is_integral_v<T> && std::is_unsigned_v<T>) {
+		}
+		else if constexpr (std::is_integral_v<T> && std::is_unsigned_v<T>)
+		{
 			const auto integerValue = std::stoul(value);
-			if constexpr (std::numeric_limits<unsigned long>::max() > std::numeric_limits<T>::max()) {
-				if (integerValue > std::numeric_limits<T>::max()) {
+			if constexpr (std::numeric_limits<unsigned long>::max() > std::numeric_limits<T>::max())
+			{
+				if (integerValue > std::numeric_limits<T>::max())
+				{
 					throw std::out_of_range("Value out of range: " + value);
 				}
 			}
 			return static_cast<T>(integerValue);
-		} else {
+		}
+		else
+		{
 			static_assert(true, "Unsupported type");
 		}
 	}


### PR DESCRIPTION
Reference: #893

This updates remaining header files with code style differences from what the `.clang-format` file recommends. These are the files found and updated by the command `make format`. Note that this `make` target ignores the Xml code, and does not process .cpp files. I think that may have been an error with the filtering options used with the `find` command.
