### PR TITLE
Use `clang-format` to set project code style

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -24,7 +24,8 @@
 using namespace NAS2D;
 
 
-namespace {
+namespace
+{
 	struct SdlStringDeleter
 	{
 		void operator()(char* string)

--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -63,8 +63,8 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 					{"screenheight", 700},
 					{"bitdepth", 32},
 					{"fullscreen", false},
-					{"vsync", true}
-				}}
+					{"vsync", true},
+				}},
 			},
 			{
 				"audio",
@@ -74,9 +74,9 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 					{"sfxvolume", 128},
 					{"channels", 2},
 					{"mixrate", 22050},
-					{"bufferlength", 1024}
-				}}
-			}
+					{"bufferlength", 1024},
+				}},
+			},
 		}
 	);
 	cf.load(configPath);

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -63,7 +63,7 @@ MixerSDL::Options MixerSDL::InvalidToDefault(const Options& options)
 		std::clamp(options.numChannels, AudioNumChannelsMin, AudioNumChannelsMax),
 		std::clamp(options.sfxVolume, AudioVolumeMin, AudioVolumeMax),
 		std::clamp(options.musicVolume, AudioVolumeMin, AudioVolumeMax),
-		std::clamp(options.bufferSize, AudioBufferSizeMin, AudioBufferSizeMax)
+		std::clamp(options.bufferSize, AudioBufferSizeMin, AudioBufferSizeMax),
 	};
 }
 
@@ -76,7 +76,7 @@ MixerSDL::Options MixerSDL::ReadConfigurationOptions()
 		audio.get<int>("channels"),
 		audio.get<int>("sfxvolume"),
 		audio.get<int>("musicvolume"),
-		audio.get<int>("bufferlength")
+		audio.get<int>("bufferlength"),
 	};
 }
 

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -92,7 +92,8 @@ void MixerSDL::WriteConfigurationOptions(const Options& options)
 }
 
 
-MixerSDL::MixerSDL() : MixerSDL(InvalidToDefault(ReadConfigurationOptions()))
+MixerSDL::MixerSDL() :
+	MixerSDL(InvalidToDefault(ReadConfigurationOptions()))
 {
 }
 

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -114,7 +114,7 @@ MixerSDL::MixerSDL(const Options& options)
 	musicVolume(options.musicVolume);
 
 	musicFinished.connect({this, &MixerSDL::onMusicFinished});
-	Mix_HookMusicFinished([](){ musicFinished(); });
+	Mix_HookMusicFinished([]() { musicFinished(); });
 }
 
 

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -18,7 +18,8 @@
 using namespace NAS2D;
 
 
-Renderer::Renderer(const std::string& appTitle) : Window(appTitle)
+Renderer::Renderer(const std::string& appTitle) :
+	Window(appTitle)
 {}
 
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -111,12 +111,14 @@ void RendererOpenGL::WriteConfigurationOptions(const Options& options)
 }
 
 
-RendererOpenGL::RendererOpenGL(const std::string& title) : RendererOpenGL(title, ReadConfigurationOptions())
+RendererOpenGL::RendererOpenGL(const std::string& title) :
+	RendererOpenGL(title, ReadConfigurationOptions())
 {
 }
 
 
-RendererOpenGL::RendererOpenGL(const std::string& title, const Options& options) : Renderer(title)
+RendererOpenGL::RendererOpenGL(const std::string& title, const Options& options) :
+	Renderer(title)
 {
 	std::cout << "Starting OpenGL Renderer:" << std::endl;
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -720,8 +720,7 @@ namespace
 		p2.y -= cy * 0.5f;
 
 		//draw the line by triangle strip
-		float line_vertex[] =
-		{
+		float line_vertex[] = {
 			p1.x - tx - Rx - cx, p1.y - ty - Ry - cy, //fading edge1
 			p2.x - tx - Rx + cx, p2.y - ty - Ry + cy,
 			p1.x - tx - cx, p1.y - ty - cy,        //core
@@ -729,11 +728,10 @@ namespace
 			p1.x + tx - cx, p1.y + ty - cy,
 			p2.x + tx + cx, p2.y + ty + cy,
 			p1.x + tx + Rx - cx, p1.y + ty + Ry - cy, //fading edge2
-			p2.x + tx + Rx + cx, p2.y + ty + Ry + cy
+			p2.x + tx + Rx + cx, p2.y + ty + Ry + cy,
 		};
 
-		float line_color[] =
-		{
+		float line_color[] = {
 			Cr, Cg, Cb, 0,
 			Cr, Cg, Cb, 0,
 			Cr, Cg, Cb, Ca,
@@ -741,7 +739,7 @@ namespace
 			Cr, Cg, Cb, Ca,
 			Cr, Cg, Cb, Ca,
 			Cr, Cg, Cb, 0,
-			Cr, Cg, Cb, 0
+			Cr, Cg, Cb, 0,
 		};
 
 		glVertexPointer(2, GL_FLOAT, 0, line_vertex);
@@ -751,8 +749,7 @@ namespace
 		// Line End Caps
 		if (lineWidth > 3.0f)
 		{
-			float line_vertex2[] =
-			{
+			float line_vertex2[] = {
 				p1.x - tx - cx, p1.y - ty - cy,
 				p1.x + tx + Rx, p1.y + ty + Ry,
 				p1.x + tx - cx, p1.y + ty - cy,
@@ -762,11 +759,10 @@ namespace
 				p2.x - tx + cx, p2.y - ty + cy,
 				p2.x + tx + Rx, p2.y + ty + Ry,
 				p2.x + tx + cx, p2.y + ty + cy,
-				p2.x + tx + Rx + cx, p2.y + ty + Ry + cy
+				p2.x + tx + Rx + cx, p2.y + ty + Ry + cy,
 			};
 
-			float line_color2[] =
-			{
+			float line_color2[] = {
 				Cr, Cg, Cb, 0, //cap1
 				Cr, Cg, Cb, 0,
 				Cr, Cg, Cb, Ca,
@@ -778,7 +774,7 @@ namespace
 				Cr, Cg, Cb, Ca,
 				Cr, Cg, Cb, 0,
 				Cr, Cg, Cb, Ca,
-				Cr, Cg, Cb, 0
+				Cr, Cg, Cb, 0,
 			};
 
 			glVertexPointer(2, GL_FLOAT, 0, line_vertex2);

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -278,10 +278,7 @@ void RendererOpenGL::drawImageToImage(const Image& source, const Image& destinat
 	}
 
 	const auto availableSize = destinationBounds.endPoint() - dstPointInt;
-	const auto clipSize = Vector{
-		std::min(sourceSize.x, availableSize.x),
-		std::min(sourceSize.y, availableSize.y),
-	}.to<float>();
+	const auto clipSize = Vector{std::min(sourceSize.x, availableSize.x), std::min(sourceSize.y, availableSize.y)}.to<float>();
 
 	setColor(Color::White);
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -56,7 +56,7 @@ namespace
 
 			p2.x, p2.y,
 			p2.x, p1.y,
-			p1.x, p1.y
+			p1.x, p1.y,
 		};
 	}
 
@@ -96,7 +96,7 @@ RendererOpenGL::Options RendererOpenGL::ReadConfigurationOptions()
 	return {
 		{graphics.get<int>("screenwidth"), graphics.get<int>("screenheight")},
 		graphics.get<bool>("fullscreen"),
-		graphics.get<bool>("vsync")
+		graphics.get<bool>("vsync"),
 	};
 }
 
@@ -280,7 +280,7 @@ void RendererOpenGL::drawImageToImage(const Image& source, const Image& destinat
 	const auto availableSize = destinationBounds.endPoint() - dstPointInt;
 	const auto clipSize = Vector{
 		std::min(sourceSize.x, availableSize.x),
-		std::min(sourceSize.y, availableSize.y)
+		std::min(sourceSize.y, availableSize.y),
 	}.to<float>();
 
 	setColor(Color::White);

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -50,13 +50,24 @@ namespace
 		const auto p2 = rect.endPoint();
 
 		return {
-			p1.x, p1.y,
-			p1.x, p2.y,
-			p2.x, p2.y,
+			p1.x,
+			p1.y,
 
-			p2.x, p2.y,
-			p2.x, p1.y,
-			p1.x, p1.y,
+			p1.x,
+			p2.y,
+
+			p2.x,
+			p2.y,
+
+
+			p2.x,
+			p2.y,
+
+			p2.x,
+			p1.y,
+
+			p1.x,
+			p1.y,
 		};
 	}
 
@@ -674,8 +685,12 @@ namespace
 		if (std::abs(dx) < ALW)
 		{
 			//vertical
-			tx = t; ty = 0.0f;
-			Rx = R; Ry = 0.0f;
+			tx = t;
+			ty = 0.0f;
+
+			Rx = R;
+			Ry = 0.0f;
+
 			if (lineWidth > 0.0f && lineWidth <= 1.0f)
 			{
 				tx = 0.5f;
@@ -685,8 +700,12 @@ namespace
 		else if (std::abs(dy) < ALW)
 		{
 			//horizontal
-			tx = 0.0f; ty = t;
-			Rx = 0.0f; Ry = R;
+			tx = 0.0f;
+			ty = t;
+
+			Rx = 0.0f;
+			Ry = R;
+
 			if (lineWidth > 0.0f && lineWidth <= 1.0f)
 			{
 				ty = 0.5f;
@@ -721,25 +740,71 @@ namespace
 
 		//draw the line by triangle strip
 		float line_vertex[] = {
-			p1.x - tx - Rx - cx, p1.y - ty - Ry - cy, //fading edge1
-			p2.x - tx - Rx + cx, p2.y - ty - Ry + cy,
-			p1.x - tx - cx, p1.y - ty - cy,        //core
-			p2.x - tx + cx, p2.y - ty + cy,
-			p1.x + tx - cx, p1.y + ty - cy,
-			p2.x + tx + cx, p2.y + ty + cy,
-			p1.x + tx + Rx - cx, p1.y + ty + Ry - cy, //fading edge2
-			p2.x + tx + Rx + cx, p2.y + ty + Ry + cy,
+			p1.x - tx - Rx - cx,
+			p1.y - ty - Ry - cy, //fading edge1
+
+			p2.x - tx - Rx + cx,
+			p2.y - ty - Ry + cy,
+
+			p1.x - tx - cx,
+			p1.y - ty - cy, //core
+
+			p2.x - tx + cx,
+			p2.y - ty + cy,
+
+			p1.x + tx - cx,
+			p1.y + ty - cy,
+
+			p2.x + tx + cx,
+			p2.y + ty + cy,
+
+			p1.x + tx + Rx - cx,
+			p1.y + ty + Ry - cy, //fading edge2
+
+			p2.x + tx + Rx + cx,
+			p2.y + ty + Ry + cy,
 		};
 
 		float line_color[] = {
-			Cr, Cg, Cb, 0,
-			Cr, Cg, Cb, 0,
-			Cr, Cg, Cb, Ca,
-			Cr, Cg, Cb, Ca,
-			Cr, Cg, Cb, Ca,
-			Cr, Cg, Cb, Ca,
-			Cr, Cg, Cb, 0,
-			Cr, Cg, Cb, 0,
+			Cr,
+			Cg,
+			Cb,
+			0,
+
+			Cr,
+			Cg,
+			Cb,
+			0,
+
+			Cr,
+			Cg,
+			Cb,
+			Ca,
+
+			Cr,
+			Cg,
+			Cb,
+			Ca,
+
+			Cr,
+			Cg,
+			Cb,
+			Ca,
+
+			Cr,
+			Cg,
+			Cb,
+			Ca,
+
+			Cr,
+			Cg,
+			Cb,
+			0,
+
+			Cr,
+			Cg,
+			Cb,
+			0,
 		};
 
 		glVertexPointer(2, GL_FLOAT, 0, line_vertex);
@@ -750,31 +815,97 @@ namespace
 		if (lineWidth > 3.0f)
 		{
 			float line_vertex2[] = {
-				p1.x - tx - cx, p1.y - ty - cy,
-				p1.x + tx + Rx, p1.y + ty + Ry,
-				p1.x + tx - cx, p1.y + ty - cy,
-				p1.x + tx + Rx - cx, p1.y + ty + Ry - cy,
-				p2.x - tx - Rx + cx, p2.y - ty - Ry + cy, //cap2
-				p2.x - tx - Rx, p2.y - ty - Ry,
-				p2.x - tx + cx, p2.y - ty + cy,
-				p2.x + tx + Rx, p2.y + ty + Ry,
-				p2.x + tx + cx, p2.y + ty + cy,
-				p2.x + tx + Rx + cx, p2.y + ty + Ry + cy,
+				p1.x - tx - cx,
+				p1.y - ty - cy,
+
+				p1.x + tx + Rx,
+				p1.y + ty + Ry,
+
+				p1.x + tx - cx,
+				p1.y + ty - cy,
+
+				p1.x + tx + Rx - cx,
+				p1.y + ty + Ry - cy,
+
+				p2.x - tx - Rx + cx,
+				p2.y - ty - Ry + cy, //cap2
+
+				p2.x - tx - Rx,
+				p2.y - ty - Ry,
+
+				p2.x - tx + cx,
+				p2.y - ty + cy,
+
+				p2.x + tx + Rx,
+				p2.y + ty + Ry,
+
+				p2.x + tx + cx,
+				p2.y + ty + cy,
+
+				p2.x + tx + Rx + cx,
+				p2.y + ty + Ry + cy,
 			};
 
 			float line_color2[] = {
-				Cr, Cg, Cb, 0, //cap1
-				Cr, Cg, Cb, 0,
-				Cr, Cg, Cb, Ca,
-				Cr, Cg, Cb, 0,
-				Cr, Cg, Cb, Ca,
-				Cr, Cg, Cb, 0,
-				Cr, Cg, Cb, 0, //cap2
-				Cr, Cg, Cb, 0,
-				Cr, Cg, Cb, Ca,
-				Cr, Cg, Cb, 0,
-				Cr, Cg, Cb, Ca,
-				Cr, Cg, Cb, 0,
+				Cr,
+				Cg,
+				Cb,
+				0, //cap1
+
+				Cr,
+				Cg,
+				Cb,
+				0,
+
+				Cr,
+				Cg,
+				Cb,
+				Ca,
+
+				Cr,
+				Cg,
+				Cb,
+				0,
+
+				Cr,
+				Cg,
+				Cb,
+				Ca,
+
+				Cr,
+				Cg,
+				Cb,
+				0,
+
+				Cr,
+				Cg,
+				Cb,
+				0, //cap2
+
+				Cr,
+				Cg,
+				Cb,
+				0,
+
+				Cr,
+				Cg,
+				Cb,
+				Ca,
+
+				Cr,
+				Cg,
+				Cb,
+				0,
+
+				Cr,
+				Cg,
+				Cb,
+				Ca,
+
+				Cr,
+				Cg,
+				Cb,
+				0,
 			};
 
 			glVertexPointer(2, GL_FLOAT, 0, line_vertex2);

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -302,7 +302,7 @@ void Window::resizeable(bool resizable)
 	}
 
 #if defined(_MSC_VER)
-	#pragma warning(suppress: 26812) // C26812 Warns to use enum class (C++), but SDL is a C library
+	#pragma warning(suppress : 26812) // C26812 Warns to use enum class (C++), but SDL is a C library
 #endif
 	SDL_SetWindowResizable(underlyingWindow, resizable ? SDL_TRUE : SDL_FALSE);
 }

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -33,23 +33,23 @@ namespace
 	}
 
 
-	#if defined(WINDOWS) || defined(WIN32)
-		/**
-		 * Gets a Windows API HWND handle to the application window.
-		 */
-		HWND getWin32Handle(SDL_Window* sdlWindow)
+#if defined(WINDOWS) || defined(WIN32)
+	/**
+	 * Gets a Windows API HWND handle to the application window.
+	 */
+	HWND getWin32Handle(SDL_Window* sdlWindow)
+	{
+		SDL_SysWMinfo systemInfo;
+		SDL_VERSION(&systemInfo.version);
+
+		if (SDL_GetWindowWMInfo(sdlWindow, &systemInfo) == 1)
 		{
-			SDL_SysWMinfo systemInfo;
-			SDL_VERSION(&systemInfo.version);
-
-			if (SDL_GetWindowWMInfo(sdlWindow, &systemInfo) == 1)
-			{
-				return systemInfo.info.win.window;
-			}
-
-			return nullptr;
+			return systemInfo.info.win.window;
 		}
-	#endif
+
+		return nullptr;
+	}
+#endif
 
 
 	/**
@@ -57,11 +57,11 @@ namespace
 	 */
 	void doModalError(const std::string& title, const std::string& message, SDL_Window* sdlWindow)
 	{
-		#if defined(WINDOWS) || defined(WIN32)
-			MessageBoxA(getWin32Handle(sdlWindow), message.c_str(), title.c_str(), MB_OK | MB_ICONERROR | MB_TASKMODAL);
-		#else
-			SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title.c_str(), message.c_str(), sdlWindow);
-		#endif
+#if defined(WINDOWS) || defined(WIN32)
+		MessageBoxA(getWin32Handle(sdlWindow), message.c_str(), title.c_str(), MB_OK | MB_ICONERROR | MB_TASKMODAL);
+#else
+		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title.c_str(), message.c_str(), sdlWindow);
+#endif
 	}
 
 
@@ -70,11 +70,11 @@ namespace
 	 */
 	void doModalAlert(const std::string& title, const std::string& message, SDL_Window* sdlWindow)
 	{
-		#if defined(WINDOWS) || defined(WIN32)
-			MessageBoxA(getWin32Handle(sdlWindow), message.c_str(), title.c_str(), MB_OK | MB_TASKMODAL);
-		#else
-			SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, title.c_str(), message.c_str(), sdlWindow);
-		#endif
+#if defined(WINDOWS) || defined(WIN32)
+		MessageBoxA(getWin32Handle(sdlWindow), message.c_str(), title.c_str(), MB_OK | MB_TASKMODAL);
+#else
+		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, title.c_str(), message.c_str(), sdlWindow);
+#endif
 	}
 
 
@@ -84,30 +84,30 @@ namespace
 	bool doModalYesNo(const std::string& title, const std::string& message, SDL_Window* sdlWindow)
 	{
 		bool isYes = false;
-		#if defined(WINDOWS) || defined(WIN32)
-			isYes = (MessageBoxA(getWin32Handle(sdlWindow), message.c_str(), title.c_str(), MB_YESNO | MB_ICONINFORMATION | MB_TASKMODAL) == IDYES);
-		#else
-			constexpr std::array<SDL_MessageBoxButtonData, 2> buttons =
-			{{
-				{SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "Yes"},
-				{SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 0, "No"},
-			}};
+#if defined(WINDOWS) || defined(WIN32)
+		isYes = (MessageBoxA(getWin32Handle(sdlWindow), message.c_str(), title.c_str(), MB_YESNO | MB_ICONINFORMATION | MB_TASKMODAL) == IDYES);
+#else
+		constexpr std::array<SDL_MessageBoxButtonData, 2> buttons =
+		{{
+			{SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "Yes"},
+			{SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 0, "No"},
+		}};
 
-			const SDL_MessageBoxData messageBoxData =
-			{
-				SDL_MESSAGEBOX_INFORMATION,
-				sdlWindow,
-				title.c_str(),
-				message.c_str(),
-				buttons.size(),
-				buttons.data(),
-				nullptr
-			};
+		const SDL_MessageBoxData messageBoxData =
+		{
+			SDL_MESSAGEBOX_INFORMATION,
+			sdlWindow,
+			title.c_str(),
+			message.c_str(),
+			buttons.size(),
+			buttons.data(),
+			nullptr
+		};
 
-			int buttonId = 0;
-			SDL_ShowMessageBox(&messageBoxData, &buttonId);
-			isYes = (buttonId == 1);
-		#endif
+		int buttonId = 0;
+		SDL_ShowMessageBox(&messageBoxData, &buttonId);
+		isYes = (buttonId == 1);
+#endif
 
 		return isYes;
 	}
@@ -301,9 +301,9 @@ void Window::resizeable(bool resizable)
 		return;
 	}
 
-	#if defined(_MSC_VER)
+#if defined(_MSC_VER)
 	#pragma warning(suppress: 26812) // C26812 Warns to use enum class (C++), but SDL is a C library
-	#endif
+#endif
 	SDL_SetWindowResizable(underlyingWindow, resizable ? SDL_TRUE : SDL_FALSE);
 }
 

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -87,21 +87,19 @@ namespace
 #if defined(WINDOWS) || defined(WIN32)
 		isYes = (MessageBoxA(getWin32Handle(sdlWindow), message.c_str(), title.c_str(), MB_YESNO | MB_ICONINFORMATION | MB_TASKMODAL) == IDYES);
 #else
-		constexpr std::array<SDL_MessageBoxButtonData, 2> buttons =
-		{{
+		constexpr std::array<SDL_MessageBoxButtonData, 2> buttons = {{
 			{SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "Yes"},
 			{SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 0, "No"},
 		}};
 
-		const SDL_MessageBoxData messageBoxData =
-		{
+		const SDL_MessageBoxData messageBoxData = {
 			SDL_MESSAGEBOX_INFORMATION,
 			sdlWindow,
 			title.c_str(),
 			message.c_str(),
 			buttons.size(),
 			buttons.data(),
-			nullptr
+			nullptr,
 		};
 
 		int buttonId = 0;

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -129,7 +129,7 @@ Window::Window(const std::string& appTitle) :
 
 Window::~Window()
 {
-	for(auto& [key, cursor] : cursors)
+	for (auto& [key, cursor] : cursors)
 	{
 		SDL_FreeCursor(cursor);
 	}

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -152,7 +152,7 @@ namespace
 			auto actions = processActions(imageSheetMap, xmlRootElement, imageCache);
 			return std::tuple{std::move(imageSheetMap), std::move(actions)};
 		}
-		catch(const std::runtime_error& error)
+		catch (const std::runtime_error& error)
 		{
 			throw std::runtime_error("Error parsing Sprite file: " + filePath + "\nError: " + error.what());
 		}

--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -285,7 +285,7 @@ namespace
 		const auto matrixSize = characterSize * GLYPH_MATRIX_SIZE;
 		SDL_Surface* fontSurface = SDL_CreateRGBSurface(SDL_SWSURFACE, matrixSize.x, matrixSize.y, BITS_32, MasksDefault.red, MasksDefault.green, MasksDefault.blue, MasksDefault.alpha);
 
-		SDL_Color white = { 255, 255, 255, 255 };
+		SDL_Color white = {255, 255, 255, 255};
 		for (const auto glyphPosition : PointInRectangleRange(Rectangle<std::size_t>{0, 0, GLYPH_MATRIX_SIZE, GLYPH_MATRIX_SIZE}))
 		{
 			const std::size_t glyph = glyphPosition.y * GLYPH_MATRIX_SIZE + glyphPosition.x;
@@ -296,7 +296,7 @@ namespace
 			{
 				SDL_SetSurfaceBlendMode(characterSurface, SDL_BLENDMODE_NONE);
 				const auto pixelPosition = glyphPosition.to<int>().skewBy(characterSize);
-				SDL_Rect rect = { pixelPosition.x, pixelPosition.y, 0, 0 };
+				SDL_Rect rect = {pixelPosition.x, pixelPosition.y, 0, 0};
 				SDL_BlitSurface(characterSurface, nullptr, fontSurface, &rect);
 				SDL_FreeSurface(characterSurface);
 			}

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -179,22 +179,22 @@ namespace
 	{
 		switch (bytesPerPixel)
 		{
-			case 1:
-				return *reinterpret_cast<const uint8_t*>(pixelAddress);
-			case 2:
-				return *reinterpret_cast<const uint16_t*>(pixelAddress);
-			case 3:
-			{
-				auto p = reinterpret_cast<const uint8_t*>(pixelAddress);
-				uint32_t p0 = p[0], p1 = p[1], p2 = p[2];
-				return (SDL_BYTEORDER == SDL_BIG_ENDIAN) ?
-					(p0 << 16 | p1 << 8 | p2) :
-					(p0 | p1 << 8 | p2 << 16);
-			}
-			case 4:
-				return *reinterpret_cast<const uint32_t*>(pixelAddress);
-			default: // Should never be possible.
-				throw std::runtime_error("Unknown pixel format with bytesPerPixel: " + std::to_string(bytesPerPixel));
+		case 1:
+			return *reinterpret_cast<const uint8_t*>(pixelAddress);
+		case 2:
+			return *reinterpret_cast<const uint16_t*>(pixelAddress);
+		case 3:
+		{
+			auto p = reinterpret_cast<const uint8_t*>(pixelAddress);
+			uint32_t p0 = p[0], p1 = p[1], p2 = p[2];
+			return (SDL_BYTEORDER == SDL_BIG_ENDIAN) ?
+				(p0 << 16 | p1 << 8 | p2) :
+				(p0 | p1 << 8 | p2 << 16);
+		}
+		case 4:
+			return *reinterpret_cast<const uint32_t*>(pixelAddress);
+		default: // Should never be possible.
+			throw std::runtime_error("Unknown pixel format with bytesPerPixel: " + std::to_string(bytesPerPixel));
 		}
 	}
 

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -26,7 +26,7 @@ using namespace NAS2D;
 
 
 unsigned int generateTexture(SDL_Surface* surface);
-unsigned int generateTexture(void *buffer, int bytesPerPixel, int width, int height);
+unsigned int generateTexture(void* buffer, int bytesPerPixel, int width, int height);
 
 
 namespace

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -183,13 +183,10 @@ namespace
 			return *reinterpret_cast<const uint8_t*>(pixelAddress);
 		case 2:
 			return *reinterpret_cast<const uint16_t*>(pixelAddress);
-		case 3:
-		{
+		case 3: {
 			auto p = reinterpret_cast<const uint8_t*>(pixelAddress);
 			uint32_t p0 = p[0], p1 = p[1], p2 = p[2];
-			return (SDL_BYTEORDER == SDL_BIG_ENDIAN) ?
-				(p0 << 16 | p1 << 8 | p2) :
-				(p0 | p1 << 8 | p2 << 16);
+			return (SDL_BYTEORDER == SDL_BIG_ENDIAN) ? (p0 << 16 | p1 << 8 | p2) : (p0 | p1 << 8 | p2 << 16);
 		}
 		case 4:
 			return *reinterpret_cast<const uint32_t*>(pixelAddress);

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -180,13 +180,9 @@ namespace
 		switch (bytesPerPixel)
 		{
 			case 1:
-			{
 				return *reinterpret_cast<const uint8_t*>(pixelAddress);
-			}
 			case 2:
-			{
 				return *reinterpret_cast<const uint16_t*>(pixelAddress);
-			}
 			case 3:
 			{
 				auto p = reinterpret_cast<const uint8_t*>(pixelAddress);
@@ -196,13 +192,9 @@ namespace
 					(p0 | p1 << 8 | p2 << 16);
 			}
 			case 4:
-			{
 				return *reinterpret_cast<const uint32_t*>(pixelAddress);
-			}
 			default: // Should never be possible.
-			{
 				throw std::runtime_error("Unknown pixel format with bytesPerPixel: " + std::to_string(bytesPerPixel));
-			}
 		}
 	}
 

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -51,7 +51,7 @@ namespace
 Image::Image(const std::string& filePath) :
 	Image{
 		filePath,
-		Utility<Filesystem>::get().readFile(filePath)
+		Utility<Filesystem>::get().readFile(filePath),
 	}
 {
 }

--- a/NAS2D/StringUtils.cpp
+++ b/NAS2D/StringUtils.cpp
@@ -29,7 +29,7 @@ namespace NAS2D
 	 */
 	std::string toLowercase(std::string str)
 	{
-		std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept->unsigned char { return static_cast<unsigned char>(::tolower(c)); });
+		std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept -> unsigned char { return static_cast<unsigned char>(::tolower(c)); });
 		return str;
 	}
 
@@ -42,7 +42,7 @@ namespace NAS2D
 	 */
 	std::string toUppercase(std::string str)
 	{
-		std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept->unsigned char { return static_cast<unsigned char>(::toupper(c)); });
+		std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) noexcept -> unsigned char { return static_cast<unsigned char>(::toupper(c)); });
 		return str;
 	}
 

--- a/makefile
+++ b/makefile
@@ -155,7 +155,7 @@ cppclean:
 .PHONY: format
 format:
 	clang-format --version
-	find NAS2D/ -path NAS2D/Xml -prune -name '*.cpp' -o -name '*.h' | xargs clang-format -i
+	find NAS2D/ -not -path 'NAS2D/Xml/*' -regex '.*\.\(cpp\|h\)' | xargs clang-format -i
 
 ### Linux development package dependencies ###
 # This section contains install rules to aid setup and compiling on Linux.


### PR DESCRIPTION
Closes #893

Fix the `make format` command to also format .cpp files. Update code style to match the `clang-format` rules.
