### PR TITLE
Make lexical `Filesystem` methods `static`

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -312,7 +312,7 @@ void Filesystem::writeFile(const std::string& filename, const std::string& data,
  *
  * \note The path separator may be more than one character
  */
-std::string Filesystem::dirSeparator() const
+std::string Filesystem::dirSeparator()
 {
 	return {std::filesystem::path::preferred_separator};
 }
@@ -325,7 +325,7 @@ std::string Filesystem::dirSeparator() const
  *
  * \return The path up to and including the last '/', or empty string if no '/'
  */
-std::string Filesystem::parentPath(std::string_view filePath) const
+std::string Filesystem::parentPath(std::string_view filePath)
 {
 	return std::string{filePath.substr(0, filePath.rfind('/') + 1)};
 }
@@ -339,7 +339,7 @@ std::string Filesystem::parentPath(std::string_view filePath) const
  * \return	Returns a string containing the file extension, including the dot (".").
  *			An empty string will be returned if the file has no extension.
  */
-std::string Filesystem::extension(std::string_view filePath) const
+std::string Filesystem::extension(std::string_view filePath)
 {
 	const auto fileName = filePath.substr(filePath.rfind('/') + 1);
 	const auto pos = fileName.rfind('.');

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -65,6 +65,53 @@ namespace
 }
 
 
+/**
+ * Gets the dir separator for the current platform
+ *
+ * The dir separator separates the directories within a path. This is typically either "\\" for Windows, or "/" for Linux.
+ *
+ * \note The path separator may be more than one character
+ */
+std::string Filesystem::dirSeparator()
+{
+	return {std::filesystem::path::preferred_separator};
+}
+
+
+/**
+ * Convenience function to get the parent directory of a file.
+ *
+ * \param filePath A file path.
+ *
+ * \return The path up to and including the last '/', or empty string if no '/'
+ */
+std::string Filesystem::parentPath(std::string_view filePath)
+{
+	return std::string{filePath.substr(0, filePath.rfind('/') + 1)};
+}
+
+
+/**
+ * Gets the extension of a given file path.
+ *
+ * \param	filePath	Path to check for an extension.
+ *
+ * \return	Returns a string containing the file extension, including the dot (".").
+ *			An empty string will be returned if the file has no extension.
+ */
+std::string Filesystem::extension(std::string_view filePath)
+{
+	const auto fileName = filePath.substr(filePath.rfind('/') + 1);
+	const auto pos = fileName.rfind('.');
+
+	if (pos != std::string::npos)
+	{
+		return std::string{fileName.substr(pos)};
+	}
+	return std::string{};
+}
+
+
 Filesystem::Filesystem(const std::string& appName, const std::string& organizationName) :
 	mBasePath{SdlString{SDL_GetBasePath()}.get()},
 	mPrefPath{SdlString{SDL_GetPrefPath(organizationName.c_str(), appName.c_str())}.get()},
@@ -302,51 +349,4 @@ void Filesystem::writeFile(const std::string& filename, const std::string& data,
 	{
 		throw std::runtime_error("Error writing file: " + filename + " : " + errorDescription());
 	}
-}
-
-
-/**
- * Gets the dir separator for the current platform
- *
- * The dir separator separates the directories within a path. This is typically either "\\" for Windows, or "/" for Linux.
- *
- * \note The path separator may be more than one character
- */
-std::string Filesystem::dirSeparator()
-{
-	return {std::filesystem::path::preferred_separator};
-}
-
-
-/**
- * Convenience function to get the parent directory of a file.
- *
- * \param filePath A file path.
- *
- * \return The path up to and including the last '/', or empty string if no '/'
- */
-std::string Filesystem::parentPath(std::string_view filePath)
-{
-	return std::string{filePath.substr(0, filePath.rfind('/') + 1)};
-}
-
-
-/**
- * Gets the extension of a given file path.
- *
- * \param	filePath	Path to check for an extension.
- *
- * \return	Returns a string containing the file extension, including the dot (".").
- *			An empty string will be returned if the file has no extension.
- */
-std::string Filesystem::extension(std::string_view filePath)
-{
-	const auto fileName = filePath.substr(filePath.rfind('/') + 1);
-	const auto pos = fileName.rfind('.');
-
-	if (pos != std::string::npos)
-	{
-		return std::string{fileName.substr(pos)};
-	}
-	return std::string{};
 }

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -26,6 +26,10 @@ namespace NAS2D
 			Overwrite,
 		};
 
+		static std::string dirSeparator();
+		static std::string parentPath(std::string_view filePath);
+		static std::string extension(std::string_view filePath);
+
 		Filesystem(const std::string& appName, const std::string& organizationName);
 		Filesystem(const Filesystem&) = delete;
 		Filesystem& operator=(const Filesystem&) = delete;
@@ -53,10 +57,6 @@ namespace NAS2D
 
 		std::string readFile(const std::string& filename) const;
 		void writeFile(const std::string& filename, const std::string& data, WriteFlags flags = WriteFlags::Overwrite);
-
-		static std::string dirSeparator();
-		static std::string parentPath(std::string_view filePath);
-		static std::string extension(std::string_view filePath);
 
 	private:
 		std::string mBasePath;

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -54,9 +54,9 @@ namespace NAS2D
 		std::string readFile(const std::string& filename) const;
 		void writeFile(const std::string& filename, const std::string& data, WriteFlags flags = WriteFlags::Overwrite);
 
-		std::string dirSeparator() const;
-		std::string parentPath(std::string_view filePath) const;
-		std::string extension(std::string_view filePath) const;
+		static std::string dirSeparator();
+		static std::string parentPath(std::string_view filePath);
+		static std::string extension(std::string_view filePath);
 
 	private:
 		std::string mBasePath;

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -116,7 +116,7 @@ namespace
 		try
 		{
 			auto& filesystem = Utility<Filesystem>::get();
-			const auto basePath = filesystem.parentPath(filePath);
+			const auto basePath = Filesystem::parentPath(filePath);
 
 			Xml::XmlDocument xmlDoc;
 			xmlDoc.parse(filesystem.readFile(filePath).c_str());

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -53,14 +53,19 @@ protected:
 };
 
 
+constexpr auto EndsWithDirSeparator = []() {
+	return testing::EndsWith(NAS2D::Filesystem::dirSeparator());
+};
+
+
 TEST_F(Filesystem, basePath) {
 	// Result is a directory, and should end with a directory separator
-	EXPECT_THAT(fs.basePath(), testing::EndsWith(NAS2D::Filesystem::dirSeparator()));
+	EXPECT_THAT(fs.basePath(), EndsWithDirSeparator());
 }
 
 TEST_F(Filesystem, prefPath) {
 	// Result is a directory, and should end with a directory separator
-	EXPECT_THAT(fs.prefPath(), testing::EndsWith(NAS2D::Filesystem::dirSeparator()));
+	EXPECT_THAT(fs.prefPath(), EndsWithDirSeparator());
 	EXPECT_THAT(fs.prefPath(), testing::HasSubstr(AppName));
 }
 

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -115,14 +115,15 @@ TEST_F(Filesystem, mountUnmount) {
 	EXPECT_THROW(fs.mount("nonExistentPath/"), std::runtime_error);
 }
 
-TEST_F(Filesystem, dirSeparator) {
+
+TEST(FilesystemStatic, dirSeparator) {
 	// Varies by platform, so we can't know the exact value ("/", "\", ":")
 	// New platforms may choose a new unique value
 	// Some platforms may not even have a hierarchal filesystem ("")
 	EXPECT_NO_THROW(NAS2D::Filesystem::dirSeparator());
 }
 
-TEST_F(Filesystem, parentPath) {
+TEST(FilesystemStatic, parentPath) {
 	EXPECT_EQ("", NAS2D::Filesystem::parentPath(""));
 	EXPECT_EQ("", NAS2D::Filesystem::parentPath("file.extension"));
 	EXPECT_EQ("/", NAS2D::Filesystem::parentPath("/"));
@@ -132,7 +133,7 @@ TEST_F(Filesystem, parentPath) {
 	EXPECT_EQ("anotherFolder/", NAS2D::Filesystem::parentPath("anotherFolder/file.extension"));
 }
 
-TEST_F(Filesystem, extension) {
+TEST(FilesystemStatic, extension) {
 	EXPECT_EQ("", NAS2D::Filesystem::extension(""));
 	EXPECT_EQ("", NAS2D::Filesystem::extension("file"));
 	EXPECT_EQ("", NAS2D::Filesystem::extension("subdir/file"));

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -23,12 +23,12 @@ protected:
 
 TEST_F(Filesystem, basePath) {
 	// Result is a directory, and should end with a directory separator
-	EXPECT_THAT(fs.basePath(), testing::EndsWith(fs.dirSeparator()));
+	EXPECT_THAT(fs.basePath(), testing::EndsWith(NAS2D::Filesystem::dirSeparator()));
 }
 
 TEST_F(Filesystem, prefPath) {
 	// Result is a directory, and should end with a directory separator
-	EXPECT_THAT(fs.prefPath(), testing::EndsWith(fs.dirSeparator()));
+	EXPECT_THAT(fs.prefPath(), testing::EndsWith(NAS2D::Filesystem::dirSeparator()));
 	EXPECT_THAT(fs.prefPath(), testing::HasSubstr(AppName));
 }
 
@@ -119,29 +119,29 @@ TEST_F(Filesystem, dirSeparator) {
 	// Varies by platform, so we can't know the exact value ("/", "\", ":")
 	// New platforms may choose a new unique value
 	// Some platforms may not even have a hierarchal filesystem ("")
-	EXPECT_NO_THROW(fs.dirSeparator());
+	EXPECT_NO_THROW(NAS2D::Filesystem::dirSeparator());
 }
 
 TEST_F(Filesystem, parentPath) {
-	EXPECT_EQ("", fs.parentPath(""));
-	EXPECT_EQ("", fs.parentPath("file.extension"));
-	EXPECT_EQ("/", fs.parentPath("/"));
-	EXPECT_EQ("data/", fs.parentPath("data/"));
-	EXPECT_EQ("data/", fs.parentPath("data/file.extension"));
-	EXPECT_EQ("data/subfolder/", fs.parentPath("data/subfolder/file.extension"));
-	EXPECT_EQ("anotherFolder/", fs.parentPath("anotherFolder/file.extension"));
+	EXPECT_EQ("", NAS2D::Filesystem::parentPath(""));
+	EXPECT_EQ("", NAS2D::Filesystem::parentPath("file.extension"));
+	EXPECT_EQ("/", NAS2D::Filesystem::parentPath("/"));
+	EXPECT_EQ("data/", NAS2D::Filesystem::parentPath("data/"));
+	EXPECT_EQ("data/", NAS2D::Filesystem::parentPath("data/file.extension"));
+	EXPECT_EQ("data/subfolder/", NAS2D::Filesystem::parentPath("data/subfolder/file.extension"));
+	EXPECT_EQ("anotherFolder/", NAS2D::Filesystem::parentPath("anotherFolder/file.extension"));
 }
 
 TEST_F(Filesystem, extension) {
-	EXPECT_EQ("", fs.extension(""));
-	EXPECT_EQ("", fs.extension("file"));
-	EXPECT_EQ("", fs.extension("subdir/file"));
-	EXPECT_EQ("", fs.extension("subdir.ext/file"));
-	EXPECT_EQ(".", fs.extension("file."));
-	EXPECT_EQ(".file", fs.extension(".file"));
+	EXPECT_EQ("", NAS2D::Filesystem::extension(""));
+	EXPECT_EQ("", NAS2D::Filesystem::extension("file"));
+	EXPECT_EQ("", NAS2D::Filesystem::extension("subdir/file"));
+	EXPECT_EQ("", NAS2D::Filesystem::extension("subdir.ext/file"));
+	EXPECT_EQ(".", NAS2D::Filesystem::extension("file."));
+	EXPECT_EQ(".file", NAS2D::Filesystem::extension(".file"));
 
-	EXPECT_EQ(".a", fs.extension("file.a"));
-	EXPECT_EQ(".txt", fs.extension("file.txt"));
-	EXPECT_EQ(".txt", fs.extension("subdir/file.txt"));
-	EXPECT_EQ(".reallyLongExtensionName", fs.extension("file.reallyLongExtensionName"));
+	EXPECT_EQ(".a", NAS2D::Filesystem::extension("file.a"));
+	EXPECT_EQ(".txt", NAS2D::Filesystem::extension("file.txt"));
+	EXPECT_EQ(".txt", NAS2D::Filesystem::extension("subdir/file.txt"));
+	EXPECT_EQ(".reallyLongExtensionName", NAS2D::Filesystem::extension("file.reallyLongExtensionName"));
 }

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -4,6 +4,38 @@
 #include <gmock/gmock.h>
 
 
+TEST(FilesystemStatic, dirSeparator) {
+	// Varies by platform, so we can't know the exact value ("/", "\", ":")
+	// New platforms may choose a new unique value
+	// Some platforms may not even have a hierarchal filesystem ("")
+	EXPECT_NO_THROW(NAS2D::Filesystem::dirSeparator());
+}
+
+TEST(FilesystemStatic, parentPath) {
+	EXPECT_EQ("", NAS2D::Filesystem::parentPath(""));
+	EXPECT_EQ("", NAS2D::Filesystem::parentPath("file.extension"));
+	EXPECT_EQ("/", NAS2D::Filesystem::parentPath("/"));
+	EXPECT_EQ("data/", NAS2D::Filesystem::parentPath("data/"));
+	EXPECT_EQ("data/", NAS2D::Filesystem::parentPath("data/file.extension"));
+	EXPECT_EQ("data/subfolder/", NAS2D::Filesystem::parentPath("data/subfolder/file.extension"));
+	EXPECT_EQ("anotherFolder/", NAS2D::Filesystem::parentPath("anotherFolder/file.extension"));
+}
+
+TEST(FilesystemStatic, extension) {
+	EXPECT_EQ("", NAS2D::Filesystem::extension(""));
+	EXPECT_EQ("", NAS2D::Filesystem::extension("file"));
+	EXPECT_EQ("", NAS2D::Filesystem::extension("subdir/file"));
+	EXPECT_EQ("", NAS2D::Filesystem::extension("subdir.ext/file"));
+	EXPECT_EQ(".", NAS2D::Filesystem::extension("file."));
+	EXPECT_EQ(".file", NAS2D::Filesystem::extension(".file"));
+
+	EXPECT_EQ(".a", NAS2D::Filesystem::extension("file.a"));
+	EXPECT_EQ(".txt", NAS2D::Filesystem::extension("file.txt"));
+	EXPECT_EQ(".txt", NAS2D::Filesystem::extension("subdir/file.txt"));
+	EXPECT_EQ(".reallyLongExtensionName", NAS2D::Filesystem::extension("file.reallyLongExtensionName"));
+}
+
+
 class Filesystem : public ::testing::Test {
 protected:
 	static constexpr auto AppName = "NAS2DUnitTests";
@@ -113,36 +145,4 @@ TEST_F(Filesystem, mountUnmount) {
 	EXPECT_FALSE(fs.exists(extraFile));
 
 	EXPECT_THROW(fs.mount("nonExistentPath/"), std::runtime_error);
-}
-
-
-TEST(FilesystemStatic, dirSeparator) {
-	// Varies by platform, so we can't know the exact value ("/", "\", ":")
-	// New platforms may choose a new unique value
-	// Some platforms may not even have a hierarchal filesystem ("")
-	EXPECT_NO_THROW(NAS2D::Filesystem::dirSeparator());
-}
-
-TEST(FilesystemStatic, parentPath) {
-	EXPECT_EQ("", NAS2D::Filesystem::parentPath(""));
-	EXPECT_EQ("", NAS2D::Filesystem::parentPath("file.extension"));
-	EXPECT_EQ("/", NAS2D::Filesystem::parentPath("/"));
-	EXPECT_EQ("data/", NAS2D::Filesystem::parentPath("data/"));
-	EXPECT_EQ("data/", NAS2D::Filesystem::parentPath("data/file.extension"));
-	EXPECT_EQ("data/subfolder/", NAS2D::Filesystem::parentPath("data/subfolder/file.extension"));
-	EXPECT_EQ("anotherFolder/", NAS2D::Filesystem::parentPath("anotherFolder/file.extension"));
-}
-
-TEST(FilesystemStatic, extension) {
-	EXPECT_EQ("", NAS2D::Filesystem::extension(""));
-	EXPECT_EQ("", NAS2D::Filesystem::extension("file"));
-	EXPECT_EQ("", NAS2D::Filesystem::extension("subdir/file"));
-	EXPECT_EQ("", NAS2D::Filesystem::extension("subdir.ext/file"));
-	EXPECT_EQ(".", NAS2D::Filesystem::extension("file."));
-	EXPECT_EQ(".file", NAS2D::Filesystem::extension(".file"));
-
-	EXPECT_EQ(".a", NAS2D::Filesystem::extension("file.a"));
-	EXPECT_EQ(".txt", NAS2D::Filesystem::extension("file.txt"));
-	EXPECT_EQ(".txt", NAS2D::Filesystem::extension("subdir/file.txt"));
-	EXPECT_EQ(".reallyLongExtensionName", NAS2D::Filesystem::extension("file.reallyLongExtensionName"));
 }

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -58,6 +58,11 @@ constexpr auto EndsWithDirSeparator = []() {
 };
 
 
+constexpr auto HasPartialPath = [](const auto& subString) {
+	return testing::HasSubstr(subString);
+};
+
+
 TEST_F(Filesystem, basePath) {
 	// Result is a directory, and should end with a directory separator
 	EXPECT_THAT(fs.basePath(), EndsWithDirSeparator());
@@ -66,14 +71,14 @@ TEST_F(Filesystem, basePath) {
 TEST_F(Filesystem, prefPath) {
 	// Result is a directory, and should end with a directory separator
 	EXPECT_THAT(fs.prefPath(), EndsWithDirSeparator());
-	EXPECT_THAT(fs.prefPath(), testing::HasSubstr(AppName));
+	EXPECT_THAT(fs.prefPath(), HasPartialPath(AppName));
 }
 
 TEST_F(Filesystem, searchPath) {
 	auto pathList = fs.searchPath();
 	EXPECT_EQ(3u, pathList.size());
-	EXPECT_THAT(pathList, Contains(testing::HasSubstr("NAS2DUnitTests")));
-	EXPECT_THAT(pathList, Contains(testing::HasSubstr("data/")));
+	EXPECT_THAT(pathList, Contains(HasPartialPath("NAS2DUnitTests")));
+	EXPECT_THAT(pathList, Contains(HasPartialPath("data/")));
 }
 
 TEST_F(Filesystem, directoryList) {
@@ -143,7 +148,7 @@ TEST_F(Filesystem, mountUnmount) {
 
 	EXPECT_FALSE(fs.exists(extraFile));
 	EXPECT_NO_THROW(fs.mount(extraMount));
-	EXPECT_THAT(fs.searchPath(), Contains(testing::HasSubstr(extraMount)));
+	EXPECT_THAT(fs.searchPath(), Contains(HasPartialPath(extraMount)));
 	EXPECT_TRUE(fs.exists(extraFile));
 
 	EXPECT_NO_THROW(fs.unmount(extraMount));


### PR DESCRIPTION
Some `Filesystem` methods work on path strings in a lexical manner, without regard to any actual filesystem object. These methods don't require a `Filesystem` object to be instantiated first. As such, they have been made `static`.

Making these methods `static` makes it easier to extract helper lambdas in the unit test code. This is useful since changing paths to use `std::filesystem::path` instead of `std::string` require some updates to the tests using these checks, so centralizing the checks makes the update easier.

Reference: #973
