### PR TITLE
Redefine and re-implement `Filesystem::extension`

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -100,14 +100,7 @@ std::string Filesystem::parentPath(std::string_view filePath)
  */
 std::string Filesystem::extension(std::string_view filePath)
 {
-	const auto fileName = filePath.substr(filePath.rfind('/') + 1);
-	const auto pos = fileName.rfind('.');
-
-	if (pos != std::string::npos)
-	{
-		return std::string{fileName.substr(pos)};
-	}
-	return std::string{};
+	return std::filesystem::path{filePath}.extension().string();
 }
 
 

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -27,7 +27,7 @@ TEST(FilesystemStatic, extension) {
 	EXPECT_EQ("", NAS2D::Filesystem::extension("subdir/file"));
 	EXPECT_EQ("", NAS2D::Filesystem::extension("subdir.ext/file"));
 	EXPECT_EQ(".", NAS2D::Filesystem::extension("file."));
-	EXPECT_EQ(".file", NAS2D::Filesystem::extension(".file"));
+	EXPECT_EQ("", NAS2D::Filesystem::extension(".file"));
 
 	EXPECT_EQ(".a", NAS2D::Filesystem::extension("file.a"));
 	EXPECT_EQ(".txt", NAS2D::Filesystem::extension("file.txt"));


### PR DESCRIPTION
Unit tests have a slight change to match up with `std::filesystem::path::extension`. In particular, there must be a `stem` before any `.` before anything is considered an `extension`.

Note: On Linux, a leading `.` is used to represent a normally hidden file or folder, much like the Hidden attribute on Windows. For example, the Linux `makefile` places intermediate files in a `.build/` folder. In this case, the whole filename is considered the `stem`, and there is no extension. The leading `.` here is used to denote a hidden file, not the start of an extension with no `stem` for the `filename`.

Noticed this while working on PR #1077.
