### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       image: "outpostuniverse/${{ matrix.image }}"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.3.1
 
     - name: Restore vcpkg dependency cache
       uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       SOLUTION_FILE_PATH: .
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Restore vcpkg dependency cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache
       with:
         path: C:\vcpkg\installed\


### PR DESCRIPTION
Eliminates warnings seen on the GitHub Actions Summary page, under the "Annotations" section.

Example of previous warnings:
https://github.com/lairworks/nas2d-core/actions/runs/4651771087
