### PR TITLE
Fix box alignment

### DIFF
--- a/NAS2D/Math/Rectangle.h
+++ b/NAS2D/Math/Rectangle.h
@@ -74,6 +74,11 @@ namespace NAS2D
 			return (width == 0) || (height == 0);
 		}
 
+		constexpr bool empty() const
+		{
+			return (width <= 0) || (height <= 0);
+		}
+
 		void size(NAS2D::Vector<BaseType> newSize)
 		{
 			width = newSize.x;

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -427,6 +427,11 @@ void RendererOpenGL::drawGradient(const Rectangle<float>& rect, Color c1, Color 
 
 void RendererOpenGL::drawBox(const Rectangle<float>& rect, Color color)
 {
+	if (rect.empty())
+	{
+		return;
+	}
+
 	glDisable(GL_TEXTURE_2D);
 
 	setColor(color);
@@ -443,6 +448,11 @@ void RendererOpenGL::drawBox(const Rectangle<float>& rect, Color color)
 
 void RendererOpenGL::drawBoxFilled(const Rectangle<float>& rect, Color color)
 {
+	if (rect.empty())
+	{
+		return;
+	}
+
 	setColor(color);
 	glDisable(GL_TEXTURE_2D);
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -436,8 +436,8 @@ void RendererOpenGL::drawBox(const Rectangle<float>& rect, Color color)
 
 	setColor(color);
 
-	const auto p1 = rect.startPoint();
-	const auto p2 = rect.endPoint();
+	const auto p1 = rect.startPoint() +  Vector{0.5, 0.5}; // OpenGL centers pixels between integer values
+	const auto p2 = rect.endPoint(); // No adjustment here so as to exclude the bottom right sides
 	const GLfloat corners[] = { p1.x, p1.y, p2.x, p1.y, p2.x, p2.y, p1.x, p2.y };
 
 	glVertexPointer(2, GL_FLOAT, 0, corners);

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -435,10 +435,11 @@ void RendererOpenGL::drawBox(const Rectangle<float>& rect, Color color)
 	glDisable(GL_TEXTURE_2D);
 
 	setColor(color);
+
 	const auto p1 = rect.startPoint();
 	const auto p2 = rect.endPoint();
-
 	const GLfloat corners[] = { p1.x, p1.y, p2.x, p1.y, p2.x, p2.y, p1.x, p2.y };
+
 	glVertexPointer(2, GL_FLOAT, 0, corners);
 	glDrawArrays(GL_LINE_LOOP, 0, 4);
 

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -68,6 +68,13 @@ NAS2D::State* TestGraphics::update()
 	r.drawCircle({150, 120}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {0.5f, 0.5f});
 	r.drawCircle({150, 170}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {1.0f, 0.5f});
 
+	for (auto i = 0; i < 10; ++i)
+	{
+		NAS2D::Rectangle<int> boxRect = {200 + 10 * i, 50, i, i};
+		r.drawBox(boxRect, NAS2D::Color::Red);
+		r.drawBoxFilled(boxRect.inset(1), NAS2D::Color::White);
+	}
+
 	return this;
 }
 


### PR DESCRIPTION
Fix alignment so `drawBox` and `drawBoxFilled` line up as expected.

Avoid drawing zero and negative area boxes.

Related: #1086 