### PR TITLE
Fix case of `#include <windows.h>`

### DIFF
--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -15,7 +15,7 @@
 #endif
 
 #if defined(WINDOWS) || defined(WIN32)
-	#include <Windows.h>
+	#include <windows.h>
 	#include <SDL2/SDL_syswm.h>
 #endif
 


### PR DESCRIPTION
This potentially matters for a Linux build using MingW, since the Linux filesystem is case sensitive. However, currently the MingW build does not trigger the Windows compile path here. Perhaps a sign the defines being checked here are a bit imprecise.

Reference:
https://github.com/OutpostUniverse/OPHD/pull/1305#issuecomment-1509181851