### PR TITLE
Add `Configuration` methods

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -40,6 +40,18 @@ Dictionary& Configuration::operator[](const std::string& key)
 }
 
 
+bool Configuration::anyLoadedConfig() const
+{
+	return !mLoadedSettings.empty();
+}
+
+
+bool Configuration::anyNonDefaultConfig() const
+{
+	return mSettings != mDefaults;
+}
+
+
 /**
  * Reads a given XML configuration file.
  *

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -28,6 +28,18 @@ Configuration::Configuration(std::map<std::string, Dictionary> defaults) :
 }
 
 
+const Dictionary& Configuration::operator[](const std::string& key) const
+{
+	return mSettings.at(key);
+}
+
+
+Dictionary& Configuration::operator[](const std::string& key)
+{
+	return mSettings.at(key);
+}
+
+
 /**
  * Reads a given XML configuration file.
  *

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -37,6 +37,9 @@ namespace NAS2D
 		const Dictionary& operator[](const std::string& key) const;
 		Dictionary& operator[](const std::string& key);
 
+		bool anyLoadedConfig() const;
+		bool anyNonDefaultConfig() const;
+
 		void loadData(const std::string& fileData);
 		void load(const std::string& filePath);
 		std::string saveData() const;

--- a/NAS2D/Configuration.h
+++ b/NAS2D/Configuration.h
@@ -34,8 +34,8 @@ namespace NAS2D
 		Configuration& operator=(Configuration&&) = delete;
 		~Configuration() = default;
 
-		const Dictionary& operator[](const std::string& key) const { return mSettings.at(key); }
-		Dictionary& operator[](const std::string& key) { return mSettings.at(key); }
+		const Dictionary& operator[](const std::string& key) const;
+		Dictionary& operator[](const std::string& key);
 
 		void loadData(const std::string& fileData);
 		void load(const std::string& filePath);

--- a/test/Configuration.test.cpp
+++ b/test/Configuration.test.cpp
@@ -38,9 +38,13 @@ TEST(Configuration, OperatorSubscript) {
 
 		EXPECT_TRUE((std::is_same_v<NAS2D::Dictionary&, decltype(value)>));
 		EXPECT_EQ(value, DefaultGraphics);
+		EXPECT_FALSE(config.anyLoadedConfig());
+		EXPECT_FALSE(config.anyNonDefaultConfig());
 
 		EXPECT_NO_THROW(config["graphics"]["customAttribute"] = "custom value");
 		EXPECT_NE(value, DefaultGraphics);
+		EXPECT_FALSE(config.anyLoadedConfig());
+		EXPECT_TRUE(config.anyNonDefaultConfig());
 	}
 }
 
@@ -68,10 +72,20 @@ TEST(Configuration, loadData) {
 
 	{
 		// Defaults (before data load)
+		EXPECT_FALSE(config.anyLoadedConfig());
+		EXPECT_FALSE(config.anyNonDefaultConfig());
 		const auto& options = config["options"];
 		EXPECT_EQ("Some string value", options.get("Key1"));
 		EXPECT_EQ("true", options.get("Key2"));
 		EXPECT_EQ("-1", options.get("Key3"));
+	}
+
+	// Load config data matching defaults
+	config.loadData(config.saveData());
+	{
+		// Defaults (after data load)
+		EXPECT_TRUE(config.anyLoadedConfig());
+		EXPECT_FALSE(config.anyNonDefaultConfig());
 	}
 
 	config.loadData(
@@ -87,6 +101,8 @@ TEST(Configuration, loadData) {
 
 	{
 		// Defaults (after data load)
+		EXPECT_TRUE(config.anyLoadedConfig());
+		EXPECT_TRUE(config.anyNonDefaultConfig());
 		const auto& options = config["options"];
 		EXPECT_EQ("Some string value", options.get("Key1"));
 		EXPECT_EQ("true", options.get("Key2"));


### PR DESCRIPTION
Move implementations to source file. Add new methods to check for loaded or non-default config data.

Note that loaded and non-default data are completely independent from each other. Loaded data may or may not match default data. Data may be non-default either because a non-default value was loaded, or because the value was updated at runtime.

A config file not existing, or existing but not containing any data will results in no loaded data (as will not calling `load` or `loadData`).
