### PR TITLE
Remove library console output

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -73,8 +73,6 @@ void Configuration::loadData(const std::string& fileData)
  */
 void Configuration::load(const std::string& filePath)
 {
-	std::cout << "Initializing Configuration... ";
-
 	const auto& filesystem = Utility<Filesystem>::get();
 	if (filesystem.exists(filePath))
 	{
@@ -83,7 +81,6 @@ void Configuration::load(const std::string& filePath)
 			// Read in the Config File.
 			auto xmlData = filesystem.readFile(filePath);
 			loadData(xmlData.c_str());
-			std::cout << "done." << std::endl;
 		}
 		catch (const std::runtime_error& e)
 		{

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -14,7 +14,6 @@
 #include "Filesystem.h"
 #include "Utility.h"
 
-#include <iostream>
 #include <algorithm>
 #include <utility>
 #include <stdexcept>

--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -9,7 +9,6 @@
 // ==================================================================================
 #include "EventHandler.h"
 #include <SDL2/SDL.h>
-#include <iostream>
 
 // UGLY ASS HACK!
 // This is required for mouse grabbing in the EventHandler class.
@@ -66,7 +65,6 @@ EventHandler::EventHandler()
 
 EventHandler::~EventHandler()
 {
-	cout << "EventHandler Terminated." << endl;
 }
 
 /**

--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -59,14 +59,6 @@ namespace NAS2D
 }
 
 
-EventHandler::EventHandler()
-{}
-
-
-EventHandler::~EventHandler()
-{
-}
-
 /**
  * Triggered whenever the application gains or loses focus.
  *

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -277,9 +277,6 @@ namespace NAS2D
 		using QuitEventSource = SignalSource<>;
 
 	public:
-		EventHandler();
-		~EventHandler();
-
 		ActivateEventSource& activate();
 
 		WindowHiddenEventSource& windowHidden();

--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -23,7 +23,6 @@
 
 #include <SDL2/SDL.h>
 
-#include <iostream>
 #include <stdexcept>
 #include <string>
 

--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -42,11 +42,6 @@ using namespace NAS2D;
  */
 Game::Game(const std::string& title, const std::string& appName, const std::string& organizationName, const std::string& configPath, const std::string& dataPath)
 {
-	std::cout << "NAS2D BUILD: " << __DATE__ << " | " << __TIME__ << '\n';
-	std::cout << "NAS2D VERSION: " << versionString() << "\n\n";
-	std::cout << "Initializing subsystems...\n\n";
-	std::cout.flush();
-
 	SDL_Init(0);
 
 	auto& fs = Utility<Filesystem>::init<Filesystem>(appName, organizationName);
@@ -91,17 +86,9 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 		Utility<Mixer>::init<MixerNull>();
 	}
 
-	std::cout << "Initializing Event Handler... ";
 	Utility<EventHandler>::get();
-	std::cout << "done.\n\n";
-	std::cout.flush();
 
 	Utility<Renderer>::init<RendererOpenGL>(title);
-
-
-	std::cout << "\nSubsystems initialized.\n\n";
-	std::cout << "===================================\n\n";
-	std::cout.flush();
 }
 
 
@@ -110,9 +97,6 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
  */
 Game::~Game()
 {
-	std::cout << "\n===================================\n\n";
-	std::cout << "Shutting down..." << std::endl;
-
 	// Destroy all of our various components in reverse order.
 	Utility<Renderer>::clear();
 	Utility<EventHandler>::clear();
@@ -122,8 +106,6 @@ Game::~Game()
 
 	// Shut down all SDL subsystems.
 	SDL_Quit();
-
-	std::cout << "\nGame object has been terminated." << std::endl;
 }
 
 
@@ -149,9 +131,6 @@ void Game::mount(const std::string& path)
  */
 void Game::go(State* state)
 {
-	std::cout << "** GAME STATE START **\n\n";
-	std::cout.flush();
-
 	StateManager stateManager;
 
 	stateManager.setState(state);

--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -80,9 +80,8 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 	{
 		Utility<Mixer>::init<MixerSDL>();
 	}
-	catch (std::exception& e)
+	catch (std::exception& /*exception*/)
 	{
-		std::cout << "Unable to create SDL Audio Mixer: " << e.what() << ". Setting NULL driver." << std::endl;
 		Utility<Mixer>::init<MixerNull>();
 	}
 

--- a/NAS2D/Game.h
+++ b/NAS2D/Game.h
@@ -34,8 +34,6 @@ namespace NAS2D
 	 * #include "NAS2D.h"
 	 * #include "MyState.h"
 	 *
-	 * #include <iostream>
-	 *
 	 * int main(int argc, char* argv[])
 	 * {
 	 *	try
@@ -44,9 +42,10 @@ namespace NAS2D
 	 *		game.mount("gfx.zip");
 	 *		game.go(new MyState());
 	 *	}
-	 *	catch (const std::exception& e)
+	 *	catch (const std::exception& exception)
 	 *	{
-	 *		std::cout << "Error: " << e.what() << std::endl;
+	 *		// Report error message in `exception.what()`
+	 *		// ...
 	 *	}
 	 *	return 0;
 	 * }

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -11,7 +11,6 @@
 #include "Renderer.h"
 #include "../Math/Rectangle.h"
 
-#include <iostream>
 #include <algorithm>
 
 
@@ -21,12 +20,6 @@ using namespace NAS2D;
 Renderer::Renderer(const std::string& appTitle) :
 	Window(appTitle)
 {}
-
-
-Renderer::~Renderer()
-{
-	std::cout << "Renderer Terminated." << std::endl;
-}
 
 
 void Renderer::drawTextShadow(const Font& font, std::string_view text, Point<float> position, Vector<float> shadowOffset, Color textColor, Color shadowColor)

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -40,7 +40,6 @@ namespace NAS2D
 		Renderer& operator=(const Renderer& rhs) = default;
 		Renderer(Renderer&& rhs) = default;
 		Renderer& operator=(Renderer&& rhs) = default;
-		virtual ~Renderer();
 
 		virtual void drawImage(const Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) = 0;
 		virtual void drawSubImage(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, Color color = Color::Normal) = 0;

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -93,22 +93,6 @@ namespace
 		const auto apiResult = glGetString(name);
 		return apiResult ? reinterpret_cast<const char*>(apiResult) : "";
 	}
-
-	void dumpGraphicsInfo(RendererOpenGL& renderer)
-	{
-		std::vector<std::string> info{
-			"- OpenGL System Info -",
-			"Vendor: " + renderer.getVendor(),
-			"Renderer: " + renderer.getRenderer(),
-			"Driver Version: " + renderer.getDriverVersion(),
-			"GLSL Version: " + renderer.getShaderVersion(),
-		};
-
-		for (const auto& str : info)
-		{
-			std::cout << "\t" << str << std::endl;
-		}
-	}
 }
 
 
@@ -594,7 +578,6 @@ void RendererOpenGL::initGL()
 	glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
 	onResize(size());
-	dumpGraphicsInfo(*this);
 }
 
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -30,7 +30,6 @@
 #include <SDL2/SDL_image.h>
 #endif
 
-#include <iostream>
 #include <algorithm>
 #include <cmath>
 #include <array>
@@ -128,8 +127,6 @@ RendererOpenGL::RendererOpenGL(const std::string& title) :
 RendererOpenGL::RendererOpenGL(const std::string& title, const Options& options) :
 	Renderer(title)
 {
-	std::cout << "Starting OpenGL Renderer:" << std::endl;
-
 	initVideo(options.resolution, options.fullscreen, options.vsync);
 }
 
@@ -142,8 +139,6 @@ RendererOpenGL::~RendererOpenGL()
 	SDL_DestroyWindow(underlyingWindow);
 	underlyingWindow = nullptr;
 	SDL_QuitSubSystem(SDL_INIT_VIDEO);
-
-	std::cout << "OpenGL Renderer Terminated." << std::endl;
 }
 
 

--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -24,7 +24,6 @@
 #include <SDL2/SDL_ttf.h>
 #endif
 
-#include <iostream>
 #include <cmath>
 #include <algorithm>
 #include <cstddef>

--- a/NAS2D/Resource/Music.cpp
+++ b/NAS2D/Resource/Music.cpp
@@ -20,7 +20,6 @@
 #include <SDL2/SDL_mixer.h>
 #endif
 
-#include <iostream>
 #include <string>
 #include <stdexcept>
 

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -14,7 +14,6 @@
 #include "../Utility.h"
 
 #include <utility>
-#include <iostream>
 #include <stdexcept>
 
 

--- a/NAS2D/StateManager.cpp
+++ b/NAS2D/StateManager.cpp
@@ -14,8 +14,6 @@
 #include "State.h"
 #include "Mixer/Mixer.h"
 
-#include <iostream>
-
 using namespace std;
 using namespace NAS2D;
 


### PR DESCRIPTION
Libraries should never generate output. It should be up to the app using the library to decide when and how output is generated.

Some background cleanup was split off into a couple of other PRs while working on this:
- #1092
- #1093
