### PR TITLE
Flatten `makefile` output folder structure

### DIFF
--- a/makefile
+++ b/makefile
@@ -33,9 +33,9 @@ RUN_PREFIX := $($(TARGET_OS)_RUN_PREFIX)
 
 SRCDIR := NAS2D
 ROOTBUILDDIR := .build
-BUILDDIR := $(ROOTBUILDDIR)/$(CONFIG)/Linux
+BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(CONFIG)/Linux
 BINDIR := lib
-INTDIR := $(BUILDDIR)/nas2d/intermediate
+INTDIR := $(BUILDDIRPREFIX)/nas2d/intermediate
 OUTPUT := $(BINDIR)/libnas2d.a
 PACKAGEDIR := $(ROOTBUILDDIR)/package
 
@@ -96,13 +96,13 @@ clean-all: | clean
 ## Unit Test project ##
 
 TESTDIR := test
-TESTINTDIR := $(BUILDDIR)/test/intermediate
+TESTINTDIR := $(BUILDDIRPREFIX)/test/intermediate
 TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.o,$(TESTSRCS))
 TESTCPPFLAGS := $(CPPFLAGS) -I./
 TESTLDFLAGS := -L$(BINDIR) $(LDFLAGS)
 TESTLIBS := -lnas2d -lgtest -lgtest_main -lgmock -lgmock_main -lpthread $(LDLIBS)
-TESTOUTPUT := $(BUILDDIR)/test/test
+TESTOUTPUT := $(BUILDDIRPREFIX)/test/test
 
 TESTDEPFLAGS = -MT $@ -MMD -MP -MF $(TESTINTDIR)/$*.Td
 TESTCOMPILE.cpp = $(CXX) $(TESTCPPFLAGS) $(TESTDEPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
@@ -130,7 +130,7 @@ $(TESTINTDIR)/%.d: ;
 include $(wildcard $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.d,$(TESTSRCS)))
 
 
-TESTGRAPHICSDIR := $(BUILDDIR)/testGraphics
+TESTGRAPHICSDIR := $(BUILDDIRPREFIX)/testGraphics
 
 .PHONY: test-graphics
 test-graphics: $(TESTGRAPHICSDIR)/testGraphics

--- a/makefile
+++ b/makefile
@@ -37,7 +37,7 @@ BUILDDIR := $(ROOTBUILDDIR)/$(CONFIG)/Linux
 BINDIR := lib
 INTDIR := $(BUILDDIR)/nas2d/intermediate
 OUTPUT := $(BINDIR)/libnas2d.a
-PACKAGEDIR := $(BUILDDIR)/package
+PACKAGEDIR := $(ROOTBUILDDIR)/package
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(INTDIR)/$*.Td
 

--- a/makefile
+++ b/makefile
@@ -33,9 +33,9 @@ RUN_PREFIX := $($(TARGET_OS)_RUN_PREFIX)
 
 SRCDIR := NAS2D
 ROOTBUILDDIR := .build
-BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(CONFIG)/Linux
+BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(CONFIG)_Linux_
 BINDIR := lib
-INTDIR := $(BUILDDIRPREFIX)/nas2d/intermediate
+INTDIR := $(BUILDDIRPREFIX)nas2d/intermediate
 OUTPUT := $(BINDIR)/libnas2d.a
 PACKAGEDIR := $(ROOTBUILDDIR)/package
 
@@ -96,13 +96,13 @@ clean-all: | clean
 ## Unit Test project ##
 
 TESTDIR := test
-TESTINTDIR := $(BUILDDIRPREFIX)/test/intermediate
+TESTINTDIR := $(BUILDDIRPREFIX)test/intermediate
 TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.o,$(TESTSRCS))
 TESTCPPFLAGS := $(CPPFLAGS) -I./
 TESTLDFLAGS := -L$(BINDIR) $(LDFLAGS)
 TESTLIBS := -lnas2d -lgtest -lgtest_main -lgmock -lgmock_main -lpthread $(LDLIBS)
-TESTOUTPUT := $(BUILDDIRPREFIX)/test/test
+TESTOUTPUT := $(BUILDDIRPREFIX)test/test
 
 TESTDEPFLAGS = -MT $@ -MMD -MP -MF $(TESTINTDIR)/$*.Td
 TESTCOMPILE.cpp = $(CXX) $(TESTCPPFLAGS) $(TESTDEPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
@@ -130,7 +130,7 @@ $(TESTINTDIR)/%.d: ;
 include $(wildcard $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.d,$(TESTSRCS)))
 
 
-TESTGRAPHICSDIR := $(BUILDDIRPREFIX)/testGraphics
+TESTGRAPHICSDIR := $(BUILDDIRPREFIX)testGraphics
 
 .PHONY: test-graphics
 test-graphics: $(TESTGRAPHICSDIR)/testGraphics


### PR DESCRIPTION
This makes it a little easier to navigate, and more consistent with how the Visual Studio projects were modified to structure the build outputs.

Related to PR #1104.

Inspired by work for #1099.
