### PR TITLE
Fix test-graphics use of removed `argv[0]` parameter

### DIFF
--- a/test-graphics/main.cpp
+++ b/test-graphics/main.cpp
@@ -19,7 +19,7 @@
 #include <string>
 
 
-int main(int /*argc*/, char* /*argv*/[])
+int main()
 {
 	try
 	{

--- a/test-graphics/main.cpp
+++ b/test-graphics/main.cpp
@@ -19,11 +19,11 @@
 #include <string>
 
 
-int main(int /*argc*/, char *argv[])
+int main(int /*argc*/, char* /*argv*/[])
 {
 	try
 	{
-		NAS2D::Game game("NAS2D Graphics Test", "NAS2D_GraphicsTest", "LairWorks", argv[0]);
+		NAS2D::Game game("NAS2D Graphics Test", "NAS2D_GraphicsTest", "LairWorks");
 		game.go(new TestGraphics());
 	}
 	catch(std::exception& e)


### PR DESCRIPTION
This was causing startup problems on Windows. This was noticed while testing changes for work on #1099.

It seems that on Windows, the startup exe path is absolute, and was detected as an existing file, and so the `Configuration` code tried to `load` it, resulting in an error. On Linux, the startup exe path is relative, and was not detected as an existing file, and so the `Configuration` code skipping trying to `load` it, since it assumed it was a config file that hadn't been generated yet (such as on first startup). Hence the error was missed on Linux.

The reason for the difference in determining if the file exists, was that relative paths are appended to each entry of the search list, whereas an absolute path replaces it completely. The relative path of the executable file was from the project folder, but the search list only included the "data" subfolder of the project folder, hence the relative path was off by one level to the executable file.
