### PR TITLE
Fix `vcpkg` caching on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/cache@v3
       id: cache
       with:
-        path: C:\vcpkg\installed\
+        path: vcpkg_installed
         key: ${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
 
     - name: Install vcpkg dependencies


### PR DESCRIPTION
This improves the cache situation for Issue #1110.

There seem to be a few weaknesses though. The `vcpkg install` step may no longer be required, as that part will be automated during the build, though we may still want to include it so we get separate step timing when the cache needs to be rebuilt. The `vcpkg install` step still takes about 1 minute, so it seems to be doing more work than simply validating dependencies are up-to-date after the cache restore. I've also noticed the cache contains both `debug` and `release` versions of all libraries. This means the cache is twice as large as previous (54 MB instead of 27 MB).

Current caches can be viewed here:
https://github.com/lairworks/nas2d-core/actions/caches
