### PR TITLE
Add `vcpkg` binary package caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,28 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
       BUILD_CONFIGURATION: Release
       SOLUTION_FILE_PATH: .
+      VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
 
     steps:
     - uses: actions/checkout@v3
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.3.1
+
+    - name: Setup NuGet credentials
+      shell: bash
+      run: |
+        $(vcpkg fetch nuget | tail -n1) \
+        sources add \
+        -source "https://nuget.pkg.github.com/lairworks/index.json" \
+        -storepasswordincleartext \
+        -name "GitHub" \
+        -username "lairworks" \
+        -password "${{ secrets.GITHUB_TOKEN }}"
+
+        $(vcpkg fetch nuget | tail -n1) \
+        setApiKey "${{ secrets.GITHUB_TOKEN }}" \
+        -source "https://nuget.pkg.github.com/lairworks/index.json"
 
     - name: Restore vcpkg dependency cache
       uses: actions/cache@v3


### PR DESCRIPTION
The GitHub hosted NuGet package repo can be used for binary package caching of `vcpkg` built dependencies. This allows for faster rebuilds of the `vcpkg` cache when some but not all packages need to be rebuilt.

Implements core feature upgrade discovered in #1110
Related to #1099
