### PR TITLE
Remove `vcpkg` pre-install step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,6 @@ jobs:
         path: vcpkg_installed
         key: ${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
 
-    - name: Install vcpkg dependencies
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: vcpkg install --triplet ${{env.PLATFORM}}-windows
-
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
 
     - name: Build
-      working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: |


### PR DESCRIPTION
This will be handled automatically as part of the build.

The pre-install step was sort of nice in that it gave independent timing for package installation, versus building the project proper. However, there was a significant startup delay running the step, which was effectively duplicated once the build started. Removing the explicit pre-install step should remove the duplicated startup time for `vcpkg` to check if all dependent packages are up-to-date.

Looks like this also solves the doubled cache size issue. Perhaps the pre-install step was doing something different that the main build.

Related to:
- PR #1112 
- Issue #1110 
- Issue #1099
- Issue #373