### PR TITLE
Fix outdated and slightly wrong `Music` error message

### DIFF
--- a/NAS2D/Resource/Music.cpp
+++ b/NAS2D/Resource/Music.cpp
@@ -39,7 +39,7 @@ Music::Music(const std::string& filePath) :
 	mMusic = Mix_LoadMUS_RW(SDL_RWFromConstMem(mBuffer.c_str(), static_cast<int>(mBuffer.size())), 1);
 	if (!mMusic)
 	{
-		throw std::runtime_error("Music::load() error: " + std::string{Mix_GetError()});
+		throw std::runtime_error("Music load error: " + std::string{Mix_GetError()});
 	}
 }
 


### PR DESCRIPTION
It seems `Music::load` was merged into the `Music` class constructor.

Noticed this while looking into #1103.
