### PR TITLE
Remove Code Analysis exclude path

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -258,7 +258,4 @@
     <None Include="..\.clang-format" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <PropertyGroup Condition="'$(Language)'=='C++'">
-    <CAExcludePath>$(VcpkgRoot)include;$(CAExcludePath)</CAExcludePath>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
There is now a `DisableAnalyzeExternal` setting which handles this case better.

Partial work for:
- #1099
