### PR TITLE
Avoid `Rectangle` internal fields

### DIFF
--- a/NAS2D/Math/PointInRectangleRange.h
+++ b/NAS2D/Math/PointInRectangleRange.h
@@ -77,7 +77,7 @@ namespace NAS2D
 
 		Iterator end() const
 		{
-			return Iterator{mRect, Vector<BaseType>{0, mRect.height}};
+			return Iterator{mRect, Vector<BaseType>{0, mRect.size().y}};
 		}
 
 	private:

--- a/NAS2D/Renderer/RectangleSkin.cpp
+++ b/NAS2D/Renderer/RectangleSkin.cpp
@@ -33,6 +33,7 @@ RectangleSkin::RectangleSkin(const Image& topLeft, const Image& top, const Image
 
 void RectangleSkin::draw(Renderer& renderer, const Rectangle<float>& rect) const
 {
+	const auto p0 = rect.startPoint();
 	const auto p1 = rect.startPoint() + mTopLeft.size().to<float>();
 	const auto p2 = rect.crossXPoint() + mTopRight.size().reflectX().to<float>();
 	const auto p3 = rect.crossYPoint() + mBottomLeft.size().reflectY().to<float>();
@@ -42,14 +43,14 @@ void RectangleSkin::draw(Renderer& renderer, const Rectangle<float>& rect) const
 	renderer.drawImageRepeated(mCenter, Rectangle<float>::Create(p1, p4));
 
 	// Draw the sides
-	renderer.drawImageRepeated(mTop, Rectangle<float>::Create({p1.x, rect.y}, p2));
+	renderer.drawImageRepeated(mTop, Rectangle<float>::Create({p1.x, p0.y}, p2));
 	renderer.drawImageRepeated(mBottom, Rectangle<float>::Create(p3, Point{p4.x, rect.endPoint().y}));
-	renderer.drawImageRepeated(mLeft, Rectangle<float>::Create({rect.x, p1.y}, p3));
+	renderer.drawImageRepeated(mLeft, Rectangle<float>::Create({p0.x, p1.y}, p3));
 	renderer.drawImageRepeated(mRight, Rectangle<float>::Create(p2, Point{rect.endPoint().x, p4.y}));
 
 	// Draw the corners
 	renderer.drawImage(mTopLeft, rect.startPoint());
-	renderer.drawImage(mTopRight, {p2.x, rect.y});
-	renderer.drawImage(mBottomLeft, {rect.x, p3.y});
+	renderer.drawImage(mTopRight, {p2.x, p0.y});
+	renderer.drawImage(mBottomLeft, {p0.x, p3.y});
 	renderer.drawImage(mBottomRight, p4);
 }

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -180,7 +180,8 @@ void RendererOpenGL::drawSubImage(const Image& image, Point<float> raster, const
 {
 	setColor(color);
 
-	const auto vertexArray = rectToQuad({raster.x, raster.y, subImageRect.width, subImageRect.height});
+	const auto& subImageSize = subImageRect.size();
+	const auto vertexArray = rectToQuad({raster.x, raster.y, subImageSize.x, subImageSize.y});
 	const auto imageSize = image.size().to<float>();
 	const auto textureCoordArray = rectToQuad(subImageRect.skewInverseBy(imageSize));
 
@@ -503,7 +504,9 @@ void RendererOpenGL::drawText(const Font& font, std::string_view text, Point<flo
 void RendererOpenGL::clipRect(const Rectangle<float>& rect)
 {
 	const auto intRect = rect.to<int>();
-	glScissor(intRect.x, size().y - (intRect.y + intRect.height), intRect.width, intRect.height);
+	const auto& position = intRect.startPoint();
+	const auto& clipSize = intRect.size();
+	glScissor(position.x, size().y - (position.y + clipSize.y), clipSize.x, clipSize.y);
 
 	glEnable(GL_SCISSOR_TEST);
 }
@@ -538,7 +541,9 @@ void RendererOpenGL::onResize(Vector<int> newSize)
 
 void RendererOpenGL::setViewport(const Rectangle<int>& viewport)
 {
-	glViewport(viewport.x, viewport.y, viewport.width, viewport.height);
+	const auto& position = viewport.startPoint();
+	const auto& size = viewport.size();
+	glViewport(position.x, position.y, size.x, size.y);
 }
 
 


### PR DESCRIPTION
Pre-work for Issue:
- #704

By avoiding direct references to internal fields, we can swap them out for packed internal formats without breaking things.
