### PR TITLE
Remove overload of `Rectangle::Create` taking `Vector`

### DIFF
--- a/NAS2D/Math/Rectangle.h
+++ b/NAS2D/Math/Rectangle.h
@@ -22,15 +22,12 @@ namespace NAS2D
 		Point<BaseType> position;
 		Vector<BaseType> size;
 
-		constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Vector<BaseType> size)
-		{
-			return {startPoint, size};
-		}
 
 		constexpr static Rectangle<BaseType> Create(Point<BaseType> startPoint, Point<BaseType> endPoint)
 		{
 			return {startPoint, endPoint - startPoint};
 		}
+
 
 		constexpr bool operator==(const Rectangle& rect) const
 		{

--- a/test/Math/Rectangle.test.cpp
+++ b/test/Math/Rectangle.test.cpp
@@ -3,15 +3,11 @@
 #include <gtest/gtest.h>
 
 
-TEST(Rectangle, CreatePointVector) {
-	EXPECT_EQ((NAS2D::Rectangle<int>{{0, 0}, {1, 1}}), NAS2D::Rectangle<int>::Create(NAS2D::Point{0, 0}, NAS2D::Vector{1, 1}));
-	EXPECT_EQ((NAS2D::Rectangle<int>{{1, 1}, {2, 3}}), NAS2D::Rectangle<int>::Create(NAS2D::Point{1, 1}, NAS2D::Vector{2, 3}));
-}
-
 TEST(Rectangle, CreatePointPoint) {
 	EXPECT_EQ((NAS2D::Rectangle<int>{{0, 0}, {1, 1}}), NAS2D::Rectangle<int>::Create(NAS2D::Point{0, 0}, NAS2D::Point{1, 1}));
 	EXPECT_EQ((NAS2D::Rectangle<int>{{1, 1}, {1, 2}}), NAS2D::Rectangle<int>::Create(NAS2D::Point{1, 1}, NAS2D::Point{2, 3}));
 }
+
 
 TEST(Rectangle, size) {
 	EXPECT_EQ((NAS2D::Vector{0, 0}), (NAS2D::Rectangle<int>{{0, 0}, {0, 0}}.size));


### PR DESCRIPTION
It's easier to just use direct construction in that case now.

Related:
- PR #1125
- PR #1124
- Issue #704
