### PR TITLE
Refactor `makefile` - Simplify `include` of dependency info

### DIFF
--- a/makefile
+++ b/makefile
@@ -60,7 +60,7 @@ nas2d: $(OUTPUT)
 $(OUTPUT): $(OBJS)
 $(OBJS): $(INTDIR)/%.o : $(SRCDIR)/%.cpp $(INTDIR)/%.d
 
-include $(wildcard $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.d,$(SRCS)))
+include $(wildcard $(patsubst %.o,%.d,$(OBJS)))
 
 
 ## Unit Test project ##
@@ -87,7 +87,7 @@ $(TESTOUTPUT): $(TESTOBJS) $(OUTPUT)
 $(TESTOBJS): PROJECT_FLAGS = $(TESTPROJECT_FLAGS)
 $(TESTOBJS): $(TESTINTDIR)/%.o : $(TESTDIR)/%.cpp $(TESTINTDIR)/%.d
 
-include $(wildcard $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.d,$(TESTSRCS)))
+include $(wildcard $(patsubst %.o,%.d,$(TESTOBJS)))
 
 
 .PHONY: check
@@ -116,7 +116,8 @@ $(TESTGRAPHICSOUTPUT): $(TESTGRAPHICSOBJS) $(OUTPUT)
 $(TESTGRAPHICSOBJS): PROJECT_FLAGS = $(TESTGRAPHICSPROJECT_FLAGS)
 $(TESTGRAPHICSOBJS): $(TESTGRAPHICSINTDIR)/%.o : $(TESTGRAPHICSDIR)/%.cpp $(TESTGRAPHICSINTDIR)/%.d
 
-include $(wildcard $(patsubst $(TESTGRAPHICSDIR)/%.cpp,$(TESTGRAPHICSINTDIR)/%.d,$(TESTGRAPHICSSRCS)))
+include $(wildcard $(patsubst %.o,%.d,$(TESTGRAPHICSOBJS)))
+
 
 .PHONY: run-test-graphics
 run-test-graphics: | test-graphics

--- a/makefile
+++ b/makefile
@@ -70,6 +70,7 @@ TESTINTDIR := $(BUILDDIRPREFIX)test/intermediate
 TESTOUTPUT := $(BUILDDIRPREFIX)test/test
 TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.o,$(TESTSRCS))
+
 TESTCPPFLAGS := $(CPPFLAGS) -I./
 TESTLDFLAGS := $(LDFLAGS)
 TESTLIBS := -lgtest -lgtest_main -lgmock -lgmock_main -lpthread $(LDLIBS)

--- a/makefile
+++ b/makefile
@@ -67,9 +67,9 @@ include $(wildcard $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.d,$(SRCS)))
 
 TESTDIR := test
 TESTINTDIR := $(BUILDDIRPREFIX)test/intermediate
+TESTOUTPUT := $(BUILDDIRPREFIX)test/test
 TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.o,$(TESTSRCS))
-TESTOUTPUT := $(BUILDDIRPREFIX)test/test
 TESTCPPFLAGS := $(CPPFLAGS) -I./
 TESTLDFLAGS := $(LDFLAGS)
 TESTLIBS := -lgtest -lgtest_main -lgmock -lgmock_main -lpthread $(LDLIBS)


### PR DESCRIPTION
Partial work for:
- #1129

Since both objects and dependency files are in the intermediate folder, it's easier to derive the dependency filename from the object filename than from the source filename. This reduces the number of project specific variables that need to be touched.
