### PR TITLE
Fix `Filesystem` get paths bug

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -10,6 +10,7 @@
 
 #include "Filesystem.h"
 
+#include <SDL2/SDL.h>
 #include <SDL2/SDL_filesystem.h>
 
 #include <algorithm>
@@ -39,12 +40,23 @@ namespace
 
 	std::string getBasePath()
 	{
-		return SdlString{SDL_GetBasePath()}.get();
+		const auto pathPtr = SdlString{SDL_GetBasePath()};
+		if (pathPtr.get() == nullptr)
+		{
+			throw std::runtime_error("Error getting BasePath: " + std::string{SDL_GetError()});
+		}
+		return pathPtr.get();
 	}
+
 
 	std::string getPrefPath(const std::string& appName, const std::string& organizationName)
 	{
-		return SdlString{SDL_GetPrefPath(organizationName.c_str(), appName.c_str())}.get();
+		const auto pathPtr = SdlString{SDL_GetPrefPath(organizationName.c_str(), appName.c_str())};
+		if (pathPtr.get() == nullptr)
+		{
+			throw std::runtime_error("Error getting PrefPath: " + std::string{SDL_GetError()});
+		}
+		return pathPtr.get();
 	}
 
 

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -37,6 +37,17 @@ namespace
 	using SdlString = std::unique_ptr<char, SdlStringDeleter>;
 
 
+	std::string getBasePath()
+	{
+		return SdlString{SDL_GetBasePath()}.get();
+	}
+
+	std::string getPrefPath(const std::string& appName, const std::string& organizationName)
+	{
+		return SdlString{SDL_GetPrefPath(organizationName.c_str(), appName.c_str())}.get();
+	}
+
+
 	bool hasFileSuffix(const std::string& filePath, const std::string& suffix)
 	{
 		return filePath.rfind(suffix, filePath.length() - suffix.length()) != std::string::npos;
@@ -105,8 +116,8 @@ std::string Filesystem::extension(std::string_view filePath)
 
 
 Filesystem::Filesystem(const std::string& appName, const std::string& organizationName) :
-	mBasePath{SdlString{SDL_GetBasePath()}.get()},
-	mPrefPath{SdlString{SDL_GetPrefPath(organizationName.c_str(), appName.c_str())}.get()},
+	mBasePath{getBasePath()},
+	mPrefPath{getPrefPath(appName, organizationName)},
 	mWritePath{},
 	mSearchPaths{}
 {


### PR DESCRIPTION
While investigating some failures for the Arch Linux build, we discovered we didn't properly check the return code for a couple of SDL path functions:
- [`SDL_GetBasePath`](https://wiki.libsdl.org/SDL2/SDL_GetBasePath)
- [`SDL_GetPrefPath`](https://wiki.libsdl.org/SDL2/SDL_GetPrefPath)

Both these functions can potentially return `NULL` if there was an error.

This can be an issue when run in a Docker container using a user ID for a user that doesn't exist in `/etc/passwd` in the container image. In particular the `HOME` environment variable may not be set, which can cause `SDL_GetPrefPath` to fail. Setting `HOME` to a path that is writable can allow the unit tests to work.

To better detect this situation, we convert the `NULL` error code to an exception with the message from `SDL_GetError`.
