### PR TITLE
Update GitHub Actions workflow to use updated Arch Linux image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - "nas2d-arch:1.3"
+        - "nas2d-arch:1.4"
     runs-on: ubuntu-latest
     container:
       image: "outpostuniverse/${{ matrix.image }}"


### PR DESCRIPTION
Missed this part of the change in PR #1139.
