### PR TITLE
Refactor `Image` constructors

### DIFF
--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -126,6 +126,14 @@ Image::Image(void* buffer, int bytesPerPixel, Vector<int> size) :
 }
 
 
+Image::Image(SDL_Surface& surface) :
+	mResourceName{},
+	mSurface{&surface},
+	mSize{mSurface->w, mSurface->h}
+{
+}
+
+
 Image::~Image()
 {
 	if (mFrameBufferObjectId != 0)

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -96,10 +96,9 @@ SDL_Surface* Image::dataToSdlSurface(void* buffer, int bytesPerPixel, Vector<int
  * \param filePath Path to an image file.
  */
 Image::Image(const std::string& filePath) :
-	Image{
-		filePath,
-		Utility<Filesystem>::get().readFile(filePath),
-	}
+	mResourceName{filePath},
+	mSurface{fileToSdlSurface(filePath)},
+	mSize{mSurface->w, mSurface->h}
 {
 }
 

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -74,6 +74,22 @@ SDL_Surface* Image::dataToSdlSurface(const std::string& data)
 }
 
 
+SDL_Surface* Image::dataToSdlSurface(void* buffer, int bytesPerPixel, Vector<int> size)
+{
+	if (buffer == nullptr)
+	{
+		throw std::runtime_error("Image construction requires non-nullptr buffer");
+	}
+
+	if (bytesPerPixel != 3 && bytesPerPixel != 4)
+	{
+		throw std::runtime_error("Image bit-depth unsupported with bytesPerPixel: " + std::to_string(bytesPerPixel));
+	}
+
+	return SDL_CreateRGBSurfaceFrom(buffer, size.x, size.y, bytesPerPixel * 8, 0, 0, 0, 0, isBigEndian ? 0x000000FF : 0xFF000000);
+}
+
+
 /**
  * Loads an Image from disk.
  *

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -122,17 +122,7 @@ Image::Image(void* buffer, int bytesPerPixel, Vector<int> size) :
 	mResourceName{generateImageName()},
 	mSize{size}
 {
-	if (buffer == nullptr)
-	{
-		throw std::runtime_error("Image construction requires non-nullptr buffer");
-	}
-
-	if (bytesPerPixel != 3 && bytesPerPixel != 4)
-	{
-		throw std::runtime_error("Image bit-depth unsupported with bytesPerPixel: " + std::to_string(bytesPerPixel));
-	}
-
-	mSurface = SDL_CreateRGBSurfaceFrom(buffer, size.x, size.y, bytesPerPixel * 8, 0, 0, 0, 0, isBigEndian ? 0x000000FF : 0xFF000000);
+	mSurface = dataToSdlSurface(buffer, bytesPerPixel, size);
 }
 
 

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -96,18 +96,16 @@ SDL_Surface* Image::dataToSdlSurface(void* buffer, int bytesPerPixel, Vector<int
  * \param filePath Path to an image file.
  */
 Image::Image(const std::string& filePath) :
-	mResourceName{filePath},
-	mSurface{fileToSdlSurface(filePath)},
-	mSize{mSurface->w, mSurface->h}
+	Image{*fileToSdlSurface(filePath)}
 {
+	mResourceName = filePath;
 }
 
 
 Image::Image(std::string resourceName, const std::string& data) :
-	mResourceName{std::move(resourceName)},
-	mSurface{dataToSdlSurface(data)},
-	mSize{mSurface->w, mSurface->h}
+	Image{*dataToSdlSurface(data)}
 {
+	mResourceName = resourceName;
 }
 
 
@@ -119,10 +117,9 @@ Image::Image(std::string resourceName, const std::string& data) :
  * \param	size			Size of the Image in pixels.
  */
 Image::Image(void* buffer, int bytesPerPixel, Vector<int> size) :
-	mResourceName{generateImageName()},
-	mSize{size}
+	Image{*dataToSdlSurface(buffer, bytesPerPixel, size)}
 {
-	mSurface = dataToSdlSurface(buffer, bytesPerPixel, size);
+	mResourceName = generateImageName();
 }
 
 

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -104,19 +104,10 @@ Image::Image(const std::string& filePath) :
 
 
 Image::Image(std::string resourceName, const std::string& data) :
-	mResourceName{std::move(resourceName)}
+	mResourceName{std::move(resourceName)},
+	mSurface{dataToSdlSurface(data)},
+	mSize{mSurface->w, mSurface->h}
 {
-	if (data.size() == 0)
-	{
-		throw std::runtime_error("Image file is empty: " + mResourceName);
-	}
-
-	mSurface = IMG_Load_RW(SDL_RWFromConstMem(data.c_str(), static_cast<int>(data.size())), 1);
-	if (!mSurface)
-	{
-		throw std::runtime_error("Image failed to load: " + std::string{SDL_GetError()});
-	}
-	mSize = Vector{mSurface->w, mSurface->h};
 }
 
 

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -50,6 +50,30 @@ namespace
 }
 
 
+SDL_Surface* Image::fileToSdlSurface(const std::string& filePath)
+{
+	const auto& data = Utility<Filesystem>::get().readFile(filePath);
+
+	if (data.size() == 0)
+	{
+		throw std::runtime_error("Image file is empty: " + filePath);
+	}
+
+	return dataToSdlSurface(data);
+}
+
+
+SDL_Surface* Image::dataToSdlSurface(const std::string& data)
+{
+	auto surface = IMG_Load_RW(SDL_RWFromConstMem(data.c_str(), static_cast<int>(data.size())), 1);
+	if (!surface)
+	{
+		throw std::runtime_error("Image failed to load: " + std::string{SDL_GetError()});
+	}
+	return surface;
+}
+
+
 /**
  * Loads an Image from disk.
  *

--- a/NAS2D/Resource/Image.h
+++ b/NAS2D/Resource/Image.h
@@ -45,6 +45,7 @@ namespace NAS2D
 		explicit Image(const std::string& filePath);
 		Image(std::string resourceName, const std::string& data);
 		Image(void* buffer, int bytesPerPixel, Vector<int> size);
+		Image(SDL_Surface& surface);
 
 		Image(const Image& rhs) = delete;
 		Image& operator=(const Image& rhs) = delete;

--- a/NAS2D/Resource/Image.h
+++ b/NAS2D/Resource/Image.h
@@ -39,6 +39,7 @@ namespace NAS2D
 	protected:
 		static SDL_Surface* fileToSdlSurface(const std::string& filePath);
 		static SDL_Surface* dataToSdlSurface(const std::string& data);
+		static SDL_Surface* dataToSdlSurface(void* buffer, int bytesPerPixel, Vector<int> size);
 
 	public:
 		explicit Image(const std::string& filePath);

--- a/NAS2D/Resource/Image.h
+++ b/NAS2D/Resource/Image.h
@@ -36,6 +36,10 @@ namespace NAS2D
 	 */
 	class Image
 	{
+	protected:
+		static SDL_Surface* fileToSdlSurface(const std::string& filePath);
+		static SDL_Surface* dataToSdlSurface(const std::string& data);
+
 	public:
 		explicit Image(const std::string& filePath);
 		Image(std::string resourceName, const std::string& data);


### PR DESCRIPTION
Prep work for:
- Issue #1127

The resources names will be removed, which will require some refactoring in the `Image` class.

The `Image` class uses constructor delegation that relies on an overload taking a resource name and a raw data string. The resource name parameter will need to be removed. However removing the resource name parameter will leave only the data parameter, which will make that overload ambiguous with the overload taking only a filename. In that case, both overloads have a single parameter and both are of the same type (`std::string`).

The future ambiguity of the file and data constructor overloads needs to be resolved. There is no obvious alternative parameter type to use, nor any obvious other parameters to add to resolve the ambiguity. This leaves the option of removing one of the constructor overloads to resolve that ambiguity. Perhaps a factory function can be used to replace that functionality, so the factory function name can be used to resolve that ambiguity while maintaining functionality. Meanwhile though, we need to unlink the constructor delegation so one of the overloads can be removed. Currently the resource caching code relies on the overload taking a filename, while no code relies on the overload taking a data string. The obvious choice will be to remove the overload taking a data string.

In preparation for removing the `Image` constructor overload taking a data string, we need to re-work the overload taking a file path so it no longer delegates to the overload taking a data string. It makes sense to rework some of the other related constructor code as well, so everything is consistent.
