### PR TITLE
Add `GTEST_OPTIONS` var for `make check`

### DIFF
--- a/makefile
+++ b/makefile
@@ -92,7 +92,7 @@ include $(wildcard $(patsubst %.o,%.d,$(TESTOBJS)))
 
 .PHONY: check
 check: | test
-	cd test && $(RUN_PREFIX) ../$(TESTOUTPUT)
+	cd test && $(RUN_PREFIX) ../$(TESTOUTPUT) $(GTEST_OPTIONS)
 
 
 ## Graphics test project ##


### PR DESCRIPTION
This makes it easier to pass options to the unit test executable. For example:
`make check GTEST_OPTIONS=--gtest_filter=Filesystem.*`

Thought of this after working on the fix in:
- PR #1140
