### PR TITLE
Add `workflow_dispatch` trigger to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   windows:


### PR DESCRIPTION
This allows a run to be triggered on demand in the GitHub Actions web interface, without needing to push a change to a branch. This can be particularly useful when checking if changes to the build environment have broken the build, even though no code changes have been made in a long time.

This may potentially help with:
- Issue #1149

... or perhaps not. No failures.
