### PR TITLE
Update key modifier functions

### DIFF
--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -750,7 +750,7 @@ bool EventHandler::textInputMode()
  */
 bool EventHandler::shift(KeyModifier mod)
 {
-	return KeyModifier::None != (mod & (KeyModifier::Shift | KeyModifier::Caps));
+	return KeyModifier::None != (mod & (KeyModifier::Shift));
 }
 
 

--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -792,7 +792,7 @@ bool EventHandler::control(KeyModifier mod)
  */
 bool EventHandler::query_shift() const
 {
-	return KeyModifier::None != (static_cast<KeyModifier>(SDL_GetModState()) & KeyModifier::Shift);
+	return shift(static_cast<KeyModifier>(SDL_GetModState()));
 }
 
 
@@ -801,7 +801,7 @@ bool EventHandler::query_shift() const
  */
 bool EventHandler::query_numlock() const
 {
-	return KeyModifier::None != (static_cast<KeyModifier>(SDL_GetModState()) & KeyModifier::Num);
+	return numlock(static_cast<KeyModifier>(SDL_GetModState()));
 }
 
 
@@ -810,7 +810,7 @@ bool EventHandler::query_numlock() const
  */
 bool EventHandler::query_control() const
 {
-	return KeyModifier::None != (static_cast<KeyModifier>(SDL_GetModState()) & KeyModifier::Ctrl);
+	return control(static_cast<KeyModifier>(SDL_GetModState()));
 }
 
 

--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -792,8 +792,7 @@ bool EventHandler::control(KeyModifier mod)
  */
 bool EventHandler::query_shift() const
 {
-	using underlying = std::underlying_type_t<KeyModifier>;
-	return KeyModifier::None != static_cast<KeyModifier>(SDL_GetModState() & static_cast<underlying>(KeyModifier::Shift));
+	return KeyModifier::None != (static_cast<KeyModifier>(SDL_GetModState()) & KeyModifier::Shift);
 }
 
 
@@ -802,8 +801,7 @@ bool EventHandler::query_shift() const
  */
 bool EventHandler::query_numlock() const
 {
-	using underlying = std::underlying_type_t<KeyModifier>;
-	return KeyModifier::None != static_cast<KeyModifier>(SDL_GetModState() & static_cast<underlying>(KeyModifier::Num));
+	return KeyModifier::None != (static_cast<KeyModifier>(SDL_GetModState()) & KeyModifier::Num);
 }
 
 
@@ -812,8 +810,7 @@ bool EventHandler::query_numlock() const
  */
 bool EventHandler::query_control() const
 {
-	using underlying = std::underlying_type_t<KeyModifier>;
-	return KeyModifier::None != static_cast<KeyModifier>(SDL_GetModState() & static_cast<underlying>(KeyModifier::Ctrl));
+	return KeyModifier::None != (static_cast<KeyModifier>(SDL_GetModState()) & KeyModifier::Ctrl);
 }
 
 

--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -790,7 +790,7 @@ bool EventHandler::control(KeyModifier mod)
 /**
  * Queries state of the Shift key modifier.
  */
-bool EventHandler::query_shift() const
+bool EventHandler::shift() const
 {
 	return shift(static_cast<KeyModifier>(SDL_GetModState()));
 }
@@ -799,7 +799,7 @@ bool EventHandler::query_shift() const
 /**
  * Queries state of the Shift key modifier.
  */
-bool EventHandler::query_numlock() const
+bool EventHandler::numlock() const
 {
 	return numlock(static_cast<KeyModifier>(SDL_GetModState()));
 }
@@ -808,7 +808,7 @@ bool EventHandler::query_numlock() const
 /**
  * Queries state of the Shift key modifier.
  */
-bool EventHandler::query_control() const
+bool EventHandler::control() const
 {
 	return control(static_cast<KeyModifier>(SDL_GetModState()));
 }

--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -748,7 +748,7 @@ bool EventHandler::textInputMode()
  *
  * \param mod	Modifier value to decode.
  */
-bool EventHandler::shift(KeyModifier mod) const
+bool EventHandler::shift(KeyModifier mod)
 {
 	return KeyModifier::None != (mod & (KeyModifier::Shift | KeyModifier::Caps));
 }
@@ -759,7 +759,7 @@ bool EventHandler::shift(KeyModifier mod) const
  *
  * \param mod	Modifier value to decode.
  */
-bool EventHandler::alt(KeyModifier mod) const
+bool EventHandler::alt(KeyModifier mod)
 {
 	return KeyModifier::None != (mod & KeyModifier::Alt);
 }
@@ -770,7 +770,7 @@ bool EventHandler::alt(KeyModifier mod) const
  *
  * \param mod	Modifier value to decode.
  */
-bool EventHandler::numlock(KeyModifier mod) const
+bool EventHandler::numlock(KeyModifier mod)
 {
 	return KeyModifier::None != (mod & KeyModifier::Num);
 }
@@ -781,7 +781,7 @@ bool EventHandler::numlock(KeyModifier mod) const
  *
  * \param mod	Modifier value to decode.
  */
-bool EventHandler::control(KeyModifier mod) const
+bool EventHandler::control(KeyModifier mod)
 {
 	return KeyModifier::None != (mod & KeyModifier::Ctrl);
 }

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -317,10 +317,10 @@ namespace NAS2D
 		void textInputMode(bool);
 		bool textInputMode();
 
-		bool shift(KeyModifier mod) const;
-		bool numlock(KeyModifier mod) const;
-		bool control(KeyModifier mod) const;
-		bool alt(KeyModifier mod) const;
+		static bool shift(KeyModifier mod);
+		static bool numlock(KeyModifier mod);
+		static bool control(KeyModifier mod);
+		static bool alt(KeyModifier mod);
 
 		bool query_shift() const;
 		bool query_numlock() const;

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -322,9 +322,9 @@ namespace NAS2D
 		static bool control(KeyModifier mod);
 		static bool alt(KeyModifier mod);
 
-		bool query_shift() const;
-		bool query_numlock() const;
-		bool query_control() const;
+		bool shift() const;
+		bool numlock() const;
+		bool control() const;
 
 		void pump();
 

--- a/test/EventHandler.test.cpp
+++ b/test/EventHandler.test.cpp
@@ -1,0 +1,36 @@
+#include "NAS2D/EventHandler.h"
+
+#include <gtest/gtest.h>
+
+
+TEST(EventHandler, shift) {
+	EXPECT_TRUE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::Shift));
+	EXPECT_TRUE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::ShiftLeft));
+	EXPECT_TRUE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::ShiftRight));
+	EXPECT_TRUE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::ShiftLeft | NAS2D::EventHandler::KeyModifier::CtrlLeft));
+	EXPECT_TRUE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::Caps));
+	EXPECT_FALSE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::Ctrl));
+	EXPECT_FALSE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::Alt));
+}
+
+TEST(EventHandler, numlock) {
+	EXPECT_TRUE(NAS2D::EventHandler::numlock(NAS2D::EventHandler::KeyModifier::Num));
+	EXPECT_TRUE(NAS2D::EventHandler::numlock(NAS2D::EventHandler::KeyModifier::Num | NAS2D::EventHandler::KeyModifier::CtrlLeft));
+	EXPECT_FALSE(NAS2D::EventHandler::numlock(NAS2D::EventHandler::KeyModifier::Shift));
+	EXPECT_FALSE(NAS2D::EventHandler::numlock(NAS2D::EventHandler::KeyModifier::Ctrl));
+	EXPECT_FALSE(NAS2D::EventHandler::numlock(NAS2D::EventHandler::KeyModifier::Alt));
+}
+
+TEST(EventHandler, control) {
+	EXPECT_TRUE(NAS2D::EventHandler::control(NAS2D::EventHandler::KeyModifier::Ctrl));
+	EXPECT_TRUE(NAS2D::EventHandler::control(NAS2D::EventHandler::KeyModifier::Ctrl | NAS2D::EventHandler::KeyModifier::CtrlLeft));
+	EXPECT_FALSE(NAS2D::EventHandler::control(NAS2D::EventHandler::KeyModifier::Shift));
+	EXPECT_FALSE(NAS2D::EventHandler::control(NAS2D::EventHandler::KeyModifier::Alt));
+}
+
+TEST(EventHandler, alt) {
+	EXPECT_TRUE(NAS2D::EventHandler::alt(NAS2D::EventHandler::KeyModifier::Alt));
+	EXPECT_TRUE(NAS2D::EventHandler::alt(NAS2D::EventHandler::KeyModifier::Alt | NAS2D::EventHandler::KeyModifier::CtrlLeft));
+	EXPECT_FALSE(NAS2D::EventHandler::alt(NAS2D::EventHandler::KeyModifier::Shift));
+	EXPECT_FALSE(NAS2D::EventHandler::alt(NAS2D::EventHandler::KeyModifier::Ctrl));
+}

--- a/test/EventHandler.test.cpp
+++ b/test/EventHandler.test.cpp
@@ -8,7 +8,7 @@ TEST(EventHandler, shift) {
 	EXPECT_TRUE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::ShiftLeft));
 	EXPECT_TRUE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::ShiftRight));
 	EXPECT_TRUE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::ShiftLeft | NAS2D::EventHandler::KeyModifier::CtrlLeft));
-	EXPECT_TRUE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::Caps));
+	EXPECT_FALSE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::Caps));
 	EXPECT_FALSE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::Ctrl));
 	EXPECT_FALSE(NAS2D::EventHandler::shift(NAS2D::EventHandler::KeyModifier::Alt));
 }


### PR DESCRIPTION
Closes #1151

Mark `KeyModifier` methods as `static`.

Remove Caps Lock checking from `shift`. We probably don't want to check `Caps` in that method. For control key combos, they should be unaffected by `Caps`. For text capitalization, we need to `xor` the state of `Shift` and `Caps` (rather than `or` them). Removing this check also makes the `shift` function consistent with `query_shift`.

Implement the `query_` prefixed methods in terms of the `static` methods.

Strip the `query_` prefix from non-static methods that query the current keyboard state.
