### PR TITLE
Use a lambda expression for custom deleter `SdlStringDeleter`

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -26,15 +26,7 @@ using namespace NAS2D;
 
 namespace
 {
-	struct SdlStringDeleter
-	{
-		void operator()(char* string)
-		{
-			SDL_free(string);
-		}
-	};
-
-
+	using SdlStringDeleter = decltype([](char* string) { SDL_free(string); });
 	using SdlString = std::unique_ptr<char, SdlStringDeleter>;
 
 


### PR DESCRIPTION
As per the chat discussion about using lambdas for the custom deleter of a `std::unique_ptr`.
