### PR TITLE
Updated MacOS image to `15.2.0` (Xcode 15.2, macOS 14.1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
 jobs:
   build-macos:
     macos:
-      xcode: "13.4.1"
+      xcode: "15.2.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
       WARN_EXTRA: "-isystem /usr/local/include"


### PR DESCRIPTION
Update MacOS build image to the latest supported version according to the CircleCI schema file.

The documentation states there is now a more recent version beyond what the schema file states, though that new version hasn't yet been added to the schema file. Using what's known in the schema file means Visual Studio Code won't underline the version number as an error.

Part of:
- Issue #1155
