### PR TITLE
Fix MacOS system include path for moved Brew path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       xcode: "15.2.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
-      WARN_EXTRA: "-isystem /usr/local/include"
+      WARN_EXTRA: "-isystem /opt/homebrew/include"
     steps:
       - checkout
       - brew-install


### PR DESCRIPTION
Related:
- Issue #1155
- PR #1157

The `-isystem` flag needed to be updated for the moved Brew include path.
