### PR TITLE
Split off Docker Make rules

### DIFF
--- a/docker/makefile
+++ b/docker/makefile
@@ -1,6 +1,11 @@
 # Build rules relating to Docker images
 
-DockerFolder := ${TopLevelFolder}/docker
+# Capture top level folder before any Makefile includes
+# Note: MAKEFILE_LIST's last entry is the last processed Makefile.
+#       That should be the current Makefile, assuming no includes
+DockerFolder := $(abspath $(dir $(lastword ${MAKEFILE_LIST})))
+TopLevelFolder := $(abspath $(DockerFolder)/..)
+
 DockerRunFlags := --volume ${TopLevelFolder}:/code --workdir=/code --rm --tty
 DockerUserFlags = --user="$(shell id --user):$(shell id --group)"
 DockerRepository := outpostuniverse

--- a/docker/makefile
+++ b/docker/makefile
@@ -1,0 +1,40 @@
+# Build rules relating to Docker images
+
+DockerFolder := ${TopLevelFolder}/docker
+DockerRunFlags := --volume ${TopLevelFolder}:/code --workdir=/code --rm --tty
+DockerUserFlags = --user="$(shell id --user):$(shell id --group)"
+DockerRepository := outpostuniverse
+
+ImageVersion_gcc := 1.5
+ImageVersion_clang := 1.4
+ImageVersion_mingw := 1.10
+ImageVersion_arch := 1.4
+
+DockerFileName = ${DockerFolder}/nas2d-$*.Dockerfile
+
+DockerImageName = ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
+DockerImageNameLatest = ${DockerRepository}/nas2d-$*:latest
+
+DockerBuildRules := build-image-gcc build-image-clang build-image-mingw build-image-arch
+DockerPushRules := push-image-gcc push-image-clang push-image-mingw push-image-arch
+DockerRunRules := run-image-gcc run-image-clang run-image-mingw run-image-arch
+DockerDebugRules := debug-image-gcc debug-image-clang debug-image-mingw debug-image-arch
+DockerDebugRootRules := root-debug-image-gcc root-debug-image-clang root-debug-image-mingw root-debug-image-arch
+
+.PHONY: ${DockerBuildRules} ${DockerPushRules} ${DockerRunRules} ${DockerDebugRules} ${DockerDebugRootRules}
+
+${DockerBuildRules}: build-image-%:
+	docker build ${DockerFolder}/ --file ${DockerFileName} --tag ${DockerImageName} --tag ${DockerImageNameLatest}
+
+${DockerPushRules}: push-image-%:
+	docker push ${DockerImageName}
+	docker push ${DockerImageNameLatest}
+
+${DockerRunRules}: run-image-%:
+	docker run ${DockerRunFlags} ${DockerUserFlags} ${DockerImageName}
+
+${DockerDebugRules}: debug-image-%:
+	docker run ${DockerRunFlags} --interactive ${DockerUserFlags} ${DockerImageName} bash
+
+${DockerDebugRootRules}: root-debug-image-%:
+	docker run ${DockerRunFlags} --interactive ${DockerImageName} bash

--- a/makefile
+++ b/makefile
@@ -1,10 +1,5 @@
 # Source http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
 
-# Capture top level folder before any Makefile includes
-# Note: MAKEFILE_LIST's last entry is the last processed Makefile.
-#       That should be the current Makefile, assuming no includes
-TopLevelFolder := $(abspath $(dir $(lastword ${MAKEFILE_LIST})))
-
 CONFIG = Debug
 Debug_CXX_FLAGS := -Og -g
 Release_CXX_FLAGS := -O3

--- a/makefile
+++ b/makefile
@@ -252,15 +252,19 @@ ImageVersion_arch := 1.4
 DockerImageName = ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
 
 DockerBuildRules := build-image-gcc build-image-clang build-image-mingw build-image-arch
+DockerPushRules := push-image-gcc push-image-clang push-image-mingw push-image-arch
 DockerRunRules := run-image-gcc run-image-clang run-image-mingw run-image-arch
 DockerDebugRules := debug-image-gcc debug-image-clang debug-image-mingw debug-image-arch
 DockerDebugRootRules := root-debug-image-gcc root-debug-image-clang root-debug-image-mingw root-debug-image-arch
-DockerPushRules := push-image-gcc push-image-clang push-image-mingw push-image-arch
 
-.PHONY: ${DockerBuildRules} ${DockerRunRules} ${DockerDebugRules} ${DockerDebugRootRules} ${DockerPushRules}
+.PHONY: ${DockerBuildRules} ${DockerPushRules} ${DockerRunRules} ${DockerDebugRules} ${DockerDebugRootRules}
 
 ${DockerBuildRules}: build-image-%:
 	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d-$*.Dockerfile --tag ${DockerImageName} --tag ${DockerRepository}/nas2d-$*:latest
+
+${DockerPushRules}: push-image-%:
+	docker push ${DockerImageName}
+	docker push ${DockerRepository}/nas2d-$*:latest
 
 ${DockerRunRules}: run-image-%:
 	docker run ${DockerRunFlags} ${DockerUserFlags} ${DockerImageName}
@@ -270,10 +274,6 @@ ${DockerDebugRules}: debug-image-%:
 
 ${DockerDebugRootRules}: root-debug-image-%:
 	docker run ${DockerRunFlags} --interactive ${DockerImageName} bash
-
-${DockerPushRules}: push-image-%:
-	docker push ${DockerImageName}
-	docker push ${DockerRepository}/nas2d-$*:latest
 
 #### CircleCI related build rules ####
 

--- a/makefile
+++ b/makefile
@@ -237,46 +237,7 @@ install-dependencies-darwin:
 
 #### Docker related build rules ####
 
-# Build rules relating to Docker images
-
-DockerFolder := ${TopLevelFolder}/docker
-DockerRunFlags := --volume ${TopLevelFolder}:/code --workdir=/code --rm --tty
-DockerUserFlags = --user="$(shell id --user):$(shell id --group)"
-DockerRepository := outpostuniverse
-
-ImageVersion_gcc := 1.5
-ImageVersion_clang := 1.4
-ImageVersion_mingw := 1.10
-ImageVersion_arch := 1.4
-
-DockerFileName = ${DockerFolder}/nas2d-$*.Dockerfile
-
-DockerImageName = ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
-DockerImageNameLatest = ${DockerRepository}/nas2d-$*:latest
-
-DockerBuildRules := build-image-gcc build-image-clang build-image-mingw build-image-arch
-DockerPushRules := push-image-gcc push-image-clang push-image-mingw push-image-arch
-DockerRunRules := run-image-gcc run-image-clang run-image-mingw run-image-arch
-DockerDebugRules := debug-image-gcc debug-image-clang debug-image-mingw debug-image-arch
-DockerDebugRootRules := root-debug-image-gcc root-debug-image-clang root-debug-image-mingw root-debug-image-arch
-
-.PHONY: ${DockerBuildRules} ${DockerPushRules} ${DockerRunRules} ${DockerDebugRules} ${DockerDebugRootRules}
-
-${DockerBuildRules}: build-image-%:
-	docker build ${DockerFolder}/ --file ${DockerFileName} --tag ${DockerImageName} --tag ${DockerImageNameLatest}
-
-${DockerPushRules}: push-image-%:
-	docker push ${DockerImageName}
-	docker push ${DockerImageNameLatest}
-
-${DockerRunRules}: run-image-%:
-	docker run ${DockerRunFlags} ${DockerUserFlags} ${DockerImageName}
-
-${DockerDebugRules}: debug-image-%:
-	docker run ${DockerRunFlags} --interactive ${DockerUserFlags} ${DockerImageName} bash
-
-${DockerDebugRootRules}: root-debug-image-%:
-	docker run ${DockerRunFlags} --interactive ${DockerImageName} bash
+include docker/makefile
 
 #### CircleCI related build rules ####
 

--- a/makefile
+++ b/makefile
@@ -250,6 +250,7 @@ ImageVersion_mingw := 1.10
 ImageVersion_arch := 1.4
 
 DockerImageName = ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
+DockerImageNameLatest = ${DockerRepository}/nas2d-$*:latest
 
 DockerBuildRules := build-image-gcc build-image-clang build-image-mingw build-image-arch
 DockerPushRules := push-image-gcc push-image-clang push-image-mingw push-image-arch
@@ -260,11 +261,11 @@ DockerDebugRootRules := root-debug-image-gcc root-debug-image-clang root-debug-i
 .PHONY: ${DockerBuildRules} ${DockerPushRules} ${DockerRunRules} ${DockerDebugRules} ${DockerDebugRootRules}
 
 ${DockerBuildRules}: build-image-%:
-	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d-$*.Dockerfile --tag ${DockerImageName} --tag ${DockerRepository}/nas2d-$*:latest
+	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d-$*.Dockerfile --tag ${DockerImageName} --tag ${DockerImageNameLatest}
 
 ${DockerPushRules}: push-image-%:
 	docker push ${DockerImageName}
-	docker push ${DockerRepository}/nas2d-$*:latest
+	docker push ${DockerImageNameLatest}
 
 ${DockerRunRules}: run-image-%:
 	docker run ${DockerRunFlags} ${DockerUserFlags} ${DockerImageName}

--- a/makefile
+++ b/makefile
@@ -249,6 +249,8 @@ ImageVersion_clang := 1.4
 ImageVersion_mingw := 1.10
 ImageVersion_arch := 1.4
 
+DockerFileName = ${DockerFolder}/nas2d-$*.Dockerfile
+
 DockerImageName = ${DockerRepository}/nas2d-$*:${ImageVersion_$*}
 DockerImageNameLatest = ${DockerRepository}/nas2d-$*:latest
 
@@ -261,7 +263,7 @@ DockerDebugRootRules := root-debug-image-gcc root-debug-image-clang root-debug-i
 .PHONY: ${DockerBuildRules} ${DockerPushRules} ${DockerRunRules} ${DockerDebugRules} ${DockerDebugRootRules}
 
 ${DockerBuildRules}: build-image-%:
-	docker build ${DockerFolder}/ --file ${DockerFolder}/nas2d-$*.Dockerfile --tag ${DockerImageName} --tag ${DockerImageNameLatest}
+	docker build ${DockerFolder}/ --file ${DockerFileName} --tag ${DockerImageName} --tag ${DockerImageNameLatest}
 
 ${DockerPushRules}: push-image-%:
 	docker push ${DockerImageName}


### PR DESCRIPTION
Split off the Docker related Make rules into their own `makefile`.

This change supports an eventual move to have Docker images built using CI.

----

By splitting these rules off from the main makefile, it makes it possible to watch for changes to either the Dockerfiles or to the build rules in the `makefile` that generate Docker images from the Dockerfiles. This can be accomplished by watching for changes in the folder `docker/` to trigger builds of Docker images.

Having Docker images built using CI can potentially speed up the uplaod of large Docker images. Docker images can be quite large, particularly for the Mingw builds, which are close to 4GB. Having to upload them after a local build can take quite a bit of time.

It might make sense to use the GitHub Docker Registry rather than DockerHub, as that could allow for building and uploading all using GitHub infrastructure.

----

Related:
- Issue #1155
