### PR TITLE
Split Docker image versions from `makefile`

### DIFF
--- a/docker/makefile
+++ b/docker/makefile
@@ -10,10 +10,7 @@ DockerRunFlags := --volume ${TopLevelFolder}:/code --workdir=/code --rm --tty
 DockerUserFlags = --user="$(shell id --user):$(shell id --group)"
 DockerRepository := outpostuniverse
 
-ImageVersion_gcc := 1.5
-ImageVersion_clang := 1.4
-ImageVersion_mingw := 1.10
-ImageVersion_arch := 1.4
+include $(wildcard $(DockerFolder)/nas2d-*.version.mk)
 
 DockerFileName = ${DockerFolder}/nas2d-$*.Dockerfile
 

--- a/docker/nas2d-arch.version.mk
+++ b/docker/nas2d-arch.version.mk
@@ -1,0 +1,1 @@
+ImageVersion_arch := 1.4

--- a/docker/nas2d-clang.version.mk
+++ b/docker/nas2d-clang.version.mk
@@ -1,0 +1,1 @@
+ImageVersion_clang := 1.4

--- a/docker/nas2d-gcc.version.mk
+++ b/docker/nas2d-gcc.version.mk
@@ -1,0 +1,1 @@
+ImageVersion_gcc := 1.5

--- a/docker/nas2d-mingw.version.mk
+++ b/docker/nas2d-mingw.version.mk
@@ -1,0 +1,1 @@
+ImageVersion_mingw := 1.10


### PR DESCRIPTION
These makes it easier to update separate images on separate branches, in parallel, and not encounter merge conflicts due to version number updates on adjacent lines.

This may also help in detecting which images need to be rebuilt, since we can watch for specific filenames, such as the Dockerfile or the associated version number file.

----

Reference:
- Issue #1155
- PR #1158
- PR #1162
