### PR TITLE
Add workflow to build Docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,10 +64,10 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - "nas2d-arch:1.4"
+        - "nas2d-arch:1.5"
     runs-on: ubuntu-latest
     container:
-      image: "outpostuniverse/${{ matrix.image }}"
+      image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/dockerBuild.yml
+++ b/.github/workflows/dockerBuild.yml
@@ -1,0 +1,29 @@
+name: Docker Build
+
+on:
+  push:
+    paths:
+      - ".github/workflows/dockerBuild.yml"
+      - "docker/*"
+  workflow_dispatch:
+
+jobs:
+  dockerBuild:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - "arch"
+    env:
+      DockerRepository: ghcr.io/${{ github.repository_owner }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: make -C docker build-image-${{ matrix.platform }}
+
+      - name: Docker login
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username "${{ github.repository_owner }}" --password-stdin
+
+      - run: make -C docker push-image-${{ matrix.platform }}

--- a/docker/makefile
+++ b/docker/makefile
@@ -8,7 +8,7 @@ TopLevelFolder := $(abspath $(DockerFolder)/..)
 
 DockerRunFlags := --volume ${TopLevelFolder}:/code --workdir=/code --rm --tty
 DockerUserFlags = --user="$(shell id --user):$(shell id --group)"
-DockerRepository := outpostuniverse
+DockerRepository ?= outpostuniverse
 
 include $(wildcard $(DockerFolder)/nas2d-*.version.mk)
 

--- a/docker/nas2d-arch.Dockerfile
+++ b/docker/nas2d-arch.Dockerfile
@@ -1,6 +1,6 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM archlinux:base-20230604.0.155602
+FROM archlinux:base-20240811.0.253648
 
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages

--- a/docker/nas2d-arch.version.mk
+++ b/docker/nas2d-arch.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_arch := 1.4
+ImageVersion_arch := 1.5


### PR DESCRIPTION
Part of:
- Issue #1155

Add a workflow to build Docker images. These images will be uploaded to GitHub's Docker image registry, rather than using Docker Hub.

Updates the Arch Linux image, as a way of testing the new workflow.
