### PR TITLE
Limit docker build workflow runs

### DIFF
--- a/.github/workflows/dockerBuild.yml
+++ b/.github/workflows/dockerBuild.yml
@@ -26,9 +26,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: make -C docker build-image-${{ matrix.platform }}
+      - name: Docker build
+        run: make -C docker build-image-${{ matrix.platform }}
 
       - name: Docker login
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username "${{ github.repository_owner }}" --password-stdin
 
-      - run: make -C docker push-image-${{ matrix.platform }}
+      - name: Docker push
+        run: make -C docker push-image-${{ matrix.platform }}

--- a/.github/workflows/dockerBuild.yml
+++ b/.github/workflows/dockerBuild.yml
@@ -2,6 +2,11 @@ name: Docker Build
 
 on:
   push:
+    # Builds should happen on feature branches
+    # Only successfully tested builds should be merged to main
+    # We don't want to rebuild after testing and verifying
+    branches-ignore:
+      - 'main'
     paths:
       - '.github/workflows/dockerBuild.yml'
       - 'docker/*'

--- a/.github/workflows/dockerBuild.yml
+++ b/.github/workflows/dockerBuild.yml
@@ -26,11 +26,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Fetch main
+        run: |
+          git remote set-branches --add origin main
+          git fetch --depth 1
+
+      - name: Check for changes
+        id: diff
+        run: |
+          set +e
+          git diff --exit-code --no-patch origin/main docker/nas2d-${{ matrix.platform }}.* ; echo "modified=$?" >> $GITHUB_OUTPUT
+
       - name: Docker build
+        if: ${{ fromJSON(steps.diff.outputs.modified) }}
         run: make -C docker build-image-${{ matrix.platform }}
 
       - name: Docker login
+        if: ${{ fromJSON(steps.diff.outputs.modified) }}
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username "${{ github.repository_owner }}" --password-stdin
 
       - name: Docker push
+        if: ${{ fromJSON(steps.diff.outputs.modified) }}
         run: make -C docker push-image-${{ matrix.platform }}

--- a/.github/workflows/dockerBuild.yml
+++ b/.github/workflows/dockerBuild.yml
@@ -3,8 +3,8 @@ name: Docker Build
 on:
   push:
     paths:
-      - ".github/workflows/dockerBuild.yml"
-      - "docker/*"
+      - '.github/workflows/dockerBuild.yml'
+      - 'docker/*'
   workflow_dispatch:
 
 jobs:
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - "arch"
+        - 'arch'
     env:
       DockerRepository: ghcr.io/${{ github.repository_owner }}
 


### PR DESCRIPTION
Support work for:
- #1155

We don't want to re-run Docker builds after merging to `main`, since they might end up differing slightly from builds tested and verified on branches.

Additionally, we don't want to waste time running builds for platforms that have no changes.
