### PR TITLE
Rename Sprite test fixture field to fix warning

### DIFF
--- a/test/Resource/Sprite.test.cpp
+++ b/test/Resource/Sprite.test.cpp
@@ -25,8 +25,8 @@ protected:
 	NAS2D::Image image{&imageBuffer, 4, {1, 1}};
 	NAS2D::AnimationSet::Frame frame{image, {{0, 0}, {1, 1}}, {0, 0}, 2};
 	NAS2D::AnimationSet::Frame frameStop{image, {{0, 0}, {1, 1}}, {0, 0}, 0};
-	NAS2D::AnimationSet animationSet{{}, {{"defaultAction", {frame}}, {"frameStopAction", {frameStop}}}};
-	SpriteDerived sprite{animationSet, "defaultAction"};
+	NAS2D::AnimationSet testAnimationSet{{}, {{"defaultAction", {frame}}, {"frameStopAction", {frameStop}}}};
+	SpriteDerived sprite{testAnimationSet, "defaultAction"};
 };
 
 


### PR DESCRIPTION
Fix Clang warning `-Wshadow-field-in-constructor`. Both a constructor parameter and a class member field had that same name, hence the shadow warning.

Part of:
- #528
