### PR TITLE
Improve `make show-warnings`

### DIFF
--- a/makefile
+++ b/makefile
@@ -178,7 +178,7 @@ $(PACKAGE_NAME): $(OUTPUT) $(shell find $(SRCDIR) -name '*.h')
 .PHONY: show-warnings
 show-warnings:
 	@$(MAKE) clean > /dev/null
-	$(MAKE) -j1 all CXX=clang++ CXXFLAGS_WARN=-Weverything 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
+	$(MAKE) --output-sync all CXX=clang++ CXXFLAGS_WARN=-Weverything 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
 	@$(MAKE) clean > /dev/null
 
 .PHONY: lint

--- a/makefile
+++ b/makefile
@@ -179,6 +179,7 @@ $(PACKAGE_NAME): $(OUTPUT) $(shell find $(SRCDIR) -name '*.h')
 show-warnings:
 	@$(MAKE) clean > /dev/null
 	$(MAKE) -j1 all CXX=clang++ CXXFLAGS_WARN=-Weverything 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
+	@$(MAKE) clean > /dev/null
 
 .PHONY: lint
 lint: cppcheck cppclean

--- a/makefile
+++ b/makefile
@@ -177,7 +177,8 @@ $(PACKAGE_NAME): $(OUTPUT) $(shell find $(SRCDIR) -name '*.h')
 
 .PHONY: show-warnings
 show-warnings:
-	$(MAKE) -j1 clean all CXX=clang++ CXXFLAGS_WARN=-Weverything 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
+	@$(MAKE) clean > /dev/null
+	$(MAKE) -j1 all CXX=clang++ CXXFLAGS_WARN=-Weverything 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
 
 .PHONY: lint
 lint: cppcheck cppclean


### PR DESCRIPTION
Noticed a few small improvements were possible for the `make show-warnings` target while looking at #528.
