### PR TITLE
Update Linux GCC and Clang build images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - build-and-test
   build-linux-gcc:
     docker:
-      - image: outpostuniverse/nas2d-gcc:1.5
+      - image: ghcr.io/lairworks/build-env-nas2d-gcc:1.6
     environment:
       WARN_EXTRA: "-Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Weffc++"
     steps:
@@ -39,7 +39,7 @@ jobs:
       - build-and-test
   build-linux-clang:
     docker:
-      - image: outpostuniverse/nas2d-clang:1.4
+      - image: ghcr.io/lairworks/build-env-nas2d-clang:1.5
     environment:
       WARN_EXTRA: "-Wdocumentation -Wdocumentation-unknown-command -Wcomma -Winconsistent-missing-destructor-override -Wmissing-prototypes -Wctad-maybe-unsupported -Wimplicit-int-float-conversion -Wsign-conversion"
     steps:

--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -20,6 +20,8 @@ jobs:
       matrix:
         platform:
         - 'arch'
+        - 'clang'
+        - 'gcc'
 
     steps:
       - uses: actions/checkout@v4

--- a/dockerBuildEnv/nas2d-clang.Dockerfile
+++ b/dockerBuildEnv/nas2d-clang.Dockerfile
@@ -1,21 +1,21 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages
 # Includes tools needed for primary CircleCI containers
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    build-essential=12.9* \
-    clang=1:14.0-* \
-    cmake=3.22.1-* \
-    libgtest-dev=1.11.0-* \
-    libgmock-dev=1.11.0-* \
-    git=1:2.34.1-* \
-    ssh=1:8.9p1-* \
-    tar=1.34* \
-    gzip=1.10-* \
+    build-essential=12.10* \
+    clang=1:18.0-* \
+    cmake=3.28.3-* \
+    libgtest-dev=1.14.0-* \
+    libgmock-dev=1.14.0-* \
+    git=1:2.43.0-* \
+    ssh=1:9.6p1-* \
+    tar=1.35+* \
+    gzip=1.12-* \
     ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
 
@@ -25,10 +25,10 @@ ENV  CC=clang
 # Install NAS2D specific dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libglew-dev=2.2.0-* \
-    libsdl2-dev=2.0.20+* \
-    libsdl2-image-dev=2.0.5+* \
-    libsdl2-mixer-dev=2.0.4+* \
-    libsdl2-ttf-dev=2.0.18+* \
+    libsdl2-dev=2.30.0+* \
+    libsdl2-image-dev=2.8.2+* \
+    libsdl2-mixer-dev=2.8.0+* \
+    libsdl2-ttf-dev=2.22.0+* \
   && rm -rf /var/lib/apt/lists/*
 
 CMD ["make", "--keep-going", "check"]

--- a/dockerBuildEnv/nas2d-clang.version.mk
+++ b/dockerBuildEnv/nas2d-clang.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_clang := 1.4
+ImageVersion_clang := 1.5

--- a/dockerBuildEnv/nas2d-gcc.Dockerfile
+++ b/dockerBuildEnv/nas2d-gcc.Dockerfile
@@ -1,6 +1,6 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages
@@ -8,15 +8,15 @@ FROM ubuntu:22.04
 # Install latest available GCC compiler (which may not be the default)
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    g++=4:11.2.0-* \
+    g++=4:13.2.0-* \
     make=4.3-* \
-    cmake=3.22.1-* \
-    libgtest-dev=1.11.0-* \
-    libgmock-dev=1.11.0-* \
-    git=1:2.34.1-* \
-    ssh=1:8.9p1-* \
-    tar=1.34+* \
-    gzip=1.10-* \
+    cmake=3.28.3-* \
+    libgtest-dev=1.14.0-* \
+    libgmock-dev=1.14.0-* \
+    git=1:2.43.0-* \
+    ssh=1:9.6p1-* \
+    tar=1.35+* \
+    gzip=1.12-* \
     ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
 
@@ -26,10 +26,10 @@ ENV  CC=gcc
 # Install NAS2D specific dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libglew-dev=2.2.0-* \
-    libsdl2-dev=2.0.20+* \
-    libsdl2-image-dev=2.0.5+* \
-    libsdl2-mixer-dev=2.0.4+* \
-    libsdl2-ttf-dev=2.0.18+* \
+    libsdl2-dev=2.30.0+* \
+    libsdl2-image-dev=2.8.2+* \
+    libsdl2-mixer-dev=2.8.0+* \
+    libsdl2-ttf-dev=2.22.0+* \
   && rm -rf /var/lib/apt/lists/*
 
 CMD ["make", "--keep-going", "check"]

--- a/dockerBuildEnv/nas2d-gcc.version.mk
+++ b/dockerBuildEnv/nas2d-gcc.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_gcc := 1.5
+ImageVersion_gcc := 1.6


### PR DESCRIPTION
Images are now built and pushed using a GitHub Actions workflow to the GitHub Docker registry. CircleCI builds will now pull from the GitHub Docker registry, rather than using DockerHub.

Part of:
- #1155
