### PR TITLE
Allow Docker build workflow to work for any default branch

### DIFF
--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -22,20 +22,22 @@ jobs:
         - 'arch'
         - 'clang'
         - 'gcc'
+    env:
+      defaultBranch: ${{ github.event.repository.default_branch }}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch main
+      - name: Fetch default branch
         run: |
-          git remote set-branches --add origin main
+          git remote set-branches --add origin "${defaultBranch}"
           git fetch --depth 1
 
       - name: Check for changes
         id: diff
         run: |
           set +e
-          git diff --exit-code --no-patch origin/main dockerBuildEnv/makefile dockerBuildEnv/nas2d-${{ matrix.platform }}.* ; echo "modified=$?" >> $GITHUB_OUTPUT
+          git diff --exit-code --no-patch "origin/${defaultBranch}" dockerBuildEnv/makefile dockerBuildEnv/nas2d-${{ matrix.platform }}.* ; echo "modified=$?" >> $GITHUB_OUTPUT
 
       - name: Docker build
         if: ${{ fromJSON(steps.diff.outputs.modified) }}

--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Fetch default branch
         run: |
           git remote set-branches --add origin "${defaultBranch}"
-          git fetch --depth 1
+          git fetch --depth 1 origin "${defaultBranch}"
 
       - name: Check for changes
         id: diff


### PR DESCRIPTION
Fix Docker build workflow so it works no matter what the default branch name is.

The script was originally written with the assumption the default branch was named `main`, however older forks may still be using a default branch name of `master`.

Fixes the problem diagnosed in:
- https://github.com/lairworks/nas2d-core/issues/1149#issuecomment-2486927491
