### PR TITLE
Implement Windows incremental build cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,35 @@ jobs:
         key: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ github.sha }}
         restore-keys: buildCache-${{ runner.os }}-${{ matrix.platform }}-
 
+    - name: Set modification times
+      if: ${{ hashFiles('.build/lastBuildSha.txt') != '' }}
+      shell: bash
+      run: |
+          # Determine SHA of last cached build (ignore cache if not marked)
+          lastBuildSha=$(<.build/lastBuildSha.txt) || exit 0
+          echo "Last build SHA: ${lastBuildSha}"
+
+          # Fetch source code for last build
+          # (exit successfully if not found, cache will be ignored)
+          git fetch --depth=1 origin "${lastBuildSha}" || exit 0
+          git switch --detach "${lastBuildSha}"
+
+          # Set last modification times to that of last build's committer time
+          # The committer time should pre-date any cached output modification time
+          commitTime=$(git log -1 --format="%cI")
+          echo "commitTime=${commitTime}"
+          find . -type f -exec touch -d "${commitTime}" '{}' +
+
+          # Re-check out current branch, which updates last modification times of modified files
+          git switch -
+
+    - name: Set build SHA
+      shell: bash
+      run: |
+          # Save copy of current SHA to be cached, and used for reference in future builds
+          mkdir --parents .build/
+          echo "${{ github.sha }}" > .build/lastBuildSha.txt
+
     - name: Build
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,12 +45,26 @@ jobs:
         path: vcpkg_installed
         key: ${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
 
+    - name: Restore incremental build cache
+      uses: actions/cache/restore@v4
+      if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+      with:
+        path: .build
+        key: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ github.sha }}
+        restore-keys: buildCache-${{ runner.os }}-${{ matrix.platform }}-
+
     - name: Build
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: |
         vcpkg integrate install
         msbuild /maxCpuCount /warnAsError /property:RunCodeAnalysis=true /property:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Save incremental build cache
+      uses: actions/cache/save@v4
+      with:
+        path: .build
+        key: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ github.sha }}
 
     - name: Test
       working-directory: ./test/


### PR DESCRIPTION
Relates to:
- https://github.com/OutpostUniverse/OPHD/issues/1418

Implements incremental build caching for Windows feature branches. This can drastically reduce the build time on feature branches, depending on how much code has changed. A full build might take 3.5 - 4 minutes. An incremental build with no changes might take 1 - 1.5 minutes.

The default branch will always do a fresh full build, without attempting to load a cache. This is to ensure a full build will always work, and to prevent any caching artifacts from accumulating over time, such as caching old files that are no longer needed, but never explicitly deleted from the build folder. The build time of the default branch is less critical, since builds there are only done after work on PRs is completed and merged, so it doesn't typically hold up additional work.
