### PR TITLE
Use `vcpkg` GitHub Actions Cache support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,13 @@ jobs:
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
+    - name: Restore vcpkg dependency cache
+      uses: actions/cache@v4
+      id: cache
+      with:
+        path: vcpkg_installed
+        key: ${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
+
     - name: Restore incremental build cache
       uses: actions/cache/restore@v4
       if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,13 +30,6 @@ jobs:
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-    - name: Restore vcpkg dependency cache
-      uses: actions/cache@v4
-      id: cache
-      with:
-        path: vcpkg_installed
-        key: ${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
-
     - name: Restore incremental build cache
       uses: actions/cache/restore@v4
       if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       id: cache
       with:
         path: vcpkg_installed
-        key: ${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
+        key: vcpkgCache-${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
 
     - name: Restore incremental build cache
       uses: actions/cache/restore@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
       BUILD_CONFIGURATION: Release
       SOLUTION_FILE_PATH: .
-      VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
+      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
     steps:
     - uses: actions/checkout@v4
@@ -23,20 +23,12 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.3.2
 
-    - name: Setup NuGet credentials
-      shell: bash
-      run: |
-        $(vcpkg fetch nuget | tail -n1) \
-        sources add \
-        -source "https://nuget.pkg.github.com/lairworks/index.json" \
-        -storepasswordincleartext \
-        -name "GitHub" \
-        -username "lairworks" \
-        -password "${{ secrets.GITHUB_TOKEN }}"
-
-        $(vcpkg fetch nuget | tail -n1) \
-        setApiKey "${{ secrets.GITHUB_TOKEN }}" \
-        -source "https://nuget.pkg.github.com/lairworks/index.json"
+    - name: Export GitHub Actions cache environment variables
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
     - name: Restore vcpkg dependency cache
       uses: actions/cache@v4


### PR DESCRIPTION
Use `vcpkg` GitHub Actions Cache support to replace the Nuget option for binary package caching.

Rename the overall package collection cache `key` for better clarity.

It appears there is still a significant speed benefit to keeping a cache of the overall collection, and not simply relying on the caches of individual binary packages. Though that was true before, when we kept an overall package collection cache, and used Nuget to cache individual binary packages.

Related:
- https://github.com/OutpostUniverse/OPHD/issues/1418
- PR #1176
