### PR TITLE
Improve docker `makefile`

### DIFF
--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -37,7 +37,7 @@ jobs:
         id: diff
         run: |
           set +e
-          git diff --exit-code --no-patch "origin/${defaultBranch}" dockerBuildEnv/makefile dockerBuildEnv/nas2d-${{ matrix.platform }}.* ; echo "modified=$?" >> $GITHUB_OUTPUT
+          git diff --exit-code --no-patch "origin/${defaultBranch}" dockerBuildEnv/nas2d-${{ matrix.platform }}.* ; echo "modified=$?" >> $GITHUB_OUTPUT
 
       - name: Docker build
         if: ${{ fromJSON(steps.diff.outputs.modified) }}

--- a/dockerBuildEnv/makefile
+++ b/dockerBuildEnv/makefile
@@ -4,9 +4,8 @@
 # Note: MAKEFILE_LIST's last entry is the last processed Makefile.
 #       That should be the current Makefile, assuming no includes
 DockerBuildEnvFolder := $(abspath $(dir $(lastword ${MAKEFILE_LIST})))
-TopLevelFolder := $(abspath $(DockerBuildEnvFolder)/..)
 
-DockerRunFlags = --volume ${TopLevelFolder}:/code --workdir=/code --rm --tty ${DockerAdditionalFlags}
+DockerRunFlags = --volume ${CURDIR}:/code --workdir=/code --rm --tty ${DockerAdditionalFlags}
 DockerUserFlags = --user="$(shell id --user):$(shell id --group)"
 DockerRepository ?= ghcr.io/lairworks
 

--- a/dockerBuildEnv/makefile
+++ b/dockerBuildEnv/makefile
@@ -9,7 +9,7 @@ DockerRunFlags = --volume ${CURDIR}:/code --workdir=/code --rm --tty ${DockerAdd
 DockerUserFlags = --user="$(shell id --user):$(shell id --group)"
 DockerRepository ?= ghcr.io/lairworks
 
-include $(wildcard $(DockerBuildEnvFolder)/nas2d-*.version.mk)
+include $(wildcard ${DockerBuildEnvFolder}/nas2d-*.version.mk)
 
 DockerFileName = ${DockerBuildEnvFolder}/nas2d-$*.Dockerfile
 

--- a/dockerBuildEnv/makefile
+++ b/dockerBuildEnv/makefile
@@ -6,7 +6,7 @@
 DockerBuildEnvFolder := $(abspath $(dir $(lastword ${MAKEFILE_LIST})))
 TopLevelFolder := $(abspath $(DockerBuildEnvFolder)/..)
 
-DockerRunFlags := --volume ${TopLevelFolder}:/code --workdir=/code --rm --tty
+DockerRunFlags = --volume ${TopLevelFolder}:/code --workdir=/code --rm --tty ${DockerAdditionalFlags}
 DockerUserFlags = --user="$(shell id --user):$(shell id --group)"
 DockerRepository ?= ghcr.io/lairworks
 


### PR DESCRIPTION
Relates to:
- Issue #1155

Make it easier to pass flags to builds done in Docker containers. In particular, this makes it easier to pass the `-j` flag to get increased parallelism.

Allow Docker container to be run with a higher level mounted folder. This can be useful for downstream projects. In particular, this makes it easier to build OPHD within a Docker container, using the existing `makefile` rules.

Disable rebuilding all Docker images due to a `makefile` change. This was needed when changing the naming scheme for Docker images, since the image names were controlled by the `makefile`. Now that the rename is done, regular maintenance and updates to the `makefile` probably shouldn't trigger a rebuild of all images.
