### PR TITLE
Add `.exe` suffix to executable Windows targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,6 +12,9 @@ TARGET_OS ?= $(CURRENT_OS)
 Windows_RUN_PREFIX := wine
 RUN_PREFIX := $($(TARGET_OS)_RUN_PREFIX)
 
+Windows_EXE_SUFFIX := .exe
+EXE_SUFFIX := $($(TARGET_OS)_EXE_SUFFIX)
+
 ROOTBUILDDIR := .build
 BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(CONFIG)_Linux_
 
@@ -62,7 +65,7 @@ include $(wildcard $(patsubst %.o,%.dep,$(OBJS)))
 
 TESTDIR := test
 TESTINTDIR := $(BUILDDIRPREFIX)test/intermediate
-TESTOUTPUT := $(BUILDDIRPREFIX)test/test
+TESTOUTPUT := $(BUILDDIRPREFIX)test/test$(EXE_SUFFIX)
 TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.o,$(TESTSRCS))
 
@@ -94,7 +97,7 @@ check: | test
 
 TESTGRAPHICSDIR := test-graphics
 TESTGRAPHICSINTDIR := $(BUILDDIRPREFIX)testGraphics/intermediate
-TESTGRAPHICSOUTPUT := $(BUILDDIRPREFIX)testGraphics/testGraphics
+TESTGRAPHICSOUTPUT := $(BUILDDIRPREFIX)testGraphics/testGraphics$(EXE_SUFFIX)
 TESTGRAPHICSSRCS := $(shell find $(TESTGRAPHICSDIR) -name '*.cpp')
 TESTGRAPHICSOBJS := $(patsubst $(TESTGRAPHICSDIR)/%.cpp,$(TESTGRAPHICSINTDIR)/%.o,$(TESTGRAPHICSSRCS))
 


### PR DESCRIPTION
Ideally the output filenames should match platform expectations. Normally the `.exe` suffix would be added anyway. Though the `makefile` rules reference the output filenames in a few places. Mostly the `.exe` suffix can be inferred. However, it is better for output names to match exactly, especially for `makefile` rules that need to determine if an output file is up-to-date.

Additionally, it was noted while looking into Wine upgrades that starting with Wine version 7, there seems to be trouble starting executable files when the `.exe` suffix is not explicitly specified. Failure to specify it can result in a hard to understand error message with code `c0000135` (`STATUS_DLL_NOT_FOUND` defined in `ntstatus.h`):
> wine: failed to open "../.build/Debug_Linux_test/test": c0000135

The same command works when the file to run is given an explicit suffix when passed to `wine`:
> "../.build/Debug_Linux_test/test.exe"

----

Relates to:
- Issue #1155
