### PR TITLE
Update `mingw` build environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - build-and-test
   build-linux-mingw:
     docker:
-      - image: outpostuniverse/nas2d-mingw:1.10
+      - image: outpostuniverse/nas2d-mingw:1.11
     environment:
       WARN_EXTRA: "-Wno-redundant-decls"
     steps:

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -43,10 +43,10 @@ RUN curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/
   echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ impish main" > /etc/apt/sources.list.d/wine.list && \
   dpkg --add-architecture i386 && \
   apt-get update && apt-get install -y --no-install-recommends \
-    wine-stable-amd64=6.0.2~impish-1 \
-    wine-stable-i386=6.0.2~impish-1 \
-    wine-stable=6.0.2~impish-1 \
-    winehq-stable=6.0.2~impish-1 \
+    wine-stable-amd64=6.0.2~* \
+    wine-stable-i386=6.0.2~* \
+    wine-stable=6.0.2~* \
+    winehq-stable=6.0.2~* \
   && rm -rf /var/lib/apt/lists/*
 
 # Set default install location for custom packages

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -43,10 +43,10 @@ RUN curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/
   echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ impish main" > /etc/apt/sources.list.d/wine.list && \
   dpkg --add-architecture i386 && \
   apt-get update && apt-get install -y --no-install-recommends \
-    wine-stable-amd64=6.0.2~* \
-    wine-stable-i386=6.0.2~* \
-    wine-stable=6.0.2~* \
-    winehq-stable=6.0.2~* \
+    wine-stable-amd64=6.0.4~* \
+    wine-stable-i386=6.0.4~* \
+    wine-stable=6.0.4~* \
+    winehq-stable=6.0.4~* \
   && rm -rf /var/lib/apt/lists/*
 
 # Set default install location for custom packages

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -43,10 +43,10 @@ RUN curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/
   echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/wine.list && \
   dpkg --add-architecture i386 && \
   apt-get update && apt-get install -y --no-install-recommends \
-    wine-stable-amd64=7.0.1~* \
-    wine-stable-i386=7.0.1~* \
-    wine-stable=7.0.1~* \
-    winehq-stable=7.0.1~* \
+    wine-stable-amd64=8.0.2~* \
+    wine-stable-i386=8.0.2~* \
+    wine-stable=8.0.2~* \
+    winehq-stable=8.0.2~* \
   && rm -rf /var/lib/apt/lists/*
 
 # Set default install location for custom packages

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -133,8 +133,13 @@ ENV WINEPATH="${WINEPATH64}"
 ENV CXX=${CXX64}
 ENV  CC=${CC64}
 
+RUN useradd --uid 1000 -m -s /bin/bash user
+USER user
+
 # Pre-setup Wine to save startup time later
 RUN wineboot
+
+USER root
 
 # Set default extra C pre-processor flags
 # This makes proper rebuilding easier in a debug session

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -39,8 +39,8 @@ ENV  CC32=${ARCH32}-gcc
 ENV  LD32=${ARCH32}-ld
 
 # Install wine so resulting unit test binaries can be run
-RUN curl -L https://dl.winehq.org/wine-builds/winehq.key | apt-key add - && \
-  add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ impish main' && \
+RUN curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
+  echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ impish main" > /etc/apt/sources.list.d/wine.list && \
   dpkg --add-architecture i386 && \
   apt-get update && apt-get install -y --no-install-recommends \
     wine-stable-amd64=6.0.2~impish-1 \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -106,9 +106,9 @@ RUN curl https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.20.2-m
   rm -rf SDL2_ttf-2.20.2/
 # Install dependencies from source packages
 RUN curl --location https://github.com/nigels-com/glew/releases/download/glew-2.2.0/glew-2.2.0.tgz | tar -xz && \
-  make -C glew-2.2.0/ SYSTEM=linux-mingw64 CC="${CC64}" LD="${LD64}" LDFLAGS.EXTRA=-L"/usr/${ARCH64}/lib/" GLEW_DEST="${INSTALL64}" install && \
+  make -C glew-2.2.0/ SYSTEM=linux-mingw64 CC="${CC64}" WARN="-Wno-cast-function-type" LD="${LD64}" LDFLAGS.EXTRA=-L"/usr/${ARCH64}/lib/" GLEW_DEST="${INSTALL64}" install && \
   make -C glew-2.2.0/ distclean && \
-  make -C glew-2.2.0/ SYSTEM=linux-mingw64 CC="${CC32}" LD="${LD32}" LDFLAGS.EXTRA=-L"/usr/${ARCH32}/lib/" GLEW_DEST="${INSTALL32}" install && \
+  make -C glew-2.2.0/ SYSTEM=linux-mingw64 CC="${CC32}" WARN="-Wno-cast-function-type" LD="${LD32}" LDFLAGS.EXTRA=-L"/usr/${ARCH32}/lib/" GLEW_DEST="${INSTALL32}" install && \
   rm -rf glew-2.2.0/ glew.*
 
 # Custom variables for install locations

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -139,12 +139,14 @@ ENV CXX=${CXX64}
 ENV  CC=${CC64}
 
 RUN useradd --uid 1000 -m -s /bin/bash user
-USER user
+
+# Cache the result of `wineboot` for faster startup (or don't for smaller images)
+# USER user
 
 # Pre-setup Wine to save startup time later
-RUN wineboot
+# RUN wineboot
 
-USER root
+# USER root
 
 # Set default extra C pre-processor flags
 # This makes proper rebuilding easier in a debug session

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -43,10 +43,10 @@ RUN curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/
   echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ impish main" > /etc/apt/sources.list.d/wine.list && \
   dpkg --add-architecture i386 && \
   apt-get update && apt-get install -y --no-install-recommends \
-    wine-stable-amd64=6.0.4~* \
-    wine-stable-i386=6.0.4~* \
-    wine-stable=6.0.4~* \
-    winehq-stable=6.0.4~* \
+    wine-stable-amd64=7.0.0.0~* \
+    wine-stable-i386=7.0.0.0~* \
+    wine-stable=7.0.0.0~* \
+    winehq-stable=7.0.0.0~* \
   && rm -rf /var/lib/apt/lists/*
 
 # Set default install location for custom packages

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -92,24 +92,29 @@ RUN \
 # Install NAS2D specific dependencies
 WORKDIR /tmp/
 # Install SDL libraries from binary packages
-RUN curl https://libsdl.org/release/SDL2-devel-2.27.1-mingw.tar.gz | tar -xz && \
-  make -C SDL2-2.27.1/ cross && \
-  rm -rf SDL2-2.27.1/
-RUN curl https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.6.3-mingw.tar.gz | tar -xz && \
-  make -C SDL2_image-2.6.3/ cross && \
-  rm -rf SDL2_image-2.6.3/
-RUN curl https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.6.3-mingw.tar.gz | tar -xz && \
-  make -C SDL2_mixer-2.6.3/ cross && \
-  rm -rf SDL2_mixer-2.6.3/
-RUN curl https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.20.2-mingw.tar.gz | tar -xz && \
-  make -C SDL2_ttf-2.20.2/ cross && \
-  rm -rf SDL2_ttf-2.20.2/
+RUN sdlVersion="2.27.1" && \
+  curl https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz | tar -xz && \
+  make -C SDL2-${sdlVersion}/ cross && \
+  rm -rf SDL2-${sdlVersion}/
+RUN sdlImageVersion="2.6.3" && \
+  curl https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz | tar -xz && \
+  make -C SDL2_image-${sdlImageVersion}/ cross && \
+  rm -rf SDL2_image-${sdlImageVersion}/
+RUN sdlMixerVersion="2.6.3" && \
+  curl https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz | tar -xz && \
+  make -C SDL2_mixer-${sdlMixerVersion}/ cross && \
+  rm -rf SDL2_mixer-${sdlMixerVersion}/
+RUN sdlTtfVersion="2.20.2" && \
+  curl https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz | tar -xz && \
+  make -C SDL2_ttf-${sdlTtfVersion}/ cross && \
+  rm -rf SDL2_ttf-${sdlTtfVersion}/
 # Install dependencies from source packages
-RUN curl --location https://github.com/nigels-com/glew/releases/download/glew-2.2.0/glew-2.2.0.tgz | tar -xz && \
-  make -C glew-2.2.0/ SYSTEM=linux-mingw64 CC="${CC64}" WARN="-Wno-cast-function-type" LD="${LD64}" LDFLAGS.EXTRA=-L"/usr/${ARCH64}/lib/" GLEW_DEST="${INSTALL64}" install && \
-  make -C glew-2.2.0/ distclean && \
-  make -C glew-2.2.0/ SYSTEM=linux-mingw64 CC="${CC32}" WARN="-Wno-cast-function-type" LD="${LD32}" LDFLAGS.EXTRA=-L"/usr/${ARCH32}/lib/" GLEW_DEST="${INSTALL32}" install && \
-  rm -rf glew-2.2.0/ glew.*
+RUN glewVersion="2.2.0" && \
+  curl --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | tar -xz && \
+  make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 CC="${CC64}" WARN="-Wno-cast-function-type" LD="${LD64}" LDFLAGS.EXTRA=-L"/usr/${ARCH64}/lib/" GLEW_DEST="${INSTALL64}" install && \
+  make -C glew-${glewVersion}/ distclean && \
+  make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 CC="${CC32}" WARN="-Wno-cast-function-type" LD="${LD32}" LDFLAGS.EXTRA=-L"/usr/${ARCH32}/lib/" GLEW_DEST="${INSTALL32}" install && \
+  rm -rf glew-${glewVersion}/ glew.*
 
 # Custom variables for install locations
 ENV INCLUDE64=${INSTALL64}include/

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -40,13 +40,13 @@ ENV  LD32=${ARCH32}-ld
 
 # Install wine so resulting unit test binaries can be run
 RUN curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
-  echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ impish main" > /etc/apt/sources.list.d/wine.list && \
+  echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/wine.list && \
   dpkg --add-architecture i386 && \
   apt-get update && apt-get install -y --no-install-recommends \
-    wine-stable-amd64=7.0.0.0~* \
-    wine-stable-i386=7.0.0.0~* \
-    wine-stable=7.0.0.0~* \
-    winehq-stable=7.0.0.0~* \
+    wine-stable-amd64=7.0.1~* \
+    wine-stable-i386=7.0.1~* \
+    wine-stable=7.0.1~* \
+    winehq-stable=7.0.1~* \
   && rm -rf /var/lib/apt/lists/*
 
 # Set default install location for custom packages

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     gzip=1.10-* \
     bzip2=1.0.8-* \
     gnupg=2.2.27-* \
-    software-properties-common=0.99.22.7 \
+    software-properties-common=0.99.22.* \
     ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
 

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -92,19 +92,19 @@ RUN \
 # Install NAS2D specific dependencies
 WORKDIR /tmp/
 # Install SDL libraries from binary packages
-RUN sdlVersion="2.27.1" && \
+RUN sdlVersion="2.30.9" && \
   curl https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz | tar -xz && \
   make -C SDL2-${sdlVersion}/ cross && \
   rm -rf SDL2-${sdlVersion}/
-RUN sdlImageVersion="2.6.3" && \
+RUN sdlImageVersion="2.8.4" && \
   curl https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz | tar -xz && \
   make -C SDL2_image-${sdlImageVersion}/ cross && \
   rm -rf SDL2_image-${sdlImageVersion}/
-RUN sdlMixerVersion="2.6.3" && \
+RUN sdlMixerVersion="2.8.0" && \
   curl https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz | tar -xz && \
   make -C SDL2_mixer-${sdlMixerVersion}/ cross && \
   rm -rf SDL2_mixer-${sdlMixerVersion}/
-RUN sdlTtfVersion="2.20.2" && \
+RUN sdlTtfVersion="2.22.0" && \
   curl https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz | tar -xz && \
   make -C SDL2_ttf-${sdlTtfVersion}/ cross && \
   rm -rf SDL2_ttf-${sdlTtfVersion}/

--- a/dockerBuildEnv/nas2d-mingw.version.mk
+++ b/dockerBuildEnv/nas2d-mingw.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_mingw := 1.10
+ImageVersion_mingw := 1.11


### PR DESCRIPTION
Part of:
- Issue #1155

Updates the Mingw build environment:
- Bump image version number
- Fix `Dockerfile` so it is buildable with current `apt` packages (`software-properties-common`)
- Fix Docker image so it is usable locally (add `user` account)
- Disable warnings when compiling `glew`
- Fix deprecation warning when installing Wine `apt` repo
- Make it easier to upgrade SDL and Glew dependencies
- Update SDL dependencies
- Update Wine package to one for Ubuntu `22.04` (matching the base image, instead of a `21.04` package)
- Update to a newer version of Wine
- Update CircleCI to build with new image

Note this PR falls short of updating the base image to Ubuntu `24.04`, as there were problems with the update that still haven't been worked out. Still, the updates so far are good progress.
