### PR TITLE
Fix `Signal` unit test undefined behavior (`gmock`)

### DIFF
--- a/test/Signal/Signal.test.cpp
+++ b/test/Signal/Signal.test.cpp
@@ -12,21 +12,38 @@ namespace {
 }
 
 
-TEST(Signal, ConnectEmitDisconnect) {
+TEST(Signal, InitEmpty) {
+	NAS2D::Signal<> signal;
+	EXPECT_TRUE(signal.empty());
+}
+
+TEST(Signal, ConnectNonEmpty) {
+	NAS2D::Signal<> signal;
 	MockHandler handler{};
 	auto delegate = NAS2D::Delegate{&handler, &MockHandler::MockMethod};
-	NAS2D::Signal<> signal;
-
-	EXPECT_TRUE(signal.empty());
 
 	signal.connect(delegate);
 	EXPECT_FALSE(signal.empty());
+}
 
-	EXPECT_CALL(handler, MockMethod());
-	signal.emit();
+TEST(Signal, DisconnectEmpty) {
+	NAS2D::Signal<> signal;
+	MockHandler handler{};
+	auto delegate = NAS2D::Delegate{&handler, &MockHandler::MockMethod};
 
+	signal.connect(delegate);
 	signal.disconnect(delegate);
 	EXPECT_TRUE(signal.empty());
+}
 
+TEST(Signal, ConnectEmitDisconnect) {
+	NAS2D::Signal<> signal;
+	MockHandler handler{};
+	auto delegate = NAS2D::Delegate{&handler, &MockHandler::MockMethod};
+
+	EXPECT_CALL(handler, MockMethod()).Times(1);
+	signal.connect(delegate);
+	signal.emit();
+	signal.disconnect(delegate);
 	signal.emit();
 }

--- a/test/Signal/Signal.test.cpp
+++ b/test/Signal/Signal.test.cpp
@@ -28,6 +28,5 @@ TEST(Signal, ConnectEmitDisconnect) {
 	signal.disconnect(delegate);
 	EXPECT_TRUE(signal.empty());
 
-	EXPECT_CALL(handler, MockMethod()).Times(0);
 	signal.emit();
 }


### PR DESCRIPTION
Closes #1159

Remove redundant `EXPECT_CALL`. The implicit `Times(1)` makes the call with `Times(0)` redundant.

Removing the redundant call removes undefined behavior caused by setting an expectation after a call to the mock handler.

Split up the unit tests so there is only one expectation per test.
