### PR TITLE
Remove unnecessary `gmock` uses

### DIFF
--- a/test/Configuration.test.cpp
+++ b/test/Configuration.test.cpp
@@ -1,6 +1,5 @@
 #include "NAS2D/Configuration.h"
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 

--- a/test/ContainerUtils.test.cpp
+++ b/test/ContainerUtils.test.cpp
@@ -1,6 +1,5 @@
 #include "NAS2D/ContainerUtils.h"
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <array>

--- a/test/Dictionary.test.cpp
+++ b/test/Dictionary.test.cpp
@@ -1,6 +1,5 @@
 #include "NAS2D/Dictionary.h"
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 

--- a/test/Math/MathUtils.test.cpp
+++ b/test/Math/MathUtils.test.cpp
@@ -2,7 +2,6 @@
 
 #include "NAS2D/Math/Point.h"
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 

--- a/test/Math/Trig.test.cpp
+++ b/test/Math/Trig.test.cpp
@@ -1,6 +1,5 @@
 #include "NAS2D/Math/Trig.h"
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -1,7 +1,7 @@
 #include "NAS2D/StringUtils.h"
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <string>
 

--- a/test/StringValue.test.cpp
+++ b/test/StringValue.test.cpp
@@ -1,7 +1,7 @@
 #include "NAS2D/StringValue.h"
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <vector>
 #include <map>

--- a/test/Version.test.cpp
+++ b/test/Version.test.cpp
@@ -1,7 +1,7 @@
 #include "NAS2D/Version.h"
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 
 TEST(Version, versionString) {


### PR DESCRIPTION
Noticed while looking into:
- Issue #1155

Remove unnecessary includes for `gmock`. Relatively few tests make use of `gmock` features. Most tests rely only on `gtest` features.

Use a consistent order when including both `gtest` and `gmock`.
