### PR TITLE
Update `gtest` and `gmock` lib order

### DIFF
--- a/makefile
+++ b/makefile
@@ -71,7 +71,7 @@ TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.o,$(TESTSRCS))
 
 TESTCPPFLAGS := $(CPPFLAGS) -I./
 TESTLDFLAGS := $(LDFLAGS)
-TESTLIBS := -lgtest -lgtest_main -lgmock -lgmock_main -lpthread $(LDLIBS)
+TESTLIBS := -lgtest -lgmock -lgmock_main -lpthread $(LDLIBS)
 
 TESTPROJECT_FLAGS = $(TESTCPPFLAGS) $(CXXFLAGS)
 TESTPROJECT_LINKFLAGS = $(TESTLDFLAGS) $(TESTLIBS)

--- a/makefile
+++ b/makefile
@@ -71,7 +71,7 @@ TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.o,$(TESTSRCS))
 
 TESTCPPFLAGS := $(CPPFLAGS) -I./
 TESTLDFLAGS := $(LDFLAGS)
-TESTLIBS := -lgtest -lgmock -lgmock_main -lpthread $(LDLIBS)
+TESTLIBS := -lgmock_main -lgmock -lgtest -lpthread $(LDLIBS)
 
 TESTPROJECT_FLAGS = $(TESTCPPFLAGS) $(CXXFLAGS)
 TESTPROJECT_LINKFLAGS = $(TESTLDFLAGS) $(TESTLIBS)


### PR DESCRIPTION
There can be only one `main` function, so we should not include both `gtest_main` and `gmock_main` libraries. Since `gmock` knows about `gtest`, the `gmock_main` library is able to initialize both `gmock` and `gtest`, so it makes the most sense to use that one.

Library order can be important. Libraries listed on the left can know about and use libraries listed to the right. Hence we should use `gmock_main` before `gmock`, and we should use `gmock` before `gtest`. Without this order, it's possible for symbols to be unresolved because the library they are found in was already processed by the time it's known the symbol is needed.

Noticed this while doing some investigation for:
- Issue #1155

Since oddities were noted in some unit tests which used `gmock` features, there was some investigation if `gmock` as being initialized properly. These changes didn't resolve the noted behavior. Nevertheless, the update does appear to be more correct than the old code.

Also discovered in the Google Test issues that depending on how the library is built, the `gtest` library may be included in the `gtest_main` and `gmock` libraries.
