### PR TITLE
Remove `StringList` alias

### DIFF
--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -126,14 +126,4 @@ namespace NAS2D
 	bool endsWith(std::string_view string, std::string_view end) noexcept;
 	bool startsWith(std::string_view string, char start) noexcept;
 	bool endsWith(std::string_view string, char end) noexcept;
-
-	/**
-	* \typedef StringList
-	* A list of std::string's.
-	*
-	* The StringList is provided primarily as a convenience typedef
-	* but is also used by some of NAS2D's functions.
-	*/
-	using StringList = std::vector<std::string>;
-
 } // namespace NAS2D

--- a/NAS2D/StringUtils.h
+++ b/NAS2D/StringUtils.h
@@ -48,7 +48,7 @@ namespace NAS2D
 		else if constexpr (std::is_same_v<T, bool>)
 		{
 			return value == "true" || value == "1" ? true : value == "false" || value == "0" ? false
-																							 : throw std::invalid_argument("Value must be 'true' or 'false': " + std::string{value});
+				: throw std::invalid_argument("Value must be 'true' or 'false': " + std::string{value});
 		}
 		else if constexpr (std::is_same_v<T, long double>)
 		{

--- a/test/StringUtils.test.cpp
+++ b/test/StringUtils.test.cpp
@@ -167,38 +167,42 @@ TEST(String, countDelimiters) {
 }
 
 TEST(String, split) {
-	EXPECT_EQ((NAS2D::StringList{}), NAS2D::split(""));
-	EXPECT_EQ((NAS2D::StringList{"a"}), NAS2D::split("a"));
+	using StringList = std::vector<std::string>;
 
-	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::split("a,b,c"));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split("abc"));
-	EXPECT_EQ((NAS2D::StringList{"", "abc"}), NAS2D::split(",abc"));
-	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::split("a,bc"));
-	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::split("ab,c"));
-	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::split("abc,"));
+	EXPECT_EQ((StringList{}), NAS2D::split(""));
+	EXPECT_EQ((StringList{"a"}), NAS2D::split("a"));
 
-	EXPECT_EQ((NAS2D::StringList{"a", "b", "c"}), NAS2D::split("a.b.c", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc"}), NAS2D::split("abc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"", "abc"}), NAS2D::split(".abc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"a", "bc"}), NAS2D::split("a.bc", '.'));
-	EXPECT_EQ((NAS2D::StringList{"ab", "c"}), NAS2D::split("ab.c", '.'));
-	EXPECT_EQ((NAS2D::StringList{"abc", ""}), NAS2D::split("abc.", '.'));
+	EXPECT_EQ((StringList{"a", "b", "c"}), NAS2D::split("a,b,c"));
+	EXPECT_EQ((StringList{"abc"}), NAS2D::split("abc"));
+	EXPECT_EQ((StringList{"", "abc"}), NAS2D::split(",abc"));
+	EXPECT_EQ((StringList{"a", "bc"}), NAS2D::split("a,bc"));
+	EXPECT_EQ((StringList{"ab", "c"}), NAS2D::split("ab,c"));
+	EXPECT_EQ((StringList{"abc", ""}), NAS2D::split("abc,"));
+
+	EXPECT_EQ((StringList{"a", "b", "c"}), NAS2D::split("a.b.c", '.'));
+	EXPECT_EQ((StringList{"abc"}), NAS2D::split("abc", '.'));
+	EXPECT_EQ((StringList{"", "abc"}), NAS2D::split(".abc", '.'));
+	EXPECT_EQ((StringList{"a", "bc"}), NAS2D::split("a.bc", '.'));
+	EXPECT_EQ((StringList{"ab", "c"}), NAS2D::split("ab.c", '.'));
+	EXPECT_EQ((StringList{"abc", ""}), NAS2D::split("abc.", '.'));
 }
 
 TEST(String, join) {
-	EXPECT_EQ("", NAS2D::join(NAS2D::StringList{}));
-	EXPECT_EQ("a", NAS2D::join(NAS2D::StringList{"a"}));
-	EXPECT_EQ("ab", NAS2D::join(NAS2D::StringList{"a", "b"}));
-	EXPECT_EQ("abc", NAS2D::join(NAS2D::StringList{"a", "b", "c"}));
+	using StringList = std::vector<std::string>;
 
-	EXPECT_EQ("ac", NAS2D::join(NAS2D::StringList{"a", "", "c"}));
+	EXPECT_EQ("", NAS2D::join(StringList{}));
+	EXPECT_EQ("a", NAS2D::join(StringList{"a"}));
+	EXPECT_EQ("ab", NAS2D::join(StringList{"a", "b"}));
+	EXPECT_EQ("abc", NAS2D::join(StringList{"a", "b", "c"}));
 
-	EXPECT_EQ("", NAS2D::join(NAS2D::StringList{}, ","));
-	EXPECT_EQ("a", NAS2D::join(NAS2D::StringList{"a"}, ","));
-	EXPECT_EQ("a,b", NAS2D::join(NAS2D::StringList{"a", "b"}, ","));
-	EXPECT_EQ("a,b,c", NAS2D::join(NAS2D::StringList{"a", "b", "c"}, ","));
+	EXPECT_EQ("ac", NAS2D::join(StringList{"a", "", "c"}));
 
-	EXPECT_EQ("a,,c", NAS2D::join(NAS2D::StringList{"a", "", "c"}, ","));
+	EXPECT_EQ("", NAS2D::join(StringList{}, ","));
+	EXPECT_EQ("a", NAS2D::join(StringList{"a"}, ","));
+	EXPECT_EQ("a,b", NAS2D::join(StringList{"a", "b"}, ","));
+	EXPECT_EQ("a,b,c", NAS2D::join(StringList{"a", "b", "c"}, ","));
 
-	EXPECT_EQ("a, b, c", NAS2D::join(NAS2D::StringList{"a", "b", "c"}, ", "));
+	EXPECT_EQ("a,,c", NAS2D::join(StringList{"a", "", "c"}, ","));
+
+	EXPECT_EQ("a, b, c", NAS2D::join(StringList{"a", "b", "c"}, ", "));
 }


### PR DESCRIPTION
Remove `StringList` alias.

It was no longer really used, and with the namespace prefix, it wasn't really any shorter or clearer than what it represented.
