### PR TITLE
Add string conversion operator for `Point` and `Vector`

### DIFF
--- a/NAS2D/Math/Point.h
+++ b/NAS2D/Math/Point.h
@@ -12,6 +12,8 @@
 
 #include "Vector.h"
 
+#include <string>
+
 
 namespace NAS2D
 {
@@ -84,6 +86,11 @@ namespace NAS2D
 		constexpr Point<NewBaseType> to() const
 		{
 			return static_cast<Point<NewBaseType>>(*this);
+		}
+
+		explicit operator std::string() const
+		{
+			return "(" + std::to_string(x) + ", " + std::to_string(y) + ")";
 		}
 	};
 

--- a/NAS2D/Math/Vector.h
+++ b/NAS2D/Math/Vector.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <string>
 #include <stdexcept>
 
 
@@ -131,6 +132,11 @@ namespace NAS2D
 		constexpr Vector<NewBaseType> to() const
 		{
 			return static_cast<Vector<NewBaseType>>(*this);
+		}
+
+		explicit operator std::string() const
+		{
+			return "(" + std::to_string(x) + ", " + std::to_string(y) + ")";
 		}
 	};
 

--- a/test/Math/Point.test.cpp
+++ b/test/Math/Point.test.cpp
@@ -82,6 +82,12 @@ TEST(Point, to) {
 	EXPECT_EQ((NAS2D::Point<float>{1.0, 2.0}), (NAS2D::Point<int>{1, 2}.to<float>()));
 }
 
+TEST(Point, stringConversion) {
+	EXPECT_EQ("(0, 0)", (std::string{NAS2D::Point{0, 0}}));
+	EXPECT_EQ("(1, 0)", (std::string{NAS2D::Point{1, 0}}));
+	EXPECT_EQ("(0, 1)", (std::string{NAS2D::Point{0, 1}}));
+}
+
 TEST(Vector, VectorPointAdd) {
 	EXPECT_EQ((NAS2D::Point{2, 3}), (NAS2D::Vector{1, 2} + NAS2D::Point<int>{1, 1}));
 }

--- a/test/Math/Vector.test.cpp
+++ b/test/Math/Vector.test.cpp
@@ -199,6 +199,12 @@ TEST(Vector, to) {
 	EXPECT_EQ((NAS2D::Vector<float>{1.0, 2.0}), (NAS2D::Vector<int>{1, 2}.to<float>()));
 }
 
+TEST(Vector, stringConversion) {
+	EXPECT_EQ("(0, 0)", (std::string{NAS2D::Vector{0, 0}}));
+	EXPECT_EQ("(1, 0)", (std::string{NAS2D::Vector{1, 0}}));
+	EXPECT_EQ("(0, 1)", (std::string{NAS2D::Vector{0, 1}}));
+}
+
 TEST(Vector, scalarVectorMultiply) {
 	EXPECT_EQ((NAS2D::Vector{2, 4}), (2 * NAS2D::Vector{1, 2}));
 }


### PR DESCRIPTION
Add an `explicit` string conversion operator for `Point` and `Vector`.

Objects can be converted by wrapping them with `std::string{}`. This is required due to `explicit` being used. We want `explicit` since otherwise code could be prone to accidental type conversions. For example, a `Point` and a `Vector` can be added, but adding a `std::string` to a `Point` is probably an error, unless there is an explicit conversion of the `Point` to a `std::string`, in which case it's clear that string concatenation is desired.

Originally I wanted to avoid adding a `<string>` header dependency to `Point.h` and `Vector.h`, since these headers are included in so many places. However it seems the `<stdexcept>` header already implicitly includes `<string>`.
