### PR TITLE
Move `Point` and `Vector` CTAD guide

### DIFF
--- a/NAS2D/Math/Point.h
+++ b/NAS2D/Math/Point.h
@@ -95,16 +95,16 @@ namespace NAS2D
 	};
 
 
+	template <typename BaseType>
+	Point(BaseType, BaseType) -> Point<BaseType>;
+
+
 	// Commutative Vector + Point
 	template <typename BaseType>
 	constexpr Point<BaseType> operator+(Vector<BaseType> vector, Point<BaseType> point)
 	{
 		return point + vector;
 	}
-
-
-	template <typename BaseType>
-	Point(BaseType, BaseType) -> Point<BaseType>;
 
 
 	// Partial order comparisons

--- a/NAS2D/Math/Vector.h
+++ b/NAS2D/Math/Vector.h
@@ -141,16 +141,16 @@ namespace NAS2D
 	};
 
 
+	template <typename BaseType>
+	Vector(BaseType, BaseType) -> Vector<BaseType>;
+
+
 	// Commutative scalar * vector
 	template <typename BaseType>
 	constexpr Vector<BaseType> operator*(BaseType scalar, Vector<BaseType> vector)
 	{
 		return vector * scalar;
 	}
-
-
-	template <typename BaseType>
-	Vector(BaseType, BaseType) -> Vector<BaseType>;
 
 
 	// Partial order comparisons


### PR DESCRIPTION
Move CTAD guide to right after `struct` definition.

Previously it was placed between operator overloads.

----

Noticed this while working on:
- PR #1189 