### PR TITLE
Allow specifying `sdl2-config` executable

### DIFF
--- a/makefile
+++ b/makefile
@@ -41,8 +41,9 @@ Darwin_OpenGL_LIBS := -lGLEW -framework OpenGL
 Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
-SDL_CONFIG_CFLAGS := $(shell type sdl2-config >/dev/null 2>&1 && sdl2-config --cflags)
-SDL_CONFIG_LIBS := $(shell type sdl2-config >/dev/null 2>&1 && sdl2-config --libs)
+SDL_CONFIG := sdl2-config
+SDL_CONFIG_CFLAGS := $(shell type $(SDL_CONFIG) >/dev/null 2>&1 && $(SDL_CONFIG) --cflags)
+SDL_CONFIG_LIBS := $(shell type $(SDL_CONFIG) >/dev/null 2>&1 && $(SDL_CONFIG) --libs)
 
 CPPFLAGS := $(CPPFLAGS_EXTRA)
 CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute -Wredundant-decls -Wformat=2 $(WARN_EXTRA)


### PR DESCRIPTION
There may be multiple `sdl2-config` executables present in a given environment. Having a variable for the executable file allows for easier customization of which executable to use.

A common case for this is doing cross compilation using Mingw to build a Windows executable from Linux. Normally the Linux environment would be setup for local building, and so `sdl2-config` would return flags suitable for a local Linux build. When doing cross compilation, there will be a separate binary install of SDL2 for Windows, which will have a separate `sdl2-config` executable, with Windows specific build flags and library paths.

----

Related:
- Issue #1155

----

Possible build command for Mingw:
```sh
make CXX=/usr/bin/x86_64-w64-mingw32-g++ SDL_CONFIG="/usr/local/x86_64-w64-mingw32/bin/sdl2-config" TARGET_OS=Windows WARN_EXTRA="-Wno-redundant-decls" CPPFLAGS_EXTRA="-DGLEW_STATIC -I/usr/local/x86_64-w64-mingw32/include/" check
```
