### PR TITLE
Use `Point` and `Vector` string conversion functions

### DIFF
--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -243,8 +243,7 @@ namespace
 		if (fontSurfaceSize != glyphSize * GLYPH_MATRIX_SIZE)
 		{
 			SDL_FreeSurface(fontSurface);
-			const auto vectorToString = [](auto vector) { return "{" + std::to_string(vector.x) + ", " + std::to_string(vector.y) + "}"; };
-			throw std::runtime_error("Unexpected font image size. Image dimensions " + vectorToString(fontSurfaceSize) + " must both be evenly divisible by " + std::to_string(GLYPH_MATRIX_SIZE));
+			throw std::runtime_error("Unexpected font image size. Image dimensions " + std::string{fontSurfaceSize} + " must both be evenly divisible by " + std::to_string(GLYPH_MATRIX_SIZE));
 		}
 
 		Font::FontInfo fontInfo;

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -147,7 +147,7 @@ Color Image::pixelColor(Point<int> point) const
 {
 	if (!Rectangle{{0, 0}, mSize}.contains(point))
 	{
-		throw std::runtime_error("Pixel coordinates out of bounds: {" + std::to_string(point.x) + ", " + std::to_string(point.y) + "}");
+		throw std::runtime_error("Pixel coordinates out of bounds: " + std::string{point});
 	}
 
 	if (!mSurface) { throw std::runtime_error("Image has no allocated surface"); }


### PR DESCRIPTION
Note this changes the coordinate wrapping from `{}` to `()`. These strings are only used in exception messages though, so aren't very user facing.

Feature was added with merge commit fcfaa91171d839451ca57635040341480a810661:
- PR #1189
