### PR TITLE
Refactor `addCursor` and add `CursorId` type

### DIFF
--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -232,9 +232,9 @@ void Window::addCursor(const std::string& filePath, int cursorId, Vector<int> ho
 		throw std::runtime_error("Failed to load cursor: " + filePath + " : " + SDL_GetError());
 	}
 
-	SDL_Cursor* cur = SDL_CreateColorCursor(surface, hotOffset.x, hotOffset.y);
+	SDL_Cursor* cursor = SDL_CreateColorCursor(surface, hotOffset.x, hotOffset.y);
 	SDL_FreeSurface(surface);
-	if (!cur)
+	if (!cursor)
 	{
 		throw std::runtime_error("Failed to create color cursor: " + filePath + " : " + SDL_GetError());
 	}
@@ -244,7 +244,7 @@ void Window::addCursor(const std::string& filePath, int cursorId, Vector<int> ho
 		SDL_FreeCursor(cursors[cursorId]);
 	}
 
-	cursors[cursorId] = cur;
+	cursors[cursorId] = cursor;
 
 	if (cursors.size() == 1)
 	{

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -218,7 +218,7 @@ void Window::showSystemPointer(bool _b)
 }
 
 
-void Window::addCursor(const std::string& filePath, int cursorId, Vector<int> hotOffset)
+void Window::addCursor(int cursorId, const std::string& filePath, Vector<int> hotOffset)
 {
 	auto imageData = Utility<Filesystem>::get().readFile(filePath);
 	if (imageData.size() == 0)

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -218,7 +218,7 @@ void Window::showSystemPointer(bool _b)
 }
 
 
-void Window::addCursor(const std::string& filePath, int cursorId, int offx, int offy)
+void Window::addCursor(const std::string& filePath, int cursorId, Vector<int> hotOffset)
 {
 	auto imageData = Utility<Filesystem>::get().readFile(filePath);
 	if (imageData.size() == 0)
@@ -232,7 +232,7 @@ void Window::addCursor(const std::string& filePath, int cursorId, int offx, int 
 		throw std::runtime_error("Failed to load cursor: " + filePath + " : " + SDL_GetError());
 	}
 
-	SDL_Cursor* cur = SDL_CreateColorCursor(surface, offx, offy);
+	SDL_Cursor* cur = SDL_CreateColorCursor(surface, hotOffset.x, hotOffset.y);
 	SDL_FreeSurface(surface);
 	if (!cur)
 	{

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -218,7 +218,7 @@ void Window::showSystemPointer(bool _b)
 }
 
 
-void Window::addCursor(int cursorId, const std::string& filePath, Vector<int> hotOffset)
+void Window::addCursor(CursorId cursorId, const std::string& filePath, Vector<int> hotOffset)
 {
 	auto imageData = Utility<Filesystem>::get().readFile(filePath);
 	if (imageData.size() == 0)
@@ -239,12 +239,12 @@ void Window::addCursor(int cursorId, const std::string& filePath, Vector<int> ho
 		throw std::runtime_error("Failed to create color cursor: " + filePath + " : " + SDL_GetError());
 	}
 
-	if (cursors.contains(cursorId))
+	if (cursors.contains(cursorId.id))
 	{
-		SDL_FreeCursor(cursors[cursorId]);
+		SDL_FreeCursor(cursors[cursorId.id]);
 	}
 
-	cursors[cursorId] = cursor;
+	cursors[cursorId.id] = cursor;
 
 	if (cursors.size() == 1)
 	{
@@ -253,9 +253,9 @@ void Window::addCursor(int cursorId, const std::string& filePath, Vector<int> ho
 }
 
 
-void Window::setCursor(int cursorId)
+void Window::setCursor(CursorId cursorId)
 {
-	SDL_SetCursor(cursors[cursorId]);
+	SDL_SetCursor(cursors[cursorId.id]);
 }
 
 

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -239,7 +239,7 @@ void Window::addCursor(int cursorId, const std::string& filePath, Vector<int> ho
 		throw std::runtime_error("Failed to create color cursor: " + filePath + " : " + SDL_GetError());
 	}
 
-	if (cursors.count(cursorId))
+	if (cursors.contains(cursorId))
 	{
 		SDL_FreeCursor(cursors[cursorId]);
 	}

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -31,7 +31,7 @@ namespace NAS2D
 		virtual void window_icon(const std::string& path);
 
 		virtual void showSystemPointer(bool);
-		virtual void addCursor(const std::string& filePath, int cursorId, Vector<int> hotOffset);
+		virtual void addCursor(int cursorId, const std::string& filePath, Vector<int> hotOffset);
 		virtual void setCursor(int cursorId);
 
 		virtual void fullscreen(bool fs, bool maintain = false);

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -15,6 +15,12 @@ namespace NAS2D
 	struct DisplayDesc;
 
 
+	struct CursorId
+	{
+		int id;
+	};
+
+
 	class Window
 	{
 	public:
@@ -31,8 +37,8 @@ namespace NAS2D
 		virtual void window_icon(const std::string& path);
 
 		virtual void showSystemPointer(bool);
-		virtual void addCursor(int cursorId, const std::string& filePath, Vector<int> hotOffset);
-		virtual void setCursor(int cursorId);
+		virtual void addCursor(CursorId cursorId, const std::string& filePath, Vector<int> hotOffset);
+		virtual void setCursor(CursorId cursorId);
 
 		virtual void fullscreen(bool fs, bool maintain = false);
 		virtual bool fullscreen() const;

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -31,7 +31,7 @@ namespace NAS2D
 		virtual void window_icon(const std::string& path);
 
 		virtual void showSystemPointer(bool);
-		virtual void addCursor(const std::string& filePath, int cursorId, int offx, int offy);
+		virtual void addCursor(const std::string& filePath, int cursorId, Vector<int> hotOffset);
 		virtual void setCursor(int cursorId);
 
 		virtual void fullscreen(bool fs, bool maintain = false);


### PR DESCRIPTION
The `CursorId` type will allow for better type safety with the `addCursor` and `setCursor` API methods.

This may help with type safety in downstream projects where an `enum` is used for the cursor types:
- Issue https://github.com/OutpostUniverse/OPHD/issues/319
