### PR TITLE
Remove `loops` argument from `Mixer`

### DIFF
--- a/NAS2D/Mixer/Mixer.cpp
+++ b/NAS2D/Mixer/Mixer.cpp
@@ -14,9 +14,9 @@
 using namespace NAS2D;
 
 
-void Mixer::playMusic(const Music& music, int loops /*= Mixer::CONTINUOUS*/)
+void Mixer::playMusic(const Music& music)
 {
-	fadeInMusic(music, loops, std::chrono::milliseconds{0});
+	fadeInMusic(music, std::chrono::milliseconds{0});
 }
 
 

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -23,7 +23,6 @@ namespace NAS2D
 	class Mixer
 	{
 	public:
-		static const int CONTINUOUS = -1;
 		static constexpr std::chrono::milliseconds DEFAULT_FADE_TIME{500};
 
 	public:
@@ -44,14 +43,13 @@ namespace NAS2D
 		 * Starts playing a Music track.
 		 *
 		 * \param music Reference to a Music Resource.
-		 * \param loops Repeat count. -1 for continuous loop.
 		 */
-		void playMusic(const Music& music, int loops = Mixer::CONTINUOUS);
+		void playMusic(const Music& music);
 		virtual void stopMusic() = 0;
 		virtual void pauseMusic() = 0;
 		virtual void resumeMusic() = 0;
 
-		virtual void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, std::chrono::milliseconds fadeInTime = Mixer::DEFAULT_FADE_TIME) = 0;
+		virtual void fadeInMusic(const Music& music, std::chrono::milliseconds fadeInTime = Mixer::DEFAULT_FADE_TIME) = 0;
 
 		virtual void fadeOutMusic(std::chrono::milliseconds fadeOutTime = Mixer::DEFAULT_FADE_TIME) = 0;
 

--- a/NAS2D/Mixer/MixerNull.cpp
+++ b/NAS2D/Mixer/MixerNull.cpp
@@ -34,7 +34,7 @@ namespace NAS2D
 	void MixerNull::resumeMusic()
 	{}
 
-	void MixerNull::fadeInMusic(const Music& /*music*/, int /*loops*/ /*= Mixer::CONTINUOUS*/, std::chrono::milliseconds /*fadeInTime*/ /*= Mixer::DEFAULT_FADE_TIME*/)
+	void MixerNull::fadeInMusic(const Music& /*music*/, std::chrono::milliseconds /*fadeInTime*/ /*= Mixer::DEFAULT_FADE_TIME*/)
 	{}
 
 	void MixerNull::fadeOutMusic(std::chrono::milliseconds /*fadeOutTime*/ /*= Mixer::DEFAULT_FADE_TIME*/)

--- a/NAS2D/Mixer/MixerNull.h
+++ b/NAS2D/Mixer/MixerNull.h
@@ -27,7 +27,7 @@ namespace NAS2D
 		void pauseMusic() override;
 		void resumeMusic() override;
 
-		void fadeInMusic(const Music& music, int loops = Mixer::CONTINUOUS, std::chrono::milliseconds fadeInTime = Mixer::DEFAULT_FADE_TIME) override;
+		void fadeInMusic(const Music& music, std::chrono::milliseconds fadeInTime = Mixer::DEFAULT_FADE_TIME) override;
 		void fadeOutMusic(std::chrono::milliseconds fadeOutTime = Mixer::DEFAULT_FADE_TIME) override;
 
 		bool musicPlaying() const override;

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -183,9 +183,9 @@ void MixerSDL::resumeMusic()
 }
 
 
-void MixerSDL::fadeInMusic(const Music& music, int loops, std::chrono::milliseconds fadeInTime)
+void MixerSDL::fadeInMusic(const Music& music, std::chrono::milliseconds fadeInTime)
 {
-	Mix_FadeInMusic(music.music(), loops, static_cast<int>(fadeInTime.count()));
+	Mix_FadeInMusic(music.music(), 0, static_cast<int>(fadeInTime.count()));
 }
 
 

--- a/NAS2D/Mixer/MixerSDL.h
+++ b/NAS2D/Mixer/MixerSDL.h
@@ -56,7 +56,7 @@ namespace NAS2D
 		void pauseMusic() override;
 		void resumeMusic() override;
 
-		void fadeInMusic(const Music& music, int loops, std::chrono::milliseconds fadeInTime) override;
+		void fadeInMusic(const Music& music, std::chrono::milliseconds fadeInTime) override;
 		void fadeOutMusic(std::chrono::milliseconds fadeOutTime) override;
 
 		bool musicPlaying() const override;


### PR DESCRIPTION
If music needs to be looped, the `musicCompleteSignalSource()` object should be used to listen for when a track ends, and make a call to play the music again.

More likely though, a game would have some kind of track list, and would switch to the next track.

----

Downstream impacts: OPHD will still play music properly, without source code modification, though will no longer loop the intro music.

----

Closes #945
