### PR TITLE
Add `Angle` class

### DIFF
--- a/NAS2D/Math/Angle.h
+++ b/NAS2D/Math/Angle.h
@@ -22,6 +22,11 @@ namespace NAS2D
 		static constexpr Angle degrees(float degrees) { return Angle{degrees}; }
 		static constexpr Angle radians(float radians) { return Angle{radToDeg(radians)}; }
 
+		constexpr Angle operator-() const { return Angle{-degreeMeasure}; }
+
+		constexpr Angle operator+(const Angle& other) const { return Angle{degreeMeasure + other.degreeMeasure}; }
+		constexpr Angle operator-(const Angle& other) const { return Angle{degreeMeasure - other.degreeMeasure}; }
+
 		constexpr float degrees() const { return degreeMeasure; }
 		constexpr float radians() const { return degToRad(degreeMeasure); }
 

--- a/NAS2D/Math/Angle.h
+++ b/NAS2D/Math/Angle.h
@@ -1,0 +1,10 @@
+#pragma once
+
+
+namespace NAS2D
+{
+	struct Angle
+	{
+		float radians;
+	};
+}

--- a/NAS2D/Math/Angle.h
+++ b/NAS2D/Math/Angle.h
@@ -27,10 +27,16 @@ namespace NAS2D
 		constexpr Angle operator+(const Angle& other) const { return Angle{degreeMeasure + other.degreeMeasure}; }
 		constexpr Angle operator-(const Angle& other) const { return Angle{degreeMeasure - other.degreeMeasure}; }
 
+		constexpr Angle operator*(float scalar) const { return Angle{degreeMeasure * scalar}; }
+		constexpr Angle operator/(float scalar) const { return Angle{degreeMeasure / scalar}; }
+
 		constexpr float degrees() const { return degreeMeasure; }
 		constexpr float radians() const { return degToRad(degreeMeasure); }
 
 	private:
 		float degreeMeasure;
 	};
+
+
+	constexpr Angle operator*(float scalar, Angle angle) { return angle * scalar; }
 }

--- a/NAS2D/Math/Angle.h
+++ b/NAS2D/Math/Angle.h
@@ -9,7 +9,7 @@ namespace NAS2D
 	{
 	protected:
 		// Non-public constructor forces the use of static factory methods
-		constexpr Angle(float radians) : radianMeasure{radians} {}
+		constexpr Angle(float degrees) : degreeMeasure{degrees} {}
 
 		static constexpr float DegreeToRadians = std::numbers::pi_v<float> / 180;
 		static constexpr float RadiansToDegrees = 180 / std::numbers::pi_v<float>;
@@ -19,13 +19,13 @@ namespace NAS2D
 
 	public:
 		// Static factory methods, with an explicit angle measure
-		static constexpr Angle degrees(float degrees) { return Angle{degToRad(degrees)}; }
-		static constexpr Angle radians(float radians) { return Angle{radians}; }
+		static constexpr Angle degrees(float degrees) { return Angle{degrees}; }
+		static constexpr Angle radians(float radians) { return Angle{radToDeg(radians)}; }
 
-		constexpr float degrees() const { return radToDeg(radianMeasure); }
-		constexpr float radians() const { return radianMeasure; }
+		constexpr float degrees() const { return degreeMeasure; }
+		constexpr float radians() const { return degToRad(degreeMeasure); }
 
 	private:
-		float radianMeasure;
+		float degreeMeasure;
 	};
 }

--- a/NAS2D/Math/Angle.h
+++ b/NAS2D/Math/Angle.h
@@ -1,10 +1,31 @@
 #pragma once
 
+#include <numbers>
+
 
 namespace NAS2D
 {
-	struct Angle
+	class Angle
 	{
-		float radians;
+	protected:
+		// Non-public constructor forces the use of static factory methods
+		constexpr Angle(float radians) : radianMeasure{radians} {}
+
+		static constexpr float DegreeToRadians = std::numbers::pi_v<float> / 180;
+		static constexpr float RadiansToDegrees = 180 / std::numbers::pi_v<float>;
+
+		static constexpr float degToRad(float degrees) { return degrees * DegreeToRadians; }
+		static constexpr float radToDeg(float radians) { return radians * RadiansToDegrees; }
+
+	public:
+		// Static factory methods, with an explicit angle measure
+		static constexpr Angle degrees(float degrees) { return Angle{degToRad(degrees)}; }
+		static constexpr Angle radians(float radians) { return Angle{radians}; }
+
+		constexpr float degrees() const { return radToDeg(radianMeasure); }
+		constexpr float radians() const { return radianMeasure; }
+
+	private:
+		float radianMeasure;
 	};
 }

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -203,6 +203,7 @@
     <ClInclude Include="Filesystem.h" />
     <ClInclude Include="FpsCounter.h" />
     <ClInclude Include="Game.h" />
+    <ClInclude Include="Math\Angle.h" />
     <ClInclude Include="Math\MathUtils.h" />
     <ClInclude Include="Math\Point.h" />
     <ClInclude Include="Math\PointInRectangleRange.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -206,6 +206,9 @@
     <ClInclude Include="Utility.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Math\Angle.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="Math\MathUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -27,6 +27,7 @@ namespace NAS2D
 
 	class Font;
 	class Image;
+	class Angle;
 
 	template <typename BaseType>
 	struct Rectangle;
@@ -43,8 +44,8 @@ namespace NAS2D
 
 		virtual void drawImage(const Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) = 0;
 		virtual void drawSubImage(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, Color color = Color::Normal) = 0;
-		virtual void drawSubImageRotated(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, float degrees, Color color = Color::Normal) = 0;
-		virtual void drawImageRotated(const Image& image, Point<float> position, float degrees, Color color = Color::Normal, float scale = 1.0f) = 0;
+		virtual void drawSubImageRotated(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, Angle angle, Color color = Color::Normal) = 0;
+		virtual void drawImageRotated(const Image& image, Point<float> position, Angle angle, Color color = Color::Normal, float scale = 1.0f) = 0;
 		virtual void drawImageStretched(const Image& image, const Rectangle<float>& rect, Color color = Color::Normal) = 0;
 		virtual void drawImageRepeated(const Image& image, const Rectangle<float>& rect) = 0;
 		virtual void drawSubImageRepeated(const Image& image, const Rectangle<float>& destination, const Rectangle<float>& source) = 0;

--- a/NAS2D/Renderer/RendererNull.h
+++ b/NAS2D/Renderer/RendererNull.h
@@ -11,6 +11,8 @@
 
 #include "Renderer.h"
 
+#include "../Math/Angle.h"
+
 
 namespace NAS2D
 {
@@ -25,9 +27,9 @@ namespace NAS2D
 		void drawImage(const Image&, Point<float>, float = 1.0, Color = Color::Normal) override {}
 
 		void drawSubImage(const Image&, Point<float>, const Rectangle<float>&, Color = Color::Normal) override {}
-		void drawSubImageRotated(const Image&, Point<float>, const Rectangle<float>&, float, Color = Color::Normal) override {}
+		void drawSubImageRotated(const Image&, Point<float>, const Rectangle<float>&, Angle, Color = Color::Normal) override {}
 
-		void drawImageRotated(const Image&, Point<float>, float, Color = Color::Normal, float = 1.0f) override {}
+		void drawImageRotated(const Image&, Point<float>, Angle, Color = Color::Normal, float = 1.0f) override {}
 		void drawImageStretched(const Image&, const Rectangle<float>&, Color = Color::Normal) override {}
 
 		void drawImageRepeated(const Image&, const Rectangle<float>&) override {}

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -13,6 +13,7 @@
 #include "../Math/VectorSizeRange.h"
 #include "../Resource/Image.h"
 #include "../Resource/Font.h"
+#include "../Math/Angle.h"
 #include "../Math/Trig.h"
 #include "../Configuration.h"
 #include "../EventHandler.h"
@@ -189,7 +190,7 @@ void RendererOpenGL::drawSubImage(const Image& image, Point<float> raster, const
 }
 
 
-void RendererOpenGL::drawSubImageRotated(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, float degrees, Color color)
+void RendererOpenGL::drawSubImageRotated(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, Angle angle, Color color)
 {
 	glPushMatrix();
 
@@ -197,7 +198,7 @@ void RendererOpenGL::drawSubImageRotated(const Image& image, Point<float> raster
 	const auto center = raster + translate;
 
 	glTranslatef(center.x, center.y, 0.0f);
-	glRotatef(degrees, 0.0f, 0.0f, 1.0f);
+	glRotatef(angle.degrees(), 0.0f, 0.0f, 1.0f);
 
 	setColor(color);
 
@@ -211,7 +212,7 @@ void RendererOpenGL::drawSubImageRotated(const Image& image, Point<float> raster
 }
 
 
-void RendererOpenGL::drawImageRotated(const Image& image, Point<float> position, float degrees, Color color, float scale)
+void RendererOpenGL::drawImageRotated(const Image& image, Point<float> position, Angle angle, Color color, float scale)
 {
 	glPushMatrix();
 
@@ -221,7 +222,7 @@ void RendererOpenGL::drawImageRotated(const Image& image, Point<float> position,
 
 	glTranslatef(center.x, center.y, 0.0f);
 
-	glRotatef(degrees, 0.0f, 0.0f, 1.0f);
+	glRotatef(angle.degrees(), 0.0f, 0.0f, 1.0f);
 
 	setColor(color);
 	glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);

--- a/NAS2D/Renderer/RendererOpenGL.h
+++ b/NAS2D/Renderer/RendererOpenGL.h
@@ -49,9 +49,9 @@ namespace NAS2D
 		void drawImage(const Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) override;
 
 		void drawSubImage(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, Color color = Color::Normal) override;
-		void drawSubImageRotated(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, float degrees, Color color = Color::Normal) override;
+		void drawSubImageRotated(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, Angle angle, Color color = Color::Normal) override;
 
-		void drawImageRotated(const Image& image, Point<float> position, float degrees, Color color = Color::Normal, float scale = 1.0f) override;
+		void drawImageRotated(const Image& image, Point<float> position, Angle angle, Color color = Color::Normal, float scale = 1.0f) override;
 		void drawImageStretched(const Image& image, const Rectangle<float>& rect, Color color = Color::Normal) override;
 
 		void drawImageRepeated(const Image& image, const Rectangle<float>& rect) override;

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -124,29 +124,29 @@ void Sprite::draw(Point<float> position) const
 	const auto& frame = (*mCurrentAction)[mCurrentFrame];
 	const auto drawPosition = position - frame.anchorOffset.to<float>();
 	const auto frameBounds = frame.bounds.to<float>();
-	Utility<Renderer>::get().drawSubImageRotated(frame.image, drawPosition, frameBounds, mRotationAngleDegrees, mTintColor);
+	Utility<Renderer>::get().drawSubImageRotated(frame.image, drawPosition, frameBounds, mRotationAngle, mTintColor);
 }
 
 
 /**
  * Sets the rotation angle of the Sprite.
  *
- * \param	angle	Angle of rotation in degrees.
+ * \param	angle	Angle of rotation.
  */
-void Sprite::rotation(float angle)
+void Sprite::rotation(Angle angle)
 {
-	mRotationAngleDegrees = angle;
+	mRotationAngle = angle;
 }
 
 
 /**
  * Gets the rotation angle of the Sprite.
  *
- * \return	Angle of rotation in degrees.
+ * \return	Angle of rotation.
  */
-float Sprite::rotation() const
+Angle Sprite::rotation() const
 {
-	return mRotationAngleDegrees;
+	return mRotationAngle;
 }
 
 

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -13,6 +13,7 @@
 #include "AnimationSet.h"
 #include "../Signal/Signal.h"
 #include "../Timer.h"
+#include "../Math/Angle.h"
 #include "../Renderer/Color.h"
 
 #include <vector>
@@ -53,8 +54,8 @@ namespace NAS2D
 		void update();
 		void draw(Point<float> position) const;
 
-		void rotation(float angle);
-		float rotation() const;
+		void rotation(Angle angle);
+		Angle rotation() const;
 
 		void alpha(uint8_t alpha);
 		uint8_t alpha() const;
@@ -76,6 +77,6 @@ namespace NAS2D
 		AnimationCompleteSignal mAnimationCompleteSignal{};
 
 		Color mTintColor{Color::Normal};
-		float mRotationAngleDegrees{0.0f};
+		Angle mRotationAngle = Angle::degrees(0.0f);
 	};
 } // namespace

--- a/test/Math/Angle.test.cpp
+++ b/test/Math/Angle.test.cpp
@@ -1,0 +1,21 @@
+#include "NAS2D/Math/Angle.h"
+
+#include <gtest/gtest.h>
+
+#include <numbers>
+
+
+TEST(Angle, degrees) {
+	constexpr auto angle = NAS2D::Angle::degrees(90.0f);
+	EXPECT_FLOAT_EQ(90.0f, angle.degrees());
+}
+
+TEST(Angle, radians) {
+	constexpr auto angle = NAS2D::Angle::radians(1.0f);
+	EXPECT_FLOAT_EQ(1.0f, angle.radians());
+}
+
+TEST(Angle, degreesToRadians) {
+	constexpr auto angle = NAS2D::Angle::degrees(180.0f);
+	EXPECT_FLOAT_EQ(std::numbers::pi_v<float>, angle.radians());
+}

--- a/test/Math/Angle.test.cpp
+++ b/test/Math/Angle.test.cpp
@@ -34,3 +34,18 @@ TEST(Angle, subtraction) {
 	constexpr auto angle = NAS2D::Angle::degrees(180.0f) - NAS2D::Angle::degrees(90.0f);
 	EXPECT_FLOAT_EQ(90.0f, angle.degrees());
 }
+
+TEST(Angle, multiply) {
+	constexpr auto angle = NAS2D::Angle::degrees(90.0f) * 2;
+	EXPECT_FLOAT_EQ(180.0f, angle.degrees());
+}
+
+TEST(Angle, divide) {
+	constexpr auto angle = NAS2D::Angle::degrees(180.0f) / 2;
+	EXPECT_FLOAT_EQ(90.0f, angle.degrees());
+}
+
+TEST(Angle, multiplyCommutative) {
+	constexpr auto angle = 2 * NAS2D::Angle::degrees(90.0f);
+	EXPECT_FLOAT_EQ(180.0f, angle.degrees());
+}

--- a/test/Math/Angle.test.cpp
+++ b/test/Math/Angle.test.cpp
@@ -19,3 +19,18 @@ TEST(Angle, degreesToRadians) {
 	constexpr auto angle = NAS2D::Angle::degrees(180.0f);
 	EXPECT_FLOAT_EQ(std::numbers::pi_v<float>, angle.radians());
 }
+
+TEST(Angle, unaryMinus) {
+	constexpr auto angle = -NAS2D::Angle::degrees(180.0f);
+	EXPECT_FLOAT_EQ(-180.0f, angle.degrees());
+}
+
+TEST(Angle, addition) {
+	constexpr auto angle = NAS2D::Angle::degrees(90.0f) + NAS2D::Angle::degrees(90.0f);
+	EXPECT_FLOAT_EQ(180.0f, angle.degrees());
+}
+
+TEST(Angle, subtraction) {
+	constexpr auto angle = NAS2D::Angle::degrees(180.0f) - NAS2D::Angle::degrees(90.0f);
+	EXPECT_FLOAT_EQ(90.0f, angle.degrees());
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -142,6 +142,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Math/Angle.test.cpp" />
     <ClCompile Include="Math/MathUtils.test.cpp" />
     <ClCompile Include="Math/Point.test.cpp" />
     <ClCompile Include="Math/PointInRectangleRange.test.cpp" />


### PR DESCRIPTION
Add a type safe `Angle` class.

The `Angle` class can set it's internal implementation to either degrees or radians, without impacting external code. The initial design used radians, but was later switched to degrees. Unmodified unit tests continued to run successfully using the new internal implementation.

The usual type safe angle operations are supported, such as unary minus, addition, subtraction, scalar multiply, scalar divide, and commutative scalar multiply.

Closes #970
