### PR TITLE
Correct backwards unit test in `Trig.test.cpp`

### DIFF
--- a/test/Math/Trig.test.cpp
+++ b/test/Math/Trig.test.cpp
@@ -4,11 +4,11 @@
 
 
 TEST(Trig, degToRadToDeg) {
-	EXPECT_FLOAT_EQ(0.0f, NAS2D::degToRad(NAS2D::radToDeg(0.0f)));
-	EXPECT_FLOAT_EQ(90.0f, NAS2D::degToRad(NAS2D::radToDeg(90.0f)));
-	EXPECT_FLOAT_EQ(180.0f, NAS2D::degToRad(NAS2D::radToDeg(180.0f)));
-	EXPECT_FLOAT_EQ(270.0f, NAS2D::degToRad(NAS2D::radToDeg(270.0f)));
-	EXPECT_FLOAT_EQ(-90.0f, NAS2D::degToRad(NAS2D::radToDeg(-90.0f)));
+	EXPECT_FLOAT_EQ(0.0f, NAS2D::radToDeg(NAS2D::degToRad(0.0f)));
+	EXPECT_FLOAT_EQ(90.0f, NAS2D::radToDeg(NAS2D::degToRad(90.0f)));
+	EXPECT_FLOAT_EQ(180.0f, NAS2D::radToDeg(NAS2D::degToRad(180.0f)));
+	EXPECT_FLOAT_EQ(270.0f, NAS2D::radToDeg(NAS2D::degToRad(270.0f)));
+	EXPECT_FLOAT_EQ(-90.0f, NAS2D::radToDeg(NAS2D::degToRad(-90.0f)));
 }
 
 TEST(Trig, getAngle) {


### PR DESCRIPTION
The errors complemented each other, and so cancelled out.

Unit test was originally written in commit:
458f0ebd7611dc5b93dce47a443eb747ce7cab8b