### PR TITLE
Refactor `test-graphics` project

### DIFF
--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -50,18 +50,18 @@ NAS2D::State* TestGraphics::update()
 
 	r.clearScreen(NAS2D::Color::Gray);
 
-	r.drawBox({{10, 50}, {40, 40}});
-	r.drawBoxFilled({{70, 50}, {40, 40}}, NAS2D::Color{200, 0, 0});
+	r.drawBox({{10, 10}, {40, 40}});
+	r.drawBoxFilled({{70, 10}, {40, 40}}, NAS2D::Color{200, 0, 0});
 
-	r.drawGradient({{10, 100}, {100, 100}}, NAS2D::Color::Blue, NAS2D::Color::Green, NAS2D::Color::Red, NAS2D::Color::Magenta);
+	r.drawGradient({{10, 60}, {100, 100}}, NAS2D::Color::Blue, NAS2D::Color::Green, NAS2D::Color::Red, NAS2D::Color::Magenta);
 
-	r.drawCircle({150, 70}, 20, NAS2D::Color{0, 200, 0, 255}, 16);
-	r.drawCircle({150, 120}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {0.5f, 0.5f});
-	r.drawCircle({150, 170}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {1.0f, 0.5f});
+	r.drawCircle({150, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16);
+	r.drawCircle({150, 70}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {0.5f, 0.5f});
+	r.drawCircle({150, 100}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {1.0f, 0.5f});
 
 	for (auto i = 0; i < 10; ++i)
 	{
-		NAS2D::Rectangle<int> boxRect = {{200 + 10 * i, 50}, {i, i}};
+		NAS2D::Rectangle<int> boxRect = {{180 + 10 * i, 10}, {i, i}};
 		r.drawBox(boxRect, NAS2D::Color::Red);
 		r.drawBoxFilled(boxRect.inset(1), NAS2D::Color::White);
 	}
@@ -69,11 +69,11 @@ NAS2D::State* TestGraphics::update()
 	for (auto i = 0u; i < 2000u; ++i)
 	{
 		const uint8_t grey = static_cast<uint8_t>(jitter()) * 2u + 100u;
-		r.drawPoint(NAS2D::Point{10 + jitter(), 250 + jitter()}, NAS2D::Color{grey, grey, grey});
+		r.drawPoint(NAS2D::Point{10 + jitter(), 170 + jitter()}, NAS2D::Color{grey, grey, grey});
 	}
 
-	r.drawImage(mDxImage, {256, 256});
-	r.drawImage(mOglImage, {768, 256});
+	r.drawImage(mDxImage, {84, 170});
+	r.drawImage(mOglImage, {84 + 512, 170});
 
 	return this;
 }

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -53,18 +53,18 @@ NAS2D::State* TestGraphics::update()
 	r.drawBox({{10, 10}, {40, 40}});
 	r.drawBoxFilled({{70, 10}, {40, 40}}, NAS2D::Color{200, 0, 0});
 
-	r.drawGradient({{10, 60}, {100, 100}}, NAS2D::Color::Blue, NAS2D::Color::Green, NAS2D::Color::Red, NAS2D::Color::Magenta);
-
-	r.drawCircle({250, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16);
-	r.drawCircle({290, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {0.5f, 0.5f});
-	r.drawCircle({330, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {1.0f, 0.5f});
-
 	for (auto i = 0; i < 10; ++i)
 	{
 		NAS2D::Rectangle<int> boxRect = {{120 + 10 * i, 10}, {i, i}};
 		r.drawBox(boxRect, NAS2D::Color::Red);
 		r.drawBoxFilled(boxRect.inset(1), NAS2D::Color::White);
 	}
+
+	r.drawCircle({250, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16);
+	r.drawCircle({290, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {0.5f, 0.5f});
+	r.drawCircle({330, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {1.0f, 0.5f});
+
+	r.drawGradient({{10, 60}, {100, 100}}, NAS2D::Color::Blue, NAS2D::Color::Green, NAS2D::Color::Red, NAS2D::Color::Magenta);
 
 	for (auto i = 0u; i < 2000u; ++i)
 	{

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -11,13 +11,6 @@
 namespace
 {
 	std::mt19937 generator;
-	std::uniform_int_distribution<int> jitterDistribution(0, 64);
-
-
-	auto jitter()
-	{
-		return jitterDistribution(generator);
-	}
 }
 
 
@@ -68,6 +61,9 @@ NAS2D::State* TestGraphics::update()
 
 	for (auto i = 0u; i < 2000u; ++i)
 	{
+		std::uniform_int_distribution<int> jitterDistribution(0, 64);
+		auto jitter = [&jitterDistribution](){ return jitterDistribution(generator); };
+
 		const uint8_t grey = static_cast<uint8_t>(jitter()) * 2u + 100u;
 		const auto offset = NAS2D::Vector{jitter(), jitter()};
 		r.drawPoint(NAS2D::Point{120, 60} + offset, NAS2D::Color{grey, grey, grey});

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -34,7 +34,9 @@ void TestGraphics::initialize()
 	NAS2D::Utility<NAS2D::EventHandler>::get().keyDown().connect({this, &TestGraphics::onKeyDown});
 
 	NAS2D::Utility<NAS2D::Renderer>::get().showSystemPointer(true);
-	NAS2D::Utility<NAS2D::Renderer>::get().minimumSize({1600, 900});
+	const auto minSize = NAS2D::Vector{10 + 1024 + 10, 134 + 512 + 10};
+	NAS2D::Utility<NAS2D::Renderer>::get().minimumSize(minSize);
+	NAS2D::Utility<NAS2D::Renderer>::get().size(minSize);
 }
 
 NAS2D::State* TestGraphics::update()

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -69,7 +69,8 @@ NAS2D::State* TestGraphics::update()
 	for (auto i = 0u; i < 2000u; ++i)
 	{
 		const uint8_t grey = static_cast<uint8_t>(jitter()) * 2u + 100u;
-		r.drawPoint(NAS2D::Point{120 + jitter(), 60 + jitter()}, NAS2D::Color{grey, grey, grey});
+		const auto offset = NAS2D::Vector{jitter(), jitter()};
+		r.drawPoint(NAS2D::Point{120, 60} + offset, NAS2D::Color{grey, grey, grey});
 	}
 
 	r.drawImage(mDxImage, {10, 170});

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -21,22 +21,25 @@ TestGraphics::TestGraphics() :
 
 TestGraphics::~TestGraphics()
 {
-	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().disconnect({this, &TestGraphics::onMouseMove});
-	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().disconnect({this, &TestGraphics::onMouseDown});
-	NAS2D::Utility<NAS2D::EventHandler>::get().keyDown().disconnect({this, &TestGraphics::onKeyDown});
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.mouseMotion().disconnect({this, &TestGraphics::onMouseMove});
+	eventHandler.mouseButtonDown().disconnect({this, &TestGraphics::onMouseDown});
+	eventHandler.keyDown().disconnect({this, &TestGraphics::onKeyDown});
 
 }
 
 void TestGraphics::initialize()
 {
-	NAS2D::Utility<NAS2D::EventHandler>::get().mouseMotion().connect({this, &TestGraphics::onMouseMove});
-	NAS2D::Utility<NAS2D::EventHandler>::get().mouseButtonDown().connect({this, &TestGraphics::onMouseDown});
-	NAS2D::Utility<NAS2D::EventHandler>::get().keyDown().connect({this, &TestGraphics::onKeyDown});
+	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
+	eventHandler.mouseMotion().connect({this, &TestGraphics::onMouseMove});
+	eventHandler.mouseButtonDown().connect({this, &TestGraphics::onMouseDown});
+	eventHandler.keyDown().connect({this, &TestGraphics::onKeyDown});
 
-	NAS2D::Utility<NAS2D::Renderer>::get().showSystemPointer(true);
+	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
+	renderer.showSystemPointer(true);
 	const auto minSize = NAS2D::Vector{10 + 1024 + 10, 134 + 512 + 10};
-	NAS2D::Utility<NAS2D::Renderer>::get().minimumSize(minSize);
-	NAS2D::Utility<NAS2D::Renderer>::get().size(minSize);
+	renderer.minimumSize(minSize);
+	renderer.size(minSize);
 }
 
 NAS2D::State* TestGraphics::update()

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -57,11 +57,11 @@ NAS2D::State* TestGraphics::update()
 	r.drawCircle({290, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {0.5f, 0.5f});
 	r.drawCircle({330, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {1.0f, 0.5f});
 
-	r.drawGradient({{10, 60}, {100, 100}}, NAS2D::Color::Blue, NAS2D::Color::Green, NAS2D::Color::Red, NAS2D::Color::Magenta);
+	r.drawGradient({{10, 60}, {64, 64}}, NAS2D::Color::Blue, NAS2D::Color::Green, NAS2D::Color::Red, NAS2D::Color::Magenta);
 
 	for (auto i = 0u; i < 2000u; ++i)
 	{
-		std::uniform_int_distribution<int> jitterDistribution(0, 64);
+		std::uniform_int_distribution<int> jitterDistribution(0, 63);
 		auto jitter = [&jitterDistribution](){ return jitterDistribution(generator); };
 
 		const uint8_t grey = static_cast<uint8_t>(jitter()) * 2u + 100u;

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -55,13 +55,13 @@ NAS2D::State* TestGraphics::update()
 
 	r.drawGradient({{10, 60}, {100, 100}}, NAS2D::Color::Blue, NAS2D::Color::Green, NAS2D::Color::Red, NAS2D::Color::Magenta);
 
-	r.drawCircle({150, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16);
-	r.drawCircle({150, 70}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {0.5f, 0.5f});
-	r.drawCircle({150, 100}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {1.0f, 0.5f});
+	r.drawCircle({250, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16);
+	r.drawCircle({290, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {0.5f, 0.5f});
+	r.drawCircle({330, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {1.0f, 0.5f});
 
 	for (auto i = 0; i < 10; ++i)
 	{
-		NAS2D::Rectangle<int> boxRect = {{180 + 10 * i, 10}, {i, i}};
+		NAS2D::Rectangle<int> boxRect = {{120 + 10 * i, 10}, {i, i}};
 		r.drawBox(boxRect, NAS2D::Color::Red);
 		r.drawBoxFilled(boxRect.inset(1), NAS2D::Color::White);
 	}
@@ -69,11 +69,11 @@ NAS2D::State* TestGraphics::update()
 	for (auto i = 0u; i < 2000u; ++i)
 	{
 		const uint8_t grey = static_cast<uint8_t>(jitter()) * 2u + 100u;
-		r.drawPoint(NAS2D::Point{10 + jitter(), 170 + jitter()}, NAS2D::Color{grey, grey, grey});
+		r.drawPoint(NAS2D::Point{120 + jitter(), 60 + jitter()}, NAS2D::Color{grey, grey, grey});
 	}
 
-	r.drawImage(mDxImage, {84, 170});
-	r.drawImage(mOglImage, {84 + 512, 170});
+	r.drawImage(mDxImage, {10, 170});
+	r.drawImage(mOglImage, {10 + 512, 170});
 
 	return this;
 }

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -66,11 +66,11 @@ NAS2D::State* TestGraphics::update()
 
 		const uint8_t grey = static_cast<uint8_t>(jitter()) * 2u + 100u;
 		const auto offset = NAS2D::Vector{jitter(), jitter()};
-		r.drawPoint(NAS2D::Point{120, 60} + offset, NAS2D::Color{grey, grey, grey});
+		r.drawPoint(NAS2D::Point{84, 60} + offset, NAS2D::Color{grey, grey, grey});
 	}
 
-	r.drawImage(mDxImage, {10, 170});
-	r.drawImage(mOglImage, {10 + 512, 170});
+	r.drawImage(mDxImage, {10, 134});
+	r.drawImage(mOglImage, {10 + 512, 134});
 
 	return this;
 }

--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -50,15 +50,6 @@ NAS2D::State* TestGraphics::update()
 
 	r.clearScreen(NAS2D::Color::Gray);
 
-	r.drawImage(mDxImage, {256, 256});
-	r.drawImage(mOglImage, {768, 256});
-
-	for (auto i = 0u; i < 2000u; ++i)
-	{
-		const uint8_t grey = static_cast<uint8_t>(jitter()) * 2u + 100u;
-		r.drawPoint(NAS2D::Point{10 + jitter(), 250 + jitter()}, NAS2D::Color{grey, grey, grey});
-	}
-
 	r.drawBox({{10, 50}, {40, 40}});
 	r.drawBoxFilled({{70, 50}, {40, 40}}, NAS2D::Color{200, 0, 0});
 
@@ -74,6 +65,15 @@ NAS2D::State* TestGraphics::update()
 		r.drawBox(boxRect, NAS2D::Color::Red);
 		r.drawBoxFilled(boxRect.inset(1), NAS2D::Color::White);
 	}
+
+	for (auto i = 0u; i < 2000u; ++i)
+	{
+		const uint8_t grey = static_cast<uint8_t>(jitter()) * 2u + 100u;
+		r.drawPoint(NAS2D::Point{10 + jitter(), 250 + jitter()}, NAS2D::Color{grey, grey, grey});
+	}
+
+	r.drawImage(mDxImage, {256, 256});
+	r.drawImage(mOglImage, {768, 256});
 
 	return this;
 }


### PR DESCRIPTION
Make the display a little more compact, and arrange the code to match reading order of the display output.

Related:
- Issue #1196

It would be nice to add some font output to the `test-graphics` project, and perhaps bounding boxes to investigate and fix the font size calculation issue. This is a bit of cleanup before such an addition.
