### PR TITLE
Add `Font::null()` static constructor

### DIFF
--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -91,7 +91,12 @@ Font::Font(const std::string& filePath) :
 
 Font::~Font()
 {
-	glDeleteTextures(1, &mFontInfo.textureId);
+	// Documentation for `glDeleteTextures` says it should be safe to delete 0
+	// However, MacOS shows a segmentation fault when 0 is passed
+	if (mFontInfo.textureId)
+	{
+		glDeleteTextures(1, &mFontInfo.textureId);
+	}
 }
 
 

--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -66,6 +66,17 @@ namespace
 }
 
 
+Font Font::null()
+{
+	return Font{};
+}
+
+
+Font::Font() :
+	mFontInfo{}
+{
+}
+
 /**
  * Instantiate a Font using a TrueType or OpenType font.
  *

--- a/NAS2D/Resource/Font.h
+++ b/NAS2D/Resource/Font.h
@@ -59,6 +59,7 @@ namespace NAS2D
 			std::vector<GlyphMetrics> metrics{};
 		};
 
+		static Font null();
 
 		Font(const std::string& filePath, unsigned int ptSize);
 		explicit Font(const std::string& filePath);
@@ -78,6 +79,9 @@ namespace NAS2D
 		// Intended only to be used by RendererOpenGL
 		// As it is so specific, it should not be part of the Font class, nor FontInfo
 		unsigned int textureId() const;
+
+	protected:
+		Font();
 
 	private:
 		FontInfo mFontInfo;

--- a/test/Resource/Font.test.cpp
+++ b/test/Resource/Font.test.cpp
@@ -1,0 +1,29 @@
+#include "NAS2D/Resource/Font.h"
+
+#include <gtest/gtest.h>
+
+
+TEST(Font, null) {
+	EXPECT_NO_THROW(NAS2D::Font::null());
+}
+
+TEST(Font, nullSafelyUsable) {
+	const auto font = NAS2D::Font::null();
+
+	EXPECT_EQ((NAS2D::Vector{0, 0}), font.glyphCellSize());
+	EXPECT_EQ((NAS2D::Vector{0, 0}), font.size(""));
+	EXPECT_EQ(0, font.width(""));
+	EXPECT_EQ(0, font.height());
+	EXPECT_EQ(0, font.ascent());
+	EXPECT_EQ(0, font.ptSize());
+
+	const auto& metrics = font.metrics();
+	EXPECT_EQ(0, metrics.size());
+
+	EXPECT_EQ(0, font.textureId());
+}
+
+TEST(Font, nullWidthNonEmptyString) {
+	const auto font = NAS2D::Font::null();
+	EXPECT_EQ(0, font.width("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
+}


### PR DESCRIPTION
This helps with writing test code for the `Font` class, and serves as a useful fallback instance.

By having a `null` instance, we can pass around a valid object to API calls expecting a `Font` instance, without fear of memory errors, or having to worry about putting guards around uses of `Font`.

Related:
- Issue #1196
