### PR TITLE
Add `drawText` calls to `test-graphics` project

### DIFF
--- a/test-graphics/TestGraphics.cpp
+++ b/test-graphics/TestGraphics.cpp
@@ -1,7 +1,9 @@
 #include "TestGraphics.h"
 
 #include <NAS2D/Utility.h>
+#include <NAS2D/Filesystem.h>
 #include <NAS2D/Renderer/Renderer.h>
+#include <NAS2D/Resource/Font.h>
 #include <NAS2D/Math/Rectangle.h>
 
 #include <functional>
@@ -11,6 +13,30 @@
 namespace
 {
 	std::mt19937 generator;
+
+
+	NAS2D::Font getFont()
+	{
+		static const std::string fileName = "../../../data/fonts/opensans.ttf";
+
+		const auto& filesystem = NAS2D::Utility<NAS2D::Filesystem>::get();
+		if (filesystem.exists(fileName))
+		{
+			return NAS2D::Font{fileName, 16};
+		}
+		return NAS2D::Font::null();
+	}
+
+
+	void drawBoundedText(NAS2D::Renderer& renderer, NAS2D::Point<int> position, const std::string& text)
+	{
+		static const NAS2D::Font font = getFont();
+
+		renderer.drawText(font, text, position);
+		const auto textSize = font.size(text);
+		const auto boxRect = NAS2D::Rectangle{position, textSize}.inset(-1);
+		renderer.drawBox(boxRect);
+	}
 }
 
 
@@ -61,6 +87,12 @@ NAS2D::State* TestGraphics::update()
 	r.drawCircle({250, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16);
 	r.drawCircle({290, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {0.5f, 0.5f});
 	r.drawCircle({330, 30}, 20, NAS2D::Color{0, 200, 0, 255}, 16, {1.0f, 0.5f});
+
+	drawBoundedText(r, {360, 10}, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+	drawBoundedText(r, {360, 34}, "abcdefghijklmnopqrstuvwxyz");
+	drawBoundedText(r, {360, 58}, "WWWW");
+	drawBoundedText(r, {360, 82}, "iii");
+	drawBoundedText(r, {360, 106}, " ");
 
 	r.drawGradient({{10, 60}, {64, 64}}, NAS2D::Color::Blue, NAS2D::Color::Green, NAS2D::Color::Red, NAS2D::Color::Magenta);
 


### PR DESCRIPTION
There are no `Font` files to load in the NAS2D project, so this change relies on having fonts available in some larger environment. If no such fonts are available then fallback to using `Font::null` so the code still runs, and doesn't require guards to prevent memory errors. That way demo code should run and display font strings when possible, and otherwise run and display some placeholder boxes where the font strings would have been displayed.

Related:
- Issue #1196
- PR #1208
