### PR TITLE
Fix `Font` size calculation

### DIFF
--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -139,7 +139,7 @@ int Font::width(std::string_view string) const
 	for (auto character : string)
 	{
 		auto glyph = std::clamp<std::size_t>(static_cast<uint8_t>(character), 0, 255);
-		width += gml[glyph].advance + gml[glyph].minX;
+		width += gml[glyph].advance;
 	}
 
 	return width;


### PR DESCRIPTION
The change makes the `width` calculation consistent with the `drawText` function.

The `test-graphics` project shows tight bounding boxes around the text with this change. The bounding boxes are drawn using the `size` method on `Font`, which internally uses the `width` method.

Related:
- Issue #1196
- PR #1209
- PR #1208
