### PR TITLE
Add `Fade` `Delegate` constructors

### DIFF
--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -34,6 +34,20 @@ Fade::Fade(Color fadeColor) :
 {}
 
 
+Fade::Fade(FadeCompleteSignal::DelegateType onFadeComplete) :
+	Fade()
+{
+	mFadeComplete.connect(onFadeComplete);
+}
+
+
+Fade::Fade(Color fadeColor, FadeCompleteSignal::DelegateType onFadeComplete) :
+	Fade(fadeColor)
+{
+	mFadeComplete.connect(onFadeComplete);
+}
+
+
 SignalSource<>& Fade::fadeComplete()
 {
 	return mFadeComplete;

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -26,7 +26,11 @@ Fade::Fade() :
 
 
 Fade::Fade(Color fadeColor) :
-	mFadeColor{fadeColor.alphaFade(255)}
+	mFadeColor{fadeColor.alphaFade(255)},
+	mDirection{FadeDirection::None},
+	mDuration{},
+	mFadeTimer{},
+	mFadeComplete{}
 {}
 
 

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -19,6 +19,12 @@
 using namespace NAS2D;
 
 
+Fade::Fade() :
+	Fade(Color::Black)
+{
+}
+
+
 Fade::Fade(Color fadeColor) :
 	mFadeColor{fadeColor.alphaFade(255)}
 {}

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -30,6 +30,8 @@ namespace NAS2D
 
 		Fade();
 		explicit Fade(Color fadeColor);
+		explicit Fade(FadeCompleteSignal::DelegateType onFadeComplete);
+		explicit Fade(Color fadeColor, FadeCompleteSignal::DelegateType onFadeComplete);
 
 		FadeCompleteSignal::Source& fadeComplete();
 

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -49,11 +49,11 @@ namespace NAS2D
 			Out
 		};
 
-		Color mFadeColor{Color::Black};
-		FadeDirection mDirection{FadeDirection::None};
-		std::chrono::milliseconds mDuration{};
-		Timer mFadeTimer{};
-		Signal<> mFadeComplete{};
+		Color mFadeColor;
+		FadeDirection mDirection;
+		std::chrono::milliseconds mDuration;
+		Timer mFadeTimer;
+		Signal<> mFadeComplete;
 	};
 
 }

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -25,7 +25,7 @@ namespace NAS2D
 	class Fade
 	{
 	public:
-		Fade(Color fadeColor = Color::Black);
+		explicit Fade(Color fadeColor = Color::Black);
 
 		SignalSource<>& fadeComplete();
 

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -25,7 +25,8 @@ namespace NAS2D
 	class Fade
 	{
 	public:
-		explicit Fade(Color fadeColor = Color::Black);
+		Fade();
+		explicit Fade(Color fadeColor);
 
 		SignalSource<>& fadeComplete();
 

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -25,10 +25,13 @@ namespace NAS2D
 	class Fade
 	{
 	public:
+		using FadeCompleteSignal = Signal<>;
+
+
 		Fade();
 		explicit Fade(Color fadeColor);
 
-		SignalSource<>& fadeComplete();
+		FadeCompleteSignal::Source& fadeComplete();
 
 		void fadeIn(std::chrono::milliseconds fadeTime);
 		void fadeOut(std::chrono::milliseconds fadeTime);
@@ -53,7 +56,7 @@ namespace NAS2D
 		FadeDirection mDirection;
 		std::chrono::milliseconds mDuration;
 		Timer mFadeTimer;
-		Signal<> mFadeComplete;
+		FadeCompleteSignal mFadeComplete;
 	};
 
 }


### PR DESCRIPTION
Add `Fade` constructors taking a `Delegate` parameter.

For typical usage, we generally expect exactly one `onFadeComplete` handler, which is known at object construction time. Might as well allow it to be specified in the constructor.

----

Related:
- https://github.com/OutpostUniverse/OPHD/issues/1573#issuecomment-2650963146

Since `Signal` can be a bit heavy, we should probably move away from using it be default. In most cases, we only want a single callback handler. If we need more, we can have a callback handler that wraps a `Signal`. Though in order to make such a change, we need to move away from relying on a `Signal` interface. That can be done by dealing directly with `Delegate`.
