### PR TITLE
Add `Signal` unit test for multi-listeners

### DIFF
--- a/test/Signal/Signal.test.cpp
+++ b/test/Signal/Signal.test.cpp
@@ -47,3 +47,17 @@ TEST(Signal, ConnectEmitDisconnect) {
 	signal.disconnect(delegate);
 	signal.emit();
 }
+
+TEST(Signal, MultiListener) {
+	NAS2D::Signal<> signal;
+	MockHandler handler1{};
+	MockHandler handler2{};
+	auto delegate1 = NAS2D::Delegate{&handler1, &MockHandler::MockMethod};
+	auto delegate2 = NAS2D::Delegate{&handler2, &MockHandler::MockMethod};
+
+	EXPECT_CALL(handler1, MockMethod()).Times(1);
+	EXPECT_CALL(handler2, MockMethod()).Times(1);
+	signal.connect(delegate1);
+	signal.connect(delegate2);
+	signal.emit();
+}


### PR DESCRIPTION
Noticed we didn't have a unit test for `Signal` that verified it could correctly deliver messages to multiple listeners.

Related:
- Issue #1218
