### PR TITLE
Add `Signal` unit test showing how to wrap `Signal` in a `Delegate`

### DIFF
--- a/test/Signal/Signal.test.cpp
+++ b/test/Signal/Signal.test.cpp
@@ -61,3 +61,20 @@ TEST(Signal, MultiListener) {
 	signal.connect(delegate2);
 	signal.emit();
 }
+
+TEST(Signal, DelegateWrappingSignal) {
+	NAS2D::Signal<> signal;
+	MockHandler handler1{};
+	MockHandler handler2{};
+	auto delegate1 = NAS2D::Delegate{&handler1, &MockHandler::MockMethod};
+	auto delegate2 = NAS2D::Delegate{&handler2, &MockHandler::MockMethod};
+
+	EXPECT_CALL(handler1, MockMethod()).Times(1);
+	EXPECT_CALL(handler2, MockMethod()).Times(1);
+	signal.connect(delegate1);
+	signal.connect(delegate2);
+
+	auto delegateHandler = NAS2D::Delegate{&signal, &decltype(signal)::emit};
+
+	delegateHandler();
+}


### PR DESCRIPTION
In case there is a `Delegate` based interface with only one callback handler allowed, this shows how a `Signal` object can be wrapped in a `Delegate` object, enabling multi-dispatch.

Related:
- Issue #1218
