### PR TITLE
Re-add missing `extern template`

### DIFF
--- a/NAS2D/Math/Point.cpp
+++ b/NAS2D/Math/Point.cpp
@@ -12,9 +12,6 @@
 
 namespace NAS2D
 {
-
 	template struct Point<int>;
-
 	template struct Point<float>;
-
 }

--- a/NAS2D/Math/Point.h
+++ b/NAS2D/Math/Point.h
@@ -132,4 +132,8 @@ namespace NAS2D
 	{
 		return p2 < p1;
 	}
+
+
+	extern template struct Point<int>;
+	extern template struct Point<float>;
 } // namespace NAS2D

--- a/NAS2D/Math/Rectangle.cpp
+++ b/NAS2D/Math/Rectangle.cpp
@@ -12,9 +12,6 @@
 
 namespace NAS2D
 {
-
 	template struct Rectangle<int>;
-
 	template struct Rectangle<float>;
-
 }

--- a/NAS2D/Math/Rectangle.h
+++ b/NAS2D/Math/Rectangle.h
@@ -150,4 +150,8 @@ namespace NAS2D
 
 	template <typename BaseType>
 	Rectangle(Point<BaseType>, Vector<BaseType>) -> Rectangle<BaseType>;
+
+
+	extern template struct Rectangle<int>;
+	extern template struct Rectangle<float>;
 } // namespace NAS2D

--- a/NAS2D/Math/Vector.cpp
+++ b/NAS2D/Math/Vector.cpp
@@ -1,0 +1,8 @@
+#include "Vector.h"
+
+
+namespace NAS2D
+{
+	template struct Vector<int>;
+	template struct Vector<float>;
+}

--- a/NAS2D/Math/Vector.h
+++ b/NAS2D/Math/Vector.h
@@ -178,4 +178,8 @@ namespace NAS2D
 	{
 		return v2 < v1;
 	}
+
+
+	extern template struct Vector<int>;
+	extern template struct Vector<float>;
 }

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -161,6 +161,7 @@
     <ClCompile Include="Math\Point.cpp" />
     <ClCompile Include="Math\Rectangle.cpp" />
     <ClCompile Include="Math\Trig.cpp" />
+    <ClCompile Include="Math\Vector.cpp" />
     <ClCompile Include="Mixer\Mixer.cpp" />
     <ClCompile Include="Mixer\MixerSDL.cpp" />
     <ClCompile Include="Mixer\MixerNull.cpp" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClCompile Include="Math\Trig.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Math\Vector.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Mixer\Mixer.cpp">
       <Filter>Source Files\Mixer</Filter>
     </ClCompile>


### PR DESCRIPTION
Re-add `extern template` declarations for `Point` and `Rectangle`. Add `extern template` declaration for `Vector`.

It's not clear these really have much impact on the build output or build times. The methods on these templates are all very simple, and likely get inlined anyway.

Part of:
- Issue #1222
