### PR TITLE
Refactor `EventHandler` aliases

### DIFF
--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -824,16 +824,25 @@ bool EventHandler::control() const
 void EventHandler::disconnectAll()
 {
 	mActivateEvent.clear();
+	mWindowHiddenEvent.clear();
+	mWindowExposedEvent.clear();
+	mWindowMinimizedEvent.clear();
+	mWindowMaximizedEvent.clear();
+	mWindowRestoredEvent.clear();
+	mWindowResizedEvent.clear();
+	mWindowMouseEnterEvent.clear();
+	mWindowMouseLeaveEvent.clear();
 	mJoystickAxisMotionEvent.clear();
 	mJoystickBallMotionEvent.clear();
 	mJoystickButtonUpEvent.clear();
 	mJoystickButtonDownEvent.clear();
 	mJoystickHatMotionEvent.clear();
-	mKeyUpEvent.clear();
 	mKeyDownEvent.clear();
+	mKeyUpEvent.clear();
 	mTextInputEvent.clear();
-	mMouseButtonUpEvent.clear();
 	mMouseButtonDownEvent.clear();
+	mMouseButtonUpEvent.clear();
+	mMouseDoubleClickEvent.clear();
 	mMouseMotionEvent.clear();
 	mMouseWheelEvent.clear();
 	mQuitEvent.clear();

--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -437,7 +437,7 @@ EventHandler::KeyUpEvent::Source& EventHandler::keyUp()
  */
 EventHandler::TextInputEvent::Source& EventHandler::textInput()
 {
-	return mTextInput;
+	return mTextInputEvent;
 }
 
 
@@ -509,7 +509,7 @@ EventHandler::MouseButtonEvent::Source& EventHandler::mouseButtonUp()
  */
 EventHandler::MouseButtonEvent::Source& EventHandler::mouseDoubleClick()
 {
-	return mMouseDoubleClick;
+	return mMouseDoubleClickEvent;
 }
 
 
@@ -658,13 +658,13 @@ void EventHandler::pump()
 			break;
 
 		case SDL_TEXTINPUT:
-			mTextInput(event.text.text);
+			mTextInputEvent(event.text.text);
 			break;
 
 		case SDL_MOUSEBUTTONDOWN:
 			if (event.button.clicks == 2)
 			{
-				mMouseDoubleClick(static_cast<MouseButton>(event.button.button), {event.button.x, event.button.y});
+				mMouseDoubleClickEvent(static_cast<MouseButton>(event.button.button), {event.button.x, event.button.y});
 			}
 
 			mMouseButtonDownEvent(static_cast<MouseButton>(event.button.button), {event.button.x, event.button.y});
@@ -831,7 +831,7 @@ void EventHandler::disconnectAll()
 	mJoystickHatMotionEvent.clear();
 	mKeyUpEvent.clear();
 	mKeyDownEvent.clear();
-	mTextInput.clear();
+	mTextInputEvent.clear();
 	mMouseButtonUpEvent.clear();
 	mMouseButtonDownEvent.clear();
 	mMouseMotionEvent.clear();

--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -78,7 +78,7 @@ namespace NAS2D
  *
  * \arg \c gained Bool value indicating whether or not the app lost focus.
  */
-EventHandler::ActivateEventSource& EventHandler::activate()
+EventHandler::ActivateEvent::Source& EventHandler::activate()
 {
 	return mActivateEvent;
 }
@@ -100,7 +100,7 @@ EventHandler::ActivateEventSource& EventHandler::activate()
  *
  * \arg \c gained Bool value indicating whether or not the window was hidden.
  */
-EventHandler::WindowHiddenEventSource& EventHandler::windowHidden()
+EventHandler::WindowHiddenEvent::Source& EventHandler::windowHidden()
 {
 	return mWindowHiddenEvent;
 }
@@ -120,7 +120,7 @@ EventHandler::WindowHiddenEventSource& EventHandler::windowHidden()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowExposedEventSource& EventHandler::windowExposed()
+EventHandler::WindowExposedEvent::Source& EventHandler::windowExposed()
 {
 	return mWindowExposedEvent;
 }
@@ -140,7 +140,7 @@ EventHandler::WindowExposedEventSource& EventHandler::windowExposed()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowMinimizedEventSource& EventHandler::windowMinimized()
+EventHandler::WindowMinimizedEvent::Source& EventHandler::windowMinimized()
 {
 	return mWindowMinimizedEvent;
 }
@@ -160,7 +160,7 @@ EventHandler::WindowMinimizedEventSource& EventHandler::windowMinimized()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowMaximizedEventSource& EventHandler::windowMaximized()
+EventHandler::WindowMaximizedEvent::Source& EventHandler::windowMaximized()
 {
 	return mWindowMaximizedEvent;
 }
@@ -180,7 +180,7 @@ EventHandler::WindowMaximizedEventSource& EventHandler::windowMaximized()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowRestoredEventSource& EventHandler::windowRestored()
+EventHandler::WindowRestoredEvent::Source& EventHandler::windowRestored()
 {
 	return mWindowRestoredEvent;
 }
@@ -200,7 +200,7 @@ EventHandler::WindowRestoredEventSource& EventHandler::windowRestored()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowResizedEventSource& EventHandler::windowResized()
+EventHandler::WindowResizedEvent::Source& EventHandler::windowResized()
 {
 	return mWindowResizedEvent;
 }
@@ -220,7 +220,7 @@ EventHandler::WindowResizedEventSource& EventHandler::windowResized()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowMouseEnterEventSource& EventHandler::windowMouseEnter()
+EventHandler::WindowMouseEnterEvent::Source& EventHandler::windowMouseEnter()
 {
 	return mWindowMouseEnterEvent;
 }
@@ -240,7 +240,7 @@ EventHandler::WindowMouseEnterEventSource& EventHandler::windowMouseEnter()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowMouseLeaveEventSource& EventHandler::windowMouseLeave()
+EventHandler::WindowMouseLeaveEvent::Source& EventHandler::windowMouseLeave()
 {
 	return mWindowMouseLeaveEvent;
 }
@@ -266,7 +266,7 @@ EventHandler::WindowMouseLeaveEventSource& EventHandler::windowMouseLeave()
  * Some joysticks use additional axis as buttons.
  * \arg \c pos Current position of the axis.
  */
-EventHandler::JoystickAxisMotionEventSource& EventHandler::joystickAxisMotion()
+EventHandler::JoystickAxisMotionEvent::Source& EventHandler::joystickAxisMotion()
 {
 	return mJoystickAxisMotionEvent;
 }
@@ -291,7 +291,7 @@ EventHandler::JoystickAxisMotionEventSource& EventHandler::joystickAxisMotion()
  * \arg \c ballId Trackball ID.
  * \arg \c change Change in relative position.
  */
-EventHandler::JoystickBallMotionEventSource& EventHandler::joystickBallMotion()
+EventHandler::JoystickBallMotionEvent::Source& EventHandler::joystickBallMotion()
 {
 	return mJoystickBallMotionEvent;
 }
@@ -316,7 +316,7 @@ EventHandler::JoystickBallMotionEventSource& EventHandler::joystickBallMotion()
  * \arg \c deviceId	Joystick ID which this event was generated from.
  * \arg \c buttonId	Button ID which the event was generated from.
  */
-EventHandler::JoystickButtonEventSource& EventHandler::joystickButtonUp()
+EventHandler::JoystickButtonEvent::Source& EventHandler::joystickButtonUp()
 {
 	return mJoystickButtonUpEvent;
 }
@@ -341,7 +341,7 @@ EventHandler::JoystickButtonEventSource& EventHandler::joystickButtonUp()
  * \arg \c deviceId	Joystick ID which this event was generated from.
  * \arg \c buttonId	Button ID which the event was generated from.
  */
-EventHandler::JoystickButtonEventSource& EventHandler::joystickButtonDown()
+EventHandler::JoystickButtonEvent::Source& EventHandler::joystickButtonDown()
 {
 	return mJoystickButtonDownEvent;
 }
@@ -366,7 +366,7 @@ EventHandler::JoystickButtonEventSource& EventHandler::joystickButtonDown()
  * \arg \c hatId	Hat ID.
  * \arg \c pos		Current position of the hat.
  */
-EventHandler::JoystickHatMotionEventSource& EventHandler::joystickHatMotion()
+EventHandler::JoystickHatMotionEvent::Source& EventHandler::joystickHatMotion()
 {
 	return mJoystickHatMotionEvent;
 }
@@ -391,7 +391,7 @@ EventHandler::JoystickHatMotionEventSource& EventHandler::joystickHatMotion()
  * \arg \c mod		Keyboard modifier.
  * \arg \c repeat	Indicates that this event is a repeat and not an initial key event.
  */
-EventHandler::KeyDownEventSource& EventHandler::keyDown()
+EventHandler::KeyDownEvent::Source& EventHandler::keyDown()
 {
 	return mKeyDownEvent;
 }
@@ -415,7 +415,7 @@ EventHandler::KeyDownEventSource& EventHandler::keyDown()
  * \arg \c key		KeyCode representing a key on the keyboard.
  * \arg \c mod		Keyboard modifier.
  */
-EventHandler::KeyUpEventSource& EventHandler::keyUp()
+EventHandler::KeyUpEvent::Source& EventHandler::keyUp()
 {
 	return mKeyUpEvent;
 }
@@ -435,7 +435,7 @@ EventHandler::KeyUpEventSource& EventHandler::keyUp()
  * void function(const std::string&);
  * \endcode
  */
-EventHandler::TextInputEventSource& EventHandler::textInput()
+EventHandler::TextInputEvent::Source& EventHandler::textInput()
 {
 	return mTextInput;
 }
@@ -459,7 +459,7 @@ EventHandler::TextInputEventSource& EventHandler::textInput()
  * \arg \c button: MouseButton value indicating which button is pressed.
  * \arg \c position: Position of the mouse button event.
  */
-EventHandler::MouseButtonEventSource& EventHandler::mouseButtonDown()
+EventHandler::MouseButtonEvent::Source& EventHandler::mouseButtonDown()
 {
 	return mMouseButtonDownEvent;
 }
@@ -483,7 +483,7 @@ EventHandler::MouseButtonEventSource& EventHandler::mouseButtonDown()
  * \arg \c button: MouseButton value indicating which button is pressed.
  * \arg \c position: Position of the mouse button event.
  */
-EventHandler::MouseButtonEventSource& EventHandler::mouseButtonUp()
+EventHandler::MouseButtonEvent::Source& EventHandler::mouseButtonUp()
 {
 	return mMouseButtonUpEvent;
 }
@@ -507,7 +507,7 @@ EventHandler::MouseButtonEventSource& EventHandler::mouseButtonUp()
  * \arg \c button: MouseButton value indicating which button is pressed.
  * \arg \c position: Position of the mouse button event.
  */
-EventHandler::MouseButtonEventSource& EventHandler::mouseDoubleClick()
+EventHandler::MouseButtonEvent::Source& EventHandler::mouseDoubleClick()
 {
 	return mMouseDoubleClick;
 }
@@ -531,7 +531,7 @@ EventHandler::MouseButtonEventSource& EventHandler::mouseDoubleClick()
  * \arg \c position: Absolute position of the mouse.
  * \arg \c change: position of the mouse relative to its last position.
  */
-EventHandler::MouseMotionEventSource& EventHandler::mouseMotion()
+EventHandler::MouseMotionEvent::Source& EventHandler::mouseMotion()
 {
 	return mMouseMotionEvent;
 }
@@ -559,7 +559,7 @@ EventHandler::MouseMotionEventSource& EventHandler::mouseMotion()
  * more than one (on Windows this value is typical 120,
  * not 1).
  */
-EventHandler::MouseWheelEventSource& EventHandler::mouseWheel()
+EventHandler::MouseWheelEvent::Source& EventHandler::mouseWheel()
 {
 	return mMouseWheelEvent;
 }
@@ -579,7 +579,7 @@ EventHandler::MouseWheelEventSource& EventHandler::mouseWheel()
  * void function(void);
  * \endcode
  */
-EventHandler::QuitEventSource& EventHandler::quit()
+EventHandler::QuitEvent::Source& EventHandler::quit()
 {
 	return mQuitEvent;
 }

--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -78,9 +78,9 @@ namespace NAS2D
  *
  * \arg \c gained Bool value indicating whether or not the app lost focus.
  */
-EventHandler::ActivateEvent::Source& EventHandler::activate()
+EventHandler::ActivateSignal::Source& EventHandler::activate()
 {
-	return mActivateEvent;
+	return mActivateSignal;
 }
 
 
@@ -100,9 +100,9 @@ EventHandler::ActivateEvent::Source& EventHandler::activate()
  *
  * \arg \c gained Bool value indicating whether or not the window was hidden.
  */
-EventHandler::WindowHiddenEvent::Source& EventHandler::windowHidden()
+EventHandler::WindowHiddenSignal::Source& EventHandler::windowHidden()
 {
-	return mWindowHiddenEvent;
+	return mWindowHiddenSignal;
 }
 
 
@@ -120,9 +120,9 @@ EventHandler::WindowHiddenEvent::Source& EventHandler::windowHidden()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowExposedEvent::Source& EventHandler::windowExposed()
+EventHandler::WindowExposedSignal::Source& EventHandler::windowExposed()
 {
-	return mWindowExposedEvent;
+	return mWindowExposedSignal;
 }
 
 
@@ -140,9 +140,9 @@ EventHandler::WindowExposedEvent::Source& EventHandler::windowExposed()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowMinimizedEvent::Source& EventHandler::windowMinimized()
+EventHandler::WindowMinimizedSignal::Source& EventHandler::windowMinimized()
 {
-	return mWindowMinimizedEvent;
+	return mWindowMinimizedSignal;
 }
 
 
@@ -160,9 +160,9 @@ EventHandler::WindowMinimizedEvent::Source& EventHandler::windowMinimized()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowMaximizedEvent::Source& EventHandler::windowMaximized()
+EventHandler::WindowMaximizedSignal::Source& EventHandler::windowMaximized()
 {
-	return mWindowMaximizedEvent;
+	return mWindowMaximizedSignal;
 }
 
 
@@ -180,9 +180,9 @@ EventHandler::WindowMaximizedEvent::Source& EventHandler::windowMaximized()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowRestoredEvent::Source& EventHandler::windowRestored()
+EventHandler::WindowRestoredSignal::Source& EventHandler::windowRestored()
 {
-	return mWindowRestoredEvent;
+	return mWindowRestoredSignal;
 }
 
 
@@ -200,9 +200,9 @@ EventHandler::WindowRestoredEvent::Source& EventHandler::windowRestored()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowResizedEvent::Source& EventHandler::windowResized()
+EventHandler::WindowResizedSignal::Source& EventHandler::windowResized()
 {
-	return mWindowResizedEvent;
+	return mWindowResizedSignal;
 }
 
 
@@ -220,9 +220,9 @@ EventHandler::WindowResizedEvent::Source& EventHandler::windowResized()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowMouseEnterEvent::Source& EventHandler::windowMouseEnter()
+EventHandler::WindowMouseEnterSignal::Source& EventHandler::windowMouseEnter()
 {
-	return mWindowMouseEnterEvent;
+	return mWindowMouseEnterSignal;
 }
 
 
@@ -240,9 +240,9 @@ EventHandler::WindowMouseEnterEvent::Source& EventHandler::windowMouseEnter()
  * void function(void);
  * \endcode
  */
-EventHandler::WindowMouseLeaveEvent::Source& EventHandler::windowMouseLeave()
+EventHandler::WindowMouseLeaveSignal::Source& EventHandler::windowMouseLeave()
 {
-	return mWindowMouseLeaveEvent;
+	return mWindowMouseLeaveSignal;
 }
 
 
@@ -266,9 +266,9 @@ EventHandler::WindowMouseLeaveEvent::Source& EventHandler::windowMouseLeave()
  * Some joysticks use additional axis as buttons.
  * \arg \c pos Current position of the axis.
  */
-EventHandler::JoystickAxisMotionEvent::Source& EventHandler::joystickAxisMotion()
+EventHandler::JoystickAxisMotionSignal::Source& EventHandler::joystickAxisMotion()
 {
-	return mJoystickAxisMotionEvent;
+	return mJoystickAxisMotionSignal;
 }
 
 
@@ -291,9 +291,9 @@ EventHandler::JoystickAxisMotionEvent::Source& EventHandler::joystickAxisMotion(
  * \arg \c ballId Trackball ID.
  * \arg \c change Change in relative position.
  */
-EventHandler::JoystickBallMotionEvent::Source& EventHandler::joystickBallMotion()
+EventHandler::JoystickBallMotionSignal::Source& EventHandler::joystickBallMotion()
 {
-	return mJoystickBallMotionEvent;
+	return mJoystickBallMotionSignal;
 }
 
 
@@ -316,9 +316,9 @@ EventHandler::JoystickBallMotionEvent::Source& EventHandler::joystickBallMotion(
  * \arg \c deviceId	Joystick ID which this event was generated from.
  * \arg \c buttonId	Button ID which the event was generated from.
  */
-EventHandler::JoystickButtonEvent::Source& EventHandler::joystickButtonUp()
+EventHandler::JoystickButtonSignal::Source& EventHandler::joystickButtonUp()
 {
-	return mJoystickButtonUpEvent;
+	return mJoystickButtonUpSignal;
 }
 
 
@@ -341,9 +341,9 @@ EventHandler::JoystickButtonEvent::Source& EventHandler::joystickButtonUp()
  * \arg \c deviceId	Joystick ID which this event was generated from.
  * \arg \c buttonId	Button ID which the event was generated from.
  */
-EventHandler::JoystickButtonEvent::Source& EventHandler::joystickButtonDown()
+EventHandler::JoystickButtonSignal::Source& EventHandler::joystickButtonDown()
 {
-	return mJoystickButtonDownEvent;
+	return mJoystickButtonDownSignal;
 }
 
 
@@ -366,9 +366,9 @@ EventHandler::JoystickButtonEvent::Source& EventHandler::joystickButtonDown()
  * \arg \c hatId	Hat ID.
  * \arg \c pos		Current position of the hat.
  */
-EventHandler::JoystickHatMotionEvent::Source& EventHandler::joystickHatMotion()
+EventHandler::JoystickHatMotionSignal::Source& EventHandler::joystickHatMotion()
 {
-	return mJoystickHatMotionEvent;
+	return mJoystickHatMotionSignal;
 }
 
 
@@ -391,9 +391,9 @@ EventHandler::JoystickHatMotionEvent::Source& EventHandler::joystickHatMotion()
  * \arg \c mod		Keyboard modifier.
  * \arg \c repeat	Indicates that this event is a repeat and not an initial key event.
  */
-EventHandler::KeyDownEvent::Source& EventHandler::keyDown()
+EventHandler::KeyDownSignal::Source& EventHandler::keyDown()
 {
-	return mKeyDownEvent;
+	return mKeyDownSignal;
 }
 
 
@@ -415,9 +415,9 @@ EventHandler::KeyDownEvent::Source& EventHandler::keyDown()
  * \arg \c key		KeyCode representing a key on the keyboard.
  * \arg \c mod		Keyboard modifier.
  */
-EventHandler::KeyUpEvent::Source& EventHandler::keyUp()
+EventHandler::KeyUpSignal::Source& EventHandler::keyUp()
 {
-	return mKeyUpEvent;
+	return mKeyUpSignal;
 }
 
 
@@ -435,9 +435,9 @@ EventHandler::KeyUpEvent::Source& EventHandler::keyUp()
  * void function(const std::string&);
  * \endcode
  */
-EventHandler::TextInputEvent::Source& EventHandler::textInput()
+EventHandler::TextInputSignal::Source& EventHandler::textInput()
 {
-	return mTextInputEvent;
+	return mTextInputSignal;
 }
 
 
@@ -459,9 +459,9 @@ EventHandler::TextInputEvent::Source& EventHandler::textInput()
  * \arg \c button: MouseButton value indicating which button is pressed.
  * \arg \c position: Position of the mouse button event.
  */
-EventHandler::MouseButtonEvent::Source& EventHandler::mouseButtonDown()
+EventHandler::MouseButtonSignal::Source& EventHandler::mouseButtonDown()
 {
-	return mMouseButtonDownEvent;
+	return mMouseButtonDownSignal;
 }
 
 
@@ -483,9 +483,9 @@ EventHandler::MouseButtonEvent::Source& EventHandler::mouseButtonDown()
  * \arg \c button: MouseButton value indicating which button is pressed.
  * \arg \c position: Position of the mouse button event.
  */
-EventHandler::MouseButtonEvent::Source& EventHandler::mouseButtonUp()
+EventHandler::MouseButtonSignal::Source& EventHandler::mouseButtonUp()
 {
-	return mMouseButtonUpEvent;
+	return mMouseButtonUpSignal;
 }
 
 
@@ -507,9 +507,9 @@ EventHandler::MouseButtonEvent::Source& EventHandler::mouseButtonUp()
  * \arg \c button: MouseButton value indicating which button is pressed.
  * \arg \c position: Position of the mouse button event.
  */
-EventHandler::MouseButtonEvent::Source& EventHandler::mouseDoubleClick()
+EventHandler::MouseButtonSignal::Source& EventHandler::mouseDoubleClick()
 {
-	return mMouseDoubleClickEvent;
+	return mMouseDoubleClickSignal;
 }
 
 
@@ -531,9 +531,9 @@ EventHandler::MouseButtonEvent::Source& EventHandler::mouseDoubleClick()
  * \arg \c position: Absolute position of the mouse.
  * \arg \c change: position of the mouse relative to its last position.
  */
-EventHandler::MouseMotionEvent::Source& EventHandler::mouseMotion()
+EventHandler::MouseMotionSignal::Source& EventHandler::mouseMotion()
 {
-	return mMouseMotionEvent;
+	return mMouseMotionSignal;
 }
 
 
@@ -559,9 +559,9 @@ EventHandler::MouseMotionEvent::Source& EventHandler::mouseMotion()
  * more than one (on Windows this value is typical 120,
  * not 1).
  */
-EventHandler::MouseWheelEvent::Source& EventHandler::mouseWheel()
+EventHandler::MouseWheelSignal::Source& EventHandler::mouseWheel()
 {
-	return mMouseWheelEvent;
+	return mMouseWheelSignal;
 }
 
 
@@ -579,9 +579,9 @@ EventHandler::MouseWheelEvent::Source& EventHandler::mouseWheel()
  * void function(void);
  * \endcode
  */
-EventHandler::QuitEvent::Source& EventHandler::quit()
+EventHandler::QuitSignal::Source& EventHandler::quit()
 {
-	return mQuitEvent;
+	return mQuitSignal;
 }
 
 
@@ -617,7 +617,7 @@ void EventHandler::warpMouse(int x, int y)
 	if (underlyingWindow)
 	{
 		SDL_WarpMouseInWindow(underlyingWindow, x, y);
-		mMouseMotionEvent.emit({x, y}, {0, 0});
+		mMouseMotionSignal.emit({x, y}, {0, 0});
 	}
 }
 
@@ -646,75 +646,75 @@ void EventHandler::pump()
 		switch (event.type)
 		{
 		case SDL_MOUSEMOTION:
-			mMouseMotionEvent({event.motion.x, event.motion.y}, {event.motion.xrel, event.motion.yrel});
+			mMouseMotionSignal({event.motion.x, event.motion.y}, {event.motion.xrel, event.motion.yrel});
 			break;
 
 		case SDL_KEYDOWN:
-			mKeyDownEvent(static_cast<KeyCode>(event.key.keysym.sym), static_cast<KeyModifier>(event.key.keysym.mod), event.key.repeat != 0 ? true : false);
+			mKeyDownSignal(static_cast<KeyCode>(event.key.keysym.sym), static_cast<KeyModifier>(event.key.keysym.mod), event.key.repeat != 0 ? true : false);
 			break;
 
 		case SDL_KEYUP:
-			mKeyUpEvent(static_cast<KeyCode>(event.key.keysym.sym), static_cast<KeyModifier>(event.key.keysym.mod));
+			mKeyUpSignal(static_cast<KeyCode>(event.key.keysym.sym), static_cast<KeyModifier>(event.key.keysym.mod));
 			break;
 
 		case SDL_TEXTINPUT:
-			mTextInputEvent(event.text.text);
+			mTextInputSignal(event.text.text);
 			break;
 
 		case SDL_MOUSEBUTTONDOWN:
 			if (event.button.clicks == 2)
 			{
-				mMouseDoubleClickEvent(static_cast<MouseButton>(event.button.button), {event.button.x, event.button.y});
+				mMouseDoubleClickSignal(static_cast<MouseButton>(event.button.button), {event.button.x, event.button.y});
 			}
 
-			mMouseButtonDownEvent(static_cast<MouseButton>(event.button.button), {event.button.x, event.button.y});
+			mMouseButtonDownSignal(static_cast<MouseButton>(event.button.button), {event.button.x, event.button.y});
 			break;
 
 		case SDL_MOUSEBUTTONUP:
-			mMouseButtonUpEvent(static_cast<MouseButton>(event.button.button), {event.button.x, event.button.y});
+			mMouseButtonUpSignal(static_cast<MouseButton>(event.button.button), {event.button.x, event.button.y});
 			break;
 
 		case SDL_MOUSEWHEEL:
-			mMouseWheelEvent({event.wheel.x, event.wheel.y});
+			mMouseWheelSignal({event.wheel.x, event.wheel.y});
 			break;
 
 		case SDL_JOYAXISMOTION:
-			mJoystickAxisMotionEvent(event.jaxis.which, event.jaxis.axis, event.jaxis.value);
+			mJoystickAxisMotionSignal(event.jaxis.which, event.jaxis.axis, event.jaxis.value);
 			break;
 
 		case SDL_JOYBALLMOTION:
-			mJoystickBallMotionEvent(event.jball.which, event.jball.ball, {event.jball.xrel, event.jball.yrel});
+			mJoystickBallMotionSignal(event.jball.which, event.jball.ball, {event.jball.xrel, event.jball.yrel});
 			break;
 
 		case SDL_JOYHATMOTION:
-			mJoystickHatMotionEvent(event.jhat.which, event.jhat.hat, event.jhat.value);
+			mJoystickHatMotionSignal(event.jhat.which, event.jhat.hat, event.jhat.value);
 			break;
 
 		case SDL_JOYBUTTONDOWN:
-			mJoystickButtonDownEvent(event.jbutton.which, event.jbutton.button);
+			mJoystickButtonDownSignal(event.jbutton.which, event.jbutton.button);
 			break;
 
 		case SDL_JOYBUTTONUP:
-			mJoystickButtonUpEvent(event.jbutton.which, event.jbutton.button);
+			mJoystickButtonUpSignal(event.jbutton.which, event.jbutton.button);
 			break;
 
 		case SDL_WINDOWEVENT:
 			// Not completely happy with this but meh, it works.
-			if (event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED) { mActivateEvent(true); }
-			else if (event.window.event == SDL_WINDOWEVENT_FOCUS_LOST) { mActivateEvent(false); }
-			else if (event.window.event == SDL_WINDOWEVENT_SHOWN) { mWindowHiddenEvent(false); }
-			else if (event.window.event == SDL_WINDOWEVENT_HIDDEN) { mWindowHiddenEvent(true); }
-			else if (event.window.event == SDL_WINDOWEVENT_EXPOSED) { mWindowExposedEvent(); }
-			else if (event.window.event == SDL_WINDOWEVENT_MINIMIZED) { mWindowMinimizedEvent(); }
-			else if (event.window.event == SDL_WINDOWEVENT_MAXIMIZED) { mWindowMaximizedEvent(); }
-			else if (event.window.event == SDL_WINDOWEVENT_RESTORED) { mWindowRestoredEvent(); }
-			else if (event.window.event == SDL_WINDOWEVENT_ENTER) { mWindowMouseEnterEvent(); }
-			else if (event.window.event == SDL_WINDOWEVENT_LEAVE) { mWindowMouseLeaveEvent(); }
-			else if (event.window.event == SDL_WINDOWEVENT_RESIZED) { mWindowResizedEvent({event.window.data1, event.window.data2}); }
+			if (event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED) { mActivateSignal(true); }
+			else if (event.window.event == SDL_WINDOWEVENT_FOCUS_LOST) { mActivateSignal(false); }
+			else if (event.window.event == SDL_WINDOWEVENT_SHOWN) { mWindowHiddenSignal(false); }
+			else if (event.window.event == SDL_WINDOWEVENT_HIDDEN) { mWindowHiddenSignal(true); }
+			else if (event.window.event == SDL_WINDOWEVENT_EXPOSED) { mWindowExposedSignal(); }
+			else if (event.window.event == SDL_WINDOWEVENT_MINIMIZED) { mWindowMinimizedSignal(); }
+			else if (event.window.event == SDL_WINDOWEVENT_MAXIMIZED) { mWindowMaximizedSignal(); }
+			else if (event.window.event == SDL_WINDOWEVENT_RESTORED) { mWindowRestoredSignal(); }
+			else if (event.window.event == SDL_WINDOWEVENT_ENTER) { mWindowMouseEnterSignal(); }
+			else if (event.window.event == SDL_WINDOWEVENT_LEAVE) { mWindowMouseLeaveSignal(); }
+			else if (event.window.event == SDL_WINDOWEVENT_RESIZED) { mWindowResizedSignal({event.window.data1, event.window.data2}); }
 			break;
 
 		case SDL_QUIT:
-			mQuitEvent();
+			mQuitSignal();
 			break;
 
 		default:
@@ -823,29 +823,29 @@ bool EventHandler::control() const
  */
 void EventHandler::disconnectAll()
 {
-	mActivateEvent.clear();
-	mWindowHiddenEvent.clear();
-	mWindowExposedEvent.clear();
-	mWindowMinimizedEvent.clear();
-	mWindowMaximizedEvent.clear();
-	mWindowRestoredEvent.clear();
-	mWindowResizedEvent.clear();
-	mWindowMouseEnterEvent.clear();
-	mWindowMouseLeaveEvent.clear();
-	mJoystickAxisMotionEvent.clear();
-	mJoystickBallMotionEvent.clear();
-	mJoystickButtonUpEvent.clear();
-	mJoystickButtonDownEvent.clear();
-	mJoystickHatMotionEvent.clear();
-	mKeyDownEvent.clear();
-	mKeyUpEvent.clear();
-	mTextInputEvent.clear();
-	mMouseButtonDownEvent.clear();
-	mMouseButtonUpEvent.clear();
-	mMouseDoubleClickEvent.clear();
-	mMouseMotionEvent.clear();
-	mMouseWheelEvent.clear();
-	mQuitEvent.clear();
+	mActivateSignal.clear();
+	mWindowHiddenSignal.clear();
+	mWindowExposedSignal.clear();
+	mWindowMinimizedSignal.clear();
+	mWindowMaximizedSignal.clear();
+	mWindowRestoredSignal.clear();
+	mWindowResizedSignal.clear();
+	mWindowMouseEnterSignal.clear();
+	mWindowMouseLeaveSignal.clear();
+	mJoystickAxisMotionSignal.clear();
+	mJoystickBallMotionSignal.clear();
+	mJoystickButtonUpSignal.clear();
+	mJoystickButtonDownSignal.clear();
+	mJoystickHatMotionSignal.clear();
+	mKeyDownSignal.clear();
+	mKeyUpSignal.clear();
+	mTextInputSignal.clear();
+	mMouseButtonDownSignal.clear();
+	mMouseButtonUpSignal.clear();
+	mMouseDoubleClickSignal.clear();
+	mMouseMotionSignal.clear();
+	mMouseWheelSignal.clear();
+	mQuitSignal.clear();
 }
 
 

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -31,63 +31,63 @@ namespace NAS2D
 		enum class MouseButton;
 
 
-		using ActivateEvent = Signal<bool>;
-		using WindowHiddenEvent = Signal<bool>;
-		using WindowExposedEvent = Signal<>;
-		using WindowMinimizedEvent = Signal<>;
-		using WindowMaximizedEvent = Signal<>;
-		using WindowRestoredEvent = Signal<>;
-		using WindowResizedEvent = Signal<Vector<int>>;
-		using WindowMouseEnterEvent = Signal<>;
-		using WindowMouseLeaveEvent = Signal<>;
+		using ActivateSignal = Signal<bool>;
+		using WindowHiddenSignal = Signal<bool>;
+		using WindowExposedSignal = Signal<>;
+		using WindowMinimizedSignal = Signal<>;
+		using WindowMaximizedSignal = Signal<>;
+		using WindowRestoredSignal = Signal<>;
+		using WindowResizedSignal = Signal<Vector<int>>;
+		using WindowMouseEnterSignal = Signal<>;
+		using WindowMouseLeaveSignal = Signal<>;
 
-		using JoystickAxisMotionEvent = Signal<int, int, int>;
-		using JoystickBallMotionEvent = Signal<int, int, Vector<int>>;
-		using JoystickButtonEvent = Signal<int, int>;
-		using JoystickHatMotionEvent = Signal<int, int, int>;
+		using JoystickAxisMotionSignal = Signal<int, int, int>;
+		using JoystickBallMotionSignal = Signal<int, int, Vector<int>>;
+		using JoystickButtonSignal = Signal<int, int>;
+		using JoystickHatMotionSignal = Signal<int, int, int>;
 
-		using KeyDownEvent = Signal<KeyCode, KeyModifier, bool>;
-		using KeyUpEvent = Signal<KeyCode, KeyModifier>;
-		using TextInputEvent = Signal<const std::string&>;
+		using KeyDownSignal = Signal<KeyCode, KeyModifier, bool>;
+		using KeyUpSignal = Signal<KeyCode, KeyModifier>;
+		using TextInputSignal = Signal<const std::string&>;
 
-		using MouseButtonEvent = Signal<MouseButton, Point<int>>;
-		using MouseMotionEvent = Signal<Point<int>, Vector<int>>;
-		using MouseWheelEvent = Signal<Vector<int>>;
+		using MouseButtonSignal = Signal<MouseButton, Point<int>>;
+		using MouseMotionSignal = Signal<Point<int>, Vector<int>>;
+		using MouseWheelSignal = Signal<Vector<int>>;
 
-		using QuitEvent = Signal<>;
+		using QuitSignal = Signal<>;
 
 	public:
-		ActivateEvent::Source& activate();
+		ActivateSignal::Source& activate();
 
-		WindowHiddenEvent::Source& windowHidden();
-		WindowExposedEvent::Source& windowExposed();
+		WindowHiddenSignal::Source& windowHidden();
+		WindowExposedSignal::Source& windowExposed();
 
-		WindowMinimizedEvent::Source& windowMinimized();
-		WindowMaximizedEvent::Source& windowMaximized();
-		WindowRestoredEvent::Source& windowRestored();
-		WindowResizedEvent::Source& windowResized();
+		WindowMinimizedSignal::Source& windowMinimized();
+		WindowMaximizedSignal::Source& windowMaximized();
+		WindowRestoredSignal::Source& windowRestored();
+		WindowResizedSignal::Source& windowResized();
 
-		WindowMouseEnterEvent::Source& windowMouseEnter();
-		WindowMouseLeaveEvent::Source& windowMouseLeave();
+		WindowMouseEnterSignal::Source& windowMouseEnter();
+		WindowMouseLeaveSignal::Source& windowMouseLeave();
 
-		JoystickAxisMotionEvent::Source& joystickAxisMotion();
-		JoystickBallMotionEvent::Source& joystickBallMotion();
-		JoystickButtonEvent::Source& joystickButtonUp();
-		JoystickButtonEvent::Source& joystickButtonDown();
-		JoystickHatMotionEvent::Source& joystickHatMotion();
+		JoystickAxisMotionSignal::Source& joystickAxisMotion();
+		JoystickBallMotionSignal::Source& joystickBallMotion();
+		JoystickButtonSignal::Source& joystickButtonUp();
+		JoystickButtonSignal::Source& joystickButtonDown();
+		JoystickHatMotionSignal::Source& joystickHatMotion();
 
-		KeyUpEvent::Source& keyUp();
-		KeyDownEvent::Source& keyDown();
+		KeyUpSignal::Source& keyUp();
+		KeyDownSignal::Source& keyDown();
 
-		TextInputEvent::Source& textInput();
+		TextInputSignal::Source& textInput();
 
-		MouseButtonEvent::Source& mouseButtonUp();
-		MouseButtonEvent::Source& mouseButtonDown();
-		MouseButtonEvent::Source& mouseDoubleClick();
-		MouseMotionEvent::Source& mouseMotion();
-		MouseWheelEvent::Source& mouseWheel();
+		MouseButtonSignal::Source& mouseButtonUp();
+		MouseButtonSignal::Source& mouseButtonDown();
+		MouseButtonSignal::Source& mouseDoubleClick();
+		MouseMotionSignal::Source& mouseMotion();
+		MouseWheelSignal::Source& mouseWheel();
 
-		QuitEvent::Source& quit();
+		QuitSignal::Source& quit();
 
 		void grabMouse();
 		void releaseMouse();
@@ -111,35 +111,35 @@ namespace NAS2D
 		void disconnectAll();
 
 	private:
-		ActivateEvent mActivateEvent{};
+		ActivateSignal mActivateSignal{};
 
-		WindowHiddenEvent mWindowHiddenEvent{};
-		WindowExposedEvent mWindowExposedEvent{};
-		WindowMinimizedEvent mWindowMinimizedEvent{};
-		WindowMaximizedEvent mWindowMaximizedEvent{};
-		WindowRestoredEvent mWindowRestoredEvent{};
-		WindowResizedEvent mWindowResizedEvent{};
-		WindowMouseEnterEvent mWindowMouseEnterEvent{};
-		WindowMouseLeaveEvent mWindowMouseLeaveEvent{};
+		WindowHiddenSignal mWindowHiddenSignal{};
+		WindowExposedSignal mWindowExposedSignal{};
+		WindowMinimizedSignal mWindowMinimizedSignal{};
+		WindowMaximizedSignal mWindowMaximizedSignal{};
+		WindowRestoredSignal mWindowRestoredSignal{};
+		WindowResizedSignal mWindowResizedSignal{};
+		WindowMouseEnterSignal mWindowMouseEnterSignal{};
+		WindowMouseLeaveSignal mWindowMouseLeaveSignal{};
 
-		JoystickAxisMotionEvent mJoystickAxisMotionEvent{};
-		JoystickBallMotionEvent mJoystickBallMotionEvent{};
-		JoystickButtonEvent mJoystickButtonUpEvent{};
-		JoystickButtonEvent mJoystickButtonDownEvent{};
-		JoystickHatMotionEvent mJoystickHatMotionEvent{};
+		JoystickAxisMotionSignal mJoystickAxisMotionSignal{};
+		JoystickBallMotionSignal mJoystickBallMotionSignal{};
+		JoystickButtonSignal mJoystickButtonUpSignal{};
+		JoystickButtonSignal mJoystickButtonDownSignal{};
+		JoystickHatMotionSignal mJoystickHatMotionSignal{};
 
-		KeyDownEvent mKeyDownEvent{};
-		KeyUpEvent mKeyUpEvent{};
+		KeyDownSignal mKeyDownSignal{};
+		KeyUpSignal mKeyUpSignal{};
 
-		TextInputEvent mTextInputEvent{};
+		TextInputSignal mTextInputSignal{};
 
-		MouseButtonEvent mMouseButtonDownEvent{};
-		MouseButtonEvent mMouseButtonUpEvent{};
-		MouseButtonEvent mMouseDoubleClickEvent{};
-		MouseMotionEvent mMouseMotionEvent{};
-		MouseWheelEvent mMouseWheelEvent{};
+		MouseButtonSignal mMouseButtonDownSignal{};
+		MouseButtonSignal mMouseButtonUpSignal{};
+		MouseButtonSignal mMouseDoubleClickSignal{};
+		MouseMotionSignal mMouseMotionSignal{};
+		MouseWheelSignal mMouseWheelSignal{};
 
-		QuitEvent mQuitEvent{};
+		QuitSignal mQuitSignal{};
 	};
 
 	void postQuitEvent();

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -31,63 +31,63 @@ namespace NAS2D
 		enum class MouseButton;
 
 
-		using ActivateEventSource = SignalSource<bool>;
-		using WindowHiddenEventSource = SignalSource<bool>;
-		using WindowExposedEventSource = SignalSource<>;
-		using WindowMinimizedEventSource = SignalSource<>;
-		using WindowMaximizedEventSource = SignalSource<>;
-		using WindowRestoredEventSource = SignalSource<>;
-		using WindowResizedEventSource = SignalSource<Vector<int>>;
-		using WindowMouseEnterEventSource = SignalSource<>;
-		using WindowMouseLeaveEventSource = SignalSource<>;
+		using ActivateEvent = Signal<bool>;
+		using WindowHiddenEvent = Signal<bool>;
+		using WindowExposedEvent = Signal<>;
+		using WindowMinimizedEvent = Signal<>;
+		using WindowMaximizedEvent = Signal<>;
+		using WindowRestoredEvent = Signal<>;
+		using WindowResizedEvent = Signal<Vector<int>>;
+		using WindowMouseEnterEvent = Signal<>;
+		using WindowMouseLeaveEvent = Signal<>;
 
-		using JoystickAxisMotionEventSource = SignalSource<int, int, int>;
-		using JoystickBallMotionEventSource = SignalSource<int, int, Vector<int>>;
-		using JoystickButtonEventSource = SignalSource<int, int>;
-		using JoystickHatMotionEventSource = SignalSource<int, int, int>;
+		using JoystickAxisMotionEvent = Signal<int, int, int>;
+		using JoystickBallMotionEvent = Signal<int, int, Vector<int>>;
+		using JoystickButtonEvent = Signal<int, int>;
+		using JoystickHatMotionEvent = Signal<int, int, int>;
 
-		using KeyDownEventSource = SignalSource<KeyCode, KeyModifier, bool>;
-		using KeyUpEventSource = SignalSource<KeyCode, KeyModifier>;
-		using TextInputEventSource = SignalSource<const std::string&>;
+		using KeyDownEvent = Signal<KeyCode, KeyModifier, bool>;
+		using KeyUpEvent = Signal<KeyCode, KeyModifier>;
+		using TextInputEvent = Signal<const std::string&>;
 
-		using MouseButtonEventSource = SignalSource<MouseButton, Point<int>>;
-		using MouseMotionEventSource = SignalSource<Point<int>, Vector<int>>;
-		using MouseWheelEventSource = SignalSource<Vector<int>>;
+		using MouseButtonEvent = Signal<MouseButton, Point<int>>;
+		using MouseMotionEvent = Signal<Point<int>, Vector<int>>;
+		using MouseWheelEvent = Signal<Vector<int>>;
 
-		using QuitEventSource = SignalSource<>;
+		using QuitEvent = Signal<>;
 
 	public:
-		ActivateEventSource& activate();
+		ActivateEvent::Source& activate();
 
-		WindowHiddenEventSource& windowHidden();
-		WindowExposedEventSource& windowExposed();
+		WindowHiddenEvent::Source& windowHidden();
+		WindowExposedEvent::Source& windowExposed();
 
-		WindowMinimizedEventSource& windowMinimized();
-		WindowMaximizedEventSource& windowMaximized();
-		WindowRestoredEventSource& windowRestored();
-		WindowResizedEventSource& windowResized();
+		WindowMinimizedEvent::Source& windowMinimized();
+		WindowMaximizedEvent::Source& windowMaximized();
+		WindowRestoredEvent::Source& windowRestored();
+		WindowResizedEvent::Source& windowResized();
 
-		WindowMouseEnterEventSource& windowMouseEnter();
-		WindowMouseLeaveEventSource& windowMouseLeave();
+		WindowMouseEnterEvent::Source& windowMouseEnter();
+		WindowMouseLeaveEvent::Source& windowMouseLeave();
 
-		JoystickAxisMotionEventSource& joystickAxisMotion();
-		JoystickBallMotionEventSource& joystickBallMotion();
-		JoystickButtonEventSource& joystickButtonUp();
-		JoystickButtonEventSource& joystickButtonDown();
-		JoystickHatMotionEventSource& joystickHatMotion();
+		JoystickAxisMotionEvent::Source& joystickAxisMotion();
+		JoystickBallMotionEvent::Source& joystickBallMotion();
+		JoystickButtonEvent::Source& joystickButtonUp();
+		JoystickButtonEvent::Source& joystickButtonDown();
+		JoystickHatMotionEvent::Source& joystickHatMotion();
 
-		KeyUpEventSource& keyUp();
-		KeyDownEventSource& keyDown();
+		KeyUpEvent::Source& keyUp();
+		KeyDownEvent::Source& keyDown();
 
-		TextInputEventSource& textInput();
+		TextInputEvent::Source& textInput();
 
-		MouseButtonEventSource& mouseButtonUp();
-		MouseButtonEventSource& mouseButtonDown();
-		MouseButtonEventSource& mouseDoubleClick();
-		MouseMotionEventSource& mouseMotion();
-		MouseWheelEventSource& mouseWheel();
+		MouseButtonEvent::Source& mouseButtonUp();
+		MouseButtonEvent::Source& mouseButtonDown();
+		MouseButtonEvent::Source& mouseDoubleClick();
+		MouseMotionEvent::Source& mouseMotion();
+		MouseWheelEvent::Source& mouseWheel();
 
-		QuitEventSource& quit();
+		QuitEvent::Source& quit();
 
 		void grabMouse();
 		void releaseMouse();

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -111,35 +111,35 @@ namespace NAS2D
 		void disconnectAll();
 
 	private:
-		Signal<bool> mActivateEvent{};
+		ActivateEvent mActivateEvent{};
 
-		Signal<bool> mWindowHiddenEvent{};
-		Signal<> mWindowExposedEvent{};
-		Signal<> mWindowMinimizedEvent{};
-		Signal<> mWindowMaximizedEvent{};
-		Signal<> mWindowRestoredEvent{};
-		Signal<Vector<int>> mWindowResizedEvent{};
-		Signal<> mWindowMouseEnterEvent{};
-		Signal<> mWindowMouseLeaveEvent{};
+		WindowHiddenEvent mWindowHiddenEvent{};
+		WindowExposedEvent mWindowExposedEvent{};
+		WindowMinimizedEvent mWindowMinimizedEvent{};
+		WindowMaximizedEvent mWindowMaximizedEvent{};
+		WindowRestoredEvent mWindowRestoredEvent{};
+		WindowResizedEvent mWindowResizedEvent{};
+		WindowMouseEnterEvent mWindowMouseEnterEvent{};
+		WindowMouseLeaveEvent mWindowMouseLeaveEvent{};
 
-		Signal<int, int, int> mJoystickAxisMotionEvent{};
-		Signal<int, int, Vector<int>> mJoystickBallMotionEvent{};
-		Signal<int, int> mJoystickButtonUpEvent{};
-		Signal<int, int> mJoystickButtonDownEvent{};
-		Signal<int, int, int> mJoystickHatMotionEvent{};
+		JoystickAxisMotionEvent mJoystickAxisMotionEvent{};
+		JoystickBallMotionEvent mJoystickBallMotionEvent{};
+		JoystickButtonEvent mJoystickButtonUpEvent{};
+		JoystickButtonEvent mJoystickButtonDownEvent{};
+		JoystickHatMotionEvent mJoystickHatMotionEvent{};
 
-		Signal<KeyCode, KeyModifier, bool> mKeyDownEvent{};
-		Signal<KeyCode, KeyModifier> mKeyUpEvent{};
+		KeyDownEvent mKeyDownEvent{};
+		KeyUpEvent mKeyUpEvent{};
 
-		Signal<const std::string&> mTextInput{};
+		TextInputEvent mTextInput{};
 
-		Signal<MouseButton, Point<int>> mMouseButtonDownEvent{};
-		Signal<MouseButton, Point<int>> mMouseButtonUpEvent{};
-		Signal<MouseButton, Point<int>> mMouseDoubleClick{};
-		Signal<Point<int>, Vector<int>> mMouseMotionEvent{};
-		Signal<Vector<int>> mMouseWheelEvent{};
+		MouseButtonEvent mMouseButtonDownEvent{};
+		MouseButtonEvent mMouseButtonUpEvent{};
+		MouseButtonEvent mMouseDoubleClick{};
+		MouseMotionEvent mMouseMotionEvent{};
+		MouseWheelEvent mMouseWheelEvent{};
 
-		Signal<> mQuitEvent{};
+		QuitEvent mQuitEvent{};
 	};
 
 	void postQuitEvent();

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -131,11 +131,11 @@ namespace NAS2D
 		KeyDownEvent mKeyDownEvent{};
 		KeyUpEvent mKeyUpEvent{};
 
-		TextInputEvent mTextInput{};
+		TextInputEvent mTextInputEvent{};
 
 		MouseButtonEvent mMouseButtonDownEvent{};
 		MouseButtonEvent mMouseButtonUpEvent{};
-		MouseButtonEvent mMouseDoubleClick{};
+		MouseButtonEvent mMouseDoubleClickEvent{};
 		MouseMotionEvent mMouseMotionEvent{};
 		MouseWheelEvent mMouseWheelEvent{};
 


### PR DESCRIPTION
Make type aliases refer to the full derived `Signal` template class. Use `::Source` alias to refer to the `SignalSource` base type. Rename aliases and members to use "Signal" rather than "Event". They are not events themselves, but rather `Signal` objects that deliver events.

Contains a bug fix where some members were missing from `EventHandler::disconnectAll()`. Being able to destruct the object would have been an easier way to ensure all sub-objects are cleared out, though that doesn't work so well with globals.

Related:
- Issue #1222
