### PR TITLE
Add `SignalSource` methods

### DIFF
--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -25,6 +25,8 @@ namespace NAS2D
 		using DelegateType = Delegate<void(Params...)>;
 
 	public:
+		std::size_t count() const { return delegateList.size(); }
+
 		bool isEmpty() const { return delegateList.empty(); }
 
 		void connect(DelegateType delegate)

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -25,7 +25,7 @@ namespace NAS2D
 		using DelegateType = Delegate<void(Params...)>;
 
 	public:
-		bool empty() const { return delegateList.empty(); }
+		bool isEmpty() const { return delegateList.empty(); }
 
 		void clear() { delegateList.clear(); }
 

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -37,8 +37,7 @@ namespace NAS2D
 
 		void connect(DelegateType delegate)
 		{
-			const auto iterator = std::find(delegateList.begin(), delegateList.end(), delegate);
-			if (iterator == delegateList.end())
+			if (!isConnected(delegate))
 			{
 				delegateList.push_back(delegate);
 			}

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -29,6 +29,12 @@ namespace NAS2D
 
 		bool isEmpty() const { return delegateList.empty(); }
 
+		bool isConnected(DelegateType delegate)
+		{
+			const auto iterator = std::find(delegateList.begin(), delegateList.end(), delegate);
+			return (iterator != delegateList.end());
+		}
+
 		void connect(DelegateType delegate)
 		{
 			const auto iterator = std::find(delegateList.begin(), delegateList.end(), delegate);

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -29,7 +29,7 @@ namespace NAS2D
 
 		bool isEmpty() const { return delegateList.empty(); }
 
-		bool isConnected(DelegateType delegate)
+		bool isConnected(DelegateType delegate) const
 		{
 			const auto iterator = std::find(delegateList.begin(), delegateList.end(), delegate);
 			return (iterator != delegateList.end());

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -27,8 +27,6 @@ namespace NAS2D
 	public:
 		bool isEmpty() const { return delegateList.empty(); }
 
-		void clear() { delegateList.clear(); }
-
 		void connect(DelegateType delegate)
 		{
 			const auto iterator = std::find(delegateList.begin(), delegateList.end(), delegate);
@@ -46,6 +44,8 @@ namespace NAS2D
 				delegateList.erase(iterator);
 			}
 		}
+
+		void clear() { delegateList.clear(); }
 
 	protected:
 		std::vector<DelegateType> delegateList{};

--- a/test/Signal/Signal.test.cpp
+++ b/test/Signal/Signal.test.cpp
@@ -12,30 +12,6 @@ namespace {
 }
 
 
-TEST(Signal, InitEmpty) {
-	NAS2D::Signal<> signal;
-	EXPECT_TRUE(signal.isEmpty());
-}
-
-TEST(Signal, ConnectNonEmpty) {
-	NAS2D::Signal<> signal;
-	MockHandler handler{};
-	auto delegate = NAS2D::Delegate{&handler, &MockHandler::MockMethod};
-
-	signal.connect(delegate);
-	EXPECT_FALSE(signal.isEmpty());
-}
-
-TEST(Signal, DisconnectEmpty) {
-	NAS2D::Signal<> signal;
-	MockHandler handler{};
-	auto delegate = NAS2D::Delegate{&handler, &MockHandler::MockMethod};
-
-	signal.connect(delegate);
-	signal.disconnect(delegate);
-	EXPECT_TRUE(signal.isEmpty());
-}
-
 TEST(Signal, ConnectEmitDisconnect) {
 	NAS2D::Signal<> signal;
 	MockHandler handler{};

--- a/test/Signal/Signal.test.cpp
+++ b/test/Signal/Signal.test.cpp
@@ -14,7 +14,7 @@ namespace {
 
 TEST(Signal, InitEmpty) {
 	NAS2D::Signal<> signal;
-	EXPECT_TRUE(signal.empty());
+	EXPECT_TRUE(signal.isEmpty());
 }
 
 TEST(Signal, ConnectNonEmpty) {
@@ -23,7 +23,7 @@ TEST(Signal, ConnectNonEmpty) {
 	auto delegate = NAS2D::Delegate{&handler, &MockHandler::MockMethod};
 
 	signal.connect(delegate);
-	EXPECT_FALSE(signal.empty());
+	EXPECT_FALSE(signal.isEmpty());
 }
 
 TEST(Signal, DisconnectEmpty) {
@@ -33,7 +33,7 @@ TEST(Signal, DisconnectEmpty) {
 
 	signal.connect(delegate);
 	signal.disconnect(delegate);
-	EXPECT_TRUE(signal.empty());
+	EXPECT_TRUE(signal.isEmpty());
 }
 
 TEST(Signal, ConnectEmitDisconnect) {

--- a/test/Signal/SignalSource.test.cpp
+++ b/test/Signal/SignalSource.test.cpp
@@ -61,3 +61,30 @@ TEST(SignalSource, DisconnectEmpty) {
 	signalSource.disconnect(delegate);
 	EXPECT_TRUE(signalSource.isEmpty());
 }
+
+TEST(SignalSource, IsConnectedInitially) {
+	NAS2D::SignalSource<> signalSource;
+	MockHandler handler{};
+	auto delegate = NAS2D::Delegate{&handler, &MockHandler::MockMethod};
+
+	EXPECT_FALSE(signalSource.isConnected(delegate));
+}
+
+TEST(SignalSource, IsConnectedAfterConnect) {
+	NAS2D::SignalSource<> signalSource;
+	MockHandler handler{};
+	auto delegate = NAS2D::Delegate{&handler, &MockHandler::MockMethod};
+
+	signalSource.connect(delegate);
+	EXPECT_TRUE(signalSource.isConnected(delegate));
+}
+
+TEST(SignalSource, IsConnectedAfterDisconnect) {
+	NAS2D::SignalSource<> signalSource;
+	MockHandler handler{};
+	auto delegate = NAS2D::Delegate{&handler, &MockHandler::MockMethod};
+
+	signalSource.connect(delegate);
+	signalSource.disconnect(delegate);
+	EXPECT_FALSE(signalSource.isConnected(delegate));
+}

--- a/test/Signal/SignalSource.test.cpp
+++ b/test/Signal/SignalSource.test.cpp
@@ -12,6 +12,32 @@ namespace {
 }
 
 
+TEST(SignalSource, InitCountZero) {
+	NAS2D::SignalSource<> signalSource;
+	EXPECT_EQ(std::size_t{0}, signalSource.count());
+}
+
+TEST(SignalSource, ConnectCountOne) {
+	NAS2D::SignalSource<> signalSource;
+	MockHandler handler{};
+	auto delegate = NAS2D::Delegate{&handler, &MockHandler::MockMethod};
+
+	signalSource.connect(delegate);
+	EXPECT_EQ(std::size_t{1}, signalSource.count());
+}
+
+TEST(SignalSource, ConnectCountTwo) {
+	NAS2D::SignalSource<> signalSource;
+	MockHandler handler1{};
+	MockHandler handler2{};
+	auto delegate1 = NAS2D::Delegate{&handler1, &MockHandler::MockMethod};
+	auto delegate2 = NAS2D::Delegate{&handler2, &MockHandler::MockMethod};
+
+	signalSource.connect(delegate1);
+	signalSource.connect(delegate2);
+	EXPECT_EQ(std::size_t{2}, signalSource.count());
+}
+
 TEST(SignalSource, InitEmpty) {
 	NAS2D::SignalSource<> signalSource;
 	EXPECT_TRUE(signalSource.isEmpty());

--- a/test/Signal/SignalSource.test.cpp
+++ b/test/Signal/SignalSource.test.cpp
@@ -88,3 +88,16 @@ TEST(SignalSource, IsConnectedAfterDisconnect) {
 	signalSource.disconnect(delegate);
 	EXPECT_FALSE(signalSource.isConnected(delegate));
 }
+
+TEST(SignalSource, ClearEmpty) {
+	NAS2D::SignalSource<> signalSource;
+	MockHandler handler1{};
+	MockHandler handler2{};
+	auto delegate1 = NAS2D::Delegate{&handler1, &MockHandler::MockMethod};
+	auto delegate2 = NAS2D::Delegate{&handler2, &MockHandler::MockMethod};
+
+	signalSource.connect(delegate1);
+	signalSource.connect(delegate2);
+	signalSource.clear();
+	EXPECT_TRUE(signalSource.isEmpty());
+}

--- a/test/Signal/SignalSource.test.cpp
+++ b/test/Signal/SignalSource.test.cpp
@@ -1,0 +1,37 @@
+#include "NAS2D/Signal/SignalSource.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+
+namespace {
+	class MockHandler {
+	public:
+		MOCK_CONST_METHOD0(MockMethod, void());
+	};
+}
+
+
+TEST(SignalSource, InitEmpty) {
+	NAS2D::SignalSource<> signalSource;
+	EXPECT_TRUE(signalSource.isEmpty());
+}
+
+TEST(SignalSource, ConnectNonEmpty) {
+	NAS2D::SignalSource<> signalSource;
+	MockHandler handler{};
+	auto delegate = NAS2D::Delegate{&handler, &MockHandler::MockMethod};
+
+	signalSource.connect(delegate);
+	EXPECT_FALSE(signalSource.isEmpty());
+}
+
+TEST(SignalSource, DisconnectEmpty) {
+	NAS2D::SignalSource<> signalSource;
+	MockHandler handler{};
+	auto delegate = NAS2D::Delegate{&handler, &MockHandler::MockMethod};
+
+	signalSource.connect(delegate);
+	signalSource.disconnect(delegate);
+	EXPECT_TRUE(signalSource.isEmpty());
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -159,6 +159,7 @@
     <ClCompile Include="Signal/Delegate.test.cpp" />
     <ClCompile Include="Signal/Signal.test.cpp" />
     <ClCompile Include="Signal/SignalConnection.test.cpp" />
+    <ClCompile Include="Signal/SignalSource.test.cpp" />
     <ClCompile Include="Configuration.test.cpp" />
     <ClCompile Include="ContainerUtils.test.cpp" />
     <ClCompile Include="Dictionary.test.cpp" />


### PR DESCRIPTION
Add methods `count` and `isConnected`.

I figured these were potentially useful for debugging odd situations.

Renamed `empty()` to `isEmpty()`. Less ambiguity over whether "empty" is an adjective or a verb.

Related:
- Issue https://github.com/OutpostUniverse/OPHD/issues/1608
