### PR TITLE
Mark `EventHandler::pump` as `virtual`

### DIFF
--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -62,6 +62,8 @@ namespace NAS2D
 		using QuitSignal = Signal<>;
 
 	public:
+		virtual ~EventHandler() = default;
+
 		ActivateSignal::Source& activate();
 
 		WindowHiddenSignal::Source& windowHidden();
@@ -111,7 +113,7 @@ namespace NAS2D
 		bool numlock() const;
 		bool control() const;
 
-		void pump();
+		virtual void pump();
 
 		void disconnectAll();
 


### PR DESCRIPTION
This enables meaningful subclassing of `EventHandler`.

As part of enabling subclassing, we also need a `virtual` destructor. The way it is accessed through `Utility` means the memory is managed using a base class pointer.

Related:
- PR #1231
- Issue https://github.com/OutpostUniverse/OPHD/issues/894
