### PR TITLE
Add `Duration` type

### DIFF
--- a/NAS2D/Duration.h
+++ b/NAS2D/Duration.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <cstdint>
+
+
+struct Duration
+{
+	uint64_t milliseconds;
+};

--- a/NAS2D/Duration.h
+++ b/NAS2D/Duration.h
@@ -5,5 +5,5 @@
 
 struct Duration
 {
-	uint64_t milliseconds;
+	uint32_t milliseconds;
 };

--- a/NAS2D/Mixer/Mixer.cpp
+++ b/NAS2D/Mixer/Mixer.cpp
@@ -16,7 +16,7 @@ using namespace NAS2D;
 
 void Mixer::playMusic(const Music& music)
 {
-	fadeInMusic(music, std::chrono::milliseconds{0});
+	fadeInMusic(music, Duration{0});
 }
 
 

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -10,20 +10,20 @@
 
 #pragma once
 
+#include "../Duration.h"
 #include "../Signal/Signal.h"
 
-#include <chrono>
 
 namespace NAS2D
 {
-
 	class Sound;
 	class Music;
+
 
 	class Mixer
 	{
 	public:
-		static constexpr std::chrono::milliseconds DefaultFadeTime{500};
+		static constexpr Duration DefaultFadeTime{500};
 
 	public:
 		Mixer() = default;
@@ -49,9 +49,9 @@ namespace NAS2D
 		virtual void pauseMusic() = 0;
 		virtual void resumeMusic() = 0;
 
-		virtual void fadeInMusic(const Music& music, std::chrono::milliseconds fadeInTime = Mixer::DefaultFadeTime) = 0;
+		virtual void fadeInMusic(const Music& music, Duration fadeInTime = Mixer::DefaultFadeTime) = 0;
 
-		virtual void fadeOutMusic(std::chrono::milliseconds fadeOutTime = Mixer::DefaultFadeTime) = 0;
+		virtual void fadeOutMusic(Duration fadeOutTime = Mixer::DefaultFadeTime) = 0;
 
 		virtual bool musicPlaying() const = 0;
 

--- a/NAS2D/Mixer/MixerNull.cpp
+++ b/NAS2D/Mixer/MixerNull.cpp
@@ -34,10 +34,10 @@ namespace NAS2D
 	void MixerNull::resumeMusic()
 	{}
 
-	void MixerNull::fadeInMusic(const Music& /*music*/, std::chrono::milliseconds /*fadeInTime*/ /*= Mixer::DefaultFadeTime*/)
+	void MixerNull::fadeInMusic(const Music& /*music*/, Duration /*fadeInTime*/ /*= Mixer::DefaultFadeTime*/)
 	{}
 
-	void MixerNull::fadeOutMusic(std::chrono::milliseconds /*fadeOutTime*/ /*= Mixer::DefaultFadeTime*/)
+	void MixerNull::fadeOutMusic(Duration /*fadeOutTime*/ /*= Mixer::DefaultFadeTime*/)
 	{}
 
 	bool MixerNull::musicPlaying() const

--- a/NAS2D/Mixer/MixerNull.h
+++ b/NAS2D/Mixer/MixerNull.h
@@ -27,8 +27,8 @@ namespace NAS2D
 		void pauseMusic() override;
 		void resumeMusic() override;
 
-		void fadeInMusic(const Music& music, std::chrono::milliseconds fadeInTime = Mixer::DefaultFadeTime) override;
-		void fadeOutMusic(std::chrono::milliseconds fadeOutTime = Mixer::DefaultFadeTime) override;
+		void fadeInMusic(const Music& music, Duration fadeInTime = Mixer::DefaultFadeTime) override;
+		void fadeOutMusic(Duration fadeOutTime = Mixer::DefaultFadeTime) override;
 
 		bool musicPlaying() const override;
 

--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -183,15 +183,15 @@ void MixerSDL::resumeMusic()
 }
 
 
-void MixerSDL::fadeInMusic(const Music& music, std::chrono::milliseconds fadeInTime)
+void MixerSDL::fadeInMusic(const Music& music, Duration fadeInTime)
 {
-	Mix_FadeInMusic(music.music(), 0, static_cast<int>(fadeInTime.count()));
+	Mix_FadeInMusic(music.music(), 0, static_cast<int>(fadeInTime.milliseconds));
 }
 
 
-void MixerSDL::fadeOutMusic(std::chrono::milliseconds fadeOutTime)
+void MixerSDL::fadeOutMusic(Duration fadeOutTime)
 {
-	Mix_FadeOutMusic(static_cast<int>(fadeOutTime.count()));
+	Mix_FadeOutMusic(static_cast<int>(fadeOutTime.milliseconds));
 }
 
 

--- a/NAS2D/Mixer/MixerSDL.h
+++ b/NAS2D/Mixer/MixerSDL.h
@@ -12,6 +12,7 @@
 
 #include "Mixer.h"
 
+
 namespace NAS2D
 {
 
@@ -56,8 +57,8 @@ namespace NAS2D
 		void pauseMusic() override;
 		void resumeMusic() override;
 
-		void fadeInMusic(const Music& music, std::chrono::milliseconds fadeInTime) override;
-		void fadeOutMusic(std::chrono::milliseconds fadeOutTime) override;
+		void fadeInMusic(const Music& music, Duration fadeInTime) override;
+		void fadeOutMusic(Duration fadeOutTime) override;
 
 		bool musicPlaying() const override;
 

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -201,6 +201,7 @@
     <ClInclude Include="ContainerUtils.h" />
     <ClInclude Include="Dictionary.h" />
     <ClInclude Include="Documentation.h" />
+    <ClInclude Include="Duration.h" />
     <ClInclude Include="EnumKeyCode.h" />
     <ClInclude Include="EnumKeyModifier.h" />
     <ClInclude Include="EnumMouseButton.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -185,6 +185,9 @@
     <ClInclude Include="Documentation.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Duration.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="EnumKeyCode.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -55,7 +55,7 @@ SignalSource<>& Fade::fadeComplete()
 
 
 // Fade in from fadeColor
-void Fade::fadeIn(std::chrono::milliseconds fadeTime)
+void Fade::fadeIn(Duration fadeTime)
 {
 	setDuration(fadeTime);
 	mDirection = FadeDirection::In;
@@ -63,7 +63,7 @@ void Fade::fadeIn(std::chrono::milliseconds fadeTime)
 
 
 // Fade out to fadeColor
-void Fade::fadeOut(std::chrono::milliseconds fadeTime)
+void Fade::fadeOut(Duration fadeTime)
 {
 	setDuration(fadeTime);
 	mDirection = FadeDirection::Out;
@@ -89,7 +89,7 @@ void Fade::update()
 		return;
 	}
 
-	const auto step = static_cast<uint8_t>(std::clamp(mFadeTimer.elapsedTicks() * 255u / static_cast<unsigned int>(mDuration.count()), 0u, 255u));
+	const auto step = static_cast<uint8_t>(std::clamp(mFadeTimer.elapsedTicks() * 255u / static_cast<unsigned int>(mDuration.milliseconds), 0u, 255u));
 	mFadeColor.alpha = (mDirection == FadeDirection::In) ? 255 - step : step;
 
 	if (step == 255)
@@ -110,9 +110,9 @@ void Fade::draw(Renderer& renderer) const
 }
 
 
-void Fade::setDuration(std::chrono::milliseconds newDuration)
+void Fade::setDuration(Duration newDuration)
 {
-	if (newDuration == decltype(newDuration)::zero())
+	if (newDuration.milliseconds == 0)
 	{
 		throw std::runtime_error("Fade duration must be positive");
 	}

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -11,10 +11,10 @@
 #pragma once
 
 #include "Color.h"
+#include "../Duration.h"
 #include "../Timer.h"
 #include "../Signal/Signal.h"
 
-#include <chrono>
 
 namespace NAS2D
 {
@@ -35,8 +35,8 @@ namespace NAS2D
 
 		FadeCompleteSignal::Source& fadeComplete();
 
-		void fadeIn(std::chrono::milliseconds fadeTime);
-		void fadeOut(std::chrono::milliseconds fadeTime);
+		void fadeIn(Duration fadeTime);
+		void fadeOut(Duration fadeTime);
 
 		bool isFading() const;
 		bool isFaded() const;
@@ -45,7 +45,7 @@ namespace NAS2D
 		void draw(Renderer& renderer) const;
 
 	private:
-		void setDuration(std::chrono::milliseconds newDuration);
+		void setDuration(Duration newDuration);
 
 		enum class FadeDirection
 		{
@@ -56,7 +56,7 @@ namespace NAS2D
 
 		Color mFadeColor;
 		FadeDirection mDirection;
-		std::chrono::milliseconds mDuration;
+		Duration mDuration;
 		Timer mFadeTimer;
 		FadeCompleteSignal mFadeComplete;
 	};

--- a/NAS2D/Timer.h
+++ b/NAS2D/Timer.h
@@ -10,6 +10,9 @@
 
 #pragma once
 
+#include <cstdint>
+
+
 namespace NAS2D
 {
 
@@ -32,21 +35,21 @@ namespace NAS2D
 	class Timer
 	{
 	public:
-		static unsigned int tick();
+		static uint32_t tick();
 
 		Timer();
-		Timer(unsigned int startTick);
+		Timer(uint32_t startTick);
 
 		Timer(const Timer&) = default;
 		Timer& operator=(const Timer&) = default;
 
-		unsigned int elapsedTicks() const;
-		unsigned int delta();
-		void adjustStartTick(unsigned int ticksForward);
+		uint32_t elapsedTicks() const;
+		uint32_t delta();
+		void adjustStartTick(uint32_t ticksForward);
 		void reset();
 
 	private:
-		unsigned int mStartTick;
+		uint32_t mStartTick;
 	};
 
 } // namespace


### PR DESCRIPTION
Using the `<chrono>` library was maybe a bit clunky just to specify an `int` duration in milliseconds.

As noticed while investigating compile times, including the `<chrono>` library significantly adds to compile times. Seeing as how we weren't really using any features of that library, it may be better to not depend on it.

Related:
- Issue https://github.com/OutpostUniverse/OPHD/issues/1573

Related documentation:
- https://wiki.libsdl.org/SDL2/SDL_GetTicks
- https://wiki.libsdl.org/SDL3_mixer/Mix_FadeInMusic
- https://wiki.libsdl.org/SDL3_mixer/Mix_FadeOutMusic
