### PR TITLE
Move methods from `EventHandler` to `Window` class

### DIFF
--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -573,7 +573,6 @@ void EventHandler::warpMouse(int x, int y)
 	if (underlyingWindow)
 	{
 		SDL_WarpMouseInWindow(underlyingWindow, x, y);
-		mMouseMotionSignal.emit({x, y}, {0, 0});
 	}
 }
 

--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -14,11 +14,6 @@
 #include <SDL2/SDL.h>
 
 
-// UGLY ASS HACK!
-// This is required for mouse grabbing in the EventHandler class.
-extern SDL_Window* underlyingWindow;
-
-
 using namespace NAS2D;
 
 
@@ -556,24 +551,6 @@ EventHandler::MouseWheelSignal::Source& EventHandler::mouseWheel()
 EventHandler::QuitSignal::Source& EventHandler::quit()
 {
 	return mQuitSignal;
-}
-
-
-/**
- * Sets the mouse pointer to a specified location within the application window.
- *
- * \param x X-Coordinate.
- * \param y Y-Coordinate.
- *
- * \note	Coordinates can only be set within the bounds of the application's
- *			window. Coordinates will be clamped for all other values.
- */
-void EventHandler::warpMouse(int x, int y)
-{
-	if (underlyingWindow)
-	{
-		SDL_WarpMouseInWindow(underlyingWindow, x, y);
-	}
 }
 
 

--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -560,24 +560,6 @@ EventHandler::QuitSignal::Source& EventHandler::quit()
 
 
 /**
- * Grabs exclusive mouse input.
- */
-void EventHandler::grabMouse()
-{
-	if (underlyingWindow) { SDL_SetWindowGrab(underlyingWindow, SDL_TRUE); }
-}
-
-
-/**
- * Releases exclusive mouse input.
- */
-void EventHandler::releaseMouse()
-{
-	if (underlyingWindow) { SDL_SetWindowGrab(underlyingWindow, SDL_FALSE); }
-}
-
-
-/**
  * Sets the mouse pointer to a specified location within the application window.
  *
  * \param x X-Coordinate.

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -96,8 +96,6 @@ namespace NAS2D
 
 		QuitSignal::Source& quit();
 
-		void grabMouse();
-		void releaseMouse();
 		void warpMouse(int x, int y);
 		void mouseRelativeMode(bool rel);
 

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -42,7 +42,6 @@ using namespace NAS2D;
 
 
 // UGLY ASS HACK!
-// This is required for mouse grabbing in the EventHandler class.
 extern SDL_Window* underlyingWindow;
 
 

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -5,6 +5,7 @@
 #include "../Utility.h"
 #include "../Filesystem.h"
 #include "../EventHandler.h"
+#include "../Math/Point.h"
 
 #include <SDL2/SDL.h>
 
@@ -26,7 +27,6 @@ using namespace NAS2D;
 
 
 // UGLY ASS HACK!
-// This is required for mouse grabbing in the EventHandler class.
 SDL_Window* underlyingWindow = nullptr;
 
 
@@ -375,6 +375,17 @@ void Window::captureMouse()
 void Window::releaseMouse()
 {
 	SDL_SetWindowGrab(underlyingWindow, SDL_FALSE);
+}
+
+
+/**
+ * Sets the mouse pointer to a specified location within the application window.
+ *
+ * \note Coordinates will be clamped to the window's dimensions.
+ */
+void Window::warpMouse(Point<int> mousePositionInWindow)
+{
+	SDL_WarpMouseInWindow(underlyingWindow, mousePositionInWindow.x, mousePositionInWindow.y);
 }
 
 

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -366,6 +366,18 @@ Vector<int> Window::getWindowClientArea() const noexcept
 }
 
 
+void Window::captureMouse()
+{
+	SDL_SetWindowGrab(underlyingWindow, SDL_TRUE);
+}
+
+
+void Window::releaseMouse()
+{
+	SDL_SetWindowGrab(underlyingWindow, SDL_FALSE);
+}
+
+
 void Window::doModalError(const std::string& title, const std::string& message) const
 {
 	::doModalError(title, message, underlyingWindow);

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -57,6 +57,9 @@ namespace NAS2D
 
 		virtual Vector<int> getWindowClientArea() const noexcept;
 
+		void captureMouse();
+		void releaseMouse();
+
 		void doModalError(const std::string& title, const std::string& message) const;
 		void doModalAlert(const std::string& title, const std::string& message) const;
 		bool doModalYesNo(const std::string& title, const std::string& message) const;

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -14,6 +14,9 @@ namespace NAS2D
 {
 	struct DisplayDesc;
 
+	template <typename BaseType>
+	struct Point;
+
 
 	struct CursorId
 	{
@@ -59,6 +62,8 @@ namespace NAS2D
 
 		void captureMouse();
 		void releaseMouse();
+
+		void warpMouse(Point<int> mousePositionInWindow);
 
 		void doModalError(const std::string& title, const std::string& message) const;
 		void doModalAlert(const std::string& title, const std::string& message) const;


### PR DESCRIPTION
Move methods from `EventHandler` to `Window` class:
- `captureMouse`
- `releaseMouse`
- `warpMouse`

Related:
- PR #1234
- PR #1231
