### PR TITLE
Remove `Signal` from `Fade`

### DIFF
--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -19,32 +19,19 @@
 using namespace NAS2D;
 
 
-Fade::Fade() :
-	Fade(Color::Black)
-{
-}
-
-
-Fade::Fade(Color fadeColor) :
-	mFadeColor{fadeColor.alphaFade(255)},
-	mDirection{FadeDirection::None},
-	mDuration{},
-	mFadeTimer{},
-	mFadeComplete{}
-{}
-
-
 Fade::Fade(DelegateType onFadeComplete) :
-	Fade()
+	Fade{Color::Black, onFadeComplete}
 {
-	mFadeComplete = onFadeComplete;
 }
 
 
 Fade::Fade(Color fadeColor, DelegateType onFadeComplete) :
-	Fade(fadeColor)
+	mFadeColor{fadeColor.alphaFade(255)},
+	mDirection{FadeDirection::None},
+	mDuration{},
+	mFadeTimer{},
+	mFadeComplete{onFadeComplete}
 {
-	mFadeComplete = onFadeComplete;
 }
 
 

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -34,14 +34,14 @@ Fade::Fade(Color fadeColor) :
 {}
 
 
-Fade::Fade(FadeCompleteSignal::DelegateType onFadeComplete) :
+Fade::Fade(DelegateType onFadeComplete) :
 	Fade()
 {
 	mFadeComplete.connect(onFadeComplete);
 }
 
 
-Fade::Fade(Color fadeColor, FadeCompleteSignal::DelegateType onFadeComplete) :
+Fade::Fade(Color fadeColor, DelegateType onFadeComplete) :
 	Fade(fadeColor)
 {
 	mFadeComplete.connect(onFadeComplete);

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -48,12 +48,6 @@ Fade::Fade(Color fadeColor, FadeCompleteSignal::DelegateType onFadeComplete) :
 }
 
 
-SignalSource<>& Fade::fadeComplete()
-{
-	return mFadeComplete;
-}
-
-
 // Fade in from fadeColor
 void Fade::fadeIn(Duration fadeTime)
 {

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -37,14 +37,14 @@ Fade::Fade(Color fadeColor) :
 Fade::Fade(DelegateType onFadeComplete) :
 	Fade()
 {
-	mFadeComplete.connect(onFadeComplete);
+	mFadeComplete = onFadeComplete;
 }
 
 
 Fade::Fade(Color fadeColor, DelegateType onFadeComplete) :
 	Fade(fadeColor)
 {
-	mFadeComplete.connect(onFadeComplete);
+	mFadeComplete = onFadeComplete;
 }
 
 
@@ -89,7 +89,10 @@ void Fade::update()
 	if (step == 255)
 	{
 		mDirection = FadeDirection::None;
-		mFadeComplete();
+		if (!mFadeComplete.empty())
+		{
+			mFadeComplete();
+		}
 	}
 }
 

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -30,7 +30,7 @@ Fade::Fade(Color fadeColor, DelegateType onFadeComplete) :
 	mDirection{FadeDirection::None},
 	mDuration{},
 	mFadeTimer{},
-	mFadeComplete{onFadeComplete}
+	mOnFadeComplete{onFadeComplete}
 {
 }
 
@@ -76,9 +76,9 @@ void Fade::update()
 	if (step == 255)
 	{
 		mDirection = FadeDirection::None;
-		if (!mFadeComplete.empty())
+		if (!mOnFadeComplete.empty())
 		{
-			mFadeComplete();
+			mOnFadeComplete();
 		}
 	}
 }

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -13,7 +13,7 @@
 #include "Color.h"
 #include "../Duration.h"
 #include "../Timer.h"
-#include "../Signal/Signal.h"
+#include "../Signal/Delegate.h"
 
 
 namespace NAS2D
@@ -25,8 +25,7 @@ namespace NAS2D
 	class Fade
 	{
 	public:
-		using FadeCompleteSignal = Signal<>;
-		using DelegateType = FadeCompleteSignal::DelegateType;
+		using DelegateType = Delegate<void()>;
 
 
 		Fade();
@@ -57,7 +56,7 @@ namespace NAS2D
 		FadeDirection mDirection;
 		Duration mDuration;
 		Timer mFadeTimer;
-		FadeCompleteSignal mFadeComplete;
+		DelegateType mFadeComplete;
 	};
 
 }

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -26,12 +26,13 @@ namespace NAS2D
 	{
 	public:
 		using FadeCompleteSignal = Signal<>;
+		using DelegateType = FadeCompleteSignal::DelegateType;
 
 
 		Fade();
 		explicit Fade(Color fadeColor);
-		explicit Fade(FadeCompleteSignal::DelegateType onFadeComplete);
-		explicit Fade(Color fadeColor, FadeCompleteSignal::DelegateType onFadeComplete);
+		explicit Fade(DelegateType onFadeComplete);
+		explicit Fade(Color fadeColor, DelegateType onFadeComplete);
 
 		void fadeIn(Duration fadeTime);
 		void fadeOut(Duration fadeTime);

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -33,8 +33,6 @@ namespace NAS2D
 		explicit Fade(FadeCompleteSignal::DelegateType onFadeComplete);
 		explicit Fade(Color fadeColor, FadeCompleteSignal::DelegateType onFadeComplete);
 
-		FadeCompleteSignal::Source& fadeComplete();
-
 		void fadeIn(Duration fadeTime);
 		void fadeOut(Duration fadeTime);
 

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -28,10 +28,8 @@ namespace NAS2D
 		using DelegateType = Delegate<void()>;
 
 
-		Fade();
-		explicit Fade(Color fadeColor);
-		explicit Fade(DelegateType onFadeComplete);
-		explicit Fade(Color fadeColor, DelegateType onFadeComplete);
+		explicit Fade(DelegateType onFadeComplete = {});
+		explicit Fade(Color fadeColor, DelegateType onFadeComplete = {});
 
 		void fadeIn(Duration fadeTime);
 		void fadeOut(Duration fadeTime);

--- a/NAS2D/Renderer/Fade.h
+++ b/NAS2D/Renderer/Fade.h
@@ -54,7 +54,7 @@ namespace NAS2D
 		FadeDirection mDirection;
 		Duration mDuration;
 		Timer mFadeTimer;
-		DelegateType mFadeComplete;
+		DelegateType mOnFadeComplete;
 	};
 
 }


### PR DESCRIPTION
Rely on `Delegate` being optionally passed to the `Fade` constructor.

This simplifies the API a little, and reduces the bloat needed for simple objects.

Related:
- Issue #1218
- Issue https://github.com/OutpostUniverse/OPHD/issues/1573
