### PR TITLE
Update `makefile` to not use `sdl2-config`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
           name: Add Brew include path to system include paths
           command: |
             echo "export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}:$(brew --prefix)/include" >> "${BASH_ENV}"
+            echo "export LDFLAGS_EXTRA=-L$(brew --prefix)/lib" >> "${BASH_ENV}"
       - build-and-test
   build-linux-gcc:
     docker:
@@ -50,6 +51,7 @@ jobs:
       - image: outpostuniverse/nas2d-mingw:1.11
     environment:
       WARN_EXTRA: "-Wno-redundant-decls"
+      LDFLAGS_EXTRA: "-L/usr/local/x86_64-w64-mingw32/lib"
     steps:
       - checkout
       - build-and-test

--- a/makefile
+++ b/makefile
@@ -41,15 +41,13 @@ Darwin_OpenGL_LIBS := -lGLEW -framework OpenGL
 Windows_OpenGL_LIBS := -lglew32 -lopengl32
 OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
-SDL_CONFIG := sdl2-config
-SDL_CONFIG_CFLAGS := $(shell type $(SDL_CONFIG) >/dev/null 2>&1 && $(SDL_CONFIG) --cflags)
-SDL_CONFIG_LIBS := $(shell type $(SDL_CONFIG) >/dev/null 2>&1 && $(SDL_CONFIG) --libs)
+SDL_LIBS := -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lSDL2
 
 CPPFLAGS := $(CPPFLAGS_EXTRA)
 CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute -Wredundant-decls -Wformat=2 $(WARN_EXTRA)
-CXXFLAGS := $(CXXFLAGS_EXTRA) $(CONFIG_CXX_FLAGS) -std=c++20 $(CXXFLAGS_WARN) $(SDL_CONFIG_CFLAGS)
+CXXFLAGS := $(CXXFLAGS_EXTRA) $(CONFIG_CXX_FLAGS) -std=c++20 $(CXXFLAGS_WARN)
 LDFLAGS := $(LDFLAGS_EXTRA)
-LDLIBS := $(LDLIBS_EXTRA) -lstdc++ -lSDL2_image -lSDL2_mixer -lSDL2_ttf $(SDL_CONFIG_LIBS) $(OpenGL_LIBS)
+LDLIBS := $(LDLIBS_EXTRA) -lstdc++ $(SDL_LIBS) $(OpenGL_LIBS)
 
 PROJECT_FLAGS = $(CPPFLAGS) $(CXXFLAGS)
 


### PR DESCRIPTION
The problem with `sdl2-config` is it would sometimes specify extra flags which were undesired, and there was no way to suppress the output of those flags. In some cases a defined macro value could be undefined, but there didn't seem to be a way to un-list a library. This sometimes caused problems with linking as not all projects need or want `SDL_main`.

It might be better to simply use `sdl2-config` in a manual way, and use it's output to guide how to use the `makefile` for a specific environment. At this point the `makefile` has sufficient customization points that any extra flags can be easily passed in. For example, `LDFLAGS_EXTRA` can be used to pass a library search path with the `-L` flag.

Related:
- Issue #1155
