### PR TITLE
Update MacOS build env to Xcode `16.2.0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
 jobs:
   build-macos:
     macos:
-      xcode: "15.4.0"
+      xcode: "16.2.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:


### PR DESCRIPTION
Related:
- Issue #1155

Available version list:
https://circleci.com/docs/using-macos/#supported-xcode-versions
