### PR TITLE
Call `EventHandler::pump()` first in game loop

### DIFF
--- a/NAS2D/StateManager.cpp
+++ b/NAS2D/StateManager.cpp
@@ -68,6 +68,8 @@ void StateManager::setState(State* state)
  */
 bool StateManager::update()
 {
+	Utility<EventHandler>::get().pump();
+
 	if (mActiveState)
 	{
 		State* nextState = mActiveState->update();
@@ -80,8 +82,6 @@ bool StateManager::update()
 		{
 			setState(nextState);
 		}
-
-		Utility<EventHandler>::get().pump();
 	}
 	else
 	{


### PR DESCRIPTION
Moving `EventHandler::pump()` first allows resize messages to be processed first, before drawing is done.

Previously, message dispatch was being handled between drawing to the back buffer, and swapping the back buffer. That meant there was a frame of lag where the back buffer being swapped in didn't match the window size after a resize event.

Note: There is still horrible flicker when resizing a window vertically, so this doesn't solve that. It's not even better in any clear way. Though in terms of looking at window sizes between the draw calls and the window sizes for back buffer swap, this does eliminate the frame of lag.

----

According to the SDL documentation:
https://wiki.libsdl.org/SDL2/SDL_PollEvent
> The common practice is to fully process the event queue once every frame, usually as a first step before updating the game's state

In particular, we probably don't want to put event polling between drawing and swapping of the back buffer, like we had it previously. That may be particularly bad when handling a resize event.

Related:
- Issue #1216
