### PR TITLE
Add `extern template` declarations for common `Signal` types

### DIFF
--- a/NAS2D/EventHandler.cpp
+++ b/NAS2D/EventHandler.cpp
@@ -19,6 +19,14 @@ using namespace NAS2D;
 
 namespace NAS2D
 {
+	template class Signal<KeyCode, KeyModifier>;
+	template class Signal<KeyCode, KeyModifier, bool>;
+	template class Signal<MouseButton, Point<int>>;
+	template class Signal<Point<int>, Vector<int>>;
+	template class Signal<Vector<int>>;
+	template class Signal<int, int, Vector<int>>;
+
+
 	/**
 	 * Posts a quit event to the event system.
 	 */

--- a/NAS2D/EventHandler.h
+++ b/NAS2D/EventHandler.h
@@ -26,6 +26,13 @@ namespace NAS2D
 	enum class KeyCode : uint32_t;
 	enum class MouseButton;
 
+	extern template class Signal<KeyCode, KeyModifier>;
+	extern template class Signal<KeyCode, KeyModifier, bool>;
+	extern template class Signal<MouseButton, Point<int>>;
+	extern template class Signal<Point<int>, Vector<int>>;
+	extern template class Signal<Vector<int>>;
+	extern template class Signal<int, int, Vector<int>>;
+
 
 	void postQuitEvent();
 

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -179,6 +179,7 @@
     <ClCompile Include="Resource\Music.cpp" />
     <ClCompile Include="Resource\Sound.cpp" />
     <ClCompile Include="Resource\Sprite.cpp" />
+    <ClCompile Include="Signal\Signal.cpp" />
     <ClCompile Include="StateManager.cpp" />
     <ClCompile Include="StringUtils.cpp" />
     <ClCompile Include="Timer.cpp" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClCompile Include="Resource\Sprite.cpp">
       <Filter>Source Files\Resource</Filter>
     </ClCompile>
+    <ClCompile Include="Signal\Signal.cpp">
+      <Filter>Source Files\Signal</Filter>
+    </ClCompile>
     <ClCompile Include="Xml\XmlParser.cpp">
       <Filter>Source Files\Xml</Filter>
     </ClCompile>

--- a/NAS2D/Signal/Signal.cpp
+++ b/NAS2D/Signal/Signal.cpp
@@ -1,0 +1,11 @@
+#include "Signal.h"
+
+
+namespace NAS2D
+{
+	template class Signal<>;
+	template class Signal<bool>;
+	template class Signal<int>;
+	template class Signal<int, int>;
+	template class Signal<int, int, int>;
+}

--- a/NAS2D/Signal/Signal.h
+++ b/NAS2D/Signal/Signal.h
@@ -52,4 +52,11 @@ namespace NAS2D
 
 		void operator()(Params... params) const { emit(params...); }
 	};
+
+
+	extern template class Signal<>;
+	extern template class Signal<bool>;
+	extern template class Signal<int>;
+	extern template class Signal<int, int>;
+	extern template class Signal<int, int, int>;
 } // namespace


### PR DESCRIPTION
Using `extern template` can have compile time and object file size benefits.

There doesn't appear to be any measurable gain from this change. Compile times appear to be about the same. Object files are about the same size. I suspect we'd need a larger more complicated template class in order to see gains here.

I figure keep it around for a bit, see if we notice any difference, and if not maybe strip it out in the future. At the very least, having this as part of project history serves as some kind of documentation on how to do it. Maybe it will be more useful in the future.

Closes #1222

----

Related:
- Issue #1222
- Issue #1245
