### PR TITLE
Add SDL version output to `test-graphics` project

### DIFF
--- a/test-graphics/SdlVersionInfo.cpp
+++ b/test-graphics/SdlVersionInfo.cpp
@@ -1,0 +1,16 @@
+#include "SdlVersionInfo.h"
+
+#include <SDL2/SDL.h>
+
+
+void printSdlVersionInfo()
+{
+	SDL_version compiled;
+	SDL_version linked;
+
+	SDL_VERSION(&compiled);
+	SDL_GetVersion(&linked);
+
+	SDL_Log("Compiled against SDL version %u.%u.%u.\n", compiled.major, compiled.minor, compiled.patch);
+	SDL_Log("Linked against SDL version %u.%u.%u.\n", linked.major, linked.minor, linked.patch);
+}

--- a/test-graphics/SdlVersionInfo.h
+++ b/test-graphics/SdlVersionInfo.h
@@ -1,0 +1,4 @@
+#pragma once
+
+
+void printSdlVersionInfo();

--- a/test-graphics/main.cpp
+++ b/test-graphics/main.cpp
@@ -8,6 +8,7 @@
 // = Acknowledgment of your use of NAS2D is appreciated but is not required.
 // ==================================================================================
 
+#include "SdlVersionInfo.h"
 #include "TestGraphics.h"
 
 #include <NAS2D/Game.h>
@@ -21,6 +22,8 @@
 
 int main()
 {
+	printSdlVersionInfo();
+
 	try
 	{
 		NAS2D::Game game("NAS2D Graphics Test", "NAS2D_GraphicsTest", "LairWorks");

--- a/test-graphics/test-graphics.vcxproj
+++ b/test-graphics/test-graphics.vcxproj
@@ -171,9 +171,11 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="SdlVersionInfo.cpp" />
     <ClCompile Include="TestGraphics.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="SdlVersionInfo.h" />
     <ClInclude Include="TestGraphics.h" />
   </ItemGroup>
   <ItemGroup>

--- a/test-graphics/test-graphics.vcxproj.filters
+++ b/test-graphics/test-graphics.vcxproj.filters
@@ -2,9 +2,11 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="SdlVersionInfo.cpp" />
     <ClCompile Include="TestGraphics.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="SdlVersionInfo.h" />
     <ClInclude Include="TestGraphics.h" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add version info output to the console when starting the `test-graphics` project.

Knowing which version of SDL is being used may help with debugging any issues encountered with SDL. Due to dynamic linking, it's possible the compile time version is different from the runtime version, so display both.

Related:
- Issue #1216
