### PR TITLE
Add exmaple of capturing lambda in `Delegate`

### DIFF
--- a/test/Signal/Delegate.test.cpp
+++ b/test/Signal/Delegate.test.cpp
@@ -63,3 +63,9 @@ TEST(Delegate, DelegateNotEqualObjects) {
 	auto delegate2 = NAS2D::Delegate{&handler2, &MockHandler::MockMethod};
 	EXPECT_NE(delegate1, delegate2);
 }
+
+TEST(Delegate, LambdaVariableCapture) {
+	const auto lambda = [](){ return 42; };
+	auto delegate = NAS2D::Delegate{&lambda, &decltype(lambda)::operator()};
+	EXPECT_EQ(42, delegate());
+}


### PR DESCRIPTION
One downside to this approach is the delegate must first be stored to a variable, so it can be referenced in two different places, and ensure those two places refers to the same type.

Related:
- Issue #1015
