### PR TITLE
Fix Clang warnings for `-Wweak-vtables`

### DIFF
--- a/NAS2D/Mixer/Mixer.cpp
+++ b/NAS2D/Mixer/Mixer.cpp
@@ -14,6 +14,11 @@
 using namespace NAS2D;
 
 
+Mixer::~Mixer()
+{
+}
+
+
 void Mixer::playMusic(const Music& music)
 {
 	fadeInMusic(music, Duration{0});

--- a/NAS2D/Mixer/Mixer.h
+++ b/NAS2D/Mixer/Mixer.h
@@ -31,7 +31,7 @@ namespace NAS2D
 		Mixer& operator=(const Mixer&) = default;
 		Mixer(Mixer&&) = default;
 		Mixer& operator=(Mixer&&) = default;
-		virtual ~Mixer() = default;
+		virtual ~Mixer();
 
 	public:
 		virtual void playSound(const Sound& sound) = 0;

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -181,6 +181,7 @@
     <ClCompile Include="Resource\Sound.cpp" />
     <ClCompile Include="Resource\Sprite.cpp" />
     <ClCompile Include="Signal\Signal.cpp" />
+    <ClCompile Include="State.cpp" />
     <ClCompile Include="StateManager.cpp" />
     <ClCompile Include="StringUtils.cpp" />
     <ClCompile Include="Timer.cpp" />

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -198,6 +198,7 @@
     <ClCompile Include="Xml\XmlParser.cpp" />
     <ClCompile Include="Xml\XmlText.cpp" />
     <ClCompile Include="Xml\XmlUnknown.cpp" />
+    <ClCompile Include="Xml\XmlVisitor.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Configuration.h" />

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -171,6 +171,7 @@
     <ClCompile Include="Renderer\Fade.cpp" />
     <ClCompile Include="Renderer\RectangleSkin.cpp" />
     <ClCompile Include="Renderer\Renderer.cpp" />
+    <ClCompile Include="Renderer\RendererNull.cpp" />
     <ClCompile Include="Renderer\RendererOpenGL.cpp" />
     <ClCompile Include="Renderer\Window.cpp" />
     <ClCompile Include="Resource\AnimationSet.cpp" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -114,6 +114,9 @@
     <ClCompile Include="Renderer\Renderer.cpp">
       <Filter>Source Files\Renderer</Filter>
     </ClCompile>
+    <ClCompile Include="Renderer\RendererNull.cpp">
+      <Filter>Source Files\Renderer</Filter>
+    </ClCompile>
     <ClCompile Include="Renderer\RendererOpenGL.cpp">
       <Filter>Source Files\Renderer</Filter>
     </ClCompile>

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClCompile Include="Game.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="State.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="StateManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -183,6 +183,9 @@
     <ClCompile Include="Xml\XmlNode.cpp">
       <Filter>Source Files\Xml</Filter>
     </ClCompile>
+    <ClCompile Include="Xml\XmlVisitor.cpp">
+      <Filter>Source Files\Xml</Filter>
+    </ClCompile>
     <ClCompile Include="StringUtils.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/NAS2D/Renderer/Renderer.cpp
+++ b/NAS2D/Renderer/Renderer.cpp
@@ -19,7 +19,13 @@ using namespace NAS2D;
 
 Renderer::Renderer(const std::string& appTitle) :
 	Window(appTitle)
-{}
+{
+}
+
+
+Renderer::~Renderer()
+{
+}
 
 
 void Renderer::drawTextShadow(const Font& font, std::string_view text, Point<float> position, Vector<float> shadowOffset, Color textColor, Color shadowColor)

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -38,6 +38,7 @@ namespace NAS2D
 		Renderer() = default;
 		Renderer(const Renderer& rhs) = default;
 		Renderer(Renderer&& rhs) = default;
+		~Renderer() override;
 
 		Renderer& operator=(const Renderer& rhs) = default;
 		Renderer& operator=(Renderer&& rhs) = default;

--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -37,8 +37,9 @@ namespace NAS2D
 	public:
 		Renderer() = default;
 		Renderer(const Renderer& rhs) = default;
-		Renderer& operator=(const Renderer& rhs) = default;
 		Renderer(Renderer&& rhs) = default;
+
+		Renderer& operator=(const Renderer& rhs) = default;
 		Renderer& operator=(Renderer&& rhs) = default;
 
 		virtual void drawImage(const Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) = 0;

--- a/NAS2D/Renderer/RendererNull.cpp
+++ b/NAS2D/Renderer/RendererNull.cpp
@@ -2,6 +2,7 @@
 
 #include "../Math/Point.h"
 #include "../Math/Vector.h"
+#include "../Math/Angle.h"
 
 
 using namespace NAS2D;

--- a/NAS2D/Renderer/RendererNull.cpp
+++ b/NAS2D/Renderer/RendererNull.cpp
@@ -1,0 +1,117 @@
+#include "RendererNull.h"
+
+#include "../Math/Point.h"
+#include "../Math/Vector.h"
+
+
+using namespace NAS2D;
+
+
+RendererNull::~RendererNull()
+{
+}
+
+
+void RendererNull::drawImage(const Image&, Point<float>, float, Color)
+{
+}
+
+
+void RendererNull::drawSubImage(const Image&, Point<float>, const Rectangle<float>&, Color)
+{
+}
+
+
+void RendererNull::drawSubImageRotated(const Image&, Point<float>, const Rectangle<float>&, Angle, Color)
+{
+}
+
+
+void RendererNull::drawImageRotated(const Image&, Point<float>, Angle, Color, float)
+{
+}
+
+
+void RendererNull::drawImageStretched(const Image&, const Rectangle<float>&, Color)
+{
+}
+
+
+void RendererNull::drawImageRepeated(const Image&, const Rectangle<float>&)
+{
+}
+
+
+void RendererNull::drawSubImageRepeated(const Image&, const Rectangle<float>&, const Rectangle<float>&)
+{
+}
+
+
+void RendererNull::drawImageToImage(const Image&, const Image&, Point<float>)
+{
+}
+
+
+void RendererNull::drawPoint(Point<float>, Color)
+{
+}
+
+
+void RendererNull::drawLine(Point<float>, Point<float>, Color, int)
+{
+}
+
+
+void RendererNull::drawBox(const Rectangle<float>&, Color)
+{
+}
+
+
+void RendererNull::drawBoxFilled(const Rectangle<float>&, Color)
+{
+}
+
+
+void RendererNull::drawCircle(Point<float>, float, Color, int, Vector<float>)
+{
+}
+
+
+void RendererNull::drawGradient(const Rectangle<float>&, Color, Color, Color, Color)
+{
+}
+
+
+void RendererNull::drawText(const Font&, std::string_view, Point<float>, Color)
+{
+}
+
+
+void RendererNull::clearScreen(Color)
+{
+}
+
+
+void RendererNull::clipRect(const Rectangle<float>&)
+{
+}
+
+
+void RendererNull::clipRectClear()
+{
+}
+
+
+void RendererNull::update()
+{
+}
+
+
+void RendererNull::setViewport(const Rectangle<int>&)
+{
+}
+
+
+void RendererNull::setOrthoProjection(const Rectangle<float>&)
+{
+}

--- a/NAS2D/Renderer/RendererNull.h
+++ b/NAS2D/Renderer/RendererNull.h
@@ -22,40 +22,40 @@ namespace NAS2D
 	public:
 		RendererNull() = default;
 
-		~RendererNull() override {}
+		~RendererNull() override;
 
-		void drawImage(const Image&, Point<float>, float = 1.0, Color = Color::Normal) override {}
+		void drawImage(const Image&, Point<float>, float = 1.0, Color = Color::Normal) override;
 
-		void drawSubImage(const Image&, Point<float>, const Rectangle<float>&, Color = Color::Normal) override {}
-		void drawSubImageRotated(const Image&, Point<float>, const Rectangle<float>&, Angle, Color = Color::Normal) override {}
+		void drawSubImage(const Image&, Point<float>, const Rectangle<float>&, Color = Color::Normal) override;
+		void drawSubImageRotated(const Image&, Point<float>, const Rectangle<float>&, Angle, Color = Color::Normal) override;
 
-		void drawImageRotated(const Image&, Point<float>, Angle, Color = Color::Normal, float = 1.0f) override {}
-		void drawImageStretched(const Image&, const Rectangle<float>&, Color = Color::Normal) override {}
+		void drawImageRotated(const Image&, Point<float>, Angle, Color = Color::Normal, float = 1.0f) override;
+		void drawImageStretched(const Image&, const Rectangle<float>&, Color = Color::Normal) override;
 
-		void drawImageRepeated(const Image&, const Rectangle<float>&) override {}
-		void drawSubImageRepeated(const Image&, const Rectangle<float>&, const Rectangle<float>&) override {}
+		void drawImageRepeated(const Image&, const Rectangle<float>&) override;
+		void drawSubImageRepeated(const Image&, const Rectangle<float>&, const Rectangle<float>&) override;
 
-		void drawImageToImage(const Image&, const Image&, Point<float>) override {}
+		void drawImageToImage(const Image&, const Image&, Point<float>) override;
 
-		void drawPoint(Point<float>, Color = Color::White) override {}
-		void drawLine(Point<float>, Point<float>, Color = Color::White, int = 1) override {}
-		void drawBox(const Rectangle<float>&, Color = Color::White) override {}
-		void drawBoxFilled(const Rectangle<float>&, Color = Color::White) override {}
-		void drawCircle(Point<float>, float, Color, int = 10, Vector<float> = Vector{1.0f, 1.0f}) override {}
+		void drawPoint(Point<float>, Color = Color::White) override;
+		void drawLine(Point<float>, Point<float>, Color = Color::White, int = 1) override;
+		void drawBox(const Rectangle<float>&, Color = Color::White) override;
+		void drawBoxFilled(const Rectangle<float>&, Color = Color::White) override;
+		void drawCircle(Point<float>, float, Color, int = 10, Vector<float> = Vector{1.0f, 1.0f}) override;
 
-		void drawGradient(const Rectangle<float>&, Color, Color, Color, Color) override {}
+		void drawGradient(const Rectangle<float>&, Color, Color, Color, Color) override;
 
-		void drawText(const Font&, std::string_view, Point<float>, Color = Color::White) override {}
+		void drawText(const Font&, std::string_view, Point<float>, Color = Color::White) override;
 
-		void clearScreen(Color = Color::Black) override {}
+		void clearScreen(Color = Color::Black) override;
 
-		void clipRect(const Rectangle<float>&) override {}
-		void clipRectClear() override {}
+		void clipRect(const Rectangle<float>&) override;
+		void clipRectClear() override;
 
-		void update() override {}
+		void update() override;
 
-		void setViewport(const Rectangle<int>&) override {}
-		void setOrthoProjection(const Rectangle<float>&) override {}
+		void setViewport(const Rectangle<int>&) override;
+		void setOrthoProjection(const Rectangle<float>&) override;
 	};
 
 } // namespace NAS2D

--- a/NAS2D/Renderer/RendererNull.h
+++ b/NAS2D/Renderer/RendererNull.h
@@ -11,11 +11,11 @@
 
 #include "Renderer.h"
 
-#include "../Math/Angle.h"
-
 
 namespace NAS2D
 {
+	class Angle;
+
 
 	class RendererNull : public Renderer
 	{

--- a/NAS2D/State.cpp
+++ b/NAS2D/State.cpp
@@ -1,0 +1,9 @@
+#include "State.h"
+
+
+using namespace NAS2D;
+
+
+void State::initialize()
+{
+}

--- a/NAS2D/State.h
+++ b/NAS2D/State.h
@@ -91,7 +91,7 @@ namespace NAS2D
 		 * of the State object. Use it for one-time initialization of any
 		 * members, event hooks, etc.
 		 */
-		virtual void initialize() = 0;
+		virtual void initialize();
 
 
 		/**

--- a/NAS2D/State.h
+++ b/NAS2D/State.h
@@ -75,7 +75,7 @@ namespace NAS2D
 	class State
 	{
 	public:
-		State() {}
+		State() = default;
 
 		virtual ~State() = default;
 

--- a/NAS2D/Xml/XmlBase.cpp
+++ b/NAS2D/Xml/XmlBase.cpp
@@ -16,6 +16,11 @@ using namespace NAS2D::Xml;
 bool XmlBase::condenseWhiteSpace = true;
 
 
+XmlBase::~XmlBase()
+{
+}
+
+
 /**
  * Get the row of the node in the document.
  *

--- a/NAS2D/Xml/XmlBase.h
+++ b/NAS2D/Xml/XmlBase.h
@@ -53,7 +53,7 @@ class XmlBase
 	friend class XmlDocument;
 
 public:
-	XmlBase() {}
+	XmlBase() = default;
 	XmlBase(const XmlBase&) = delete;
 	void operator=(const XmlBase& base) = delete;
 	virtual ~XmlBase() = default;

--- a/NAS2D/Xml/XmlBase.h
+++ b/NAS2D/Xml/XmlBase.h
@@ -56,7 +56,7 @@ public:
 	XmlBase() = default;
 	XmlBase(const XmlBase&) = delete;
 	void operator=(const XmlBase& base) = delete;
-	virtual ~XmlBase() = default;
+	virtual ~XmlBase();
 
 	/**
 	 * Writes the XML entity to a string buffer.

--- a/NAS2D/Xml/XmlVisitor.cpp
+++ b/NAS2D/Xml/XmlVisitor.cpp
@@ -1,0 +1,46 @@
+#include "XmlVisitor.h"
+
+
+using namespace NAS2D::Xml;
+
+
+bool XmlVisitor::visitEnter(const XmlDocument&)
+{
+	return true;
+}
+
+
+bool XmlVisitor::visitExit(const XmlDocument&)
+{
+	return true;
+}
+
+
+bool XmlVisitor::visitEnter(const XmlElement&, const XmlAttribute*)
+{
+	return true;
+}
+
+
+bool XmlVisitor::visitExit(const XmlElement&)
+{
+	return true;
+}
+
+
+bool XmlVisitor::visit(const XmlText&)
+{
+	return true;
+}
+
+
+bool XmlVisitor::visit(const XmlComment&)
+{
+	return true;
+}
+
+
+bool XmlVisitor::visit(const XmlUnknown&)
+{
+	return true;
+}

--- a/NAS2D/Xml/XmlVisitor.h
+++ b/NAS2D/Xml/XmlVisitor.h
@@ -43,15 +43,15 @@ class XmlVisitor
 public:
 	virtual ~XmlVisitor() = default;
 
-	virtual bool visitEnter(const XmlDocument&) { return true; }
-	virtual bool visitExit(const XmlDocument&) { return true; }
+	virtual bool visitEnter(const XmlDocument&);
+	virtual bool visitExit(const XmlDocument&);
 
-	virtual bool visitEnter(const XmlElement&, const XmlAttribute*) { return true; }
-	virtual bool visitExit(const XmlElement&) { return true; }
+	virtual bool visitEnter(const XmlElement&, const XmlAttribute*);
+	virtual bool visitExit(const XmlElement&);
 
-	virtual bool visit(const XmlText&) { return true; }
-	virtual bool visit(const XmlComment&) { return true; }
-	virtual bool visit(const XmlUnknown&) { return true; }
+	virtual bool visit(const XmlText&);
+	virtual bool visit(const XmlComment&);
+	virtual bool visit(const XmlUnknown&);
 };
 
 } // namespace Xml

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -36,21 +36,23 @@ TEST(FilesystemStatic, extension) {
 }
 
 
-class Filesystem : public ::testing::Test {
-protected:
-	static constexpr auto AppName = "NAS2DUnitTests";
-	static constexpr auto OrganizationName = "LairWorks";
+namespace {
+	class Filesystem : public ::testing::Test {
+	protected:
+		static constexpr auto AppName = "NAS2DUnitTests";
+		static constexpr auto OrganizationName = "LairWorks";
 
-	Filesystem() :
-		fs(AppName, OrganizationName)
-	{
-		fs.mount(fs.basePath());
-		fs.mount("data/");
-		fs.mountReadWrite(fs.prefPath());
-	}
+		Filesystem() :
+			fs(AppName, OrganizationName)
+		{
+			fs.mount(fs.basePath());
+			fs.mount("data/");
+			fs.mountReadWrite(fs.prefPath());
+		}
 
-	NAS2D::Filesystem fs;
-};
+		NAS2D::Filesystem fs;
+	};
+}
 
 
 constexpr auto EndsWithDirSeparator = []() {


### PR DESCRIPTION
Ensure classes with `virtual` member functions have at least one out-of-line definition in their source file.

Related:
- Issue #528
