### PR TITLE
Convert `Mix_Music` forward declare to include in `Music.h`

### DIFF
--- a/NAS2D/Resource/Music.cpp
+++ b/NAS2D/Resource/Music.cpp
@@ -14,12 +14,6 @@
 
 #include <SDL2/SDL.h>
 
-#if defined(__XCODE_BUILD__)
-#include <SDL2_mixer/SDL_mixer.h>
-#else
-#include <SDL2/SDL_mixer.h>
-#endif
-
 #include <string>
 #include <stdexcept>
 

--- a/NAS2D/Resource/Music.h
+++ b/NAS2D/Resource/Music.h
@@ -13,8 +13,11 @@
 #include <string>
 #include <map>
 
-
-typedef struct _Mix_Music Mix_Music;
+#if defined(__XCODE_BUILD__)
+#include <SDL2_mixer/SDL_mixer.h>
+#else
+#include <SDL2/SDL_mixer.h>
+#endif
 
 
 namespace NAS2D


### PR DESCRIPTION
The `Mix_Music` typedef points to a `struct` that was renamed. There's no easy way to deal with that and maintain a forward declare. We would need to forward declare for one of two possible type names, before we've seen the include that would tell us which name it should be.

I suppose we could add some pointer casting, but that should be avoided.

Considering how infrequently the `Music.h` header is included by other files, we're probably fine doing a full SDL include for now. Once things have stabilized on the new version we could eventually switch back to a forward declare. As a bonus, that forward declare will then be for a name that is not reserved.

Closes #1242

Related:
- Issue #1242
- PR https://github.com/OutpostUniverse/OPHD/pull/1655
