### PR TITLE
Remove Clang `-Wpadded` warnings from XML code

### DIFF
--- a/NAS2D/Xml/XmlBase.h
+++ b/NAS2D/Xml/XmlBase.h
@@ -127,21 +127,6 @@ protected:
 	ParseLocation location{};
 
 private:
-	struct Entity
-	{
-		const char* str;
-		unsigned int strLength;
-		char chr;
-	};
-
-	enum
-	{
-		NUM_ENTITY = 5,
-		MAX_ENTITY_LENGTH = 6
-
-	};
-
-	static Entity entity[NUM_ENTITY];
 	static bool condenseWhiteSpace;
 };
 

--- a/NAS2D/Xml/XmlDocument.h
+++ b/NAS2D/Xml/XmlDocument.h
@@ -59,12 +59,10 @@ private:
 
 private:
 	XmlErrorCode _errorId{};
-
-	bool _error{};
-
-	std::string _errorDesc{};
-
 	XmlBase::ParseLocation _errorLocation{};
+	std::string _errorDesc{};
+	bool _error{};
+	char padding[7];
 };
 
 } // namespace Xml

--- a/NAS2D/Xml/XmlMemoryBuffer.cpp
+++ b/NAS2D/Xml/XmlMemoryBuffer.cpp
@@ -37,7 +37,7 @@ inline void line_break(const std::string& linebreak, std::string& buffer)
 }
 
 
-XmlMemoryBuffer::XmlMemoryBuffer() : depth(0), _indent("\t"), _lineBreak("\n")
+XmlMemoryBuffer::XmlMemoryBuffer() : _indent("\t"), _lineBreak("\n"), depth(0)
 {}
 
 

--- a/NAS2D/Xml/XmlMemoryBuffer.h
+++ b/NAS2D/Xml/XmlMemoryBuffer.h
@@ -53,11 +53,12 @@ public:
 	const std::string& buffer();
 
 private:
-	int depth;
-
 	std::string _buffer{};
 	std::string _indent;
 	std::string _lineBreak;
+	int depth;
+protected:
+	int _padding{};
 };
 
 } // namespace Xml

--- a/NAS2D/Xml/XmlNode.cpp
+++ b/NAS2D/Xml/XmlNode.cpp
@@ -17,11 +17,11 @@ using namespace NAS2D::Xml;
 XmlNode::XmlNode() :
 	XmlBase(),
 	_parent(nullptr),
-	_type(NodeType::XML_UNKNOWN),
 	_firstChild(nullptr),
 	_lastChild(nullptr),
 	_prev(nullptr),
-	_next(nullptr)
+	_next(nullptr),
+	_type(NodeType::XML_UNKNOWN)
 {}
 
 
@@ -33,11 +33,11 @@ XmlNode::XmlNode() :
 XmlNode::XmlNode(NodeType type) :
 	XmlBase(),
 	_parent(nullptr),
-	_type(type),
 	_firstChild(nullptr),
 	_lastChild(nullptr),
 	_prev(nullptr),
-	_next(nullptr)
+	_next(nullptr),
+	_type(type)
 {}
 
 

--- a/NAS2D/Xml/XmlNode.h
+++ b/NAS2D/Xml/XmlNode.h
@@ -153,15 +153,13 @@ protected:
 	XmlNode* identify(const char* start);
 
 	XmlNode* _parent;
-	NodeType _type;
-
 	XmlNode* _firstChild;
 	XmlNode* _lastChild;
-
-	std::string _value{};
-
 	XmlNode* _prev;
 	XmlNode* _next;
+	std::string _value{};
+	NodeType _type;
+	int _padding{};
 
 private:
 	friend class XmlDocument;

--- a/NAS2D/Xml/XmlParser.cpp
+++ b/NAS2D/Xml/XmlParser.cpp
@@ -70,24 +70,35 @@ namespace
 		"Error parsing CDATA.",
 		"Error adding XmlDocument to document: XmlDocument can only be at the root.",
 	};
+
+	struct Entity
+	{
+		const char* str;
+		unsigned int strLength;
+		char chr;
+	};
+
+	enum
+	{
+		NUM_ENTITY = 5,
+		MAX_ENTITY_LENGTH = 6
+
+	};
+
+	Entity entity[NUM_ENTITY] =
+	{
+		{ "&amp;",  5, '&' },
+		{ "&lt;",   4, '<' },
+		{ "&gt;",   4, '>' },
+		{ "&quot;", 6, '\"' },
+		{ "&apos;", 6, '\'' }
+	};
 }
 
 
 namespace NAS2D
 {
 namespace Xml {
-
-// Note that "PutString" hardcodes the same list. This is less flexible
-// than it appears. Changing the entries or order will break putstring.
-XmlBase::Entity XmlBase::entity[ XmlBase::NUM_ENTITY ] =
-{
-	{ "&amp;",  5, '&' },
-	{ "&lt;",   4, '<' },
-	{ "&gt;",   4, '>' },
-	{ "&quot;", 6, '\"' },
-	{ "&apos;", 6, '\'' }
-};
-
 
 int XmlBase::isAlpha(unsigned char anyByte)
 {

--- a/NAS2D/Xml/XmlText.h
+++ b/NAS2D/Xml/XmlText.h
@@ -64,6 +64,7 @@ protected:
 
 private:
 	bool cdata{}; // true if this should be input and output as a CDATA style text element
+	char padding[7]{};
 };
 
 } // namespace Xml


### PR DESCRIPTION
I normally avoid maintenance work on the XML code, though the headers were generating those warnings for every include, which obscured similar warnings for other parts of the code.

Related:
- Issue #528
