### PR TITLE
Update `make show-warnings`

### DIFF
--- a/makefile
+++ b/makefile
@@ -185,10 +185,12 @@ $(PACKAGE_NAME): $(OUTPUT) $(shell find $(SRCDIR) -name '*.h')
 
 ## Linting ##
 
+WarnNoUninteresting := -Wno-c++98-compat-pedantic -Wno-pre-c++17-compat
+
 .PHONY: show-warnings
 show-warnings:
 	@$(MAKE) clean-all > /dev/null
-	$(MAKE) --output-sync all CXX=clang++ CXXFLAGS_WARN=-Weverything 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
+	$(MAKE) --output-sync all CXX=clang++ CXXFLAGS_WARN="-Weverything $(WarnNoUninteresting)" 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
 	@$(MAKE) clean-all > /dev/null
 
 .PHONY: lint

--- a/makefile
+++ b/makefile
@@ -187,9 +187,9 @@ $(PACKAGE_NAME): $(OUTPUT) $(shell find $(SRCDIR) -name '*.h')
 
 .PHONY: show-warnings
 show-warnings:
-	@$(MAKE) clean > /dev/null
+	@$(MAKE) clean-all > /dev/null
 	$(MAKE) --output-sync all CXX=clang++ CXXFLAGS_WARN=-Weverything 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
-	@$(MAKE) clean > /dev/null
+	@$(MAKE) clean-all > /dev/null
 
 .PHONY: lint
 lint: cppcheck cppclean


### PR DESCRIPTION
Update `make show-warnings` so it consistently shows warnings for the unit test and demo project as well as the main library project.

Add list of uninteresting warnings to suppress, such as code being incompatible with obsolete versions of C++.

Related:
- Issue #528
