### PR TITLE
Move `SDL_Window*` to `Window` member field

### DIFF
--- a/NAS2D/Renderer/Renderer.h
+++ b/NAS2D/Renderer/Renderer.h
@@ -36,12 +36,7 @@ namespace NAS2D
 	{
 	public:
 		Renderer() = default;
-		Renderer(const Renderer& rhs) = default;
-		Renderer(Renderer&& rhs) = default;
 		~Renderer() override;
-
-		Renderer& operator=(const Renderer& rhs) = default;
-		Renderer& operator=(Renderer&& rhs) = default;
 
 		virtual void drawImage(const Image& image, Point<float> position, float scale = 1.0, Color color = Color::Normal) = 0;
 		virtual void drawSubImage(const Image& image, Point<float> raster, const Rectangle<float>& subImageRect, Color color = Color::Normal) = 0;

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -41,10 +41,6 @@
 using namespace NAS2D;
 
 
-// UGLY ASS HACK!
-extern SDL_Window* underlyingWindow;
-
-
 namespace
 {
 	constexpr std::array<GLfloat, 12> rectToQuad(Rectangle<GLfloat> rect)

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -131,8 +131,8 @@ RendererOpenGL::~RendererOpenGL()
 	Utility<EventHandler>::get().windowResized().disconnect({this, &RendererOpenGL::onResize});
 
 	SDL_GL_DeleteContext(sdlOglContext);
-	SDL_DestroyWindow(underlyingWindow);
-	underlyingWindow = nullptr;
+	SDL_DestroyWindow(window);
+	window = nullptr;
 	SDL_QuitSubSystem(SDL_INIT_VIDEO);
 }
 
@@ -529,7 +529,7 @@ void RendererOpenGL::clearScreen(Color color)
 
 void RendererOpenGL::update()
 {
-	SDL_GL_SwapWindow(underlyingWindow);
+	SDL_GL_SwapWindow(window);
 }
 
 
@@ -593,9 +593,9 @@ void RendererOpenGL::initSdl(Vector<int> resolution, bool fullscreen)
 	}
 
 	const Uint32 sdlFlags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | (fullscreen ? SDL_WINDOW_FULLSCREEN : 0);
-	underlyingWindow = SDL_CreateWindow(title().c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, resolution.x, resolution.y, sdlFlags);
+	window = SDL_CreateWindow(title().c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, resolution.x, resolution.y, sdlFlags);
 
-	if (!underlyingWindow)
+	if (!window)
 	{
 		throw std::runtime_error("Failed to create SDL window");
 	}
@@ -615,7 +615,7 @@ void RendererOpenGL::initSdlGL(bool vsync)
 
 	SDL_GL_SetSwapInterval(vsync ? 1 : 0);
 
-	sdlOglContext = SDL_GL_CreateContext(underlyingWindow);
+	sdlOglContext = SDL_GL_CreateContext(window);
 	if (!sdlOglContext)
 	{
 		throw std::runtime_error("Failed to create SDL OpenGL context");

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -158,7 +158,7 @@ void Window::setResolution(Vector<int> newResolution)
 
 std::vector<DisplayDesc> Window::getDisplayModes() const
 {
-	const auto displayIndex = SDL_GetWindowDisplayIndex(underlyingWindow);
+	const auto displayIndex = SDL_GetWindowDisplayIndex(window);
 	const auto numResolutions = SDL_GetNumDisplayModes(displayIndex);
 	if (numResolutions < 0)
 	{
@@ -179,7 +179,7 @@ std::vector<DisplayDesc> Window::getDisplayModes() const
 
 DisplayDesc Window::getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const
 {
-	const auto displayIndex = SDL_GetWindowDisplayIndex(underlyingWindow);
+	const auto displayIndex = SDL_GetWindowDisplayIndex(window);
 	SDL_DisplayMode preferredMode{};
 	preferredMode.w = preferredDisplayDesc.width;
 	preferredMode.h = preferredDisplayDesc.height;
@@ -203,7 +203,7 @@ void Window::window_icon(const std::string& path)
 		throw std::runtime_error("Failed to set window icon: " + path + " : " + SDL_GetError());
 	}
 
-	SDL_SetWindowIcon(underlyingWindow, icon);
+	SDL_SetWindowIcon(window, icon);
 	SDL_FreeSurface(icon);
 }
 
@@ -260,35 +260,35 @@ void Window::fullscreen(bool fullscreen, bool maintain)
 	if (fullscreen)
 	{
 		const auto windowFlags = maintain ? SDL_WINDOW_FULLSCREEN : SDL_WINDOW_FULLSCREEN_DESKTOP;
-		SDL_SetWindowFullscreen(underlyingWindow, windowFlags);
-		SDL_SetWindowResizable(underlyingWindow, SDL_FALSE);
+		SDL_SetWindowFullscreen(window, windowFlags);
+		SDL_SetWindowResizable(window, SDL_FALSE);
 	}
 	else
 	{
-		SDL_SetWindowFullscreen(underlyingWindow, 0);
+		SDL_SetWindowFullscreen(window, 0);
 		const auto windowSize = size();
-		SDL_SetWindowSize(underlyingWindow, windowSize.x, windowSize.y);
+		SDL_SetWindowSize(window, windowSize.x, windowSize.y);
 		onResize(windowSize);
-		SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+		SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 	}
 }
 
 
 bool Window::fullscreen() const
 {
-	return isAnyWindowFlagSet(underlyingWindow, SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP);
+	return isAnyWindowFlagSet(window, SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP);
 }
 
 
 void Window::maximize()
 {
-	SDL_MaximizeWindow(underlyingWindow);
+	SDL_MaximizeWindow(window);
 }
 
 
 bool Window::isMaximized() const
 {
-	const auto flags = SDL_GetWindowFlags(underlyingWindow);
+	const auto flags = SDL_GetWindowFlags(window);
 	return (flags & SDL_WINDOW_MAXIMIZED);
 }
 
@@ -303,30 +303,30 @@ void Window::resizeable(bool resizable)
 #if defined(_MSC_VER)
 	#pragma warning(suppress : 26812) // C26812 Warns to use enum class (C++), but SDL is a C library
 #endif
-	SDL_SetWindowResizable(underlyingWindow, resizable ? SDL_TRUE : SDL_FALSE);
+	SDL_SetWindowResizable(window, resizable ? SDL_TRUE : SDL_FALSE);
 }
 
 
 bool Window::resizeable() const
 {
-	return isAnyWindowFlagSet(underlyingWindow, SDL_WINDOW_RESIZABLE);
+	return isAnyWindowFlagSet(window, SDL_WINDOW_RESIZABLE);
 }
 
 
 void Window::minimumSize(Vector<int> newSize)
 {
-	SDL_SetWindowMinimumSize(underlyingWindow, newSize.x, newSize.y);
+	SDL_SetWindowMinimumSize(window, newSize.x, newSize.y);
 
 	// Read back the window size, in case it was changed
 	// Window may need to have been enlarged to the minimum size
-	SDL_GetWindowSize(underlyingWindow, &newSize.x, &newSize.y);
+	SDL_GetWindowSize(window, &newSize.x, &newSize.y);
 	onResize(newSize);
 }
 
 
 Vector<int> Window::size() const
 {
-	if (isAnyWindowFlagSet(underlyingWindow, SDL_WINDOW_FULLSCREEN_DESKTOP))
+	if (isAnyWindowFlagSet(window, SDL_WINDOW_FULLSCREEN_DESKTOP))
 	{
 		SDL_DisplayMode dm;
 		if (SDL_GetDesktopDisplayMode(0, &dm) != 0)
@@ -343,9 +343,9 @@ Vector<int> Window::size() const
 
 void Window::size(Vector<int> newSize)
 {
-	SDL_SetWindowSize(underlyingWindow, newSize.x, newSize.y);
+	SDL_SetWindowSize(window, newSize.x, newSize.y);
 	onResize(newSize);
-	SDL_SetWindowPosition(underlyingWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+	SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 }
 
 
@@ -357,20 +357,20 @@ void Window::onResize(Vector<int> /*newSize*/)
 Vector<int> Window::getWindowClientArea() const noexcept
 {
 	Vector<int> size;
-	SDL_GetWindowSize(underlyingWindow, &size.x, &size.y);
+	SDL_GetWindowSize(window, &size.x, &size.y);
 	return size;
 }
 
 
 void Window::captureMouse()
 {
-	SDL_SetWindowGrab(underlyingWindow, SDL_TRUE);
+	SDL_SetWindowGrab(window, SDL_TRUE);
 }
 
 
 void Window::releaseMouse()
 {
-	SDL_SetWindowGrab(underlyingWindow, SDL_FALSE);
+	SDL_SetWindowGrab(window, SDL_FALSE);
 }
 
 
@@ -381,23 +381,23 @@ void Window::releaseMouse()
  */
 void Window::warpMouse(Point<int> mousePositionInWindow)
 {
-	SDL_WarpMouseInWindow(underlyingWindow, mousePositionInWindow.x, mousePositionInWindow.y);
+	SDL_WarpMouseInWindow(window, mousePositionInWindow.x, mousePositionInWindow.y);
 }
 
 
 void Window::doModalError(const std::string& title, const std::string& message) const
 {
-	::doModalError(title, message, underlyingWindow);
+	::doModalError(title, message, window);
 }
 
 
 void Window::doModalAlert(const std::string& title, const std::string& message) const
 {
-	::doModalAlert(title, message, underlyingWindow);
+	::doModalAlert(title, message, window);
 }
 
 
 bool Window::doModalYesNo(const std::string& title, const std::string& message) const
 {
-	return ::doModalYesNo(title, message, underlyingWindow);
+	return ::doModalYesNo(title, message, window);
 }

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -26,15 +26,11 @@
 using namespace NAS2D;
 
 
-// UGLY ASS HACK!
-SDL_Window* underlyingWindow = nullptr;
-
-
 namespace
 {
-	bool isAnyWindowFlagSet(Uint32 testFlags)
+	bool isAnyWindowFlagSet(SDL_Window* window, Uint32 testFlags)
 	{
-		return (SDL_GetWindowFlags(underlyingWindow) & testFlags) != 0;
+		return (SDL_GetWindowFlags(window) & testFlags) != 0;
 	}
 
 
@@ -280,7 +276,7 @@ void Window::fullscreen(bool fullscreen, bool maintain)
 
 bool Window::fullscreen() const
 {
-	return isAnyWindowFlagSet(SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP);
+	return isAnyWindowFlagSet(underlyingWindow, SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP);
 }
 
 
@@ -313,7 +309,7 @@ void Window::resizeable(bool resizable)
 
 bool Window::resizeable() const
 {
-	return isAnyWindowFlagSet(SDL_WINDOW_RESIZABLE);
+	return isAnyWindowFlagSet(underlyingWindow, SDL_WINDOW_RESIZABLE);
 }
 
 
@@ -330,7 +326,7 @@ void Window::minimumSize(Vector<int> newSize)
 
 Vector<int> Window::size() const
 {
-	if (isAnyWindowFlagSet(SDL_WINDOW_FULLSCREEN_DESKTOP))
+	if (isAnyWindowFlagSet(underlyingWindow, SDL_WINDOW_FULLSCREEN_DESKTOP))
 	{
 		SDL_DisplayMode dm;
 		if (SDL_GetDesktopDisplayMode(0, &dm) != 0)

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -80,6 +80,6 @@ namespace NAS2D
 		Vector<int> mResolution{1600, 900};
 		std::string mTitle;
 		std::map<int, SDL_Cursor*> cursors{};
-		SDL_Window* underlyingWindow{nullptr};
+		SDL_Window* window{nullptr};
 	};
 }

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -8,6 +8,7 @@
 
 
 struct SDL_Cursor;
+struct SDL_Window;
 
 
 namespace NAS2D
@@ -79,5 +80,6 @@ namespace NAS2D
 		Vector<int> mResolution{1600, 900};
 		std::string mTitle;
 		std::map<int, SDL_Cursor*> cursors{};
+		SDL_Window* underlyingWindow{nullptr};
 	};
 }

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -29,7 +29,10 @@ namespace NAS2D
 	public:
 		Window();
 		Window(const std::string& appTitle);
+		Window(const Window&) = delete;
 		virtual ~Window();
+
+		Window& operator=(const Window&) = delete;
 
 		virtual std::vector<DisplayDesc> getDisplayModes() const;
 		virtual DisplayDesc getClosestMatchingDisplayMode(const DisplayDesc& preferredDisplayDesc) const;


### PR DESCRIPTION
This gets rid of a long standing hack concerning how the `SDL_Window*` handle is shared.

Fix Clang warning `-Wmissing-variable-declarations`.

Related:
- Issue #528
