### PR TITLE
Fix `Fade` race condition

### DIFF
--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -78,7 +78,7 @@ void Fade::update()
 		return;
 	}
 
-	const auto step = static_cast<uint8_t>(std::clamp(mFadeTimer.elapsedTicks() * 255u / static_cast<unsigned int>(mDuration.milliseconds), 0u, 255u));
+	const auto step = static_cast<uint8_t>(std::clamp<unsigned int>(mFadeTimer.elapsedTicks() * 255u / mDuration.milliseconds, 0u, 255u));
 	mFadeColor.alpha = (mDirection == FadeDirection::In) ? 255 - step : step;
 
 	if (step == 255)

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -20,6 +20,12 @@
 using namespace NAS2D;
 
 
+namespace
+{
+	constexpr uint8_t alphaOpaque = 255;
+}
+
+
 Fade::Fade(DelegateType onFadeComplete) :
 	Fade{Color::Black, onFadeComplete}
 {
@@ -27,7 +33,7 @@ Fade::Fade(DelegateType onFadeComplete) :
 
 
 Fade::Fade(Color fadeColor, DelegateType onFadeComplete) :
-	mFadeColor{fadeColor.alphaFade(255)},
+	mFadeColor{fadeColor.alphaFade(alphaOpaque)},
 	mDirection{FadeDirection::None},
 	mDuration{},
 	mFadeTimer{},
@@ -60,7 +66,7 @@ bool Fade::isFading() const
 
 bool Fade::isFaded() const
 {
-	return (mDirection == FadeDirection::None) && (mFadeColor.alpha == 255);
+	return (mDirection == FadeDirection::None) && (mFadeColor.alpha == alphaOpaque);
 }
 
 

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -22,6 +22,7 @@ using namespace NAS2D;
 
 namespace
 {
+	constexpr uint8_t alphaTransparent = 0;
 	constexpr uint8_t alphaOpaque = 255;
 }
 
@@ -93,7 +94,7 @@ void Fade::update()
 
 void Fade::draw(Renderer& renderer) const
 {
-	if (mFadeColor.alpha > 0)
+	if (mFadeColor.alpha != alphaTransparent)
 	{
 		const auto displayRect = Rectangle{{0, 0}, renderer.size()};
 		renderer.drawBoxFilled(displayRect, mFadeColor);

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -99,7 +99,7 @@ void Fade::setDuration(Duration newDuration)
 {
 	if (newDuration.milliseconds == 0)
 	{
-		throw std::runtime_error("Fade duration must be positive");
+		throw std::domain_error("Fade duration must be positive");
 	}
 
 	mDuration = newDuration;

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -60,7 +60,7 @@ bool Fade::isFading() const
 
 bool Fade::isFaded() const
 {
-	return (mFadeColor.alpha == 255);
+	return (mDirection == FadeDirection::None) && (mFadeColor.alpha == 255);
 }
 
 

--- a/NAS2D/Renderer/Fade.cpp
+++ b/NAS2D/Renderer/Fade.cpp
@@ -14,6 +14,7 @@
 #include "../Math/Rectangle.h"
 
 #include <algorithm>
+#include <stdexcept>
 
 
 using namespace NAS2D;


### PR DESCRIPTION
Update `Fade::isFaded()` to only return `true` when there is an active fade in progress.

Previously, when a fade in was started, `isFaded` could return true if it was checked within the first `1/255` of the fade duration. This could cause fade transitions to abort early, and with unexpected results, such as triggering behavior for a fade in the opposite direction. For instance, in OPHD, starting a new game could suddenly abort as if a game had just ended.

Closes #1202
