### PR TITLE
Improve `scaleLinear` to avoid `OutputType` wrap around

### DIFF
--- a/NAS2D/Math/MathUtils.h
+++ b/NAS2D/Math/MathUtils.h
@@ -48,7 +48,7 @@ namespace NAS2D
 	template <typename InputType, typename OutputType>
 	constexpr OutputType scaleLinear(const InputType& value, const InputType& domainPoint1, const InputType& domainPoint2, const OutputType& rangePoint1, const OutputType& rangePoint2)
 	{
-		return (value - domainPoint1) * (rangePoint2 - rangePoint1) / (domainPoint2 - domainPoint1) + rangePoint1;
+		return static_cast<OutputType>((value - domainPoint1) * (rangePoint2 - rangePoint1) / (domainPoint2 - domainPoint1) + rangePoint1);
 	}
 
 } // namespace NAS2D

--- a/NAS2D/Math/MathUtils.h
+++ b/NAS2D/Math/MathUtils.h
@@ -48,7 +48,7 @@ namespace NAS2D
 	template <typename InputType, typename OutputType>
 	constexpr OutputType scaleLinear(const InputType& value, const InputType& domainPoint1, const InputType& domainPoint2, const OutputType& rangePoint1, const OutputType& rangePoint2)
 	{
-		return static_cast<OutputType>((value - domainPoint1) * (rangePoint2 - rangePoint1) / (domainPoint2 - domainPoint1) + rangePoint1);
+		return static_cast<OutputType>(((domainPoint2 - value) * rangePoint1 + (value - domainPoint1) * rangePoint2) / (domainPoint2 - domainPoint1));
 	}
 
 } // namespace NAS2D

--- a/NAS2D/Math/MathUtils.h
+++ b/NAS2D/Math/MathUtils.h
@@ -46,7 +46,7 @@ namespace NAS2D
 	 * InputType and OutputType must support all arithmetic operators and all arithmetic operators between each other.
 	 */
 	template <typename InputType, typename OutputType>
-	OutputType scaleLinear(const InputType& value, const InputType& domainPoint1, const InputType& domainPoint2, const OutputType& rangePoint1, const OutputType& rangePoint2)
+	constexpr OutputType scaleLinear(const InputType& value, const InputType& domainPoint1, const InputType& domainPoint2, const OutputType& rangePoint1, const OutputType& rangePoint2)
 	{
 		return (value - domainPoint1) * (rangePoint2 - rangePoint1) / (domainPoint2 - domainPoint1) + rangePoint1;
 	}

--- a/test/Math/MathUtils.test.cpp
+++ b/test/Math/MathUtils.test.cpp
@@ -100,6 +100,22 @@ TEST(MathUtils, roundUpPowerOf2) {
 	EXPECT_EQ(2147483648u, NAS2D::roundUpPowerOf2(2147483648));
 }
 
+TEST(MathUtils, scaleLinearForwardUint8toUint8) {
+	EXPECT_EQ(uint8_t{0}, NAS2D::scaleLinear(uint8_t{0}, uint8_t{0}, uint8_t{255}, uint8_t{0}, uint8_t{255}));
+	EXPECT_EQ(uint8_t{64}, NAS2D::scaleLinear(uint8_t{64}, uint8_t{0}, uint8_t{255}, uint8_t{0}, uint8_t{255}));
+	EXPECT_EQ(uint8_t{128}, NAS2D::scaleLinear(uint8_t{128}, uint8_t{0}, uint8_t{255}, uint8_t{0}, uint8_t{255}));
+	EXPECT_EQ(uint8_t{192}, NAS2D::scaleLinear(uint8_t{192}, uint8_t{0}, uint8_t{255}, uint8_t{0}, uint8_t{255}));
+	EXPECT_EQ(uint8_t{255}, NAS2D::scaleLinear(uint8_t{255}, uint8_t{0}, uint8_t{255}, uint8_t{0}, uint8_t{255}));
+}
+
+TEST(MathUtils, scaleLinearReverseUint8toUint8) {
+	EXPECT_EQ(uint8_t{255}, NAS2D::scaleLinear(uint8_t{0}, uint8_t{0}, uint8_t{255}, uint8_t{255}, uint8_t{0}));
+	EXPECT_EQ(uint8_t{191}, NAS2D::scaleLinear(uint8_t{64}, uint8_t{0}, uint8_t{255}, uint8_t{255}, uint8_t{0}));
+	EXPECT_EQ(uint8_t{127}, NAS2D::scaleLinear(uint8_t{128}, uint8_t{0}, uint8_t{255}, uint8_t{255}, uint8_t{0}));
+	EXPECT_EQ(uint8_t{63}, NAS2D::scaleLinear(uint8_t{192}, uint8_t{0}, uint8_t{255}, uint8_t{255}, uint8_t{0}));
+	EXPECT_EQ(uint8_t{0}, NAS2D::scaleLinear(uint8_t{255}, uint8_t{0}, uint8_t{255}, uint8_t{255}, uint8_t{0}));
+}
+
 TEST(MathUtils, scaleLinearFloatFahrenheitToCelsius) {
 	// Fahrenheit to Celsius
 	EXPECT_NEAR(-18.33333f, NAS2D::scaleLinear(-1.0f, 32.0f, 212.0f, 0.0f, 100.0f), 0.0001f);

--- a/test/Math/MathUtils.test.cpp
+++ b/test/Math/MathUtils.test.cpp
@@ -116,6 +116,14 @@ TEST(MathUtils, scaleLinearReverseUint8toUint8) {
 	EXPECT_EQ(uint8_t{0}, NAS2D::scaleLinear(uint8_t{255}, uint8_t{0}, uint8_t{255}, uint8_t{255}, uint8_t{0}));
 }
 
+TEST(MathUtils, scaleLinearForwardUint32toUint8) {
+	EXPECT_EQ(uint8_t{0}, NAS2D::scaleLinear(uint32_t{0}, uint32_t{0}, uint32_t{10000}, uint8_t{0}, uint8_t{255}));
+	EXPECT_EQ(uint8_t{63}, NAS2D::scaleLinear(uint32_t{2500}, uint32_t{0}, uint32_t{10000}, uint8_t{0}, uint8_t{255}));
+	EXPECT_EQ(uint8_t{127}, NAS2D::scaleLinear(uint32_t{5000}, uint32_t{0}, uint32_t{10000}, uint8_t{0}, uint8_t{255}));
+	EXPECT_EQ(uint8_t{191}, NAS2D::scaleLinear(uint32_t{7500}, uint32_t{0}, uint32_t{10000}, uint8_t{0}, uint8_t{255}));
+	EXPECT_EQ(uint8_t{255}, NAS2D::scaleLinear(uint32_t{10000}, uint32_t{0}, uint32_t{10000}, uint8_t{0}, uint8_t{255}));
+}
+
 TEST(MathUtils, scaleLinearFloatFahrenheitToCelsius) {
 	// Fahrenheit to Celsius
 	EXPECT_NEAR(-18.33333f, NAS2D::scaleLinear(-1.0f, 32.0f, 212.0f, 0.0f, 100.0f), 0.0001f);

--- a/test/Math/MathUtils.test.cpp
+++ b/test/Math/MathUtils.test.cpp
@@ -124,6 +124,14 @@ TEST(MathUtils, scaleLinearForwardUint32toUint8) {
 	EXPECT_EQ(uint8_t{255}, NAS2D::scaleLinear(uint32_t{10000}, uint32_t{0}, uint32_t{10000}, uint8_t{0}, uint8_t{255}));
 }
 
+TEST(MathUtils, scaleLinearReverseUint32toUint8) {
+	EXPECT_EQ(uint8_t{255}, NAS2D::scaleLinear(uint32_t{0}, uint32_t{0}, uint32_t{10000}, uint8_t{255}, uint8_t{0}));
+	EXPECT_EQ(uint8_t{191}, NAS2D::scaleLinear(uint32_t{2500}, uint32_t{0}, uint32_t{10000}, uint8_t{255}, uint8_t{0}));
+	EXPECT_EQ(uint8_t{127}, NAS2D::scaleLinear(uint32_t{5000}, uint32_t{0}, uint32_t{10000}, uint8_t{255}, uint8_t{0}));
+	EXPECT_EQ(uint8_t{63}, NAS2D::scaleLinear(uint32_t{7500}, uint32_t{0}, uint32_t{10000}, uint8_t{255}, uint8_t{0}));
+	EXPECT_EQ(uint8_t{0}, NAS2D::scaleLinear(uint32_t{10000}, uint32_t{0}, uint32_t{10000}, uint8_t{255}, uint8_t{0}));
+}
+
 TEST(MathUtils, scaleLinearFloatFahrenheitToCelsius) {
 	// Fahrenheit to Celsius
 	EXPECT_NEAR(-18.33333f, NAS2D::scaleLinear(-1.0f, 32.0f, 212.0f, 0.0f, 100.0f), 0.0001f);


### PR DESCRIPTION
Improve `scaleLinear` so it avoids problematic wrap around when `OutputType` is `unsigned` and the slope is negative.

The previous code could trigger wrap around, and then perform multiplication and division on the already wrapped around value. This produces incorrect results. Instead, each `OutputType` value is independently scaled, so the result is the sum of a weighted average between the two. This avoids triggering wrap around.

Noticed this while working on:
- PR #1263
- PR #1262
- Issue #1202
