### PR TITLE
Add helper `verifyNotZero`

### DIFF
--- a/NAS2D/Math/IsZero.cpp
+++ b/NAS2D/Math/IsZero.cpp
@@ -1,0 +1,32 @@
+#include "IsZero.h"
+
+#include <cmath>
+#include <stdexcept>
+
+
+namespace NAS2D
+{
+	bool isZero(float value)
+	{
+		return std::fpclassify(value) == FP_ZERO;
+	}
+
+
+	bool isZero(double value)
+	{
+		return std::fpclassify(value) == FP_ZERO;
+	}
+
+
+	bool isZero(long double value)
+	{
+		return std::fpclassify(value) == FP_ZERO;
+	}
+
+
+	// Defined in source file to limit include of `<stdexcept>`
+	void throwDomainError(const char* errorMessage)
+	{
+		throw std::domain_error(errorMessage);
+	}
+}

--- a/NAS2D/Math/IsZero.h
+++ b/NAS2D/Math/IsZero.h
@@ -1,0 +1,45 @@
+#pragma once
+
+
+namespace NAS2D
+{
+	// Smaller values would be promoted to at least an int during mathematical operations
+	// Larger values could wrap around to 0 if coerced and truncated so handle them specially
+	// Floats can produce warnings if compared directly so use their classification instead
+
+	constexpr bool isZero(int value) { return value == 0; }
+	constexpr bool isZero(long int value) { return value == 0; }
+	constexpr bool isZero(long long int value) { return value == 0; }
+
+	constexpr bool isZero(unsigned int value) { return value == 0; }
+	constexpr bool isZero(unsigned long int value) { return value == 0; }
+	constexpr bool isZero(unsigned long long int value) { return value == 0; }
+
+	bool isZero(float value);
+	bool isZero(double value);
+	bool isZero(long double value);
+
+
+	// Allow throwing specific exceptions without full include of `<stdexcept>`
+	[[noreturn]] void throwDomainError(const char* errorMessage);
+
+
+	template <typename NumericType>
+	constexpr void verifyNotZero(NumericType value, const char* errorMessage)
+	{
+		if (isZero(value))
+		{
+			throwDomainError(errorMessage);
+		}
+	}
+
+
+	template <typename NumericType>
+	constexpr void verifyNotZero(NumericType value1, NumericType value2, const char* errorMessage)
+	{
+		if (isZero(value1) || isZero(value2))
+		{
+			throwDomainError(errorMessage);
+		}
+	}
+}

--- a/NAS2D/Math/Point.h
+++ b/NAS2D/Math/Point.h
@@ -69,10 +69,7 @@ namespace NAS2D
 
 		constexpr Point skewInverseBy(const Vector<BaseType>& other) const
 		{
-			if (other.x == 0 || other.y == 0)
-			{
-				throw std::domain_error("Cannot skewInverseBy a vector with a zero component");
-			}
+			verifyNotZero(other.x, other.y, "Cannot skewInverseBy a vector with a zero component");
 			return {x / other.x, y / other.y};
 		}
 

--- a/NAS2D/Math/Vector.h
+++ b/NAS2D/Math/Vector.h
@@ -10,8 +10,9 @@
 
 #pragma once
 
+#include "IsZero.h"
+
 #include <string>
-#include <stdexcept>
 
 
 namespace NAS2D
@@ -65,10 +66,7 @@ namespace NAS2D
 
 		Vector& operator/=(BaseType scalar)
 		{
-			if (scalar == 0)
-			{
-				throw std::domain_error("Cannot divide vector by 0");
-			}
+			verifyNotZero(scalar, "Cannot divide vector by 0");
 			x /= scalar;
 			y /= scalar;
 			return *this;
@@ -81,10 +79,7 @@ namespace NAS2D
 
 		constexpr Vector operator/(BaseType scalar) const
 		{
-			if (scalar == 0)
-			{
-				throw std::domain_error("Cannot divide vector by 0");
-			}
+			verifyNotZero(scalar, "Cannot divide vector by 0");
 			return {x / scalar, y / scalar};
 		}
 
@@ -95,10 +90,7 @@ namespace NAS2D
 
 		constexpr Vector skewInverseBy(const Vector& other) const
 		{
-			if (other.x == 0 || other.y == 0)
-			{
-				throw std::domain_error("Cannot skewInverseBy a vector with a zero component");
-			}
+			verifyNotZero(other.x, other.y, "Cannot skewInverseBy a vector with a zero component");
 			return {x / other.x, y / other.y};
 		}
 

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -158,6 +158,7 @@
     <ClCompile Include="FpsCounter.cpp" />
     <ClCompile Include="Game.cpp" />
     <ClCompile Include="ParserHelper.cpp" />
+    <ClCompile Include="Math\IsZero.cpp" />
     <ClCompile Include="Math\MathUtils.cpp" />
     <ClCompile Include="Math\Point.cpp" />
     <ClCompile Include="Math\Rectangle.cpp" />
@@ -214,6 +215,7 @@
     <ClInclude Include="FpsCounter.h" />
     <ClInclude Include="Game.h" />
     <ClInclude Include="Math\Angle.h" />
+    <ClInclude Include="Math\IsZero.h" />
     <ClInclude Include="Math\MathUtils.h" />
     <ClInclude Include="Math\Point.h" />
     <ClInclude Include="Math\PointInRectangleRange.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClCompile Include="Timer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Math\IsZero.cpp">
+      <Filter>Source Files\Math</Filter>
+    </ClCompile>
     <ClCompile Include="Math\MathUtils.cpp">
       <Filter>Source Files\Math</Filter>
     </ClCompile>
@@ -249,6 +252,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Math\Angle.h">
+      <Filter>Header Files\Math</Filter>
+    </ClInclude>
+    <ClInclude Include="Math\IsZero.h">
       <Filter>Header Files\Math</Filter>
     </ClInclude>
     <ClInclude Include="Math\MathUtils.h">


### PR DESCRIPTION
Add helper function `verifyNotZero` that can be used to pre-check division operations and avoid undefined behavior from division by 0.

The checks are done as `constexpr` when possible, such as for integer types. For floating point types the checks are done by first classifying the number and checking the type of float. The floating point classification avoids triggering warnings caused by direct comparisons against 0.

A helper method to `throw` a `std::domain_error` is used so an exception can be generated without requiring the calling code to do a full include of `<stdexcept>`. This can save on compile time, particularly when used in headers for template definitions which are commonly included.

Removes several instances of Clang warnings show for flag `-Wfloat-equal`.

Related:
- Issue #1245
- Issue #528

----

Documentation:
- https://en.cppreference.com/w/cpp/language/attributes/noreturn
- https://en.cppreference.com/w/cpp/numeric/math/fpclassify
- https://en.cppreference.com/w/cpp/error/domain_error
- https://en.cppreference.com/w/cpp/language/types
- https://en.cppreference.com/w/cpp/language/operator_arithmetic
- https://en.cppreference.com/w/cpp/language/usual_arithmetic_conversions

Interesting discussion which mentioned `fpclassify`:
- https://patchwork.ozlabs.org/project/glibc/patch/acb6602e-b299-b3b1-4d90-9232efe1ec9c@redhat.com/
