### PR TITLE
Remove `package` and upload artifacts steps on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,6 @@ commands:
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" test
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" check
       - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" demoGraphics
-      - run: make package
-      - store_artifacts:
-          path: .build/package/
 
 jobs:
   build-macos:


### PR DESCRIPTION
We don't really use these. They would make more sense with automated release packaging, and only if we automated release packages for those platforms. They might make sense if people were following along with the builds and downloading binary packages, rather than building for themselves. So far though, there is no indication anyone is doing this, or is even aware that it was possible.

On the other hand, the CircleCI usage statistics show we are way over for both compute and storage. Disabling build artifacts should drastically cut down on storage. It may also cut down quite a bit on CPU usage too, since upload can sometimes be a bit slow. A recent MacOS build showed 43s upload on a 2:13 build. It's made worse by MacOS being the platform that costs the most credits. So far we aren't paying for them, but we should probably still try to stay within the limits of the free usage tier.