### PR TITLE
Add `makefile` targets to list and delete GitHub caches

### DIFF
--- a/makefile
+++ b/makefile
@@ -256,3 +256,29 @@ circleci-validate:
 	circleci config validate
 circleci-build:
 	circleci build
+
+
+## GitHub ##
+.PHONY: cache-list-all cache-list-main cache-list-branch cache-delete-main-stale cache-delete-branch
+GhCacheKeyIncremental := buildCache-
+GhCacheLimit := 100
+GhCacheFields := id,ref,key,version,sizeInBytes,createdAt,lastAccessedAt
+GhCacheListJson := gh cache list --limit $(GhCacheLimit) --json $(GhCacheFields)
+GhCacheListMain := $(GhCacheListJson) --ref refs/heads/main --key $(GhCacheKeyIncremental) --jq 'sort_by(.lastAccessedAt)'
+GhCacheListBranch := $(GhCacheListJson) --jq '.[] | select(.ref!="refs/heads/main")'
+GhCacheDeleteIds := xargs -I '{}' gh cache delete '{}'
+
+cache-list-all:
+	$(GhCacheListJson)
+
+cache-list-main:
+	$(GhCacheListMain)
+
+cache-list-branch:
+	$(GhCacheListBranch)
+
+cache-delete-main-stale:
+	$(GhCacheListMain) | jq '.[0:-2] | .[] .id' | $(GhCacheDeleteIds)
+
+cache-delete-branch:
+	$(GhCacheListBranch) | jq '.id' | $(GhCacheDeleteIds)


### PR DESCRIPTION
Partly this is to document how to manipulate GitHub caches from the command line. Mostly they expire and disappear on their own. Though there may be some cases where bad workflow code may generate a bunch of bad caches that need to be cleared. The web interface only supports deleting caches one at a time. The command line interface is much more useful for mass clearing of caches.
