### PR TITLE
Extract default config to functions

### DIFF
--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -84,8 +84,8 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 	fs.mountSoftFail(fs.basePath() / dataPath);
 	fs.mountReadWrite(fs.prefPath());
 
-	Configuration& cf = Utility<Configuration>::init(defaultConfig());
-	cf.load(configPath);
+	Configuration& configuration = Utility<Configuration>::init(defaultConfig());
+	configuration.load(configPath);
 
 	try
 	{

--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -54,6 +54,14 @@ namespace
 			{"bufferlength", 1024},
 		}};
 	}
+
+	std::map<std::string, NAS2D::Dictionary> defaultConfig()
+	{
+		return {
+			{"graphics", defaultConfigGraphics()},
+			{"audio", defaultConfigAudio()},
+		};
+	}
 }
 
 
@@ -76,18 +84,7 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 	fs.mountSoftFail(fs.basePath() / dataPath);
 	fs.mountReadWrite(fs.prefPath());
 
-	Configuration& cf = Utility<Configuration>::init(
-		std::map<std::string, NAS2D::Dictionary>{
-			{
-				"graphics",
-				defaultConfigGraphics()
-			},
-			{
-				"audio",
-				defaultConfigAudio()
-			},
-		}
-	);
+	Configuration& cf = Utility<Configuration>::init(defaultConfig());
 	cf.load(configPath);
 
 	try

--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -29,6 +29,34 @@
 
 using namespace NAS2D;
 
+
+namespace
+{
+	NAS2D::Dictionary defaultConfigGraphics()
+	{
+		return {{
+			{"screenwidth", 1000},
+			{"screenheight", 700},
+			{"bitdepth", 32},
+			{"fullscreen", false},
+			{"vsync", true},
+		}};
+	}
+
+	NAS2D::Dictionary defaultConfigAudio()
+	{
+		return {{
+			{"mixer", "SDL"},
+			{"musicvolume", 100},
+			{"sfxvolume", 128},
+			{"channels", 2},
+			{"mixrate", 22050},
+			{"bufferlength", 1024},
+		}};
+	}
+}
+
+
 /**
  * Starts the engine by initializing all of the engine sub components and
  * setting up any default values should they be needed.
@@ -52,24 +80,11 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 		std::map<std::string, NAS2D::Dictionary>{
 			{
 				"graphics",
-				{{
-					{"screenwidth", 1000},
-					{"screenheight", 700},
-					{"bitdepth", 32},
-					{"fullscreen", false},
-					{"vsync", true},
-				}},
+				defaultConfigGraphics()
 			},
 			{
 				"audio",
-				{{
-					{"mixer", "SDL"},
-					{"musicvolume", 100},
-					{"sfxvolume", 128},
-					{"channels", 2},
-					{"mixrate", 22050},
-					{"bufferlength", 1024},
-				}},
+				defaultConfigAudio()
 			},
 		}
 	);

--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -69,9 +69,9 @@ namespace
  * Starts the engine by initializing all of the engine sub components and
  * setting up any default values should they be needed.
  *
- * \param	title		The title that should be used for the game window.
- * \param appName		The name of the app (used to create an app data write path)
- * \param organizationName		The name of the organization (used to create an app data write path)
+ * \param	title	The title that should be used for the game window.
+ * \param	appName	The name of the app (used to create an app data write path)
+ * \param	organizationName	The name of the organization (used to create an app data write path)
  * \param	configPath	Path to the Config file. Defaults to 'config.xml'.
  * \param	dataPath	Initial data path. Defaults to 'data'.
  */


### PR DESCRIPTION
Potentially these functions could eventually move to the `MixerSDL` and `RendererOpenGL` code, where the settings would have more meaning. Currently range checking and validation of values is done in those files.

Cleaning up the `Game` class may help with reducing global constructors (which generate Clang warnings), and potentially help with reducing code repetition.

Related:
- Issue #528
- Issue #1245
