### PR TITLE
Update `stringFrom` to support `Point` and `Vector`

### DIFF
--- a/NAS2D/Math/Point.h
+++ b/NAS2D/Math/Point.h
@@ -12,8 +12,6 @@
 
 #include "Vector.h"
 
-#include <string>
-
 
 namespace NAS2D
 {
@@ -83,11 +81,6 @@ namespace NAS2D
 		constexpr Point<NewBaseType> to() const
 		{
 			return Point<NewBaseType>(*this);
-		}
-
-		explicit operator std::string() const
-		{
-			return "(" + std::to_string(x) + ", " + std::to_string(y) + ")";
 		}
 	};
 

--- a/NAS2D/Math/Vector.h
+++ b/NAS2D/Math/Vector.h
@@ -12,8 +12,6 @@
 
 #include "IsZero.h"
 
-#include <string>
-
 
 namespace NAS2D
 {
@@ -124,11 +122,6 @@ namespace NAS2D
 		constexpr Vector<NewBaseType> to() const
 		{
 			return Vector<NewBaseType>(*this);
-		}
-
-		explicit operator std::string() const
-		{
-			return "(" + std::to_string(x) + ", " + std::to_string(y) + ")";
 		}
 	};
 

--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -11,6 +11,7 @@
 
 #include "../Filesystem.h"
 #include "../Utility.h"
+#include "../StringFrom.h"
 #include "../Math/MathUtils.h"
 #include "../Math/PointInRectangleRange.h"
 
@@ -272,7 +273,7 @@ namespace
 		if (fontSurfaceSize != glyphSize * GlyphMatrixSize)
 		{
 			SDL_FreeSurface(fontSurface);
-			throw std::runtime_error("Unexpected font image size. Image dimensions " + std::string{fontSurfaceSize} + " must both be evenly divisible by " + std::to_string(GlyphMatrixSize));
+			throw std::runtime_error("Unexpected font image size. Image dimensions " + stringFrom(fontSurfaceSize) + " must both be evenly divisible by " + std::to_string(GlyphMatrixSize));
 		}
 
 		Font::FontInfo fontInfo;

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -13,6 +13,7 @@
 #include "../Math/Rectangle.h"
 #include "../Filesystem.h"
 #include "../Utility.h"
+#include "../StringFrom.h"
 
 #if defined(__XCODE_BUILD__)
 #include <GLEW/GLEW.h>
@@ -148,7 +149,7 @@ Color Image::pixelColor(Point<int> point) const
 {
 	if (!Rectangle{{0, 0}, mSize}.contains(point))
 	{
-		throw std::runtime_error("Pixel coordinates out of bounds: " + std::string{point});
+		throw std::runtime_error("Pixel coordinates out of bounds: " + stringFrom(point));
 	}
 
 	if (!mSurface) { throw std::runtime_error("Image has no allocated surface"); }

--- a/NAS2D/StringFrom.h
+++ b/NAS2D/StringFrom.h
@@ -6,6 +6,10 @@
 
 namespace NAS2D
 {
+	template <typename BaseType> struct Point;
+	template <typename BaseType> struct Vector;
+
+
 	template <typename T>
 	std::string stringFrom(T value)
 	{
@@ -21,5 +25,19 @@ namespace NAS2D
 		{
 			return std::to_string(value);
 		}
+	}
+
+
+	template <typename BaseType>
+	std::string stringFrom(Point<BaseType> point)
+	{
+		return "(" + std::to_string(point.x) + ", " + std::to_string(point.y) + ")";
+	}
+
+
+	template <typename BaseType>
+	std::string stringFrom(Vector<BaseType> vector)
+	{
+		return "(" + std::to_string(vector.x) + ", " + std::to_string(vector.y) + ")";
 	}
 }

--- a/test/Math/Point.test.cpp
+++ b/test/Math/Point.test.cpp
@@ -89,12 +89,6 @@ TEST(Point, to) {
 	EXPECT_EQ((NAS2D::Point<float>{1.0, 2.0}), (NAS2D::Point<int>{1, 2}.to<float>()));
 }
 
-TEST(Point, stringConversion) {
-	EXPECT_EQ("(0, 0)", (std::string{NAS2D::Point{0, 0}}));
-	EXPECT_EQ("(1, 0)", (std::string{NAS2D::Point{1, 0}}));
-	EXPECT_EQ("(0, 1)", (std::string{NAS2D::Point{0, 1}}));
-}
-
 TEST(Point, VectorPointAdd) {
 	EXPECT_EQ((NAS2D::Point{2, 3}), (NAS2D::Vector{1, 2} + NAS2D::Point<int>{1, 1}));
 }

--- a/test/Math/Vector.test.cpp
+++ b/test/Math/Vector.test.cpp
@@ -208,12 +208,6 @@ TEST(Vector, to) {
 	EXPECT_EQ((NAS2D::Vector<float>{1.0, 2.0}), (NAS2D::Vector<int>{1, 2}.to<float>()));
 }
 
-TEST(Vector, stringConversion) {
-	EXPECT_EQ("(0, 0)", (std::string{NAS2D::Vector{0, 0}}));
-	EXPECT_EQ("(1, 0)", (std::string{NAS2D::Vector{1, 0}}));
-	EXPECT_EQ("(0, 1)", (std::string{NAS2D::Vector{0, 1}}));
-}
-
 TEST(Vector, scalarVectorMultiply) {
 	EXPECT_EQ((NAS2D::Vector{2, 4}), (2 * NAS2D::Vector{1, 2}));
 }

--- a/test/StringFrom.test.cpp
+++ b/test/StringFrom.test.cpp
@@ -1,5 +1,8 @@
 #include "NAS2D/StringFrom.h"
 
+#include "NAS2D/Math/Point.h"
+#include "NAS2D/Math/Vector.h"
+
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -60,4 +63,16 @@ TEST(StringFrom, stringFrom) {
 	// Implicit string conversion
 	ImplicitStringConversionTestFixture implicitStringConversionTestFixture{"testString"};
 	EXPECT_EQ("testString", NAS2D::stringFrom(implicitStringConversionTestFixture));
+}
+
+TEST(StringFrom, point) {
+	EXPECT_EQ("(0, 0)", NAS2D::stringFrom(NAS2D::Point{0, 0}));
+	EXPECT_EQ("(1, 0)", NAS2D::stringFrom(NAS2D::Point{1, 0}));
+	EXPECT_EQ("(0, 1)", NAS2D::stringFrom(NAS2D::Point{0, 1}));
+}
+
+TEST(StringFrom, vector) {
+	EXPECT_EQ("(0, 0)", NAS2D::stringFrom(NAS2D::Vector{0, 0}));
+	EXPECT_EQ("(1, 0)", NAS2D::stringFrom(NAS2D::Vector{1, 0}));
+	EXPECT_EQ("(0, 1)", NAS2D::stringFrom(NAS2D::Vector{0, 1}));
 }

--- a/test/StringFrom.test.cpp
+++ b/test/StringFrom.test.cpp
@@ -24,6 +24,11 @@ namespace
 }
 
 
+TEST(StringFrom, implicitConversion) {
+	ImplicitStringConversionTestFixture implicitStringConversionTestFixture{"testString"};
+	EXPECT_EQ("testString", NAS2D::stringFrom(implicitStringConversionTestFixture));
+}
+
 TEST(StringFrom, stringFrom) {
 	EXPECT_EQ("SomeStringValue", NAS2D::stringFrom("SomeStringValue"));
 	EXPECT_EQ("SomeStringValue", NAS2D::stringFrom(std::string{"SomeStringValue"}));
@@ -59,10 +64,6 @@ TEST(StringFrom, stringFrom) {
 	EXPECT_THAT(NAS2D::stringFrom(0.0f), testing::StartsWith("0.0"));
 	EXPECT_THAT(NAS2D::stringFrom(0.0), testing::StartsWith("0.0"));
 	EXPECT_THAT(NAS2D::stringFrom(0.0l), testing::StartsWith("0.0"));
-
-	// Implicit string conversion
-	ImplicitStringConversionTestFixture implicitStringConversionTestFixture{"testString"};
-	EXPECT_EQ("testString", NAS2D::stringFrom(implicitStringConversionTestFixture));
 }
 
 TEST(StringFrom, point) {

--- a/test/StringFrom.test.cpp
+++ b/test/StringFrom.test.cpp
@@ -29,10 +29,12 @@ TEST(StringFrom, implicitConversion) {
 	EXPECT_EQ("testString", NAS2D::stringFrom(implicitStringConversionTestFixture));
 }
 
-TEST(StringFrom, stringFrom) {
+TEST(StringFrom, string) {
 	EXPECT_EQ("SomeStringValue", NAS2D::stringFrom("SomeStringValue"));
 	EXPECT_EQ("SomeStringValue", NAS2D::stringFrom(std::string{"SomeStringValue"}));
+}
 
+TEST(StringFrom, stringFrom) {
 	EXPECT_EQ("false", NAS2D::stringFrom(false));
 	EXPECT_EQ("true", NAS2D::stringFrom(true));
 

--- a/test/StringFrom.test.cpp
+++ b/test/StringFrom.test.cpp
@@ -39,7 +39,7 @@ TEST(StringFrom, boolean) {
 	EXPECT_EQ("true", NAS2D::stringFrom(true));
 }
 
-TEST(StringFrom, stringFrom) {
+TEST(StringFrom, integers) {
 	using signedChar = signed char;
 	using unsignedChar = unsigned char;
 	EXPECT_EQ("-1", NAS2D::stringFrom(signedChar{-1}));
@@ -63,7 +63,9 @@ TEST(StringFrom, stringFrom) {
 	EXPECT_EQ("-1", NAS2D::stringFrom(-1ll));
 	EXPECT_EQ("0", NAS2D::stringFrom(0ll));
 	EXPECT_EQ("1", NAS2D::stringFrom(1ull));
+}
 
+TEST(StringFrom, floatingPoint) {
 	// Ignore precision beyond one decimal place
 	EXPECT_THAT(NAS2D::stringFrom(0.0f), testing::StartsWith("0.0"));
 	EXPECT_THAT(NAS2D::stringFrom(0.0), testing::StartsWith("0.0"));

--- a/test/StringFrom.test.cpp
+++ b/test/StringFrom.test.cpp
@@ -34,10 +34,12 @@ TEST(StringFrom, string) {
 	EXPECT_EQ("SomeStringValue", NAS2D::stringFrom(std::string{"SomeStringValue"}));
 }
 
-TEST(StringFrom, stringFrom) {
+TEST(StringFrom, boolean) {
 	EXPECT_EQ("false", NAS2D::stringFrom(false));
 	EXPECT_EQ("true", NAS2D::stringFrom(true));
+}
 
+TEST(StringFrom, stringFrom) {
 	using signedChar = signed char;
 	using unsignedChar = unsigned char;
 	EXPECT_EQ("-1", NAS2D::stringFrom(signedChar{-1}));


### PR DESCRIPTION
Add support to `stringFrom` for converting `Point` and `Vector`.

This allows removing the `<string>` include from `Point` and `Vector`.

Related:
- Issue #1245
