### PR TITLE
Add `Toolchain` variable to `makefile`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
     docker:
       - image: ghcr.io/lairworks/build-env-nas2d-clang:1.5
     environment:
-      WARN_EXTRA: "-Wdocumentation -Wdocumentation-unknown-command -Wcomma -Winconsistent-missing-destructor-override -Wmissing-prototypes -Wctad-maybe-unsupported -Wimplicit-int-float-conversion -Wsign-conversion"
+      Toolchain: "clang"
     steps:
       - checkout
       - build-and-test
@@ -47,8 +47,7 @@ jobs:
     docker:
       - image: ghcr.io/lairworks/build-env-nas2d-mingw:1.13
     environment:
-      WARN_EXTRA: "-Wno-redundant-decls"
-      LDFLAGS_EXTRA: "-L/usr/local/x86_64-w64-mingw32/lib"
+      Toolchain: "mingw"
     steps:
       - checkout
       - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
     docker:
       - image: ghcr.io/lairworks/build-env-nas2d-gcc:1.6
     environment:
-      WARN_EXTRA: "-Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Weffc++"
+      Toolchain: "gcc"
     steps:
       - checkout
       - build-and-test

--- a/makefile
+++ b/makefile
@@ -7,14 +7,20 @@ TARGET_OS ?= $(CURRENT_OS)
 # Toolchain: gcc, clang, mingw, (or blank for environment default)
 Toolchain :=
 
+PkgConfig := pkg-config
+
 gccCXX := g++
+gccPkgConfig := $(PkgConfig)
 gccTARGET_OS := $(TARGET_OS)
 clangCXX := clang++
+clangPkgConfig := $(PkgConfig)
 clangTARGET_OS := $(TARGET_OS)
 mingwCXX := x86_64-w64-mingw32-g++
+mingwPkgConfig := x86_64-w64-mingw32-pkg-config
 mingwTARGET_OS := Windows
 
 CXX := $($(Toolchain)CXX)
+PkgConfig := $($(Toolchain)PkgConfig)
 TARGET_OS := $($(Toolchain)TARGET_OS)
 
 # Build configuration
@@ -25,13 +31,13 @@ Release_CXX_FLAGS := -O3
 CONFIG_CXX_FLAGS := $($(CONFIG)_CXX_FLAGS)
 
 
-WindowsPreprocessorFlags = $(shell x86_64-w64-mingw32-pkg-config --cflags-only-I sdl2) -DGLEW_STATIC
+WindowsPreprocessorFlags = $(shell $(PkgConfig) --cflags-only-I sdl2) -DGLEW_STATIC
 PreprocessorFlags := $($(TARGET_OS)PreprocessorFlags)
 
 WindowsSpecialWarnFlags = -Wno-redundant-decls
 SpecialWarnFlags := $($(TARGET_OS)SpecialWarnFlags)
 
-WindowsLibrarySearchPath = $(shell x86_64-w64-mingw32-pkg-config --libs-only-L sdl2)
+WindowsLibrarySearchPath = $(shell $(PkgConfig) --libs-only-L sdl2)
 LibrarySearchPath := $($(TARGET_OS)LibrarySearchPath)
 
 WindowsExeSuffix := .exe

--- a/makefile
+++ b/makefile
@@ -212,11 +212,15 @@ $(PACKAGE_NAME): $(OUTPUT) $(shell find $(SRCDIR) -name '*.h')
 ## Linting ##
 
 clangWarnNotInterested := -Wno-c++98-compat-pedantic -Wno-pre-c++17-compat
+clangWarnAllowed := -Wno-padded
+clangWarnKnown := -Wno-global-constructors -Wno-exit-time-destructors -Wno-unused-member-function
+clangWarnShow := -Weverything $(clangWarnNotInterested)
+clangWarnFlags := $(clangWarnShow) $(clangWarnAllowed) $(clangWarnKnown)
 
 .PHONY: show-warnings
 show-warnings:
 	@$(MAKE) clean-all > /dev/null
-	$(MAKE) --output-sync all CXX=clang++ CXXFLAGS_WARN="-Weverything $(clangWarnNotInterested)" 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
+	$(MAKE) --output-sync all CXX=clang++ CXXFLAGS_WARN="$(clangWarnShow)" 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
 	@$(MAKE) clean-all > /dev/null
 
 .PHONY: lint

--- a/makefile
+++ b/makefile
@@ -38,15 +38,13 @@ Release_CXX_FLAGS := -O3
 CONFIG_CXX_FLAGS := $($(CONFIG)_CXX_FLAGS)
 
 # Target specific settings
-WindowsPreprocessorFlags = $(shell $(PkgConfig) --cflags-only-I sdl2) -DGLEW_STATIC
+WindowsSpecialPreprocessorFlags = -DGLEW_STATIC
 WindowsSpecialWarnFlags = -Wno-redundant-decls
-WindowsLibrarySearchPath = $(shell $(PkgConfig) --libs-only-L sdl2)
 WindowsExeSuffix := .exe
 WindowsRunPrefix := wine
 
-PreprocessorFlags := $($(TARGET_OS)PreprocessorFlags)
+SpecialPreprocessorFlags := $($(TARGET_OS)SpecialPreprocessorFlags)
 SpecialWarnFlags := $($(TARGET_OS)SpecialWarnFlags)
-LibrarySearchPath := $($(TARGET_OS)LibrarySearchPath)
 ExeSuffix := $($(TARGET_OS)ExeSuffix)
 RunPrefix := $($(TARGET_OS)RunPrefix)
 
@@ -63,6 +61,9 @@ OUTPUT := $(BINDIR)/libnas2d.a
 SRCS := $(shell find $(SRCDIR) -name '*.cpp')
 OBJS := $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.o,$(SRCS))
 
+IncludeSearchPath := $(shell $(PkgConfig) --cflags-only-I sdl2)
+LibrarySearchPath := $(shell $(PkgConfig) --libs-only-L sdl2)
+
 Linux_OpenGL_LIBS := -lGLEW -lGL
 Darwin_OpenGL_LIBS := -lGLEW -framework OpenGL
 Windows_OpenGL_LIBS := -lglew32 -lopengl32
@@ -70,7 +71,7 @@ OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 SDL_LIBS := -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lSDL2
 
-CPPFLAGS := $(PreprocessorFlags) $(CPPFLAGS_EXTRA)
+CPPFLAGS := $(IncludeSearchPath) $(SpecialPreprocessorFlags) $(CPPFLAGS_EXTRA)
 CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute -Wredundant-decls -Wformat=2 $(SpecialWarnFlags) $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) $(CONFIG_CXX_FLAGS) -std=c++20 $(CXXFLAGS_WARN)
 LDFLAGS := $(LibrarySearchPath) $(LDFLAGS_EXTRA)

--- a/makefile
+++ b/makefile
@@ -15,18 +15,25 @@ TARGET_OS ?= $(CURRENT_OS)
 Toolchain :=
 
 PkgConfig := pkg-config
+WarnFlags := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute -Wredundant-decls -Wformat=2
 
 gccCXX := g++
+gccWarnFlags := $(WarnFlags)
 gccPkgConfig := $(PkgConfig)
 gccTARGET_OS := $(TARGET_OS)
+
 clangCXX := clang++
+clangWarnFlags := $(WarnFlags)
 clangPkgConfig := $(PkgConfig)
 clangTARGET_OS := $(TARGET_OS)
+
 mingwCXX := x86_64-w64-mingw32-g++
+mingwWarnFlags := $(WarnFlags)
 mingwPkgConfig := x86_64-w64-mingw32-pkg-config
 mingwTARGET_OS := Windows
 
 CXX := $($(Toolchain)CXX)
+WarnFlags := $($(Toolchain)WarnFlags)
 PkgConfig := $($(Toolchain)PkgConfig)
 TARGET_OS := $($(Toolchain)TARGET_OS)
 
@@ -72,7 +79,7 @@ OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 SDL_LIBS := -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lSDL2
 
 CPPFLAGS := $(IncludeSearchPath) $(SpecialPreprocessorFlags) $(CPPFLAGS_EXTRA)
-CXXFLAGS_WARN := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute -Wredundant-decls -Wformat=2 $(SpecialWarnFlags) $(WARN_EXTRA)
+CXXFLAGS_WARN := $(WarnFlags) $(SpecialWarnFlags) $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) $(CONFIG_CXX_FLAGS) -std=c++20 $(CXXFLAGS_WARN)
 LDFLAGS := $(LibrarySearchPath) $(LDFLAGS_EXTRA)
 LDLIBS := $(LDLIBS_EXTRA) -lstdc++ $(SDL_LIBS) $(OpenGL_LIBS)

--- a/makefile
+++ b/makefile
@@ -1,5 +1,12 @@
 # Source http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
 
+## Default and top-level targets ##
+
+.DEFAULT_GOAL := nas2d
+
+.PHONY: all
+all: nas2d test demoGraphics
+
 # Determine OS (Linux, Darwin, ...)
 CURRENT_OS := $(shell uname 2>/dev/null || echo Unknown)
 TARGET_OS ?= $(CURRENT_OS)
@@ -45,14 +52,6 @@ RunPrefix := $($(TARGET_OS)RunPrefix)
 
 ROOTBUILDDIR := .build
 BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(CONFIG)_Linux_
-
-
-## Default and top-level targets ##
-
-.DEFAULT_GOAL := nas2d
-
-.PHONY: all
-all: nas2d test demoGraphics
 
 
 ## NAS2D project ##

--- a/makefile
+++ b/makefile
@@ -211,12 +211,12 @@ $(PACKAGE_NAME): $(OUTPUT) $(shell find $(SRCDIR) -name '*.h')
 
 ## Linting ##
 
-WarnNoUninteresting := -Wno-c++98-compat-pedantic -Wno-pre-c++17-compat
+clangWarnNotInterested := -Wno-c++98-compat-pedantic -Wno-pre-c++17-compat
 
 .PHONY: show-warnings
 show-warnings:
 	@$(MAKE) clean-all > /dev/null
-	$(MAKE) --output-sync all CXX=clang++ CXXFLAGS_WARN="-Weverything $(WarnNoUninteresting)" 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
+	$(MAKE) --output-sync all CXX=clang++ CXXFLAGS_WARN="-Weverything $(clangWarnNotInterested)" 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
 	@$(MAKE) clean-all > /dev/null
 
 .PHONY: lint

--- a/makefile
+++ b/makefile
@@ -23,7 +23,11 @@ gccPkgConfig := $(PkgConfig)
 gccTARGET_OS := $(TARGET_OS)
 
 clangCXX := clang++
-clangWarnFlags := $(WarnFlags)
+clangWarnNotInterested := -Wno-c++98-compat-pedantic -Wno-pre-c++17-compat
+clangWarnAllowed := -Wno-padded
+clangWarnKnown := -Wno-global-constructors -Wno-exit-time-destructors -Wno-unused-member-function
+clangWarnShow := -Weverything $(clangWarnNotInterested)
+clangWarnFlags := $(clangWarnShow) $(clangWarnAllowed) $(clangWarnKnown)
 clangPkgConfig := $(PkgConfig)
 clangTARGET_OS := $(TARGET_OS)
 
@@ -210,12 +214,6 @@ $(PACKAGE_NAME): $(OUTPUT) $(shell find $(SRCDIR) -name '*.h')
 
 
 ## Linting ##
-
-clangWarnNotInterested := -Wno-c++98-compat-pedantic -Wno-pre-c++17-compat
-clangWarnAllowed := -Wno-padded
-clangWarnKnown := -Wno-global-constructors -Wno-exit-time-destructors -Wno-unused-member-function
-clangWarnShow := -Weverything $(clangWarnNotInterested)
-clangWarnFlags := $(clangWarnShow) $(clangWarnAllowed) $(clangWarnKnown)
 
 .PHONY: show-warnings
 show-warnings:

--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ CURRENT_OS := $(shell uname 2>/dev/null || echo Unknown)
 TARGET_OS ?= $(CURRENT_OS)
 
 # Toolchain: gcc, clang, mingw, (or blank for environment default)
-Toolchain :=
+Toolchain ?=
 
 PkgConfig := pkg-config
 WarnFlags := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute -Wredundant-decls -Wformat=2

--- a/makefile
+++ b/makefile
@@ -24,8 +24,8 @@ gccTARGET_OS := $(TARGET_OS)
 
 clangCXX := clang++
 clangWarnNotInterested := -Wno-c++98-compat-pedantic -Wno-pre-c++17-compat
-clangWarnAllowed := -Wno-padded
-clangWarnKnown := -Wno-global-constructors -Wno-exit-time-destructors -Wno-unused-member-function
+clangWarnAllowed := -Wno-padded -Wno-cast-function-type-strict
+clangWarnKnown := -Wno-unsafe-buffer-usage -Wno-global-constructors -Wno-exit-time-destructors -Wno-unused-member-function
 clangWarnShow := -Weverything $(clangWarnNotInterested)
 clangWarnFlags := $(clangWarnShow) $(clangWarnAllowed) $(clangWarnKnown)
 clangPkgConfig := $(PkgConfig)

--- a/makefile
+++ b/makefile
@@ -18,7 +18,7 @@ PkgConfig := pkg-config
 WarnFlags := -Wall -Wextra -Wpedantic -Wzero-as-null-pointer-constant -Wnull-dereference -Wold-style-cast -Wcast-qual -Wcast-align -Wdouble-promotion -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wmissing-declarations -Wmissing-include-dirs -Winvalid-pch -Wmissing-format-attribute -Wredundant-decls -Wformat=2
 
 gccCXX := g++
-gccWarnFlags := $(WarnFlags)
+gccWarnFlags := $(WarnFlags) -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Weffc++
 gccPkgConfig := $(PkgConfig)
 gccTARGET_OS := $(TARGET_OS)
 

--- a/makefile
+++ b/makefile
@@ -4,10 +4,13 @@
 CURRENT_OS := $(shell uname 2>/dev/null || echo Unknown)
 TARGET_OS ?= $(CURRENT_OS)
 
+# Build configuration
 CONFIG = Debug
+
 Debug_CXX_FLAGS := -Og -g
 Release_CXX_FLAGS := -O3
 CONFIG_CXX_FLAGS := $($(CONFIG)_CXX_FLAGS)
+
 
 WindowsPreprocessorFlags = $(shell x86_64-w64-mingw32-pkg-config --cflags-only-I sdl2) -DGLEW_STATIC
 PreprocessorFlags := $($(TARGET_OS)PreprocessorFlags)

--- a/makefile
+++ b/makefile
@@ -61,8 +61,8 @@ OUTPUT := $(BINDIR)/libnas2d.a
 SRCS := $(shell find $(SRCDIR) -name '*.cpp')
 OBJS := $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.o,$(SRCS))
 
-IncludeSearchPath := $(shell $(PkgConfig) --cflags-only-I sdl2)
-LibrarySearchPath := $(shell $(PkgConfig) --libs-only-L sdl2)
+IncludeSearchPath := $(shell type $(PkgConfig) >/dev/null 2>&1 && $(PkgConfig) --cflags-only-I sdl2)
+LibrarySearchPath := $(shell type $(PkgConfig) >/dev/null 2>&1 && $(PkgConfig) --libs-only-L sdl2)
 
 Linux_OpenGL_LIBS := -lGLEW -lGL
 Darwin_OpenGL_LIBS := -lGLEW -framework OpenGL

--- a/makefile
+++ b/makefile
@@ -4,6 +4,19 @@
 CURRENT_OS := $(shell uname 2>/dev/null || echo Unknown)
 TARGET_OS ?= $(CURRENT_OS)
 
+# Toolchain: gcc, clang, mingw, (or blank for environment default)
+Toolchain :=
+
+gccCXX := g++
+gccTARGET_OS := $(TARGET_OS)
+clangCXX := clang++
+clangTARGET_OS := $(TARGET_OS)
+mingwCXX := x86_64-w64-mingw32-g++
+mingwTARGET_OS := Windows
+
+CXX := $($(Toolchain)CXX)
+TARGET_OS := $($(Toolchain)TARGET_OS)
+
 # Build configuration
 CONFIG = Debug
 

--- a/makefile
+++ b/makefile
@@ -30,20 +30,17 @@ Debug_CXX_FLAGS := -Og -g
 Release_CXX_FLAGS := -O3
 CONFIG_CXX_FLAGS := $($(CONFIG)_CXX_FLAGS)
 
-
+# Target specific settings
 WindowsPreprocessorFlags = $(shell $(PkgConfig) --cflags-only-I sdl2) -DGLEW_STATIC
-PreprocessorFlags := $($(TARGET_OS)PreprocessorFlags)
-
 WindowsSpecialWarnFlags = -Wno-redundant-decls
-SpecialWarnFlags := $($(TARGET_OS)SpecialWarnFlags)
-
 WindowsLibrarySearchPath = $(shell $(PkgConfig) --libs-only-L sdl2)
-LibrarySearchPath := $($(TARGET_OS)LibrarySearchPath)
-
 WindowsExeSuffix := .exe
-ExeSuffix := $($(TARGET_OS)ExeSuffix)
-
 WindowsRunPrefix := wine
+
+PreprocessorFlags := $($(TARGET_OS)PreprocessorFlags)
+SpecialWarnFlags := $($(TARGET_OS)SpecialWarnFlags)
+LibrarySearchPath := $($(TARGET_OS)LibrarySearchPath)
+ExeSuffix := $($(TARGET_OS)ExeSuffix)
 RunPrefix := $($(TARGET_OS)RunPrefix)
 
 ROOTBUILDDIR := .build

--- a/makefile
+++ b/makefile
@@ -1,13 +1,13 @@
 # Source http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
 
+# Determine OS (Linux, Darwin, ...)
+CURRENT_OS := $(shell uname 2>/dev/null || echo Unknown)
+TARGET_OS ?= $(CURRENT_OS)
+
 CONFIG = Debug
 Debug_CXX_FLAGS := -Og -g
 Release_CXX_FLAGS := -O3
 CONFIG_CXX_FLAGS := $($(CONFIG)_CXX_FLAGS)
-
-# Determine OS (Linux, Darwin, ...)
-CURRENT_OS := $(shell uname 2>/dev/null || echo Unknown)
-TARGET_OS ?= $(CURRENT_OS)
 
 WindowsPreprocessorFlags = $(shell x86_64-w64-mingw32-pkg-config --cflags-only-I sdl2) -DGLEW_STATIC
 PreprocessorFlags := $($(TARGET_OS)PreprocessorFlags)


### PR DESCRIPTION
Add a `Toolchain` variable to the `makefile`, which can be used to easily switch between `gcc`, `clang`, and `mingw`.

This can auto set the compiler (`CXX`), `pkg-config` tool, warnings appropriate for the compiler, and target OS.

The main motivation for this change was to make it easier to run Mingw builds in a local Linux environment. It was found this support also makes it easy to switch warning flags too. In particular, a base set of warning flags were being used that was common to all supported compilers. Instead, now we can set warning flags that are specific to the compiler `Toolchain` that is selected, allowing for much more stringent checks, by default.

Related:
- Issue #1241
- Issue #528
