### PR TITLE
Output unit tests in color under Wine

### DIFF
--- a/makefile
+++ b/makefile
@@ -53,11 +53,13 @@ WindowsSpecialPreprocessorFlags = -DGLEW_STATIC
 WindowsSpecialWarnFlags = -Wno-redundant-decls
 WindowsExeSuffix := .exe
 WindowsRunPrefix := wine
+WindowsRunSuffixUnitTest := --gtest_color=yes | cat -
 
 SpecialPreprocessorFlags := $($(TARGET_OS)SpecialPreprocessorFlags)
 SpecialWarnFlags := $($(TARGET_OS)SpecialWarnFlags)
 ExeSuffix := $($(TARGET_OS)ExeSuffix)
 RunPrefix := $($(TARGET_OS)RunPrefix)
+RunSuffixUnitTest := $($(TARGET_OS)RunSuffixUnitTest)
 
 ROOTBUILDDIR := .build
 BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(CONFIG)_Linux_
@@ -128,7 +130,7 @@ $(TESTOBJS): $(TESTINTDIR)/%.o : $(TESTDIR)/%.cpp $(TESTINTDIR)/%.dep
 
 .PHONY: check
 check: | test
-	cd test && $(RunPrefix) ../$(TESTOUTPUT) $(GTEST_OPTIONS)
+	cd test && $(RunPrefix) ../$(TESTOUTPUT) $(GTEST_OPTIONS) $(RunSuffixUnitTest)
 
 
 ## Graphics demo project ##


### PR DESCRIPTION
Previously the ANSI escape codes were being output to the console rather than interpreted as color codes. Piping the output through `cat` seems to enable color, though the unit tests have to explicitly enable color codes when the output is not going directly to the terminal.

Interestingly, this seems to make output noticeably faster. Output is near instant, rather than scrolling for 1-2 seconds.

Related:
- PR #1275
- Issue #1241
