### PR TITLE
Eliminate release package name as `makefile` target

### DIFF
--- a/makefile
+++ b/makefile
@@ -207,10 +207,8 @@ Linux_TAR_RENAME_FLAG := --transform='s/^$(SRCDIR)/include\/\0/'
 TAR_RENAME_FLAG := $($(CURRENT_OS)_TAR_RENAME_FLAG)
 
 .PHONY: package
-package: $(PACKAGE_NAME)
-
-$(PACKAGE_NAME): $(OUTPUT) $(shell find $(SRCDIR) -name '*.h')
-	@mkdir -p "${@D}"
+package: $(OUTPUT) $(shell find $(SRCDIR) -name '*.h')
+	@mkdir -p "$(PACKAGEDIR)"
 	# Package an "include/" folder containing all header files, plus the library file
 	find $(SRCDIR) -name '*.h' | tar -czf $(PACKAGE_NAME) $(TAR_RENAME_FLAG) -T - $(OUTPUT)
 


### PR DESCRIPTION
Using `PACKAGE_NAME` as a `makefile` target forces evaluation of the variable. This forces evaluation of the `VERSION` variable, which invokes `git`. When running the build in a Docker container, with a mounted folder, from a submodule folder, that can produce warnings. Since the package name isn't particularly important, we can get rid of it as a `makefile` target and exclusively use the generic `.PHONY` target. This means we won't detect when the package output is up-to-date and so will always do a re-package. Though we don't typically run the `package` target so that's not much of a loss. It's mostly only run as part of CI, and in that context the output is never up-to-date, so it always needs to run there anyway.

Example warning when running container on a submodule:
> fatal: not a git repository: /code/../.git/modules/nas2d-core

This is caused by the `.git` file of the submodule pointing to the `.git` folder of the parent repository. Typically that may be the OPHD repository. When the Docker container mounts the code folder, it may only mount the submodule folder, and so that link doesn't point anywhere in the mounted image.

Related:
- Issue #1241
