### PR TITLE
Improve Darwin support in `makefile`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,6 @@ jobs:
     steps:
       - checkout
       - brew-install
-      - run:
-          name: Add Brew include path to system include paths
-          command: |
-            echo "export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}:$(brew --prefix)/include" >> "${BASH_ENV}"
-            echo "export LDFLAGS_EXTRA=-L$(brew --prefix)/lib" >> "${BASH_ENV}"
       - build-and-test
   build-linux-gcc:
     docker:

--- a/makefile
+++ b/makefile
@@ -56,10 +56,8 @@ WindowsRunPrefix := wine
 WindowsRunSuffixUnitTest := --gtest_color=yes | cat -
 
 DarwinIncludeSearchFlags = -isystem$(shell brew --prefix)/include
-DarwinLibrarySearchFlags = -L$(shell brew --prefix)/lib
 
 IncludeSearchFlags := $($(TARGET_OS)IncludeSearchFlags)
-LibrarySearchFlags := $($(TARGET_OS)LibrarySearchFlags)
 SpecialPreprocessorFlags := $($(TARGET_OS)SpecialPreprocessorFlags)
 SpecialWarnFlags := $($(TARGET_OS)SpecialWarnFlags)
 ExeSuffix := $($(TARGET_OS)ExeSuffix)
@@ -80,7 +78,7 @@ SRCS := $(shell find $(SRCDIR) -name '*.cpp')
 OBJS := $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.o,$(SRCS))
 
 IncludeSearchFlags := $(shell type $(PkgConfig) >/dev/null 2>&1 && $(PkgConfig) --cflags-only-I sdl2) $(IncludeSearchFlags)
-LibrarySearchFlags := $(shell type $(PkgConfig) >/dev/null 2>&1 && $(PkgConfig) --libs-only-L sdl2) $(LibrarySearchFlags)
+LibrarySearchFlags := $(shell type $(PkgConfig) >/dev/null 2>&1 && $(PkgConfig) --libs-only-L sdl2)
 
 Linux_OpenGL_LIBS := -lGLEW -lGL
 Darwin_OpenGL_LIBS := -lGLEW -framework OpenGL

--- a/makefile
+++ b/makefile
@@ -55,6 +55,11 @@ WindowsExeSuffix := .exe
 WindowsRunPrefix := wine
 WindowsRunSuffixUnitTest := --gtest_color=yes | cat -
 
+DarwinIncludeSearchPath = -isystem$(shell brew --prefix)/include
+DarwinLibrarySearchPath = -L$(shell brew --prefix)/lib
+
+IncludeSearchPath := $($(TARGET_OS)IncludeSearchPath)
+LibrarySearchPath := $($(TARGET_OS)LibrarySearchPath)
 SpecialPreprocessorFlags := $($(TARGET_OS)SpecialPreprocessorFlags)
 SpecialWarnFlags := $($(TARGET_OS)SpecialWarnFlags)
 ExeSuffix := $($(TARGET_OS)ExeSuffix)
@@ -74,8 +79,8 @@ OUTPUT := $(BINDIR)/libnas2d.a
 SRCS := $(shell find $(SRCDIR) -name '*.cpp')
 OBJS := $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.o,$(SRCS))
 
-IncludeSearchPath := $(shell type $(PkgConfig) >/dev/null 2>&1 && $(PkgConfig) --cflags-only-I sdl2)
-LibrarySearchPath := $(shell type $(PkgConfig) >/dev/null 2>&1 && $(PkgConfig) --libs-only-L sdl2)
+IncludeSearchPath := $(shell type $(PkgConfig) >/dev/null 2>&1 && $(PkgConfig) --cflags-only-I sdl2) $(IncludeSearchPath)
+LibrarySearchPath := $(shell type $(PkgConfig) >/dev/null 2>&1 && $(PkgConfig) --libs-only-L sdl2) $(LibrarySearchPath)
 
 Linux_OpenGL_LIBS := -lGLEW -lGL
 Darwin_OpenGL_LIBS := -lGLEW -framework OpenGL

--- a/makefile
+++ b/makefile
@@ -55,11 +55,11 @@ WindowsExeSuffix := .exe
 WindowsRunPrefix := wine
 WindowsRunSuffixUnitTest := --gtest_color=yes | cat -
 
-DarwinIncludeSearchPath = -isystem$(shell brew --prefix)/include
-DarwinLibrarySearchPath = -L$(shell brew --prefix)/lib
+DarwinIncludeSearchFlags = -isystem$(shell brew --prefix)/include
+DarwinLibrarySearchFlags = -L$(shell brew --prefix)/lib
 
-IncludeSearchPath := $($(TARGET_OS)IncludeSearchPath)
-LibrarySearchPath := $($(TARGET_OS)LibrarySearchPath)
+IncludeSearchFlags := $($(TARGET_OS)IncludeSearchFlags)
+LibrarySearchFlags := $($(TARGET_OS)LibrarySearchFlags)
 SpecialPreprocessorFlags := $($(TARGET_OS)SpecialPreprocessorFlags)
 SpecialWarnFlags := $($(TARGET_OS)SpecialWarnFlags)
 ExeSuffix := $($(TARGET_OS)ExeSuffix)
@@ -79,8 +79,8 @@ OUTPUT := $(BINDIR)/libnas2d.a
 SRCS := $(shell find $(SRCDIR) -name '*.cpp')
 OBJS := $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.o,$(SRCS))
 
-IncludeSearchPath := $(shell type $(PkgConfig) >/dev/null 2>&1 && $(PkgConfig) --cflags-only-I sdl2) $(IncludeSearchPath)
-LibrarySearchPath := $(shell type $(PkgConfig) >/dev/null 2>&1 && $(PkgConfig) --libs-only-L sdl2) $(LibrarySearchPath)
+IncludeSearchFlags := $(shell type $(PkgConfig) >/dev/null 2>&1 && $(PkgConfig) --cflags-only-I sdl2) $(IncludeSearchFlags)
+LibrarySearchFlags := $(shell type $(PkgConfig) >/dev/null 2>&1 && $(PkgConfig) --libs-only-L sdl2) $(LibrarySearchFlags)
 
 Linux_OpenGL_LIBS := -lGLEW -lGL
 Darwin_OpenGL_LIBS := -lGLEW -framework OpenGL
@@ -89,10 +89,10 @@ OpenGL_LIBS := $($(TARGET_OS)_OpenGL_LIBS)
 
 SDL_LIBS := -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lSDL2
 
-CPPFLAGS := $(IncludeSearchPath) $(SpecialPreprocessorFlags) $(CPPFLAGS_EXTRA)
+CPPFLAGS := $(IncludeSearchFlags) $(SpecialPreprocessorFlags) $(CPPFLAGS_EXTRA)
 CXXFLAGS_WARN := $(WarnFlags) $(SpecialWarnFlags) $(WARN_EXTRA)
 CXXFLAGS := $(CXXFLAGS_EXTRA) $(CONFIG_CXX_FLAGS) -std=c++20 $(CXXFLAGS_WARN)
-LDFLAGS := $(LibrarySearchPath) $(LDFLAGS_EXTRA)
+LDFLAGS := $(LibrarySearchFlags) $(LDFLAGS_EXTRA)
 LDLIBS := $(LDLIBS_EXTRA) -lstdc++ $(SDL_LIBS) $(OpenGL_LIBS)
 
 PROJECT_FLAGS = $(CPPFLAGS) $(CXXFLAGS)


### PR DESCRIPTION
Auto select `brew` folders for include and library search paths when `Darwin` environment is detected.

Closes #1241
