### PR TITLE
Add `FilesystemPath` class

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -14,6 +14,7 @@
 #include <SDL2/SDL_filesystem.h>
 
 #include <algorithm>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <stdexcept>

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -64,7 +64,7 @@ namespace
 		for (const auto& searchPath : searchPaths)
 		{
 			const auto& filePath = searchPath / path;
-			if (std::filesystem::exists(filePath))
+			if (std::filesystem::exists(filePath.string()))
 			{
 				return filePath.string();
 			}
@@ -177,7 +177,7 @@ RealPath Filesystem::prefPath() const
 int Filesystem::mountSoftFail(const RealPath& path)
 {
 	mSearchPaths.push_back(path);
-	return std::filesystem::exists(path);
+	return std::filesystem::exists(path.string());
 }
 
 
@@ -202,7 +202,7 @@ void Filesystem::mount(const RealPath& path)
  */
 void Filesystem::mountReadWrite(const RealPath& path)
 {
-	std::filesystem::create_directories(path);
+	std::filesystem::create_directories(path.string());
 	mWritePath = path;
 
 	// Mount for read access
@@ -244,7 +244,7 @@ std::vector<VirtualPath> Filesystem::directoryList(const VirtualPath& dir, const
 
 	for (const auto& searchPath : mSearchPaths)
 	{
-		const auto dirPath = searchPath / dir;
+		const auto dirPath = (searchPath / dir).string();
 		if (std::filesystem::is_directory(dirPath))
 		{
 			for (const auto& dirEntry : std::filesystem::directory_iterator(dirPath))
@@ -282,7 +282,7 @@ bool Filesystem::isDirectory(const VirtualPath& path) const
 void Filesystem::makeDirectory(const VirtualPath& path)
 {
 	const auto& filePath = mWritePath / path;
-	std::filesystem::create_directories(filePath);
+	std::filesystem::create_directories(filePath.string());
 }
 
 
@@ -308,7 +308,7 @@ bool Filesystem::exists(const VirtualPath& path) const
 void Filesystem::del(const VirtualPath& filename)
 {
 	const auto& filePath = mWritePath / filename;
-	if (!std::filesystem::remove(filePath))
+	if (!std::filesystem::remove(filePath.string()))
 	{
 		throw std::runtime_error("Error deleting file: " + filename.string() + " : " + errorDescription());
 	}

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -353,7 +353,7 @@ void Filesystem::writeFile(const VirtualPath& filename, const std::string& data,
 	}
 
 	const auto& filePath = mWritePath / filename;
-	std::ofstream file{filePath, std::ios::out | std::ios::binary};
+	std::ofstream file{filePath.string(), std::ios::out | std::ios::binary};
 	if (!file)
 	{
 		throw std::runtime_error("Error opening file for writing: " + filename.string() + " : " + errorDescription());

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -58,7 +58,7 @@ namespace
 	}
 
 
-	std::string findFirstPath(const std::filesystem::path& path, const std::vector<std::filesystem::path>& searchPaths)
+	std::string findFirstPath(const VirtualPath& path, const std::vector<RealPath>& searchPaths)
 	{
 		for (const auto& searchPath : searchPaths)
 		{
@@ -147,7 +147,7 @@ Filesystem::Filesystem(const std::string& appName, const std::string& organizati
  *
  * The base path may or may not be the current working directory.
  */
-std::filesystem::path Filesystem::basePath() const
+RealPath Filesystem::basePath() const
 {
 	return mBasePath;
 }
@@ -160,7 +160,7 @@ std::filesystem::path Filesystem::basePath() const
  *
  * \note This path is dependent on the Operating System (OS).
  */
-std::filesystem::path Filesystem::prefPath() const
+RealPath Filesystem::prefPath() const
 {
 	return mPrefPath;
 }
@@ -173,7 +173,7 @@ std::filesystem::path Filesystem::prefPath() const
  *
  * \return Nonzero on success, zero on error.
  */
-int Filesystem::mountSoftFail(const std::filesystem::path& path)
+int Filesystem::mountSoftFail(const RealPath& path)
 {
 	mSearchPaths.push_back(path);
 	return std::filesystem::exists(path);
@@ -185,7 +185,7 @@ int Filesystem::mountSoftFail(const std::filesystem::path& path)
  *
  * \param path	File path to add.
  */
-void Filesystem::mount(const std::filesystem::path& path)
+void Filesystem::mount(const RealPath& path)
 {
 	if (mountSoftFail(path) == 0)
 	{
@@ -199,7 +199,7 @@ void Filesystem::mount(const std::filesystem::path& path)
  *
  * \param path	File path to add.
  */
-void Filesystem::mountReadWrite(const std::filesystem::path& path)
+void Filesystem::mountReadWrite(const RealPath& path)
 {
 	std::filesystem::create_directories(path);
 	mWritePath = path;
@@ -214,7 +214,7 @@ void Filesystem::mountReadWrite(const std::filesystem::path& path)
  *
  * \param path	File path to remove.
  */
-void Filesystem::unmount(const std::filesystem::path& path)
+void Filesystem::unmount(const RealPath& path)
 {
 	mSearchPaths.erase(std::remove(mSearchPaths.begin(), mSearchPaths.end(), path), mSearchPaths.end());
 }
@@ -223,7 +223,7 @@ void Filesystem::unmount(const std::filesystem::path& path)
 /**
  * Returns a list of directories in the Search Path.
  */
-std::vector<std::filesystem::path> Filesystem::searchPath() const
+std::vector<RealPath> Filesystem::searchPath() const
 {
 	return mSearchPaths;
 }
@@ -237,9 +237,9 @@ std::vector<std::filesystem::path> Filesystem::searchPath() const
  *
  * \note	This function will also return the names of any directories in a specified search path
  */
-std::vector<std::filesystem::path> Filesystem::directoryList(const std::filesystem::path& dir, const std::string& filter) const
+std::vector<VirtualPath> Filesystem::directoryList(const VirtualPath& dir, const std::string& filter) const
 {
-	std::vector<std::filesystem::path> fileList;
+	std::vector<VirtualPath> fileList;
 
 	for (const auto& searchPath : mSearchPaths)
 	{
@@ -266,7 +266,7 @@ std::vector<std::filesystem::path> Filesystem::directoryList(const std::filesyst
  *
  * \param path	Path to check.
  */
-bool Filesystem::isDirectory(const std::filesystem::path& path) const
+bool Filesystem::isDirectory(const VirtualPath& path) const
 {
 	const auto& filePath = findFirstPath(path, mSearchPaths);
 	return std::filesystem::is_directory(filePath);
@@ -278,7 +278,7 @@ bool Filesystem::isDirectory(const std::filesystem::path& path) const
  *
  * \param path	Path of the directory to create.
  */
-void Filesystem::makeDirectory(const std::filesystem::path& path)
+void Filesystem::makeDirectory(const VirtualPath& path)
 {
 	const auto& filePath = mWritePath / path;
 	std::filesystem::create_directories(filePath);
@@ -292,7 +292,7 @@ void Filesystem::makeDirectory(const std::filesystem::path& path)
  *
  * Returns Returns \c true if the specified file or directory exists. Otherwise, returns \c false.
  */
-bool Filesystem::exists(const std::filesystem::path& path) const
+bool Filesystem::exists(const VirtualPath& path) const
 {
 	const auto& filePath = findFirstPath(path, mSearchPaths);
 	return !filePath.empty();
@@ -304,7 +304,7 @@ bool Filesystem::exists(const std::filesystem::path& path) const
  *
  * \param	filename	Path of the file to delete relative to the Filesystem root directory.
  */
-void Filesystem::del(const std::filesystem::path& filename)
+void Filesystem::del(const VirtualPath& filename)
 {
 	const auto& filePath = mWritePath / filename;
 	if (!std::filesystem::remove(filePath))
@@ -314,7 +314,7 @@ void Filesystem::del(const std::filesystem::path& filename)
 }
 
 
-std::string Filesystem::readFile(const std::filesystem::path& filename) const
+std::string Filesystem::readFile(const VirtualPath& filename) const
 {
 	const auto& filePath = findFirstPath(filename, mSearchPaths);
 	if (filePath.empty())
@@ -344,7 +344,7 @@ std::string Filesystem::readFile(const std::filesystem::path& filename) const
 }
 
 
-void Filesystem::writeFile(const std::filesystem::path& filename, const std::string& data, WriteFlags flags)
+void Filesystem::writeFile(const VirtualPath& filename, const std::string& data, WriteFlags flags)
 {
 	if (flags != WriteFlags::Overwrite && exists(filename))
 	{

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -10,16 +10,17 @@
 
 #pragma once
 
+#include "FilesystemPath.h"
+
 #include <vector>
 #include <string>
 #include <string_view>
-#include <filesystem>
 
 
 namespace NAS2D
 {
-	using RealPath = std::filesystem::path;
-	using VirtualPath = std::filesystem::path;
+	using RealPath = FilesystemPath;
+	using VirtualPath = FilesystemPath;
 
 
 	class Filesystem

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -18,6 +18,10 @@
 
 namespace NAS2D
 {
+	using RealPath = std::filesystem::path;
+	using VirtualPath = std::filesystem::path;
+
+
 	class Filesystem
 	{
 	public:
@@ -38,31 +42,31 @@ namespace NAS2D
 		Filesystem& operator=(Filesystem&&) = delete;
 		~Filesystem() = default;
 
-		std::filesystem::path basePath() const;
-		std::filesystem::path prefPath() const;
+		RealPath basePath() const;
+		RealPath prefPath() const;
 
-		int mountSoftFail(const std::filesystem::path& path);
-		void mount(const std::filesystem::path& path);
-		void mountReadWrite(const std::filesystem::path& path);
-		void unmount(const std::filesystem::path& path);
+		int mountSoftFail(const RealPath& path);
+		void mount(const RealPath& path);
+		void mountReadWrite(const RealPath& path);
+		void unmount(const RealPath& path);
 
-		std::vector<std::filesystem::path> searchPath() const;
+		std::vector<RealPath> searchPath() const;
 
-		std::vector<std::filesystem::path> directoryList(const std::filesystem::path& dir, const std::string& filter = std::string{}) const;
+		std::vector<VirtualPath> directoryList(const VirtualPath& dir, const std::string& filter = std::string{}) const;
 
-		bool isDirectory(const std::filesystem::path& path) const;
-		void makeDirectory(const std::filesystem::path& path);
+		bool isDirectory(const VirtualPath& path) const;
+		void makeDirectory(const VirtualPath& path);
 
-		bool exists(const std::filesystem::path& path) const;
-		void del(const std::filesystem::path& path);
+		bool exists(const VirtualPath& path) const;
+		void del(const VirtualPath& path);
 
-		std::string readFile(const std::filesystem::path& filename) const;
-		void writeFile(const std::filesystem::path& filename, const std::string& data, WriteFlags flags = WriteFlags::Overwrite);
+		std::string readFile(const VirtualPath& filename) const;
+		void writeFile(const VirtualPath& filename, const std::string& data, WriteFlags flags = WriteFlags::Overwrite);
 
 	private:
-		std::filesystem::path mBasePath;
-		std::filesystem::path mPrefPath;
-		std::filesystem::path mWritePath;
-		std::vector<std::filesystem::path> mSearchPaths;
+		RealPath mBasePath;
+		RealPath mPrefPath;
+		RealPath mWritePath;
+		std::vector<RealPath> mSearchPaths;
 	};
 }

--- a/NAS2D/FilesystemPath.cpp
+++ b/NAS2D/FilesystemPath.cpp
@@ -42,9 +42,9 @@ bool FilesystemPath::operator<(const FilesystemPath& other) const
 }
 
 
-FilesystemPath FilesystemPath::operator/(std::string path) const
+FilesystemPath FilesystemPath::operator/(const FilesystemPath& path) const
 {
-	return (std::filesystem::path{mPath} / std::filesystem::path{path}).string();
+	return (std::filesystem::path{mPath} / std::filesystem::path{path.string()}).string();
 }
 
 

--- a/NAS2D/FilesystemPath.cpp
+++ b/NAS2D/FilesystemPath.cpp
@@ -24,12 +24,6 @@ FilesystemPath::FilesystemPath(std::string path) :
 }
 
 
-FilesystemPath::operator std::string() const
-{
-	return mPath;
-}
-
-
 bool FilesystemPath::operator==(const FilesystemPath& other) const
 {
 	return mPath == other.mPath;

--- a/NAS2D/FilesystemPath.cpp
+++ b/NAS2D/FilesystemPath.cpp
@@ -1,6 +1,7 @@
 #include "FilesystemPath.h"
 
 #include <filesystem>
+#include <utility>
 
 
 using namespace NAS2D;
@@ -19,7 +20,7 @@ FilesystemPath::FilesystemPath(const char* path) :
 
 
 FilesystemPath::FilesystemPath(std::string path) :
-	mPath{path}
+	mPath{std::move(path)}
 {
 }
 
@@ -48,7 +49,7 @@ FilesystemPath FilesystemPath::stem() const
 }
 
 
-std::string FilesystemPath::string() const
+const std::string& FilesystemPath::string() const
 {
 	return mPath;
 }

--- a/NAS2D/FilesystemPath.cpp
+++ b/NAS2D/FilesystemPath.cpp
@@ -1,0 +1,64 @@
+#include "FilesystemPath.h"
+
+
+using namespace NAS2D;
+
+
+FilesystemPath::FilesystemPath() :
+	mPath{}
+{
+}
+
+
+FilesystemPath::FilesystemPath(const char* path) :
+	mPath{path}
+{
+}
+
+
+FilesystemPath::FilesystemPath(std::string path) :
+	mPath{path}
+{
+}
+
+
+FilesystemPath::operator std::filesystem::path() const
+{
+	return mPath;
+}
+
+
+FilesystemPath::operator std::string() const
+{
+	return mPath;
+}
+
+
+bool FilesystemPath::operator==(const FilesystemPath& other) const
+{
+	return mPath == other.mPath;
+}
+
+
+bool FilesystemPath::operator<(const FilesystemPath& other) const
+{
+	return mPath < other.mPath;
+}
+
+
+FilesystemPath FilesystemPath::operator/(std::string path) const
+{
+	return (std::filesystem::path{mPath} / std::filesystem::path{path}).string();
+}
+
+
+FilesystemPath FilesystemPath::stem() const
+{
+	return std::filesystem::path{mPath}.stem().string();
+}
+
+
+std::string FilesystemPath::string() const
+{
+	return mPath;
+}

--- a/NAS2D/FilesystemPath.cpp
+++ b/NAS2D/FilesystemPath.cpp
@@ -1,5 +1,7 @@
 #include "FilesystemPath.h"
 
+#include <filesystem>
+
 
 using namespace NAS2D;
 
@@ -19,12 +21,6 @@ FilesystemPath::FilesystemPath(const char* path) :
 FilesystemPath::FilesystemPath(std::string path) :
 	mPath{path}
 {
-}
-
-
-FilesystemPath::operator std::filesystem::path() const
-{
-	return mPath;
 }
 
 

--- a/NAS2D/FilesystemPath.h
+++ b/NAS2D/FilesystemPath.h
@@ -12,8 +12,6 @@ namespace NAS2D
 		FilesystemPath(const char* path);
 		FilesystemPath(std::string path);
 
-		operator std::string() const;
-
 		bool operator==(const FilesystemPath& other) const;
 		bool operator<(const FilesystemPath& other) const;
 		FilesystemPath operator/(const FilesystemPath& path) const;

--- a/NAS2D/FilesystemPath.h
+++ b/NAS2D/FilesystemPath.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+#include <filesystem>
+
+
+namespace NAS2D
+{
+	class FilesystemPath
+	{
+	public:
+		FilesystemPath();
+		FilesystemPath(const char* path);
+		FilesystemPath(std::string path);
+
+		operator std::filesystem::path() const;
+		operator std::string() const;
+
+		bool operator==(const FilesystemPath& other) const;
+		bool operator<(const FilesystemPath& other) const;
+		FilesystemPath operator/(std::string path) const;
+
+		FilesystemPath stem() const;
+		std::string string() const;
+	private:
+		std::string mPath;
+	};
+}

--- a/NAS2D/FilesystemPath.h
+++ b/NAS2D/FilesystemPath.h
@@ -16,7 +16,7 @@ namespace NAS2D
 
 		bool operator==(const FilesystemPath& other) const;
 		bool operator<(const FilesystemPath& other) const;
-		FilesystemPath operator/(std::string path) const;
+		FilesystemPath operator/(const FilesystemPath& path) const;
 
 		FilesystemPath stem() const;
 		std::string string() const;

--- a/NAS2D/FilesystemPath.h
+++ b/NAS2D/FilesystemPath.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <filesystem>
 
 
 namespace NAS2D
@@ -13,7 +12,6 @@ namespace NAS2D
 		FilesystemPath(const char* path);
 		FilesystemPath(std::string path);
 
-		operator std::filesystem::path() const;
 		operator std::string() const;
 
 		bool operator==(const FilesystemPath& other) const;

--- a/NAS2D/FilesystemPath.h
+++ b/NAS2D/FilesystemPath.h
@@ -17,7 +17,7 @@ namespace NAS2D
 		FilesystemPath operator/(const FilesystemPath& path) const;
 
 		FilesystemPath stem() const;
-		std::string string() const;
+		const std::string& string() const;
 	private:
 		std::string mPath;
 	};

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -155,6 +155,7 @@
     <ClCompile Include="EnumKeyModifier.cpp" />
     <ClCompile Include="EventHandler.cpp" />
     <ClCompile Include="Filesystem.cpp" />
+    <ClCompile Include="FilesystemPath.cpp" />
     <ClCompile Include="FpsCounter.cpp" />
     <ClCompile Include="Game.cpp" />
     <ClCompile Include="ParserHelper.cpp" />
@@ -212,6 +213,7 @@
     <ClInclude Include="EnumMouseButton.h" />
     <ClInclude Include="EventHandler.h" />
     <ClInclude Include="Filesystem.h" />
+    <ClInclude Include="FilesystemPath.h" />
     <ClInclude Include="FpsCounter.h" />
     <ClInclude Include="Game.h" />
     <ClInclude Include="Math\Angle.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -63,6 +63,9 @@
     <ClCompile Include="Filesystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="FilesystemPath.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="FpsCounter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -228,6 +231,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Filesystem.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="FilesystemPath.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="FpsCounter.h">

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -87,13 +87,13 @@ TEST_F(Filesystem, directoryList) {
 	{
 		auto pathList = fs.directoryList("");
 		EXPECT_LE(1u, pathList.size());
-		EXPECT_THAT(pathList, testing::Contains(std::filesystem::path{"file.txt"}));
+		EXPECT_THAT(pathList, testing::Contains(NAS2D::VirtualPath{"file.txt"}));
 	}
 
 	{
 		auto pathList = fs.directoryList("", "txt");
 		EXPECT_LE(1u, pathList.size());
-		EXPECT_THAT(pathList, testing::Contains(std::filesystem::path{"file.txt"}));
+		EXPECT_THAT(pathList, testing::Contains(NAS2D::VirtualPath{"file.txt"}));
 	}
 }
 


### PR DESCRIPTION
Add `FilesystemPath` class, which hides the dependence on the `<filesystem>` library.

This allows for the removal of the `<filesystem>` include from the `Filesystem.h` header file, where it was transitively included by many other files. As seen during compile time investigations, the `<filesystem>` header was a bit slow to include.

Type aliases were introduced to mark which values referred to real filesystem paths vs virtual filesystem paths. So far they are aliases for the same type, so there is no real added type safety. Though considering uses of the library relied a lot on implicit type conversions from `std::string` and `const char*` we probably don't want to be too picky about types.

Related:
- Issue #1215
- Issue #1245
