### PR TITLE
Only add to search path if folder exists

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -176,8 +176,12 @@ RealPath Filesystem::prefPath() const
  */
 int Filesystem::mountSoftFail(const RealPath& path)
 {
-	mSearchPaths.push_back(path);
-	return std::filesystem::exists(path.string());
+	const auto result = std::filesystem::exists(path.string());
+	if (result)
+	{
+		mSearchPaths.push_back(path);
+	}
+	return result;
 }
 
 


### PR DESCRIPTION
This prevents constantly searching for files in folders that don't exist when `VirtualPath` operations are later called.

This was noticed awhile back when working on an OPHD feature to search for the "data" folder. It didn't prevent correct operation, but did result in sub-optimal performance.

Related:
- Issue #1215
- PR https://github.com/OutpostUniverse/OPHD/pull/1526
