### PR TITLE
Add `FilesystemPath` string conversion operator

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -194,7 +194,7 @@ void Filesystem::mount(const RealPath& path)
 {
 	if (mountSoftFail(path) == 0)
 	{
-		throw std::runtime_error("Error mounting search path: " + path.string() + " : " + errorDescription());
+		throw std::runtime_error("Error mounting search path: " + path + " : " + errorDescription());
 	}
 }
 
@@ -314,7 +314,7 @@ void Filesystem::del(const VirtualPath& filename)
 	const auto& filePath = mWritePath / filename;
 	if (!std::filesystem::remove(std::string{filePath}))
 	{
-		throw std::runtime_error("Error deleting file: " + filename.string() + " : " + errorDescription());
+		throw std::runtime_error("Error deleting file: " + filename + " : " + errorDescription());
 	}
 }
 
@@ -324,13 +324,13 @@ std::string Filesystem::readFile(const VirtualPath& filename) const
 	const auto& filePath = findFirstPath(filename, mSearchPaths);
 	if (filePath.empty())
 	{
-		throw std::runtime_error("Error opening file: " + filename.string() + " : File does not exist");
+		throw std::runtime_error("Error opening file: " + filename + " : File does not exist");
 	}
 
 	std::ifstream file{filePath, std::ios::in | std::ios::binary};
 	if (!file)
 	{
-		throw std::runtime_error("Error opening file: " + filename.string() + " : " + errorDescription());
+		throw std::runtime_error("Error opening file: " + filename + " : " + errorDescription());
 	}
 
 	const auto fileSize = std::filesystem::file_size(filePath);
@@ -342,7 +342,7 @@ std::string Filesystem::readFile(const VirtualPath& filename) const
 	file.read(fileBuffer.data(), static_cast<std::streamsize>(bufferSize));
 	if (!file)
 	{
-		throw std::runtime_error("Error reading file: " + filename.string() + " : " + errorDescription());
+		throw std::runtime_error("Error reading file: " + filename + " : " + errorDescription());
 	}
 
 	return fileBuffer;
@@ -353,19 +353,19 @@ void Filesystem::writeFile(const VirtualPath& filename, const std::string& data,
 {
 	if (flags != WriteFlags::Overwrite && exists(filename))
 	{
-		throw std::runtime_error("Overwrite flag not specified and file already exists: " + filename.string());
+		throw std::runtime_error("Overwrite flag not specified and file already exists: " + filename);
 	}
 
 	const auto& filePath = mWritePath / filename;
 	std::ofstream file{filePath.string(), std::ios::out | std::ios::binary};
 	if (!file)
 	{
-		throw std::runtime_error("Error opening file for writing: " + filename.string() + " : " + errorDescription());
+		throw std::runtime_error("Error opening file for writing: " + filename + " : " + errorDescription());
 	}
 
 	file << data;
 	if (!file)
 	{
-		throw std::runtime_error("Error writing file: " + filename.string() + " : " + errorDescription());
+		throw std::runtime_error("Error writing file: " + filename + " : " + errorDescription());
 	}
 }

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -64,7 +64,7 @@ namespace
 		for (const auto& searchPath : searchPaths)
 		{
 			const auto& filePath = searchPath / path;
-			if (std::filesystem::exists(filePath.string()))
+			if (std::filesystem::exists(std::string{filePath}))
 			{
 				return filePath.string();
 			}
@@ -176,7 +176,7 @@ RealPath Filesystem::prefPath() const
  */
 int Filesystem::mountSoftFail(const RealPath& path)
 {
-	const auto result = std::filesystem::exists(path.string());
+	const auto result = std::filesystem::exists(std::string{path});
 	if (result)
 	{
 		mSearchPaths.push_back(path);
@@ -206,7 +206,7 @@ void Filesystem::mount(const RealPath& path)
  */
 void Filesystem::mountReadWrite(const RealPath& path)
 {
-	std::filesystem::create_directories(path.string());
+	std::filesystem::create_directories(std::string{path});
 	mWritePath = path;
 
 	// Mount for read access
@@ -248,7 +248,7 @@ std::vector<VirtualPath> Filesystem::directoryList(const VirtualPath& dir, const
 
 	for (const auto& searchPath : mSearchPaths)
 	{
-		const auto dirPath = (searchPath / dir).string();
+		const auto dirPath = std::string{searchPath / dir};
 		if (std::filesystem::is_directory(dirPath))
 		{
 			for (const auto& dirEntry : std::filesystem::directory_iterator(dirPath))
@@ -285,8 +285,8 @@ bool Filesystem::isDirectory(const VirtualPath& path) const
  */
 void Filesystem::makeDirectory(const VirtualPath& path)
 {
-	const auto& filePath = mWritePath / path;
-	std::filesystem::create_directories(filePath.string());
+	const auto& filePath = std::string{mWritePath / path};
+	std::filesystem::create_directories(filePath);
 }
 
 
@@ -312,7 +312,7 @@ bool Filesystem::exists(const VirtualPath& path) const
 void Filesystem::del(const VirtualPath& filename)
 {
 	const auto& filePath = mWritePath / filename;
-	if (!std::filesystem::remove(filePath.string()))
+	if (!std::filesystem::remove(std::string{filePath}))
 	{
 		throw std::runtime_error("Error deleting file: " + filename.string() + " : " + errorDescription());
 	}

--- a/NAS2D/FilesystemPath.cpp
+++ b/NAS2D/FilesystemPath.cpp
@@ -59,3 +59,15 @@ const std::string& FilesystemPath::string() const
 {
 	return mPath;
 }
+
+
+std::string NAS2D::operator+(const char* string, const FilesystemPath& path)
+{
+	return string + std::string{path};
+}
+
+
+std::string NAS2D::operator+(const FilesystemPath& path, const char* string)
+{
+	return std::string{path} + string;
+}

--- a/NAS2D/FilesystemPath.cpp
+++ b/NAS2D/FilesystemPath.cpp
@@ -45,7 +45,7 @@ bool FilesystemPath::operator<(const FilesystemPath& other) const
 
 FilesystemPath FilesystemPath::operator/(const FilesystemPath& path) const
 {
-	return (std::filesystem::path{mPath} / std::filesystem::path{path.string()}).string();
+	return (std::filesystem::path{mPath} / std::filesystem::path{std::string{path}}).string();
 }
 
 

--- a/NAS2D/FilesystemPath.cpp
+++ b/NAS2D/FilesystemPath.cpp
@@ -25,6 +25,12 @@ FilesystemPath::FilesystemPath(std::string path) :
 }
 
 
+FilesystemPath::operator const std::string&() const
+{
+	return mPath;
+}
+
+
 bool FilesystemPath::operator==(const FilesystemPath& other) const
 {
 	return mPath == other.mPath;

--- a/NAS2D/FilesystemPath.h
+++ b/NAS2D/FilesystemPath.h
@@ -22,4 +22,8 @@ namespace NAS2D
 	private:
 		std::string mPath;
 	};
+
+
+	std::string operator+(const char* string, const FilesystemPath& path);
+	std::string operator+(const FilesystemPath& path, const char* string);
 }

--- a/NAS2D/FilesystemPath.h
+++ b/NAS2D/FilesystemPath.h
@@ -12,6 +12,7 @@ namespace NAS2D
 		FilesystemPath(const char* path);
 		FilesystemPath(std::string path);
 
+		explicit operator const std::string&() const;
 		bool operator==(const FilesystemPath& other) const;
 		bool operator<(const FilesystemPath& other) const;
 		FilesystemPath operator/(const FilesystemPath& path) const;

--- a/test/FilesystemPath.test.cpp
+++ b/test/FilesystemPath.test.cpp
@@ -49,3 +49,9 @@ TEST(FilesystemPath, string) {
 	const auto path = NAS2D::FilesystemPath{"a/b/c/"};
 	EXPECT_EQ(std::string{"a/b/c/"}, path.string());
 }
+
+TEST(FilesystemPath, constCharStarConcat) {
+	const auto path = NAS2D::FilesystemPath{"a/b/c/"};
+	EXPECT_EQ(std::string{"Path is: a/b/c/"}, "Path is: " + path);
+	EXPECT_EQ(std::string{"a/b/c/ was the path"}, path + " was the path");
+}

--- a/test/FilesystemPath.test.cpp
+++ b/test/FilesystemPath.test.cpp
@@ -21,6 +21,10 @@ TEST(FilesystemPath, constructionString) {
 	EXPECT_EQ("a/b/c/", path.string());
 }
 
+TEST(FilesystemPath, operatorString) {
+	const auto path = NAS2D::FilesystemPath{std::string{"a/b/c/"}};
+	EXPECT_EQ(std::string{"a/b/c/"}, std::string{path});
+}
 
 TEST(FilesystemPath, operatorEqual) {
 	const auto path = NAS2D::FilesystemPath{"a/b/c/"};

--- a/test/FilesystemPath.test.cpp
+++ b/test/FilesystemPath.test.cpp
@@ -9,12 +9,10 @@ TEST(FilesystemPath, constructionDefault) {
 	EXPECT_EQ("", path.string());
 }
 
-
 TEST(FilesystemPath, constructionConstCharStar) {
 	const auto path = NAS2D::FilesystemPath{"a/b/c/"};
 	EXPECT_EQ("a/b/c/", path.string());
 }
-
 
 TEST(FilesystemPath, constructionString) {
 	const auto path = NAS2D::FilesystemPath{std::string{"a/b/c/"}};
@@ -31,12 +29,10 @@ TEST(FilesystemPath, operatorEqual) {
 	EXPECT_EQ(NAS2D::FilesystemPath{"a/b/c/"}, path);
 }
 
-
 TEST(FilesystemPath, operatorLess) {
 	const auto path = NAS2D::FilesystemPath{"a/b/c/"};
 	EXPECT_LT(NAS2D::FilesystemPath{"a/b/b/"}, path);
 }
-
 
 TEST(FilesystemPath, operatorSlash) {
 	const auto path = NAS2D::FilesystemPath{"a/b/c/"};
@@ -44,12 +40,10 @@ TEST(FilesystemPath, operatorSlash) {
 	EXPECT_EQ(NAS2D::FilesystemPath{"a/b/c/filename"}, path / "filename");
 }
 
-
 TEST(FilesystemPath, stem) {
 	const auto path = NAS2D::FilesystemPath{"path/to/filename.ext"};
 	EXPECT_EQ(NAS2D::FilesystemPath{"filename"}, path.stem());
 }
-
 
 TEST(FilesystemPath, string) {
 	const auto path = NAS2D::FilesystemPath{"a/b/c/"};


### PR DESCRIPTION
For debugging purposes it's convenient have to have `FilesystemPath` easily convert to a `std::string`.

It also helps to have concatenation operations with string literals.

This conversion operator existed previously, though was not marked as `explicit`.

I was tempted to remove the `string()` method when this was added. One reason to keep it is the `std::filesystem::path` class has a `string()` method, so it makes the two types more compatible. For a program using `auto`, it may be possible to switch between them for simple cases.

Related:
- Issue #1285
- PR #1279
  - Commit 8bd64736540d56dc660ec9e3d7b3d67381073f6e
  - Commit 8fec3609dc2f819ace6f45d1d8514aaa4fc10b1a
- PR #1284
