### PR TITLE
Add method `FilesystemPath::parent()`

### DIFF
--- a/NAS2D/FilesystemPath.cpp
+++ b/NAS2D/FilesystemPath.cpp
@@ -49,6 +49,14 @@ FilesystemPath FilesystemPath::operator/(const FilesystemPath& path) const
 }
 
 
+FilesystemPath FilesystemPath::parent() const
+{
+	// Keep the trailing "/" as part of the folder name
+	// This is contrary to how <filesystem> behaves, which strips the trailing "/"
+	return ((std::filesystem::path{mPath} / "").parent_path().remove_filename()).string();
+}
+
+
 FilesystemPath FilesystemPath::stem() const
 {
 	return std::filesystem::path{mPath}.stem().string();

--- a/NAS2D/FilesystemPath.h
+++ b/NAS2D/FilesystemPath.h
@@ -17,6 +17,7 @@ namespace NAS2D
 		bool operator<(const FilesystemPath& other) const;
 		FilesystemPath operator/(const FilesystemPath& path) const;
 
+		FilesystemPath parent() const;
 		FilesystemPath stem() const;
 		const std::string& string() const;
 	private:

--- a/test/FilesystemPath.test.cpp
+++ b/test/FilesystemPath.test.cpp
@@ -40,6 +40,30 @@ TEST(FilesystemPath, operatorSlash) {
 	EXPECT_EQ(NAS2D::FilesystemPath{"a/b/c/filename"}, path / "filename");
 }
 
+TEST(FilesystemPath, parentFoldersRelative) {
+	const auto path = NAS2D::FilesystemPath{"a/b/c/"};
+	EXPECT_EQ(NAS2D::FilesystemPath{"a/b/"}, path.parent());
+	EXPECT_EQ(NAS2D::FilesystemPath{"a/"}, path.parent().parent());
+	EXPECT_EQ(NAS2D::FilesystemPath{""}, path.parent().parent().parent());
+}
+
+TEST(FilesystemPath, parentFoldersAbsolute) {
+	const auto path = NAS2D::FilesystemPath{"/a/b/c/"};
+	EXPECT_EQ(NAS2D::FilesystemPath{"/a/b/"}, path.parent());
+	EXPECT_EQ(NAS2D::FilesystemPath{"/a/"}, path.parent().parent());
+	EXPECT_EQ(NAS2D::FilesystemPath{"/"}, path.parent().parent().parent());
+}
+
+TEST(FilesystemPath, parentFileRelative) {
+	const auto path = NAS2D::FilesystemPath{"a/b/c/filename"};
+	EXPECT_EQ(NAS2D::FilesystemPath{"a/b/c/"}, path.parent());
+}
+
+TEST(FilesystemPath, parentFileAbsolute) {
+	const auto path = NAS2D::FilesystemPath{"/a/b/c/filename"};
+	EXPECT_EQ(NAS2D::FilesystemPath{"/a/b/c/"}, path.parent());
+}
+
 TEST(FilesystemPath, stem) {
 	const auto path = NAS2D::FilesystemPath{"path/to/filename.ext"};
 	EXPECT_EQ(NAS2D::FilesystemPath{"filename"}, path.stem());


### PR DESCRIPTION
Add method `FilesystemPath::parent()` and associated unit tests.

Related:
- Issue #1285
