### PR TITLE
Add method `FilesystemPath::isRelative()`

### DIFF
--- a/NAS2D/FilesystemPath.cpp
+++ b/NAS2D/FilesystemPath.cpp
@@ -50,6 +50,12 @@ FilesystemPath FilesystemPath::operator/(const FilesystemPath& path) const
 }
 
 
+bool FilesystemPath::isRelative() const
+{
+	return std::filesystem::path{mPath}.is_relative();
+}
+
+
 std::size_t FilesystemPath::componentCount() const
 {
 	// Don't treat a trailing "/" as an extra path component

--- a/NAS2D/FilesystemPath.h
+++ b/NAS2D/FilesystemPath.h
@@ -18,6 +18,7 @@ namespace NAS2D
 		bool operator<(const FilesystemPath& other) const;
 		FilesystemPath operator/(const FilesystemPath& path) const;
 
+		bool isRelative() const;
 		std::size_t componentCount() const;
 		FilesystemPath parent() const;
 		FilesystemPath stem() const;

--- a/test/FilesystemPath.test.cpp
+++ b/test/FilesystemPath.test.cpp
@@ -40,6 +40,12 @@ TEST(FilesystemPath, operatorSlash) {
 	EXPECT_EQ(NAS2D::FilesystemPath{"a/b/c/filename"}, path / "filename");
 }
 
+TEST(FilesystemPath, isRelative) {
+	EXPECT_TRUE(NAS2D::FilesystemPath{""}.isRelative());
+	EXPECT_TRUE(NAS2D::FilesystemPath{"a/"}.isRelative());
+	EXPECT_TRUE(NAS2D::FilesystemPath{"a/filename"}.isRelative());
+}
+
 TEST(FilesystemPath, componentCountRelative) {
 	EXPECT_EQ(0u, NAS2D::FilesystemPath{""}.componentCount());
 	EXPECT_EQ(1u, NAS2D::FilesystemPath{"a/"}.componentCount());


### PR DESCRIPTION
It's tempting to add an `isAbsolute()` method as well, though the positive form of the test case presents challenges with Windows. The path "/" is considered relative on Windows (relative to the drive of the current working directory), while it is absolute on Linux and MacOS. Meanwhile a path such as "C:\" won't have the same meaning on Linux and MacOS, where it would be considered a relative filename.

The same could be said for the negative form of an `isRelative` test. That's one reason why there are no negative tests for this member function.

Related:
- Issue #1285
