### PR TITLE
Add method `FilesystemPath::absolute()`

### DIFF
--- a/NAS2D/FilesystemPath.cpp
+++ b/NAS2D/FilesystemPath.cpp
@@ -65,6 +65,12 @@ std::size_t FilesystemPath::componentCount() const
 }
 
 
+FilesystemPath FilesystemPath::absolute() const
+{
+	return std::filesystem::absolute(mPath).string();
+}
+
+
 FilesystemPath FilesystemPath::parent() const
 {
 	// Keep the trailing "/" as part of the folder name

--- a/NAS2D/FilesystemPath.h
+++ b/NAS2D/FilesystemPath.h
@@ -20,6 +20,7 @@ namespace NAS2D
 
 		bool isRelative() const;
 		std::size_t componentCount() const;
+		FilesystemPath absolute() const;
 		FilesystemPath parent() const;
 		FilesystemPath stem() const;
 		const std::string& string() const;

--- a/test/FilesystemPath.test.cpp
+++ b/test/FilesystemPath.test.cpp
@@ -62,6 +62,18 @@ TEST(FilesystemPath, componentCountAbsolute) {
 	EXPECT_EQ(5u, NAS2D::FilesystemPath{"/a/b/c/filename"}.componentCount());
 }
 
+TEST(FilesystemPath, absoluteRelative) {
+	const auto path = NAS2D::FilesystemPath{"a"} / "filename";
+	const auto pathAbsolute = path.absolute();
+	EXPECT_THAT(pathAbsolute, testing::EndsWith(path));
+	EXPECT_NE(path, pathAbsolute);
+}
+
+TEST(FilesystemPath, absoluteAbsolute) {
+	const auto path = NAS2D::FilesystemPath{"a/filename"}.absolute();
+	EXPECT_EQ(path, path.absolute());
+}
+
 TEST(FilesystemPath, parentFoldersRelative) {
 	const auto path = NAS2D::FilesystemPath{"a/b/c/"};
 	EXPECT_EQ(NAS2D::FilesystemPath{"a/b/"}, path.parent());


### PR DESCRIPTION
Add method to convert relative paths to absolute paths.

A path that is already absolute should not be modified.

This may help with writing unit tests that work for all of Windows, Linux, and MacOS. In particular, paths starting with `/` are absolute on Linux and MacOS, but relative on Windows (since they are relative to the drive of the current working directory).

Related:
- Issue #1285
