### PR TITLE
Add `FilesystemPathParents`

### DIFF
--- a/NAS2D/FilesystemPathParents.cpp
+++ b/NAS2D/FilesystemPathParents.cpp
@@ -1,0 +1,100 @@
+#include "FilesystemPathParents.h"
+
+#include <algorithm>
+
+
+namespace
+{
+	std::size_t parentCount(const NAS2D::FilesystemPath& path)
+	{
+		std::size_t count = 1;
+		for (auto lastPath = path, nextPath = path.parent(); lastPath != nextPath;)
+		{
+			++count;
+			lastPath = nextPath;
+			nextPath = nextPath.parent();
+		}
+		return count;
+	}
+}
+
+
+namespace NAS2D
+{
+	static_assert(std::forward_iterator<FilesystemPathParents::Iterator>);
+
+
+	FilesystemPathParents::FilesystemPathParents(const FilesystemPath& folder) :
+		FilesystemPathParents(folder, parentCount(folder))
+	{
+	}
+
+
+	FilesystemPathParents::FilesystemPathParents(const FilesystemPath& folder, std::size_t maxLevels) :
+		mPath{folder},
+		mMaxLevels{std::min(maxLevels, parentCount(folder))}
+	{
+	}
+
+
+	std::size_t FilesystemPathParents::size() const
+	{
+		return mMaxLevels;
+	}
+
+
+	FilesystemPathParents::Iterator FilesystemPathParents::begin() const
+	{
+		return {mPath, mMaxLevels};
+	}
+
+
+	FilesystemPathParents::Iterator FilesystemPathParents::end() const
+	{
+		return {};
+	}
+
+
+	FilesystemPathParents::Iterator::Iterator() :
+		FilesystemPathParents::Iterator::Iterator("", 0)
+	{
+	}
+
+
+	FilesystemPathParents::Iterator::Iterator(const FilesystemPath& folder, std::size_t levelsRemaining) :
+		mPath{folder},
+		mLevelsRemaining{levelsRemaining}
+	{
+	}
+
+
+	bool FilesystemPathParents::Iterator::operator==(const Iterator& other) const
+	{
+		return mLevelsRemaining == other.mLevelsRemaining && (mLevelsRemaining == 0 || mPath == other.mPath);
+	}
+
+
+	FilesystemPathParents::Iterator& FilesystemPathParents::Iterator::operator++()
+	{
+		if (mLevelsRemaining > 0)
+		{
+			mPath = mPath.parent();
+			--mLevelsRemaining;
+		}
+		return *this;
+	}
+
+
+	FilesystemPathParents::Iterator FilesystemPathParents::Iterator::operator++(int)
+	{
+		auto temp = *this;
+		++*this;
+		return temp;
+	}
+
+
+	const FilesystemPath& FilesystemPathParents::Iterator::operator*() const
+	{
+		return mPath;
+	}
+}

--- a/NAS2D/FilesystemPathParents.h
+++ b/NAS2D/FilesystemPathParents.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "FilesystemPath.h"
+
+
+namespace NAS2D
+{
+	class FilesystemPathParents
+	{
+	public:
+		class Iterator;
+
+		FilesystemPathParents(const FilesystemPath& folder);
+		FilesystemPathParents(const FilesystemPath& folder, std::size_t maxLevels);
+
+		std::size_t size() const;
+
+		Iterator begin() const;
+		Iterator end() const;
+
+	private:
+		FilesystemPath mPath;
+		std::size_t mMaxLevels;
+
+
+	public:
+		class Iterator
+		{
+		public:
+			using value_type = FilesystemPath;
+			using difference_type = std::ptrdiff_t;
+
+			Iterator();
+			Iterator(const FilesystemPath& folder, std::size_t levelsRemaining);
+
+			bool operator==(const Iterator& other) const;
+
+			Iterator& operator++();
+			Iterator operator++(int);
+
+			const FilesystemPath& operator*() const;
+
+		private:
+			FilesystemPath mPath;
+			std::size_t mLevelsRemaining;
+		};
+	};
+}

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -156,6 +156,7 @@
     <ClCompile Include="EventHandler.cpp" />
     <ClCompile Include="Filesystem.cpp" />
     <ClCompile Include="FilesystemPath.cpp" />
+    <ClCompile Include="FilesystemPathParents.cpp" />
     <ClCompile Include="FpsCounter.cpp" />
     <ClCompile Include="Game.cpp" />
     <ClCompile Include="ParserHelper.cpp" />
@@ -214,6 +215,7 @@
     <ClInclude Include="EventHandler.h" />
     <ClInclude Include="Filesystem.h" />
     <ClInclude Include="FilesystemPath.h" />
+    <ClInclude Include="FilesystemPathParents.h" />
     <ClInclude Include="FpsCounter.h" />
     <ClInclude Include="Game.h" />
     <ClInclude Include="Math\Angle.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClCompile Include="FilesystemPath.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="FilesystemPathParents.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="FpsCounter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -234,6 +237,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="FilesystemPath.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="FilesystemPathParents.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="FpsCounter.h">

--- a/test/FilesystemPathParents.test.cpp
+++ b/test/FilesystemPathParents.test.cpp
@@ -1,0 +1,45 @@
+#include "NAS2D/FilesystemPathParents.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+
+TEST(FilesystemPathParents, sizeRelativeTrailingSlash) {
+	EXPECT_EQ(1u, NAS2D::FilesystemPathParents{""}.size());
+	EXPECT_EQ(2u, NAS2D::FilesystemPathParents{"a/"}.size());
+	EXPECT_EQ(3u, NAS2D::FilesystemPathParents{"a/b/"}.size());
+	EXPECT_EQ(4u, NAS2D::FilesystemPathParents{"a/b/c/"}.size());
+}
+
+TEST(FilesystemPathParents, sizeRelativeNoTrailingSlash) {
+	EXPECT_EQ(1u, NAS2D::FilesystemPathParents{""}.size());
+	EXPECT_EQ(2u, NAS2D::FilesystemPathParents{"a"}.size());
+	EXPECT_EQ(3u, NAS2D::FilesystemPathParents{"a/b"}.size());
+	EXPECT_EQ(4u, NAS2D::FilesystemPathParents{"a/b/c"}.size());
+}
+
+TEST(FilesystemPathParents, sizeAbsoluteTrailingSlash) {
+	EXPECT_EQ(1u, NAS2D::FilesystemPathParents{"/"}.size());
+	EXPECT_EQ(2u, NAS2D::FilesystemPathParents{"/a/"}.size());
+	EXPECT_EQ(3u, NAS2D::FilesystemPathParents{"/a/b/"}.size());
+	EXPECT_EQ(4u, NAS2D::FilesystemPathParents{"/a/b/c/"}.size());
+}
+
+TEST(FilesystemPathParents, sizeAbsoluteNoTrailingSlash) {
+	EXPECT_EQ(1u, NAS2D::FilesystemPathParents{"/"}.size());
+	EXPECT_EQ(2u, NAS2D::FilesystemPathParents{"/a"}.size());
+	EXPECT_EQ(3u, NAS2D::FilesystemPathParents{"/a/b"}.size());
+	EXPECT_EQ(4u, NAS2D::FilesystemPathParents{"/a/b/c"}.size());
+}
+
+TEST(FilesystemPathParents, iterationValuesRelative) {
+	const auto parentPaths = NAS2D::FilesystemPathParents("a/b/c/");
+	const auto paths = std::vector(parentPaths.begin(), parentPaths.end());
+	ASSERT_THAT(paths, testing::ElementsAre("a/b/c/", "a/b/", "a/", ""));
+}
+
+TEST(FilesystemPathParents, iterationValuesAbsolute) {
+	const auto parentPaths = NAS2D::FilesystemPathParents("/a/b/c/");
+	const auto paths = std::vector(parentPaths.begin(), parentPaths.end());
+	ASSERT_THAT(paths, testing::ElementsAre("/a/b/c/", "/a/b/", "/a/", "/"));
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -165,6 +165,7 @@
     <ClCompile Include="Dictionary.test.cpp" />
     <ClCompile Include="Filesystem.test.cpp" />
     <ClCompile Include="FilesystemPath.test.cpp" />
+    <ClCompile Include="FilesystemPathParents.test.cpp" />
     <ClCompile Include="ParserHelper.test.cpp" />
     <ClCompile Include="StringFrom.test.cpp" />
     <ClCompile Include="StringFromTo.test.cpp" />


### PR DESCRIPTION
Add a `FilesystemPathParents` collection class, which allows for easy iteration over parent folders, with an optional maximum number of levels.

This is maybe a little overkill to put into NAS2D. Not sure if we really want to provide this as a library feature, or treat it as an internal implementation detail that could be simplified or removed in the future. Potentially just the code from the `parentCount` function could have been used to implement the path searching feature for #1285. Though having the full abstraction means something custom could be easily written if the issue feature isn't a perfect match. It might also be nice to have this as part of history if nothing more than to document how to do this sort of thing.

Related:
- #1285
