### PR TITLE
Add method `Filesystem::findInParents`

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -10,6 +10,8 @@
 
 #include "Filesystem.h"
 
+#include "FilesystemPathParents.h"
+
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_filesystem.h>
 
@@ -164,6 +166,26 @@ RealPath Filesystem::basePath() const
 RealPath Filesystem::prefPath() const
 {
 	return mPrefPath;
+}
+
+
+RealPath Filesystem::findInParents(const RealPath& path, const RealPath& startPath) const
+{
+	return findInParents(path, startPath, std::numeric_limits<std::size_t>::max());
+}
+
+
+RealPath Filesystem::findInParents(const RealPath& path, const RealPath& startPath, std::size_t maxLevels) const
+{
+	for (const auto& currentPath : FilesystemPathParents(startPath, maxLevels))
+	{
+		const auto checkPath = currentPath / path.string();
+		if (std::filesystem::exists(std::string{checkPath}))
+		{
+			return checkPath.string();
+		}
+	}
+	return {};
 }
 
 

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -46,6 +46,9 @@ namespace NAS2D
 		RealPath basePath() const;
 		RealPath prefPath() const;
 
+		RealPath findInParents(const RealPath& path, const RealPath& startPath) const;
+		RealPath findInParents(const RealPath& path, const RealPath& startPath, std::size_t maxLevels) const;
+
 		int mountSoftFail(const RealPath& path);
 		void mount(const RealPath& path);
 		void mountReadWrite(const RealPath& path);

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -76,6 +76,21 @@ TEST_F(Filesystem, prefPath) {
 	EXPECT_THAT(fs.prefPath(), HasPartialPath(AppName));
 }
 
+TEST_F(Filesystem, findInParentsExist) {
+	// Try to find the unit test project folder
+	const auto folder = "test/";
+	EXPECT_THAT(fs.findInParents(folder, fs.basePath()), testing::EndsWith(folder));
+	EXPECT_THAT(fs.findInParents(folder, fs.basePath(), 4), testing::EndsWith(folder));
+}
+
+TEST_F(Filesystem, findInParentsNotExist) {
+	EXPECT_EQ("", fs.findInParents("FolderThatDoesNotExist/", fs.basePath(), 0));
+	EXPECT_EQ("", fs.findInParents("FolderThatDoesNotExist/", fs.basePath(), 1));
+	EXPECT_EQ("", fs.findInParents("FolderThatDoesNotExist/", fs.basePath(), 2));
+	EXPECT_EQ("", fs.findInParents("FolderThatDoesNotExist/", fs.basePath(), 3));
+	EXPECT_EQ("", fs.findInParents("FolderThatDoesNotExist/", fs.basePath(), 4));
+}
+
 TEST_F(Filesystem, searchPath) {
 	auto pathList = fs.searchPath();
 	EXPECT_EQ(3u, pathList.size());


### PR DESCRIPTION
Add method `Filesystem::findInParents`, which can be used to find a `RealPath` to an asset folder to be mounted.

Build systems often place the executable in a build folder, which is possibly a few levels deeper than the repository folder. It's helpful to be able to search upwards to find the repository folder, and hence the asset folder. Additionally, there may be multiple compiled binaries to support multiple platforms. By searching upward we can package all of them together, so the user has the option of installing a single package, and using the binary that's appropriate to their system. This is true even for a network share or USB drive, where the files may be accessed by multiple types of systems.

Related:
- Issue #1285
