### PR TITLE
Update `Game` to allow for mount path searching

### DIFF
--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -82,7 +82,7 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 
 	auto& fs = Utility<Filesystem>::init<Filesystem>(appName, organizationName);
 	fs.mountSoftFail(dataPath);
-	fs.mountSoftFail(fs.basePath() / dataPath);
+	fs.mountSoftFail(fs.findInParents(dataPath, fs.basePath()));
 	fs.mountReadWrite(fs.prefPath());
 
 	Configuration& configuration = Utility<Configuration>::init(defaultConfig());

--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -132,6 +132,20 @@ void Game::mount(const std::string& path)
 
 
 /**
+ * Adds an additional directory to the search path of the Filesystem.
+ *
+ * The path is searched for starting from the `basePath` and searching up.
+ *
+ * \param path	Path to add to the search path.
+ */
+void Game::mountFindFromBase(const std::string& path)
+{
+	auto& filesystem = Utility<Filesystem>::get();
+	filesystem.mount(filesystem.findInParents(path, filesystem.basePath()));
+}
+
+
+/**
  * Primes the EventHandler and StateManager and enters the main game loop.
  *
  * \param state	A pointer to a State object.

--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -121,8 +121,7 @@ Game::~Game()
 
 
 /**
- * Adds an additional directory or archive to the search path
- * of the Filesystem.
+ * Adds an additional directory to the search path of the Filesystem.
  *
  * \param path	Path to add to the search path.
  */

--- a/NAS2D/Game.h
+++ b/NAS2D/Game.h
@@ -58,6 +58,7 @@ namespace NAS2D
 		~Game();
 
 		void mount(const std::string& path);
+		void mountFindFromBase(const std::string& path);
 
 		void go(State* state);
 	};


### PR DESCRIPTION
Update `Game` to do mount path searching, searching upwards from the executable file's folder, so mounted files are no longer so dependent on having the current working directory set to an appropriate folder.

Related:
- Issue #1285
