### PR TITLE
Simplify data mounting in test and demo projects

### DIFF
--- a/demoGraphics/DemoGraphics.cpp
+++ b/demoGraphics/DemoGraphics.cpp
@@ -19,7 +19,7 @@ namespace
 
 	NAS2D::Font getFont()
 	{
-		static const std::string fileName = "../../../data/fonts/opensans.ttf";
+		static const std::string fileName = "fonts/opensans.ttf";
 
 		const auto& filesystem = NAS2D::Utility<NAS2D::Filesystem>::get();
 		if (filesystem.exists(fileName))
@@ -55,7 +55,6 @@ DemoGraphics::~DemoGraphics()
 	eventHandler.mouseMotion().disconnect({this, &DemoGraphics::onMouseMove});
 	eventHandler.mouseButtonDown().disconnect({this, &DemoGraphics::onMouseDown});
 	eventHandler.keyDown().disconnect({this, &DemoGraphics::onKeyDown});
-
 }
 
 void DemoGraphics::initialize()

--- a/demoGraphics/main.cpp
+++ b/demoGraphics/main.cpp
@@ -27,6 +27,7 @@ int main()
 	try
 	{
 		NAS2D::Game game("NAS2D Graphics Test", "NAS2D_GraphicsTest", "LairWorks");
+		game.mountFindFromBase("demoGraphics/data/");
 		game.go(new DemoGraphics());
 	}
 	catch(std::exception& e)

--- a/makefile
+++ b/makefile
@@ -161,7 +161,7 @@ $(DEMOGRAPHICSOBJS): $(DEMOGRAPHICSINTDIR)/%.o : $(DEMOGRAPHICSDIR)/%.cpp $(DEMO
 
 .PHONY: run-demoGraphics
 run-demoGraphics: | demoGraphics
-	cd demoGraphics/ && $(RunPrefix) ../$(DEMOGRAPHICSOUTPUT) ; cd ..
+	$(RunPrefix) $(DEMOGRAPHICSOUTPUT)
 
 
 ## Compile rules ##

--- a/makefile
+++ b/makefile
@@ -133,7 +133,7 @@ $(TESTOBJS): $(TESTINTDIR)/%.o : $(TESTDIR)/%.cpp $(TESTINTDIR)/%.dep
 
 .PHONY: check
 check: | test
-	cd test && $(RunPrefix) ../$(TESTOUTPUT) $(GTEST_OPTIONS) $(RunSuffixUnitTest)
+	$(RunPrefix) $(TESTOUTPUT) $(GTEST_OPTIONS) $(RunSuffixUnitTest)
 
 
 ## Graphics demo project ##

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -46,7 +46,7 @@ namespace {
 			fs(AppName, OrganizationName)
 		{
 			fs.mount(fs.basePath());
-			fs.mount(fs.findInParents("test/", fs.basePath()) / "data/");
+			fs.mount(fs.findInParents("test/data/", fs.basePath()));
 			fs.mountReadWrite(fs.prefPath());
 		}
 
@@ -153,8 +153,7 @@ TEST_F(Filesystem, isDirectoryMakeDirectory) {
 }
 
 TEST_F(Filesystem, mountUnmount) {
-	const auto projectFolder = fs.findInParents("test/", fs.basePath());
-	const auto extraMount = projectFolder / "data/extraData/";
+	const auto extraMount = fs.findInParents("test/data/extraData/", fs.basePath());
 	const std::string extraFile = "extraFile.txt";
 
 	EXPECT_FALSE(fs.exists(extraFile));

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -153,7 +153,8 @@ TEST_F(Filesystem, isDirectoryMakeDirectory) {
 }
 
 TEST_F(Filesystem, mountUnmount) {
-	const std::string extraMount = "data/extraData/";
+	const auto projectFolder = fs.findInParents("test/", fs.basePath());
+	const auto extraMount = projectFolder / "data/extraData/";
 	const std::string extraFile = "extraFile.txt";
 
 	EXPECT_FALSE(fs.exists(extraFile));

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -46,7 +46,7 @@ namespace {
 			fs(AppName, OrganizationName)
 		{
 			fs.mount(fs.basePath());
-			fs.mount("data/");
+			fs.mount(fs.findInParents("test/", fs.basePath()) / "data/");
 			fs.mountReadWrite(fs.prefPath());
 		}
 


### PR DESCRIPTION
Make use of parent path searching to simplify mounting of data asset folders for the unit test and demo projects.

Related:
- Issue #1285

Closes #1285
