### PR TITLE
Add method `Sprite::isPaused`

### DIFF
--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -116,6 +116,12 @@ void Sprite::resume()
 }
 
 
+bool Sprite::isPaused() const
+{
+	return mPaused || (*mCurrentAction)[mCurrentFrame].isStopFrame();
+}
+
+
 /**
  * Sets the animation playback frame.
  *

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -52,6 +52,7 @@ namespace NAS2D
 		void play(const std::string& action);
 		void pause();
 		void resume();
+		bool isPaused() const;
 
 		void setFrame(std::size_t frameIndex);
 

--- a/test/Resource/Sprite.test.cpp
+++ b/test/Resource/Sprite.test.cpp
@@ -34,6 +34,15 @@ TEST_F(Sprite, size) {
 	EXPECT_EQ((NAS2D::Vector{1, 1}), sprite.size());
 }
 
+TEST_F(Sprite, isPaused) {
+	EXPECT_FALSE(sprite.isPaused());
+}
+
+TEST_F(Sprite, isPausedStopAnimation) {
+	sprite.play("frameStopAction");
+	EXPECT_TRUE(sprite.isPaused());
+}
+
 TEST_F(Sprite, advanceByTimeDelta) {
 	EXPECT_EQ(0u, sprite.advanceByTimeDelta(0u));
 	EXPECT_EQ(0u, sprite.advanceByTimeDelta(1u));


### PR DESCRIPTION
We will drop the completion callback from `Sprite`, so as a replacement we're adding a method that can check if a `Sprite` has reached a stop frame.

Currently a `Sprite` can be manually paused, or automatically paused by reaching a stop frame.

The case for manual pausing is a bit unclear, much like the case for the animation complete callback was unclear.

Related:
- Issue #1218
