### PR TITLE
Remove `Sprite` rotation field

### DIFF
--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -132,7 +132,7 @@ void Sprite::draw(Point<float> position) const
 	const auto& frame = (*mCurrentAction)[mCurrentFrame];
 	const auto drawPosition = position - frame.anchorOffset.to<float>();
 	const auto frameBounds = frame.bounds.to<float>();
-	Utility<Renderer>::get().drawSubImageRotated(frame.image, drawPosition, frameBounds, Angle::degrees(0.0f), mTintColor);
+	Utility<Renderer>::get().drawSubImage(frame.image, drawPosition, frameBounds, mTintColor);
 }
 
 

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -134,6 +134,15 @@ void Sprite::draw(Point<float> position) const
 }
 
 
+void Sprite::draw(Point<float> position, Angle rotation) const
+{
+	const auto& frame = (*mCurrentAction)[mCurrentFrame];
+	const auto drawPosition = position - frame.anchorOffset.to<float>();
+	const auto frameBounds = frame.bounds.to<float>();
+	Utility<Renderer>::get().drawSubImageRotated(frame.image, drawPosition, frameBounds, rotation, mTintColor);
+}
+
+
 /**
  * Sets the rotation angle of the Sprite.
  *

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -9,7 +9,9 @@
 // ==================================================================================
 
 #include "Sprite.h"
+
 #include "ResourceCache.h"
+#include "../Math/Angle.h"
 #include "../Renderer/Renderer.h"
 #include "../Utility.h"
 
@@ -130,7 +132,7 @@ void Sprite::draw(Point<float> position) const
 	const auto& frame = (*mCurrentAction)[mCurrentFrame];
 	const auto drawPosition = position - frame.anchorOffset.to<float>();
 	const auto frameBounds = frame.bounds.to<float>();
-	Utility<Renderer>::get().drawSubImageRotated(frame.image, drawPosition, frameBounds, mRotationAngle, mTintColor);
+	Utility<Renderer>::get().drawSubImageRotated(frame.image, drawPosition, frameBounds, Angle::degrees(0.0f), mTintColor);
 }
 
 
@@ -140,28 +142,6 @@ void Sprite::draw(Point<float> position, Angle rotation) const
 	const auto drawPosition = position - frame.anchorOffset.to<float>();
 	const auto frameBounds = frame.bounds.to<float>();
 	Utility<Renderer>::get().drawSubImageRotated(frame.image, drawPosition, frameBounds, rotation, mTintColor);
-}
-
-
-/**
- * Sets the rotation angle of the Sprite.
- *
- * \param	angle	Angle of rotation.
- */
-void Sprite::rotation(Angle angle)
-{
-	mRotationAngle = angle;
-}
-
-
-/**
- * Gets the rotation angle of the Sprite.
- *
- * \return	Angle of rotation.
- */
-Angle Sprite::rotation() const
-{
-	return mRotationAngle;
 }
 
 

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -52,6 +52,7 @@ namespace NAS2D
 
 		void update();
 		void draw(Point<float> position) const;
+		void draw(Point<float> position, Angle rotation) const;
 
 		void rotation(Angle angle);
 		Angle rotation() const;

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -12,7 +12,6 @@
 
 #include "AnimationSet.h"
 #include "../Timer.h"
-#include "../Math/Angle.h"
 #include "../Renderer/Color.h"
 
 #include <vector>
@@ -21,6 +20,9 @@
 
 namespace NAS2D
 {
+	class Angle;
+
+
 	/**
 	 * Sprite resource.
 	 *
@@ -74,6 +76,5 @@ namespace NAS2D
 		Timer mTimer{};
 
 		Color mTintColor{Color::Normal};
-		Angle mRotationAngle = Angle::degrees(0.0f);
 	};
 } // namespace


### PR DESCRIPTION
Add `draw` overload that takes an `Angle`, and remove internal `Sprite` field for rotation angle.

We should handle the rotation angle as an external concern. This is particularly true for games that have a slanted camera angle. For a slanted camera angle you need a whole new set of images for an object drawn at a different range, rather than simply rotating an image head on.

Related:
- Issue #1245
- Issue #970
