### PR TITLE
Rename type aliases to `ImageSheets` and `Actions`

### DIFF
--- a/NAS2D/Resource/AnimationSet.h
+++ b/NAS2D/Resource/AnimationSet.h
@@ -38,20 +38,20 @@ namespace NAS2D
 			bool isStopFrame() const;
 		};
 
-		using ImageSheetMap = std::map<std::string, std::string>;
-		using ActionsMap = std::map<std::string, std::vector<Frame>>;
+		using ImageSheets = std::map<std::string, std::string>;
+		using Actions = std::map<std::string, std::vector<Frame>>;
 
 
 		explicit AnimationSet(std::string fileName);
 		AnimationSet(std::string fileName, ResourceCache<Image, std::string>& imageCache);
-		AnimationSet(ImageSheetMap imageSheetMap, ActionsMap actions);
+		AnimationSet(ImageSheets imageSheets, Actions actions);
 
 		std::vector<std::string> actionNames() const;
 		const std::vector<Frame>& frames(const std::string& actionName) const;
 
 	private:
-		ImageSheetMap mImageSheetMap;
-		ActionsMap mActions;
+		ImageSheets mImageSheets;
+		Actions mActions;
 	};
 
 } // namespace


### PR DESCRIPTION
Potentially these won't be `std::map` types in a future update. We should probably avoid naming things based on types. That is especially true when refactoring may change the underlying type.

Related:
- Issue #991
