### PR TITLE
Only attempt to install `vcpkg` packages when no cache restored

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,8 @@ jobs:
         path: vcpkg_installed
         key: vcpkgCache-${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
 
-    - name: Pre-install vcpkg dependencies
+    - name: Install vcpkg dependencies
+      if: steps.cacheRestoreVcpkg.outputs.cache-hit != 'true'
       env:
         VcpkgManifestInstall: true
       run: |


### PR DESCRIPTION
This should only run when the cache expires, or is invalidated, and otherwise leave us with a valid cache from a previous run. This should avoid the many spurious updates that `vcpkg` attempts to do, even when the packages should be version locked.

Related:
- PR https://github.com/OutpostUniverse/OPHD/pull/1716
