### PR TITLE
Remove code for the obsolete `vcpkg` `x-gha` binary cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
       Platform: ${{ matrix.platform }}
       Configuration: Release
       VcpkgManifestInstall: false
-      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
     steps:
     - uses: actions/checkout@v4
@@ -27,13 +26,6 @@ jobs:
       run: |
         vcpkg --version
         vcpkg integrate install
-
-    - name: Export GitHub Actions cache environment variables
-      uses: actions/github-script@v7
-      with:
-        script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
     - name: Restore vcpkg dependency cache
       uses: actions/cache/restore@v4


### PR DESCRIPTION
For now we just cache the entire `vcpkg_installed` folder, and with binary caching for individual dependencies.

Related:
- PR #1302
