### PR TITLE
Refactor `SignalSource` to reduce header includes

### DIFF
--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -45,11 +45,7 @@ namespace NAS2D
 
 		void disconnect(DelegateType delegate)
 		{
-			const auto iterator = std::find(delegateList.begin(), delegateList.end(), delegate);
-			if (iterator != delegateList.end())
-			{
-				delegateList.erase(iterator);
-			}
+			std::erase(delegateList, delegate);
 		}
 
 		void clear() { delegateList.clear(); }

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -31,8 +31,11 @@ namespace NAS2D
 
 		bool isConnected(DelegateType delegate) const
 		{
-			const auto iterator = std::find(delegateList.begin(), delegateList.end(), delegate);
-			return (iterator != delegateList.end());
+			for (const auto& referenceDelegate : delegateList)
+			{
+				if (referenceDelegate == delegate) { return true; }
+			}
+			return false;
 		}
 
 		void connect(DelegateType delegate)

--- a/NAS2D/Signal/SignalSource.h
+++ b/NAS2D/Signal/SignalSource.h
@@ -11,8 +11,8 @@
 #pragma once
 
 #include "Delegate.h"
+
 #include <vector>
-#include <algorithm>
 
 
 namespace NAS2D


### PR DESCRIPTION
Remove `<algorithm>` include from `SignalSource`, replacing `std::find` uses with `std::erase` (from `<vector>`), or by using a range-for loop.

Related:
- Issue #1245
