### PR TITLE
Add `Font::width(char)` overload

### DIFF
--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -160,6 +160,16 @@ int Font::width(std::string_view string) const
 }
 
 
+int Font::width(char character) const
+{
+	const auto& gml = mFontInfo.metrics;
+	if (gml.empty()) { return 0; }
+
+	const auto glyphIndex = std::clamp<std::size_t>(static_cast<uint8_t>(character), 0, 255);
+	return gml[glyphIndex].advance;
+}
+
+
 /**
  * Gets the height in pixels of the Font.
  */

--- a/NAS2D/Resource/Font.h
+++ b/NAS2D/Resource/Font.h
@@ -70,6 +70,7 @@ namespace NAS2D
 		Vector<int> glyphCellSize() const;
 		Vector<int> size(std::string_view string) const;
 		int width(std::string_view string) const;
+		int width(char character) const;
 		int height() const;
 		int ascent() const;
 		unsigned int ptSize() const;

--- a/test/Resource/Font.test.cpp
+++ b/test/Resource/Font.test.cpp
@@ -27,3 +27,8 @@ TEST(Font, nullWidthNonEmptyString) {
 	const auto font = NAS2D::Font::null();
 	EXPECT_EQ(0, font.width("ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
 }
+
+TEST(Font, nullWidthChar) {
+	const auto font = NAS2D::Font::null();
+	EXPECT_EQ(0, font.width('A'));
+}


### PR DESCRIPTION
Sometimes it may be more convenient, or possibly even more efficient if we could get the `width` of individual `char` elements. Perhaps to build up a string of some unknown length, that must fit within a given pixel limit.

There was some iteration in OPHD in `TextField::onMouseDown` that was sub-optimal. Instead of a single loop, incrementing by individual character widths, it had a call to `Font::width(std::string_view) const`, which resulted in a nested loop, and a lot of wasted effort as the width of the entire string was recalculated for each new `char` added. It could have passed each new `char` as it's own `std::string_view`, though that still seems like extra work for a simple operation.

Related:
- Issue #1311
- https://github.com/OutpostUniverse/OPHD/issues/1872
