### PR TITLE
Add `Image::resized` method

### DIFF
--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -170,6 +170,22 @@ Color Image::pixelColor(Point<int> point) const
 }
 
 
+Image Image::resized(Vector<int> newSize) const
+{
+	const auto* format = mSurface->format;
+	auto resizedSurface = SDL_CreateRGBSurface(0, newSize.x, newSize.y, format->BytesPerPixel * 8, format->Rmask, format->Gmask, format->Bmask, format->Amask);
+	if (!resizedSurface) { throw std::runtime_error("Failed to created resized surface: " + stringFrom(newSize) + " : " + std::string{SDL_GetError()}); }
+
+	if (SDL_BlitScaled(mSurface, nullptr, resizedSurface, nullptr))
+	{
+		SDL_FreeSurface(resizedSurface);
+		throw std::runtime_error("Failed to scale image to new size: " + stringFrom(newSize) + " : " + std::string{SDL_GetError()});
+	}
+
+	return Image{*resizedSurface};
+}
+
+
 unsigned int Image::textureId() const
 {
 	if (mTextureId == 0)

--- a/NAS2D/Resource/Image.h
+++ b/NAS2D/Resource/Image.h
@@ -58,6 +58,8 @@ namespace NAS2D
 
 		Color pixelColor(Point<int> point) const;
 
+		Image resized(Vector<int> newSize) const;
+
 	protected:
 		friend class RendererOpenGL;
 		unsigned int textureId() const;

--- a/demoGraphics/DemoGraphics.cpp
+++ b/demoGraphics/DemoGraphics.cpp
@@ -44,6 +44,7 @@ namespace
 
 DemoGraphics::DemoGraphics() :
 	mGear{"Gear.png"},
+	mResizedGear{mGear.resized(mGear.size() / 2)},
 	mDxImage{"Test_DirectX.png"},
 	mOglImage{"Test_OpenGL.png"},
 	mTimer{}
@@ -112,6 +113,7 @@ NAS2D::State* DemoGraphics::update()
 	}
 
 	const auto angle = NAS2D::Angle::degrees(static_cast<float>(mTimer.tick() * 360 / 10 / 1000));
+	renderer.drawImageRotated(mResizedGear, {198, 30}, angle);
 	renderer.drawImageRotated(mGear, {158, 60}, angle);
 	renderer.drawImageRotated(mGear, {219, 60}, -angle);
 

--- a/demoGraphics/DemoGraphics.h
+++ b/demoGraphics/DemoGraphics.h
@@ -34,6 +34,7 @@ protected:
 
 private:
 	NAS2D::Image mGear;
+	NAS2D::Image mResizedGear;
 	NAS2D::Image mDxImage;
 	NAS2D::Image mOglImage;
 	NAS2D::Timer mTimer;


### PR DESCRIPTION
Add `Image Image::resized(Vector<int> newSize) const` method, which returns a new `Image` object with the target `newSize`, and contains a copy of the source image with resizing done using nearest neighbour pixel matching.

Related:
- Issue #1312
