### PR TITLE
Add `Image::sliced` method

### DIFF
--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -186,6 +186,23 @@ Image Image::resized(Vector<int> newSize) const
 }
 
 
+Image Image::sliced(Rectangle<int> sliceArea) const
+{
+	const auto* format = mSurface->format;
+	auto newSurface = SDL_CreateRGBSurface(0, sliceArea.size.x, sliceArea.size.y, format->BytesPerPixel * 8, format->Rmask, format->Gmask, format->Bmask, format->Amask);
+	if (!newSurface) { throw std::runtime_error("Failed to created sliced surface: " + stringFrom(sliceArea) + " : " + std::string{SDL_GetError()}); }
+
+	const auto sdlSliceRect = SDL_Rect{sliceArea.position.x, sliceArea.position.y, sliceArea.size.x, sliceArea.size.y};
+	if (SDL_BlitSurface(mSurface, &sdlSliceRect, newSurface, nullptr))
+	{
+		SDL_FreeSurface(newSurface);
+		throw std::runtime_error("Failed to slice image area: " + stringFrom(sliceArea) + " : " + std::string{SDL_GetError()});
+	}
+
+	return Image{*newSurface};
+}
+
+
 unsigned int Image::textureId() const
 {
 	if (mTextureId == 0)

--- a/NAS2D/Resource/Image.h
+++ b/NAS2D/Resource/Image.h
@@ -21,8 +21,7 @@ namespace NAS2D
 {
 	struct Color;
 
-	template <typename BaseType>
-	struct Point;
+	template <typename BaseType> struct Point;
 
 
 	/**

--- a/NAS2D/Resource/Image.h
+++ b/NAS2D/Resource/Image.h
@@ -22,6 +22,7 @@ namespace NAS2D
 	struct Color;
 
 	template <typename BaseType> struct Point;
+	template <typename BaseType> struct Rectangle;
 
 
 	/**
@@ -58,6 +59,7 @@ namespace NAS2D
 		Color pixelColor(Point<int> point) const;
 
 		Image resized(Vector<int> newSize) const;
+		Image sliced(Rectangle<int> sliceArea) const;
 
 	protected:
 		friend class RendererOpenGL;

--- a/NAS2D/StringFrom.h
+++ b/NAS2D/StringFrom.h
@@ -8,6 +8,7 @@ namespace NAS2D
 {
 	template <typename BaseType> struct Point;
 	template <typename BaseType> struct Vector;
+	template <typename BaseType> struct Rectangle;
 
 
 	template <typename T>
@@ -39,5 +40,12 @@ namespace NAS2D
 	std::string stringFrom(Vector<BaseType> vector)
 	{
 		return "(" + std::to_string(vector.x) + ", " + std::to_string(vector.y) + ")";
+	}
+
+
+	template <typename BaseType>
+	std::string stringFrom(Rectangle<BaseType> rectangle)
+	{
+		return "(" + stringFrom(rectangle.position) + ", " + stringFrom(rectangle.size) + ")";
 	}
 }

--- a/demoGraphics/DemoGraphics.cpp
+++ b/demoGraphics/DemoGraphics.cpp
@@ -45,6 +45,7 @@ namespace
 DemoGraphics::DemoGraphics() :
 	mGear{"Gear.png"},
 	mResizedGear{mGear.resized(mGear.size() / 2)},
+	mSlicedGear{mGear.sliced({{mGear.size().x / 5, 0}, mGear.size() * 2 / 5})},
 	mDxImage{"Test_DirectX.png"},
 	mOglImage{"Test_OpenGL.png"},
 	mTimer{}
@@ -111,6 +112,8 @@ NAS2D::State* DemoGraphics::update()
 		const auto offset = NAS2D::Vector{jitter(), jitter()};
 		renderer.drawPoint(NAS2D::Point{84, 60} + offset, NAS2D::Color{grey, grey, grey});
 	}
+
+	renderer.drawImage(mSlicedGear, {165, 30});
 
 	const auto angle = NAS2D::Angle::degrees(static_cast<float>(mTimer.tick() * 360 / 10 / 1000));
 	renderer.drawImageRotated(mResizedGear, {198, 30}, angle);

--- a/demoGraphics/DemoGraphics.h
+++ b/demoGraphics/DemoGraphics.h
@@ -35,6 +35,7 @@ protected:
 private:
 	NAS2D::Image mGear;
 	NAS2D::Image mResizedGear;
+	NAS2D::Image mSlicedGear;
 	NAS2D::Image mDxImage;
 	NAS2D::Image mOglImage;
 	NAS2D::Timer mTimer;


### PR DESCRIPTION
Add `Image Image::sliced(Rectangle<int> sliceArea) const` method, which returns a new `Image` object with size equal to `sliceArea.size`, and a copy of the pixel data from the `sliceArea` of the original `Image`.

Related:
- Issue #1312
- PR #1313
