### PR TITLE
Remove old declarations for `Sprite::rotation` methods

### DIFF
--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -56,9 +56,6 @@ namespace NAS2D
 		void draw(Point<float> position) const;
 		void draw(Point<float> position, Angle rotation) const;
 
-		void rotation(Angle angle);
-		Angle rotation() const;
-
 		void alpha(uint8_t alpha);
 		uint8_t alpha() const;
 		void color(Color color);


### PR DESCRIPTION
The method implementations along with the associated field were removed from `Sprite` a long time back. Attempting to use those methods would have resulted in a compile error.

Related:
- Issue #970
- PR #1299
