### PR TITLE
Add `RectangleSkin::minSize`

### DIFF
--- a/NAS2D/Renderer/RectangleSkin.cpp
+++ b/NAS2D/Renderer/RectangleSkin.cpp
@@ -37,26 +37,26 @@ Vector<int> RectangleSkin::minSize() const
 }
 
 
-void RectangleSkin::draw(Renderer& renderer, const Rectangle<float>& rect) const
+void RectangleSkin::draw(Renderer& renderer, const Rectangle<int>& rect) const
 {
 	const auto p0 = rect.position;
-	const auto p1 = rect.position + mTopLeft.size().to<float>();
-	const auto p2 = rect.crossXPoint() + mTopRight.size().reflectX().to<float>();
-	const auto p3 = rect.crossYPoint() + mBottomLeft.size().reflectY().to<float>();
-	const auto p4 = rect.endPoint() - mBottomRight.size().to<float>();
+	const auto p1 = rect.position + mTopLeft.size();
+	const auto p2 = rect.crossXPoint() + mTopRight.size().reflectX();
+	const auto p3 = rect.crossYPoint() + mBottomLeft.size().reflectY();
+	const auto p4 = rect.endPoint() - mBottomRight.size();
 
 	// Draw the center area
-	renderer.drawImageRepeated(mCenter, Rectangle<float>::Create(p1, p4));
+	renderer.drawImageRepeated(mCenter, Rectangle<int>::Create(p1, p4));
 
 	// Draw the sides
-	renderer.drawImageRepeated(mTop, Rectangle<float>::Create({p1.x, p0.y}, p2));
-	renderer.drawImageRepeated(mBottom, Rectangle<float>::Create(p3, Point{p4.x, rect.endPoint().y}));
-	renderer.drawImageRepeated(mLeft, Rectangle<float>::Create({p0.x, p1.y}, p3));
-	renderer.drawImageRepeated(mRight, Rectangle<float>::Create(p2, Point{rect.endPoint().x, p4.y}));
+	renderer.drawImageRepeated(mTop, Rectangle<int>::Create({p1.x, p0.y}, p2));
+	renderer.drawImageRepeated(mBottom, Rectangle<int>::Create(p3, Point{p4.x, rect.endPoint().y}));
+	renderer.drawImageRepeated(mLeft, Rectangle<int>::Create({p0.x, p1.y}, p3));
+	renderer.drawImageRepeated(mRight, Rectangle<int>::Create(p2, Point{rect.endPoint().x, p4.y}));
 
 	// Draw the corners
 	renderer.drawImage(mTopLeft, rect.position);
-	renderer.drawImage(mTopRight, {p2.x, p0.y});
-	renderer.drawImage(mBottomLeft, {p0.x, p3.y});
+	renderer.drawImage(mTopRight, Point{p2.x, p0.y});
+	renderer.drawImage(mBottomLeft, Point{p0.x, p3.y});
 	renderer.drawImage(mBottomRight, p4);
 }

--- a/NAS2D/Renderer/RectangleSkin.cpp
+++ b/NAS2D/Renderer/RectangleSkin.cpp
@@ -31,6 +31,12 @@ RectangleSkin::RectangleSkin(const Image& topLeft, const Image& top, const Image
 {}
 
 
+Vector<int> RectangleSkin::minSize() const
+{
+	return mTopLeft.size() + mBottomRight.size();
+}
+
+
 void RectangleSkin::draw(Renderer& renderer, const Rectangle<float>& rect) const
 {
 	const auto p0 = rect.position;

--- a/NAS2D/Renderer/RectangleSkin.cpp
+++ b/NAS2D/Renderer/RectangleSkin.cpp
@@ -39,6 +39,9 @@ Vector<int> RectangleSkin::minSize() const
 
 void RectangleSkin::draw(Renderer& renderer, const Rectangle<int>& rect) const
 {
+	// Partial order comparison - must hold for both components simultaneously
+	if (!(minSize() <= rect.size)) { return; }
+
 	const auto p0 = rect.position;
 	const auto p1 = rect.position + mTopLeft.size();
 	const auto p2 = rect.crossXPoint() + mTopRight.size().reflectX();

--- a/NAS2D/Renderer/RectangleSkin.h
+++ b/NAS2D/Renderer/RectangleSkin.h
@@ -27,7 +27,7 @@ namespace NAS2D
 
 		Vector<int> minSize() const;
 
-		void draw(Renderer& renderer, const Rectangle<float>& rect) const;
+		void draw(Renderer& renderer, const Rectangle<int>& rect) const;
 
 	private:
 		const Image& mTopLeft;

--- a/NAS2D/Renderer/RectangleSkin.h
+++ b/NAS2D/Renderer/RectangleSkin.h
@@ -16,6 +16,7 @@ namespace NAS2D
 	class Image;
 	class Renderer;
 
+	template <typename BaseType> struct Vector;
 	template <typename BaseType> struct Rectangle;
 
 
@@ -23,6 +24,8 @@ namespace NAS2D
 	{
 	public:
 		RectangleSkin(const Image& topLeft, const Image& top, const Image& topRight, const Image& left, const Image& center, const Image& right, const Image& bottomLeft, const Image& bottom, const Image& bottomRight);
+
+		Vector<int> minSize() const;
 
 		void draw(Renderer& renderer, const Rectangle<float>& rect) const;
 

--- a/NAS2D/Renderer/RectangleSkin.h
+++ b/NAS2D/Renderer/RectangleSkin.h
@@ -16,8 +16,7 @@ namespace NAS2D
 	class Image;
 	class Renderer;
 
-	template <typename BaseType>
-	struct Rectangle;
+	template <typename BaseType> struct Rectangle;
 
 
 	class RectangleSkin


### PR DESCRIPTION
Ensure a `RectangleSkin` meets a certain minimum size before trying to draw it.

The corner images are always drawn at their natural size, without any kind of clipping or stretching. If the draw `rect` isn't at least big enough for these images, it will either draw outside of the given bounds, or draw over opposite corner images. Either way the result won't look good.

Convert `Rectangle` parameter `BaseType` from `float` to `int`. All uses pass in `int` based `Rectangle` instances, and really `int` is the only type that really makes sense for this class. All the `Image` components have `int` based sizes.

Related:
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issuecomment-3063510114
