### PR TITLE
Add `makefile` helpers

### DIFF
--- a/.cppinclude.json
+++ b/.cppinclude.json
@@ -1,0 +1,6 @@
+{
+	"project_dir": "NAS2D",
+	"include_dirs": ["/usr/include"],
+	"ignore_dirs": [],
+	"ignore_files": ["windows.h"]
+}

--- a/makefile
+++ b/makefile
@@ -240,6 +240,18 @@ format:
 	clang-format --version
 	find NAS2D/ -not -path 'NAS2D/Xml/*' -regex '.*\.\(cpp\|h\)' | xargs clang-format -i
 
+
+## Debugging ##
+
+.PHONY: stale
+stale:
+	@$(MAKE) -n | grep -oE '[^ ]+\.cpp$$' || true
+
+.PHONY: stale-objs
+stale-objs:
+	@$(MAKE) -n | grep -oE '[^ ]+\.o$$' || true
+
+
 ### Linux development package dependencies ###
 # This section contains install rules to aid setup and compiling on Linux.
 # Only a few common Linux distributions are covered. Other distributions

--- a/makefile
+++ b/makefile
@@ -252,6 +252,13 @@ stale-objs:
 	@$(MAKE) -n | grep -oE '[^ ]+\.o$$' || true
 
 
+## Compile performance ##
+
+.PHONY: flame-charts
+flame-charts:
+	$(MAKE) all CXX=clang++ CXXFLAGS_EXTRA="-ftime-trace"
+
+
 ### Linux development package dependencies ###
 # This section contains install rules to aid setup and compiling on Linux.
 # Only a few common Linux distributions are covered. Other distributions

--- a/makefile
+++ b/makefile
@@ -225,7 +225,7 @@ show-warnings:
 	@$(MAKE) clean-all > /dev/null
 
 .PHONY: lint
-lint: cppcheck cppclean
+lint: cppcheck cppclean cppinclude
 
 .PHONY: cppcheck
 cppcheck:
@@ -234,6 +234,10 @@ cppcheck:
 .PHONY: cppclean
 cppclean:
 	cppclean "$(SRCDIR)" --exclude="NAS2D.h" --exclude="Xml"
+
+.PHONY: cppinclude
+cppinclude:
+	cppinclude
 
 .PHONY: format
 format:


### PR DESCRIPTION
Add a few helpful `makefile` targets, taken from OPHD.

Related:
- PR https://github.com/OutpostUniverse/OPHD/pull/1895
- PR https://github.com/OutpostUniverse/OPHD/pull/1886
- PR https://github.com/OutpostUniverse/OPHD/pull/1105
