### PR TITLE
Remove unnecessary calls to `.c_str()`

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -79,7 +79,7 @@ void Configuration::load(const std::string& filePath)
 		{
 			// Read in the Config File.
 			auto xmlData = filesystem.readFile(filePath);
-			loadData(xmlData.c_str());
+			loadData(xmlData);
 		}
 		catch (const std::runtime_error& e)
 		{

--- a/NAS2D/ParserHelper.cpp
+++ b/NAS2D/ParserHelper.cpp
@@ -64,7 +64,7 @@ namespace NAS2D
 
 	Xml::XmlElement* dictionaryToAttributes(const std::string& tagName, const Dictionary& dictionary)
 	{
-		auto* element = new Xml::XmlElement(tagName.c_str());
+		auto* element = new Xml::XmlElement(tagName);
 		for (const auto& key : dictionary.keys())
 		{
 			element->attribute(key, dictionary.get(key));


### PR DESCRIPTION
No sense to converting from a `std::string` to a C-string, then back to a new `std::string`. This wastes time scanning for the length of the C-string to form the new `std::string`.

The unnecessary use of `.c_str()` was pointed out by Codacy.

Related:
- Issue #528
