### PR TITLE
Add method `Color::alphaBlend`

### DIFF
--- a/NAS2D/Renderer/Color.cpp
+++ b/NAS2D/Renderer/Color.cpp
@@ -53,3 +53,13 @@ Color Color::alphaFade(uint8_t newAlpha) const
 {
 	return {red, green, blue, newAlpha};
 }
+
+Color Color::alphaBlend(Color background) const
+{
+	return {
+		static_cast<uint8_t>((red * alpha + background.red * (255 - alpha)) / 255),
+		static_cast<uint8_t>((green * alpha + background.green * (255 - alpha)) / 255),
+		static_cast<uint8_t>((blue * alpha + background.blue * (255 - alpha)) / 255),
+		static_cast<uint8_t>((alpha * alpha + background.alpha * (255 - alpha)) / 255),
+	};
+}

--- a/NAS2D/Renderer/Color.h
+++ b/NAS2D/Renderer/Color.h
@@ -27,6 +27,7 @@ namespace NAS2D
 		bool operator!=(Color other) const;
 
 		Color alphaFade(uint8_t newAlpha) const;
+		Color alphaBlend(Color background) const;
 
 
 		static const Color Black;

--- a/test/Renderer/Color.test.cpp
+++ b/test/Renderer/Color.test.cpp
@@ -32,3 +32,14 @@ TEST(Color, alphaFade) {
 	EXPECT_EQ((NAS2D::Color{0, 0, 255, 128}), NAS2D::Color::Blue.alphaFade(128));
 	EXPECT_EQ((NAS2D::Color{0, 0, 255, 0}), NAS2D::Color::Blue.alphaFade(0));
 }
+
+TEST(Color, alphaBlend) {
+	EXPECT_EQ((NAS2D::Color{0, 0, 0, 255}), (NAS2D::Color{0, 0, 0, 255}.alphaBlend({255, 255, 255, 255})));
+	EXPECT_EQ((NAS2D::Color{255, 255, 255, 255}), (NAS2D::Color{255, 255, 255, 255}.alphaBlend({255, 255, 255, 255})));
+
+	EXPECT_EQ((NAS2D::Color{255, 255, 255, 255}), (NAS2D::Color{0, 0, 0, 0}.alphaBlend({255, 255, 255, 255})));
+	EXPECT_EQ((NAS2D::Color{255, 255, 255, 255}), (NAS2D::Color{255, 255, 255, 0}.alphaBlend({255, 255, 255, 255})));
+	EXPECT_EQ((NAS2D::Color{0, 0, 0, 255}), (NAS2D::Color{255, 255, 255, 0}.alphaBlend({0, 0, 0, 255})));
+
+	EXPECT_EQ((NAS2D::Color{128, 127, 0, 191}), (NAS2D::Color{255, 0, 0, 128}.alphaBlend({0, 255, 0, 255})));
+}


### PR DESCRIPTION
Add method `Color::alphaBlend`, which might be useful if OPHD were to allow for multiple overlays to be active at once.

Related:
- Comment https://github.com/OutpostUniverse/OPHD/issues/1754#issue-3140552199
> Perhaps we should allow multiple overlays to be active at once.
