### PR TITLE
Set Windows runner to `windows-2025`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [x86, x64]
-    runs-on: windows-latest
+    runs-on: windows-2025
     env:
       Platform: ${{ matrix.platform }}
       Configuration: Release


### PR DESCRIPTION
The `windows-latest` tag will be updated to `windows-2025` later this month. It would be nice to upgrade now, and get consistent run results. We should probably be more explicit about version dependencies anyway.

It should be noted that `windows-2022` will not have tools that support C++23.

----

Supported runner tags can be found at:
- https://github.com/actions/runner-images

----

Related:
- Issue #1291
