### PR TITLE
Add method `Font::widthBoundedSubstringLength`

### DIFF
--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -170,6 +170,25 @@ int Font::width(char character) const
 }
 
 
+std::size_t Font::widthBoundedSubstringLength(std::string_view string, int widthBound) const
+{
+	const auto& gml = mFontInfo.metrics;
+	if (gml.empty()) { return 0; }
+
+	std::size_t substringLength = 0;
+	int currentStringWidth = 0;
+	for (const auto character : string)
+	{
+		const auto glyphIndex = std::clamp<std::size_t>(static_cast<uint8_t>(character), 0, 255);
+		const auto characterWidth = gml[glyphIndex].advance;
+		currentStringWidth += characterWidth;
+		if (currentStringWidth > widthBound) { return substringLength; }
+		++substringLength;
+	}
+	return substringLength;
+}
+
+
 /**
  * Gets the height in pixels of the Font.
  */

--- a/NAS2D/Resource/Font.h
+++ b/NAS2D/Resource/Font.h
@@ -12,6 +12,7 @@
 #include "../Math/Vector.h"
 #include "../Math/Rectangle.h"
 
+#include <cstddef>
 #include <string_view>
 #include <string>
 #include <vector>
@@ -71,6 +72,7 @@ namespace NAS2D
 		Vector<int> size(std::string_view string) const;
 		int width(std::string_view string) const;
 		int width(char character) const;
+		std::size_t widthBoundedSubstringLength(std::string_view string, int widthBound) const;
 		int height() const;
 		int ascent() const;
 		unsigned int ptSize() const;

--- a/NAS2D/Resource/Font.h
+++ b/NAS2D/Resource/Font.h
@@ -12,9 +12,9 @@
 #include "../Math/Vector.h"
 #include "../Math/Rectangle.h"
 
+#include <string_view>
 #include <string>
 #include <vector>
-#include <string_view>
 
 
 namespace NAS2D

--- a/test/Resource/Font.test.cpp
+++ b/test/Resource/Font.test.cpp
@@ -32,3 +32,9 @@ TEST(Font, nullWidthChar) {
 	const auto font = NAS2D::Font::null();
 	EXPECT_EQ(0, font.width('A'));
 }
+
+TEST(Font, nullWidthBoundedSubstringLength) {
+	const auto font = NAS2D::Font::null();
+	EXPECT_EQ(0, font.widthBoundedSubstringLength("", 0));
+	EXPECT_EQ(0, font.widthBoundedSubstringLength("A", 0));
+}


### PR DESCRIPTION
Add method `Font::widthBoundedSubstringLength` for use with string clipping and word wrap.

Closes #1311

----

Related:
- Issue #1311
