### PR TITLE
Offset `drawLine` so coordinates matches other draw methods

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -339,7 +339,8 @@ void RendererOpenGL::drawLine(Point<float> startPosition, Point<float> endPositi
 	glDisable(GL_TEXTURE_2D);
 	glEnableClientState(GL_COLOR_ARRAY);
 
-	line(startPosition, endPosition, static_cast<float>(lineWidth), color);
+	const auto offset = Vector<float>{0.5, 0.5};
+	line(startPosition + offset, endPosition + offset, static_cast<float>(lineWidth), color);
 
 	glDisableClientState(GL_COLOR_ARRAY);
 	glEnable(GL_TEXTURE_2D);


### PR DESCRIPTION
The way OpenGL works requires an offset of `{0.5, 0.5}` to be dead center on pixel coordinates.

It was noticed in OPHD that `drawLine` seemed to be offset by 1 pixel towards the top and left, rather than at the expected coordinates.
