### PR TITLE
Wrap `Duration` type in `NAS2D` namespace

### DIFF
--- a/NAS2D/Duration.h
+++ b/NAS2D/Duration.h
@@ -3,7 +3,10 @@
 #include <cstdint>
 
 
-struct Duration
+namespace NAS2D
 {
-	uint32_t milliseconds;
-};
+	struct Duration
+	{
+		uint32_t milliseconds;
+	};
+}


### PR DESCRIPTION
This is basically a source compatibility breaking bug fix. When the type was added, it wasn't properly added to the `NAS2D` namespace, where it should have been.

Related:
- PR #1233 (bug introduced)
- PR #1327
