### PR TITLE
Add `Duration` operations

### DIFF
--- a/NAS2D/Duration.h
+++ b/NAS2D/Duration.h
@@ -21,4 +21,8 @@ namespace NAS2D
 
 	inline Duration operator+(Duration duration1, Duration duration2) { return Duration{duration1.milliseconds + duration2.milliseconds}; }
 	inline Duration operator-(Duration duration1, Duration duration2) { return Duration{duration1.milliseconds - duration2.milliseconds}; }
+
+	inline Duration operator*(Duration duration, uint32_t scalar) { return Duration{duration.milliseconds * scalar}; }
+	inline Duration operator/(Duration duration, uint32_t scalar) { return Duration{duration.milliseconds / scalar}; }
+	inline Duration operator%(Duration duration, uint32_t scalar) { return Duration{duration.milliseconds % scalar}; }
 }

--- a/NAS2D/Duration.h
+++ b/NAS2D/Duration.h
@@ -18,4 +18,7 @@ namespace NAS2D
 	inline bool operator>(Duration duration1, Duration duration2) { return duration1.milliseconds > duration2.milliseconds; }
 	inline bool operator<=(Duration duration1, Duration duration2) { return duration1.milliseconds <= duration2.milliseconds; }
 	inline bool operator>=(Duration duration1, Duration duration2) { return duration1.milliseconds >= duration2.milliseconds; }
+
+	inline Duration operator+(Duration duration1, Duration duration2) { return Duration{duration1.milliseconds + duration2.milliseconds}; }
+	inline Duration operator-(Duration duration1, Duration duration2) { return Duration{duration1.milliseconds - duration2.milliseconds}; }
 }

--- a/NAS2D/Duration.h
+++ b/NAS2D/Duration.h
@@ -9,4 +9,13 @@ namespace NAS2D
 	{
 		uint32_t milliseconds;
 	};
+
+
+	inline bool operator==(Duration duration1, Duration duration2) { return duration1.milliseconds == duration2.milliseconds; }
+	inline bool operator!=(Duration duration1, Duration duration2) { return duration1.milliseconds != duration2.milliseconds; }
+
+	inline bool operator<(Duration duration1, Duration duration2) { return duration1.milliseconds < duration2.milliseconds; }
+	inline bool operator>(Duration duration1, Duration duration2) { return duration1.milliseconds > duration2.milliseconds; }
+	inline bool operator<=(Duration duration1, Duration duration2) { return duration1.milliseconds <= duration2.milliseconds; }
+	inline bool operator>=(Duration duration1, Duration duration2) { return duration1.milliseconds >= duration2.milliseconds; }
 }

--- a/test/Duration.test.cpp
+++ b/test/Duration.test.cpp
@@ -30,3 +30,25 @@ TEST(Duration, OperatorMinus) {
 	EXPECT_EQ(NAS2D::Duration{1}, NAS2D::Duration{1} - NAS2D::Duration{0});
 	EXPECT_EQ(NAS2D::Duration{1}, NAS2D::Duration{2} - NAS2D::Duration{1});
 }
+
+TEST(Duration, OperatorMultiply) {
+	EXPECT_EQ(NAS2D::Duration{0}, NAS2D::Duration{0} * 0);
+	EXPECT_EQ(NAS2D::Duration{0}, NAS2D::Duration{1} * 0);
+	EXPECT_EQ(NAS2D::Duration{1}, NAS2D::Duration{1} * 1);
+	EXPECT_EQ(NAS2D::Duration{4}, NAS2D::Duration{2} * 2);
+}
+
+TEST(Duration, OperatorDivide) {
+	EXPECT_EQ(NAS2D::Duration{0}, NAS2D::Duration{0} / 1);
+	EXPECT_EQ(NAS2D::Duration{1}, NAS2D::Duration{1} / 1);
+	EXPECT_EQ(NAS2D::Duration{2}, NAS2D::Duration{2} / 1);
+	EXPECT_EQ(NAS2D::Duration{2}, NAS2D::Duration{4} / 2);
+}
+
+TEST(Duration, OperatorModulo) {
+	EXPECT_EQ(NAS2D::Duration{0}, NAS2D::Duration{0} % 1);
+	EXPECT_EQ(NAS2D::Duration{0}, NAS2D::Duration{1} % 1);
+	EXPECT_EQ(NAS2D::Duration{0}, NAS2D::Duration{0} % 2);
+	EXPECT_EQ(NAS2D::Duration{1}, NAS2D::Duration{1} % 2);
+	EXPECT_EQ(NAS2D::Duration{0}, NAS2D::Duration{2} % 2);
+}

--- a/test/Duration.test.cpp
+++ b/test/Duration.test.cpp
@@ -1,0 +1,18 @@
+#include "NAS2D/Duration.h"
+
+#include <gtest/gtest.h>
+
+
+TEST(Duration, OperatorCompare) {
+	EXPECT_EQ(NAS2D::Duration{0}, NAS2D::Duration{0});
+	EXPECT_NE(NAS2D::Duration{0}, NAS2D::Duration{1});
+
+	EXPECT_LT(NAS2D::Duration{0}, NAS2D::Duration{1});
+	EXPECT_GT(NAS2D::Duration{1}, NAS2D::Duration{0});
+
+	EXPECT_LE(NAS2D::Duration{0}, NAS2D::Duration{0});
+	EXPECT_LE(NAS2D::Duration{0}, NAS2D::Duration{1});
+
+	EXPECT_GE(NAS2D::Duration{0}, NAS2D::Duration{0});
+	EXPECT_GE(NAS2D::Duration{1}, NAS2D::Duration{0});
+}

--- a/test/Duration.test.cpp
+++ b/test/Duration.test.cpp
@@ -16,3 +16,17 @@ TEST(Duration, OperatorCompare) {
 	EXPECT_GE(NAS2D::Duration{0}, NAS2D::Duration{0});
 	EXPECT_GE(NAS2D::Duration{1}, NAS2D::Duration{0});
 }
+
+TEST(Duration, OperatorPlus) {
+	EXPECT_EQ(NAS2D::Duration{0}, NAS2D::Duration{0} + NAS2D::Duration{0});
+	EXPECT_EQ(NAS2D::Duration{1}, NAS2D::Duration{0} + NAS2D::Duration{1});
+	EXPECT_EQ(NAS2D::Duration{1}, NAS2D::Duration{1} + NAS2D::Duration{0});
+	EXPECT_EQ(NAS2D::Duration{2}, NAS2D::Duration{1} + NAS2D::Duration{1});
+}
+
+TEST(Duration, OperatorMinus) {
+	EXPECT_EQ(NAS2D::Duration{0}, NAS2D::Duration{0} - NAS2D::Duration{0});
+	EXPECT_EQ(NAS2D::Duration{0}, NAS2D::Duration{1} - NAS2D::Duration{1});
+	EXPECT_EQ(NAS2D::Duration{1}, NAS2D::Duration{1} - NAS2D::Duration{0});
+	EXPECT_EQ(NAS2D::Duration{1}, NAS2D::Duration{2} - NAS2D::Duration{1});
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -163,6 +163,7 @@
     <ClCompile Include="Configuration.test.cpp" />
     <ClCompile Include="ContainerUtils.test.cpp" />
     <ClCompile Include="Dictionary.test.cpp" />
+    <ClCompile Include="Duration.test.cpp" />
     <ClCompile Include="Filesystem.test.cpp" />
     <ClCompile Include="FilesystemPath.test.cpp" />
     <ClCompile Include="FilesystemPathParents.test.cpp" />


### PR DESCRIPTION
Add basic operator support to `Duration`, covering comparison, addition, subtraction, scalar multiplication, division, and modulo.
