### PR TITLE
Use `elapsedTicks` instead of `ticks` in DemoGraphics project

### DIFF
--- a/demoGraphics/DemoGraphics.cpp
+++ b/demoGraphics/DemoGraphics.cpp
@@ -115,7 +115,7 @@ NAS2D::State* DemoGraphics::update()
 
 	renderer.drawImage(mSlicedGear, {165, 30});
 
-	const auto angle = NAS2D::Angle::degrees(static_cast<float>(mTimer.tick() * 360 / 10 / 1000));
+	const auto angle = NAS2D::Angle::degrees(static_cast<float>(mTimer.elapsedTicks() * 360 / 10 / 1000));
 	renderer.drawImageRotated(mResizedGear, {198, 30}, angle);
 	renderer.drawImageRotated(mGear, {158, 60}, angle);
 	renderer.drawImageRotated(mGear, {219, 60}, -angle);


### PR DESCRIPTION
The `ticks` method is a global/static function, which returns a value unrelated to the specific `Timer` object. If a delay is added to startup, such as by `sleep(2)`, then using `ticks` will cause the gears to be already significantly rotated when they come into view. Whereas using `elapsedTicks` will give a value relative to when the `Timer` was created, which means the gears will be in their initial start position.

Noticed this while making updates to the `Duration` and `Timer` code.

Related:
- PR #1329
- PR #1328
- PR #1327
