### PR TITLE
Increase `Duration` precision to 64-bits

### DIFF
--- a/NAS2D/Duration.h
+++ b/NAS2D/Duration.h
@@ -7,7 +7,7 @@ namespace NAS2D
 {
 	struct Duration
 	{
-		uint32_t milliseconds;
+		uint64_t milliseconds;
 	};
 
 
@@ -25,10 +25,10 @@ namespace NAS2D
 	inline Duration operator+(Duration duration1, Duration duration2) { return Duration{duration1.milliseconds + duration2.milliseconds}; }
 	inline Duration operator-(Duration duration1, Duration duration2) { return Duration{duration1.milliseconds - duration2.milliseconds}; }
 
-	inline Duration operator*(Duration duration, uint32_t scalar) { return Duration{duration.milliseconds * scalar}; }
+	inline Duration operator*(Duration duration, uint64_t scalar) { return Duration{duration.milliseconds * scalar}; }
 
-	inline Duration operator/(Duration duration, uint32_t scalar) { return Duration{duration.milliseconds / scalar}; }
-	inline uint32_t operator/(Duration duration, Duration duration2) { return duration.milliseconds / duration2.milliseconds; }
+	inline Duration operator/(Duration duration, uint64_t scalar) { return Duration{duration.milliseconds / scalar}; }
+	inline uint64_t operator/(Duration duration, Duration duration2) { return duration.milliseconds / duration2.milliseconds; }
 
 	inline Duration operator%(Duration duration, Duration duration2) { return Duration{duration.milliseconds % duration2.milliseconds}; }
 }

--- a/NAS2D/Timer.cpp
+++ b/NAS2D/Timer.cpp
@@ -18,7 +18,7 @@
 using namespace NAS2D;
 
 
-uint32_t Timer::tick()
+uint64_t Timer::tick()
 {
 	return SDL_GetTicks();
 }
@@ -29,7 +29,7 @@ Timer::Timer() :
 {}
 
 
-Timer::Timer(uint32_t startTick) :
+Timer::Timer(uint64_t startTick) :
 	mStartTick{startTick}
 {}
 

--- a/NAS2D/Timer.cpp
+++ b/NAS2D/Timer.cpp
@@ -20,7 +20,7 @@ using namespace NAS2D;
 
 uint64_t Timer::tick()
 {
-	return SDL_GetTicks();
+	return SDL_GetTicks64();
 }
 
 

--- a/NAS2D/Timer.h
+++ b/NAS2D/Timer.h
@@ -37,10 +37,10 @@ namespace NAS2D
 	class Timer
 	{
 	public:
-		static uint32_t tick();
+		static uint64_t tick();
 
 		Timer();
-		Timer(uint32_t startTick);
+		Timer(uint64_t startTick);
 
 		Timer(const Timer&) = default;
 		Timer& operator=(const Timer&) = default;
@@ -51,7 +51,7 @@ namespace NAS2D
 		void reset();
 
 	private:
-		uint32_t mStartTick;
+		uint64_t mStartTick;
 	};
 
 } // namespace

--- a/NAS2D/Timer.h
+++ b/NAS2D/Timer.h
@@ -32,7 +32,7 @@ namespace NAS2D
 	 *
 	 * A static method is provided for the raw time in ticks.
 	 *
-	 * With the current implementation, raw ticks are since app startup, and wrap back to 0 after about 49 days.
+	 * Raw ticks are since app startup.
 	 */
 	class Timer
 	{


### PR DESCRIPTION
This increases the wrap around time from about 49 days to over half a billion years.

The SDL2 documentation for `SDL_GetTicks` recommends using `SDL_GetTicks64`, with increased 64-bit precision. In SDL2, the `SDL_GetTicks` function is 64-bit.

Related:
- PR #1331
- PR #1327
