### PR TITLE
Add `AnimationSequence` class

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -178,6 +178,7 @@
     <ClCompile Include="Renderer\RendererOpenGL.cpp" />
     <ClCompile Include="Renderer\Window.cpp" />
     <ClCompile Include="Resource\AnimationFrame.cpp" />
+    <ClCompile Include="Resource\AnimationSequence.cpp" />
     <ClCompile Include="Resource\AnimationSet.cpp" />
     <ClCompile Include="Resource\Font.cpp" />
     <ClCompile Include="Resource\Image.cpp" />
@@ -243,6 +244,7 @@
     <ClInclude Include="Renderer\Window.h" />
     <ClInclude Include="Resource\ResourceCache.h" />
     <ClInclude Include="Resource\AnimationFrame.h" />
+    <ClInclude Include="Resource\AnimationSequence.h" />
     <ClInclude Include="Resource\AnimationSet.h" />
     <ClInclude Include="Resource\Font.h" />
     <ClInclude Include="Resource\Image.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClCompile Include="Resource\AnimationFrame.cpp">
       <Filter>Source Files\Resource</Filter>
     </ClCompile>
+    <ClCompile Include="Resource\AnimationSequence.cpp">
+      <Filter>Source Files\Resource</Filter>
+    </ClCompile>
     <ClCompile Include="Resource\AnimationSet.cpp">
       <Filter>Source Files\Resource</Filter>
     </ClCompile>
@@ -327,6 +330,9 @@
       <Filter>Header Files\Renderer</Filter>
     </ClInclude>
     <ClInclude Include="Resource\AnimationFrame.h">
+      <Filter>Header Files\Resource</Filter>
+    </ClInclude>
+    <ClInclude Include="Resource\AnimationSequence.h">
       <Filter>Header Files\Resource</Filter>
     </ClInclude>
     <ClInclude Include="Resource\AnimationSet.h">

--- a/NAS2D/Resource/AnimationSequence.cpp
+++ b/NAS2D/Resource/AnimationSequence.cpp
@@ -1,0 +1,32 @@
+#include "AnimationSequence.h"
+
+#include "AnimationFrame.h"
+
+#include <utility>
+
+
+using namespace NAS2D;
+
+
+AnimationSequence::AnimationSequence(std::vector<AnimationFrame> frames) :
+	mFrames{std::move(frames)}
+{
+}
+
+
+bool AnimationSequence::empty() const
+{
+	return mFrames.empty();
+}
+
+
+std::size_t AnimationSequence::frameCount() const
+{
+	return mFrames.size();
+}
+
+
+const AnimationFrame& AnimationSequence::frame(std::size_t index) const
+{
+	return mFrames.at(index);
+}

--- a/NAS2D/Resource/AnimationSequence.h
+++ b/NAS2D/Resource/AnimationSequence.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <vector>
+
+
+namespace NAS2D
+{
+	struct AnimationFrame;
+
+
+	class AnimationSequence
+	{
+	public:
+		AnimationSequence(std::vector<AnimationFrame> frames);
+
+		bool empty() const;
+		std::size_t frameCount() const;
+		const AnimationFrame& frame(std::size_t index) const;
+
+	private:
+		std::vector<AnimationFrame> mFrames;
+	};
+}

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -214,7 +214,7 @@ namespace
 				throw std::runtime_error("Sprite Action redefinition: '" + actionName + "' " + endTag(action->row()));
 			}
 
-			actions[actionName] = processFrames(imageSheets, action, imageCache);
+			actions.try_emplace(actionName, processFrames(imageSheets, action, imageCache));
 
 			if (actions.at(actionName).empty())
 			{

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -52,7 +52,7 @@ namespace
 	std::tuple<ImageSheets, Actions> processXml(const std::string& filePath, ImageCache& imageCache);
 	ImageSheets processImageSheets(const std::string& basePath, const Xml::XmlElement* element, ImageCache& imageCache);
 	Actions processActions(const ImageSheets& imageSheets, const Xml::XmlElement* element, ImageCache& imageCache);
-	std::vector<AnimationFrame> processFrames(const ImageSheets& imageSheets, const Xml::XmlElement* element, ImageCache& imageCache);
+	AnimationSequence processFrames(const ImageSheets& imageSheets, const Xml::XmlElement* element, ImageCache& imageCache);
 }
 
 
@@ -85,7 +85,7 @@ std::vector<std::string> AnimationSet::actionNames() const
 }
 
 
-const std::vector<AnimationFrame>& AnimationSet::frames(const std::string& actionName) const
+const AnimationSequence& AnimationSet::frames(const std::string& actionName) const
 {
 	if (mActions.find(actionName) == mActions.end())
 	{
@@ -229,7 +229,7 @@ namespace
 	/**
 	 * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
 	 */
-	std::vector<AnimationFrame> processFrames(const ImageSheets& imageSheets, const Xml::XmlElement* element, ImageCache& imageCache)
+	AnimationSequence processFrames(const ImageSheets& imageSheets, const Xml::XmlElement* element, ImageCache& imageCache)
 	{
 		std::vector<AnimationFrame> frameList;
 
@@ -272,7 +272,7 @@ namespace
 			frameList.push_back(AnimationFrame{image, frameRect, anchorOffset, {delay}});
 		}
 
-		return frameList;
+		return {frameList};
 	}
 
 }

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -216,7 +216,7 @@ namespace
 
 			actions[actionName] = processFrames(imageSheets, action, imageCache);
 
-			if (actions[actionName].empty())
+			if (actions.at(actionName).empty())
 			{
 				throw std::runtime_error("Sprite Action contains no valid frames: " + actionName);
 			}

--- a/NAS2D/Resource/AnimationSet.h
+++ b/NAS2D/Resource/AnimationSet.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include "AnimationSequence.h"
+
 #include <map>
 #include <vector>
 #include <string>
@@ -29,7 +31,7 @@ namespace NAS2D
 	{
 	public:
 		using ImageSheets = std::map<std::string, std::string>;
-		using Actions = std::map<std::string, std::vector<AnimationFrame>>;
+		using Actions = std::map<std::string, AnimationSequence>;
 
 
 		explicit AnimationSet(std::string fileName);
@@ -37,7 +39,7 @@ namespace NAS2D
 		AnimationSet(ImageSheets imageSheets, Actions actions);
 
 		std::vector<std::string> actionNames() const;
-		const std::vector<AnimationFrame>& frames(const std::string& actionName) const;
+		const AnimationSequence& frames(const std::string& actionName) const;
 
 	private:
 		ImageSheets mImageSheets;

--- a/NAS2D/Resource/AnimationSet.h
+++ b/NAS2D/Resource/AnimationSet.h
@@ -19,11 +19,7 @@
 
 namespace NAS2D
 {
-	struct Duration;
-	struct AnimationFrame;
 	class Image;
-	template <typename BaseType> struct Vector;
-	template <typename BaseType> struct Rectangle;
 	template <typename Resource, typename... Params> class ResourceCache;
 
 

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -11,6 +11,7 @@
 #include "Sprite.h"
 
 #include "AnimationFrame.h"
+#include "AnimationSequence.h"
 #include "AnimationSet.h"
 #include "ResourceCache.h"
 #include "../Math/Angle.h"
@@ -50,13 +51,13 @@ Sprite::Sprite(const AnimationSet& animationSet, const std::string& initialActio
 
 Vector<int> Sprite::size() const
 {
-	return (*mCurrentAction)[mCurrentFrame].bounds.size;
+	return (*mCurrentAction).frame(mCurrentFrame).bounds.size;
 }
 
 
 Point<int> Sprite::origin(Point<int> point) const
 {
-	return point - (*mCurrentAction)[mCurrentFrame].anchorOffset;
+	return point - (*mCurrentAction).frame(mCurrentFrame).anchorOffset;
 }
 
 
@@ -111,7 +112,7 @@ void Sprite::resume()
 
 bool Sprite::isPaused() const
 {
-	return mPaused || (*mCurrentAction)[mCurrentFrame].isStopFrame();
+	return mPaused || (*mCurrentAction).frame(mCurrentFrame).isStopFrame();
 }
 
 
@@ -122,7 +123,7 @@ bool Sprite::isPaused() const
  */
 void Sprite::setFrame(std::size_t frameIndex)
 {
-	mCurrentFrame = frameIndex % mCurrentAction->size();
+	mCurrentFrame = frameIndex % mCurrentAction->frameCount();
 }
 
 
@@ -134,7 +135,7 @@ void Sprite::update()
 
 void Sprite::draw(Point<float> position) const
 {
-	const auto& frame = (*mCurrentAction)[mCurrentFrame];
+	const auto& frame = (*mCurrentAction).frame(mCurrentFrame);
 	const auto drawPosition = position - frame.anchorOffset.to<float>();
 	const auto frameBounds = frame.bounds.to<float>();
 	Utility<Renderer>::get().drawSubImage(frame.image, drawPosition, frameBounds, mTintColor);
@@ -143,7 +144,7 @@ void Sprite::draw(Point<float> position) const
 
 void Sprite::draw(Point<float> position, Angle rotation) const
 {
-	const auto& frame = (*mCurrentAction)[mCurrentFrame];
+	const auto& frame = (*mCurrentAction).frame(mCurrentFrame);
 	const auto drawPosition = position - frame.anchorOffset.to<float>();
 	const auto frameBounds = frame.bounds.to<float>();
 	Utility<Renderer>::get().drawSubImageRotated(frame.image, drawPosition, frameBounds, rotation, mTintColor);
@@ -200,7 +201,7 @@ Duration Sprite::advanceByTimeDelta(Duration timeDelta)
 	const auto& frames = *mCurrentAction;
 	for (;;)
 	{
-		const auto& frame = frames[mCurrentFrame];
+		const auto& frame = frames.frame(mCurrentFrame);
 
 		if (frame.isStopFrame())
 		{
@@ -215,7 +216,7 @@ Duration Sprite::advanceByTimeDelta(Duration timeDelta)
 
 		accumulator += frame.frameDelay;
 		mCurrentFrame++;
-		if (mCurrentFrame >= frames.size())
+		if (mCurrentFrame >= frames.frameCount())
 		{
 			mCurrentFrame = 0;
 		}

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -21,6 +21,7 @@ namespace NAS2D
 {
 	struct Duration;
 	struct AnimationFrame;
+	class AnimationSequence;
 	class AnimationSet;
 	class Angle;
 	template <typename BaseType> struct Point;
@@ -70,7 +71,7 @@ namespace NAS2D
 
 	private:
 		const AnimationSet& mAnimationSet;
-		const std::vector<AnimationFrame>* mCurrentAction{nullptr};
+		const AnimationSequence* mCurrentAction{nullptr};
 		std::size_t mCurrentFrame{0};
 
 		bool mPaused{false};

--- a/test/Resource/Sprite.test.cpp
+++ b/test/Resource/Sprite.test.cpp
@@ -2,6 +2,7 @@
 
 #include "NAS2D/Duration.h"
 #include "NAS2D/Resource/AnimationFrame.h"
+#include "NAS2D/Resource/AnimationSequence.h"
 #include "NAS2D/Resource/AnimationSet.h"
 #include "NAS2D/Resource/Image.h"
 
@@ -29,7 +30,7 @@ namespace {
 		NAS2D::Image image{&imageBuffer, 4, imageSize};
 		NAS2D::AnimationFrame frame{image, imageRect, anchorOffset, {2}};
 		NAS2D::AnimationFrame frameStop{image, imageRect, anchorOffset, {0}};
-		NAS2D::AnimationSet testAnimationSet{{}, {{"defaultAction", {frame}}, {"frameStopAction", {frameStop}}}};
+		NAS2D::AnimationSet testAnimationSet{{}, {{"defaultAction", {{frame}}}, {"frameStopAction", {{frameStop}}}}};
 		SpriteDerived sprite{testAnimationSet, "defaultAction"};
 	};
 }


### PR DESCRIPTION
Add `AnimationSequence` class.

Right now this class simply wraps a `std::vector<AnimationFrame>` to provide a higher level abstraction, and isolation from the details of `std::vector`. Additionally it creates enough separation from `AnimationSet` and the `std::map` it contains that we don't need to worry about forward declares being used as template parameters. Forward declares are allowable for `std::vector` and `std::list`, though there is no standard guarantee for `std::map`, even though it seems to be commonly allowed by major compilers.

Related:
- Issue #991
- Issue #1245
- PR #1333
