### PR TITLE
Add `AnimationSequence` destructor

### DIFF
--- a/NAS2D/Resource/AnimationSequence.cpp
+++ b/NAS2D/Resource/AnimationSequence.cpp
@@ -14,6 +14,11 @@ AnimationSequence::AnimationSequence(std::vector<AnimationFrame> frames) :
 }
 
 
+AnimationSequence::~AnimationSequence()
+{
+}
+
+
 bool AnimationSequence::empty() const
 {
 	return mFrames.empty();

--- a/NAS2D/Resource/AnimationSequence.h
+++ b/NAS2D/Resource/AnimationSequence.h
@@ -13,6 +13,7 @@ namespace NAS2D
 	public:
 		AnimationSequence(std::vector<AnimationFrame> frames);
 		AnimationSequence(const AnimationSequence&) = default;
+		~AnimationSequence();
 
 		bool empty() const;
 		std::size_t frameCount() const;

--- a/NAS2D/Resource/AnimationSequence.h
+++ b/NAS2D/Resource/AnimationSequence.h
@@ -13,6 +13,7 @@ namespace NAS2D
 	public:
 		AnimationSequence(std::vector<AnimationFrame> frames);
 		AnimationSequence(const AnimationSequence&) = default;
+		AnimationSequence(AnimationSequence&&) = default;
 		~AnimationSequence();
 
 		bool empty() const;

--- a/NAS2D/Resource/AnimationSequence.h
+++ b/NAS2D/Resource/AnimationSequence.h
@@ -12,6 +12,7 @@ namespace NAS2D
 	{
 	public:
 		AnimationSequence(std::vector<AnimationFrame> frames);
+		AnimationSequence(const AnimationSequence&) = default;
 
 		bool empty() const;
 		std::size_t frameCount() const;


### PR DESCRIPTION
This is needed to force instantiation of the `std::vector` destructor in the implementation file, rather than in the translation unit that includes the `AnimationSequence` header. This is important since the element type `AnimationFrame` is forward declared in the header, and a full definition is needed to instantiate the `std::vector` destructor.

Related:
- PR #1334
