### PR TITLE
Remove `Sprite` constructor overload taking `filePath`

### DIFF
--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -13,7 +13,6 @@
 #include "AnimationFrame.h"
 #include "AnimationSequence.h"
 #include "AnimationSet.h"
-#include "ResourceCache.h"
 #include "../Math/Angle.h"
 #include "../Math/Point.h"
 #include "../Math/Vector.h"
@@ -26,20 +25,6 @@
 
 
 using namespace NAS2D;
-
-
-namespace
-{
-	using AnimationCache = ResourceCache<AnimationSet, std::string>;
-	AnimationCache animationCache;
-}
-
-
-Sprite::Sprite(const std::string& filePath, const std::string& initialAction) :
-	mAnimationSet{animationCache.load(filePath)},
-	mCurrentAction{&mAnimationSet.frames(initialAction)}
-{
-}
 
 
 Sprite::Sprite(const AnimationSet& animationSet, const std::string& initialAction) :

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -37,7 +37,6 @@ namespace NAS2D
 	class Sprite
 	{
 	public:
-		Sprite(const std::string& filePath, const std::string& initialAction);
 		Sprite(const AnimationSet& animationSet, const std::string& initialAction);
 		Sprite(const Sprite&) = default;
 		Sprite(Sprite&&) = default;


### PR DESCRIPTION
Instead we should load file data into an `AnimationSet` first, and then create the `Sprite` instance using the `AnimationSet`. The static file data is represented by the `AnimationSet` class. A `Sprite` class is a specific instance that has a current animation state.

Related:
- Issue #991
- PR #1333
- PR #1334
- PR #1335
- PR https://github.com/OutpostUniverse/OPHD/pull/2152
