### PR TITLE
Remove outdated and low value `Sprite` comments

### DIFF
--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -67,10 +67,6 @@ std::vector<std::string> Sprite::actions() const
  * \param	action	Name of the action to use for animation. Actions are not
  *			case sensitive. "Case", "caSe", "CASE", etc. will all be viewed
  *			as identical.
- *
- * \note	If the named action doesn't exist, a warning message will
- *			be written to the log and the default action will be used
- *			instead.
  */
 void Sprite::play(const std::string& action)
 {

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -50,20 +50,12 @@ Point<int> Sprite::origin(Point<int> point) const
 }
 
 
-/**
- * Gets a list of Actions available for the Sprite.
- *
- * \return	std::vector<std::string> of actions.
- */
 std::vector<std::string> Sprite::actions() const
 {
 	return mAnimationSet.actionNames();
 }
 
 
-/**
- * Plays an action animation.
- */
 void Sprite::play(const std::string& action)
 {
 	mCurrentAction = &mAnimationSet.frames(action);
@@ -73,18 +65,12 @@ void Sprite::play(const std::string& action)
 }
 
 
-/**
- * Pauses animation for this Sprite.
- */
 void Sprite::pause()
 {
 	mPaused = true;
 }
 
 
-/**
- * Resumes the action of the Sprite.
- */
 void Sprite::resume()
 {
 	mPaused = false;
@@ -97,11 +83,6 @@ bool Sprite::isPaused() const
 }
 
 
-/**
- * Sets the animation playback frame.
- *
- * \param	frameIndex	New frame index
- */
 void Sprite::setFrame(std::size_t frameIndex)
 {
 	mCurrentFrame = frameIndex % mCurrentAction->frameCount();
@@ -132,38 +113,24 @@ void Sprite::draw(Point<float> position, Angle rotation) const
 }
 
 
-/**
- * Sets the alpha value for the Sprite.
- *
- * \param	alpha	Alpha value to set between 0 - 255.
- */
 void Sprite::alpha(uint8_t alpha)
 {
 	mTintColor.alpha = alpha;
 }
 
 
-/**
- * Gets the alpha value for the Sprite.
- */
 uint8_t Sprite::alpha() const
 {
 	return mTintColor.alpha;
 }
 
 
-/**
- * Sets the color tint of the Sprite.
- */
 void Sprite::color(Color color)
 {
 	mTintColor = color;
 }
 
 
-/**
- * Gets the color tint of the Sprite.
- */
 Color Sprite::color() const
 {
 	return mTintColor;

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -63,10 +63,6 @@ std::vector<std::string> Sprite::actions() const
 
 /**
  * Plays an action animation.
- *
- * \param	action	Name of the action to use for animation. Actions are not
- *			case sensitive. "Case", "caSe", "CASE", etc. will all be viewed
- *			as identical.
  */
 void Sprite::play(const std::string& action)
 {

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -28,10 +28,8 @@ namespace NAS2D
 
 
 	/**
-	 * Sprite resource.
-	 *
-	 * The Sprite Class is a self-contained group of Image resources that displays
-	 * Images at a specified screen coordinate in sequence to display an animation.
+	 * Sprite represents an object with a set of animation sequences that can be
+	 * selected, animated, and displayed at a specified screen coordinate.
 	 */
 	class Sprite
 	{


### PR DESCRIPTION
Noticed some comments were a bit dated during recent work, though forget to adjust them at that time.

Related:
- Issue #991
- PR #1337
- PR #734 (convert logging errors to exceptions)
- PR #746
