### PR TITLE
Allow access to `AnimationSet` of a `Sprite`

### DIFF
--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -38,6 +38,12 @@ Sprite::Sprite(const AnimationSet& animationSet, const std::string& initialActio
 }
 
 
+const AnimationSet& Sprite::animationSet() const
+{
+	return mAnimationSet;
+}
+
+
 Vector<int> Sprite::size() const
 {
 	return (*mCurrentAction).frame(mCurrentFrame).bounds.size;

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -56,12 +56,6 @@ Point<int> Sprite::origin(Point<int> point) const
 }
 
 
-std::vector<std::string> Sprite::actions() const
-{
-	return mAnimationSet.actionNames();
-}
-
-
 void Sprite::play(const std::string& action)
 {
 	mCurrentAction = &mAnimationSet.frames(action);

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -56,12 +56,9 @@ Point<int> Sprite::origin(Point<int> point) const
 }
 
 
-void Sprite::play(const std::string& action)
+bool Sprite::isPaused() const
 {
-	mCurrentAction = &mAnimationSet.frames(action);
-	mCurrentFrame = 0;
-	mTimer.reset();
-	resume();
+	return mPaused || (*mCurrentAction).frame(mCurrentFrame).isStopFrame();
 }
 
 
@@ -77,9 +74,12 @@ void Sprite::resume()
 }
 
 
-bool Sprite::isPaused() const
+void Sprite::play(const std::string& action)
 {
-	return mPaused || (*mCurrentAction).frame(mCurrentFrame).isStopFrame();
+	mCurrentAction = &mAnimationSet.frames(action);
+	mCurrentFrame = 0;
+	mTimer.reset();
+	resume();
 }
 
 

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -46,11 +46,10 @@ namespace NAS2D
 		Vector<int> size() const;
 		Point<int> origin(Point<int> point) const;
 
-		void play(const std::string& action);
+		bool isPaused() const;
 		void pause();
 		void resume();
-		bool isPaused() const;
-
+		void play(const std::string& action);
 		void setFrame(std::size_t frameIndex);
 
 		void update();

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -46,8 +46,6 @@ namespace NAS2D
 		Vector<int> size() const;
 		Point<int> origin(Point<int> point) const;
 
-		std::vector<std::string> actions() const;
-
 		void play(const std::string& action);
 		void pause();
 		void resume();

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -41,6 +41,8 @@ namespace NAS2D
 		Sprite& operator=(const Sprite&) = delete;
 		Sprite& operator=(Sprite&&) = delete;
 
+		const AnimationSet& animationSet() const;
+
 		Vector<int> size() const;
 		Point<int> origin(Point<int> point) const;
 


### PR DESCRIPTION
Allow access to `AnimationSet` of a `Sprite`, and remove unnecessary `Sprite::actions()`, which can be access through `animationSet.actionNames()`.

Related:
- Issue #991
