### PR TITLE
Fix error reporting of bad `version` in sprite file loading

### DIFF
--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -132,7 +132,7 @@ namespace
 			}
 			if (version != SpriteVersion)
 			{
-				throw std::runtime_error("Sprite version mismatch. Expected: " + std::string{SpriteVersion} + " Actual: " + versionString());
+				throw std::runtime_error("Sprite version mismatch. Expected: " + std::string{SpriteVersion} + " Actual: " + version);
 			}
 
 			// Note:


### PR DESCRIPTION
This bug has some interesting history. Back in commit 6738da544acf78c22ba84b549bcf0982a15aa3a3 (https://github.com/lairworks/nas2d-core/commit/6738da544acf78c22ba84b549bcf0982a15aa3a3#r166329568) a local variable named `versionString` was removed, which was shadowing the name of a global function, while the error reporting line where the variable was used was not updated. This meant the error reporting line was now printing the address of the global function rather than the version string read from the file.

Later on, in commit 585b734ae4dd42a072f7557a4a1ca1346e65433c (PR #46) it was noticed from a warning message that a function address was being printed. This was "corrected" by calling the function and passing the result as part of the error reporting message, rather than printing the address of the global function. It wasn't noticed the function didn't have anything to do with the value that should have been printed. And why would it be noticed, since this was now 4 months after the removal of the shadowing local variable by a different committer. There was no obvious context, and it was assumed the error was simply a lack of parenthesis to actually call the function, rather than the function not being the original intended target for printing.

Related:
- Issue #991
