### PR TITLE
Remove unnecessary `Version` include

### DIFF
--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -19,7 +19,6 @@
 #include "../Filesystem.h"
 #include "../ContainerUtils.h"
 #include "../ParserHelper.h"
-#include "../Version.h"
 #include "../Xml/Xml.h"
 #include "../Math/Vector.h"
 #include "../Math/Rectangle.h"


### PR DESCRIPTION
This was missing during the recent update in PR #1340.

Related:
- PR #1340
- Issue #991
