### PR TITLE
Refactor `AnimationSet` file loading - Split loading and indexing

### DIFF
--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -184,7 +184,7 @@ namespace
 
 			if (imageSheets.contains(id))
 			{
-				throwLoadError("Image sheet redefinition: id: " + id, node);
+				throw std::runtime_error("Image sheet redefinition: id: " + id);
 			}
 
 			const auto imagePath = basePath + src;

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -26,7 +26,6 @@
 #include "../Math/Vector.h"
 #include "../Math/Rectangle.h"
 
-#include <tuple>
 #include <utility>
 
 
@@ -43,9 +42,14 @@ namespace
 	using ImageSheets = AnimationSet::ImageSheets;
 	using Actions = AnimationSet::Actions;
 
+	struct AnimationFileData
+	{
+		ImageSheets imageSheets;
+		Actions actions;
+	};
 
 	[[noreturn]] void throwLoadError(std::string_view message, const Xml::XmlNode* node);
-	std::tuple<ImageSheets, Actions> processXml(std::string_view filePath, ImageCache& imageCache);
+	AnimationFileData processXml(std::string_view filePath, ImageCache& imageCache);
 	ImageSheets processImageSheets(const std::string& basePath, const Xml::XmlElement* element, ImageCache& imageCache);
 	Actions processActions(const ImageSheets& imageSheets, const Xml::XmlElement* element, ImageCache& imageCache);
 	AnimationSequence processFrames(const ImageSheets& imageSheets, const Xml::XmlElement* element, ImageCache& imageCache);
@@ -105,7 +109,7 @@ namespace
 	 *
 	 * \param filePath	File path of the sprite XML definition file.
 	 */
-	std::tuple<ImageSheets, Actions> processXml(std::string_view filePath, ImageCache& imageCache)
+	AnimationFileData processXml(std::string_view filePath, ImageCache& imageCache)
 	{
 		try
 		{

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -62,6 +62,12 @@ namespace
 		std::vector<AnimationFrameData> frames;
 	};
 
+	struct AnimationFileData
+	{
+		std::vector<AnimationImageSheetReference> imageSheetReferences;
+		std::vector<AnimationAction> actions;
+	};
+
 	struct AnimationFileIndexedData
 	{
 		ImageSheets imageSheets;
@@ -167,8 +173,12 @@ namespace
 			// Here instead of going through each element and calling a processing function to handle
 			// it, we just iterate through all nodes to find sprite sheets. This allows us to define
 			// image sheets anywhere in the sprite file.
-			auto imageSheets = loadImages(processImageSheets(spriteElement), basePath, imageCache);
-			auto actions = indexActions(processActions(spriteElement), imageSheets, imageCache);
+			const auto animationFileData = AnimationFileData{
+				processImageSheets(spriteElement),
+				processActions(spriteElement),
+			};
+			auto imageSheets = loadImages(animationFileData.imageSheetReferences, basePath, imageCache);
+			auto actions = indexActions(animationFileData.actions, imageSheets, imageCache);
 			return {
 				std::move(imageSheets),
 				std::move(actions)

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -266,7 +266,7 @@ namespace
 
 			if (!imageSheets.contains(sheetId))
 			{
-				throwLoadError("Frame definition references undefined imagesheet: " + sheetId, frame);
+				throw std::runtime_error("Frame definition references undefined imagesheet: " + sheetId);
 			}
 
 			const auto& filePath = imageSheets.at(sheetId);
@@ -275,7 +275,7 @@ namespace
 			const auto imageRect = Rectangle{{0, 0}, image.size()};
 			if (!imageRect.contains(frameRect))
 			{
-				throwLoadError("Frame bounds exceeds image sheet bounds: " + sheetId + " : " + stringFrom(frameRect), frame);
+				throw std::runtime_error("Frame bounds exceeds image sheet bounds: " + sheetId + " : " + stringFrom(frameRect));
 			}
 
 			frameList.push_back(AnimationFrame{image, frameRect, anchorOffset, {delay}});

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -215,7 +215,7 @@ namespace
 			}
 			if (actions.contains(actionName))
 			{
-				throwLoadError("Action redefinition: " + actionName, action);
+				throw std::runtime_error("Action redefinition: " + actionName);
 			}
 
 			actions.try_emplace(actionName, processFrames(imageSheets, action, imageCache));

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -42,6 +42,12 @@ namespace
 	using ImageSheets = AnimationSet::ImageSheets;
 	using Actions = AnimationSet::Actions;
 
+	struct AnimationImageSheetReference
+	{
+		std::string id;
+		std::string filePath;
+	};
+
 	struct AnimationFileData
 	{
 		ImageSheets imageSheets;
@@ -173,26 +179,28 @@ namespace
 		for (const auto* node = element->firstChildElement("imagesheet"); node; node = node->nextSiblingElement("imagesheet"))
 		{
 			const auto dictionary = attributesToDictionary(*node);
-			const auto id = dictionary.get("id");
-			const auto src = dictionary.get("src");
+			const auto imageSheetReference = AnimationImageSheetReference{
+				dictionary.get("id"),
+				dictionary.get("src")
+			};
 
-			if (id.empty())
+			if (imageSheetReference.id.empty())
 			{
 				throwLoadError("Image sheet definition has `id` of length zero", node);
 			}
 
-			if (src.empty())
+			if (imageSheetReference.filePath.empty())
 			{
 				throwLoadError("Image sheet definition has `src` of length zero", node);
 			}
 
-			if (imageSheets.contains(id))
+			if (imageSheets.contains(imageSheetReference.id))
 			{
-				throw std::runtime_error("Image sheet redefinition: id: " + id);
+				throw std::runtime_error("Image sheet redefinition: id: " + imageSheetReference.id);
 			}
 
-			const auto imagePath = basePath + src;
-			imageSheets.try_emplace(id, imagePath);
+			const auto imagePath = basePath + imageSheetReference.filePath;
+			imageSheets.try_emplace(imageSheetReference.id, imagePath);
 			imageCache.load(imagePath);
 		}
 

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -77,7 +77,7 @@ namespace
 	[[noreturn]] void throwLoadError(std::string_view message, const Xml::XmlNode* node);
 	AnimationFileIndexedData readAndIndexAnimationFile(std::string_view filePath, ImageCache& imageCache);
 	AnimationFileData readAnimationFileData(std::string_view fileData);
-	std::vector<AnimationImageSheetReference> processImageSheets(const Xml::XmlElement* element);
+	std::vector<AnimationImageSheetReference> readImageSheetReferences(const Xml::XmlElement* element);
 	ImageSheets loadImages(const std::vector<AnimationImageSheetReference>& imageSheetReferences, const std::string& basePath, ImageCache& imageCache);
 	std::vector<AnimationAction> processActions(const Xml::XmlElement* element);
 	Actions indexActions(const std::vector<AnimationAction>& actionDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache);
@@ -192,7 +192,7 @@ namespace
 		// it, we just iterate through all nodes to find sprite sheets. This allows us to define
 		// image sheets anywhere in the sprite file.
 		return {
-			processImageSheets(spriteElement),
+			readImageSheetReferences(spriteElement),
 			processActions(spriteElement),
 		};
 	}
@@ -206,7 +206,7 @@ namespace
 	 *			element in a sprite definition, these elements can appear
 	 *			anywhere in a Sprite XML definition.
 	 */
-	std::vector<AnimationImageSheetReference> processImageSheets(const Xml::XmlElement* element)
+	std::vector<AnimationImageSheetReference> readImageSheetReferences(const Xml::XmlElement* element)
 	{
 		std::vector<AnimationImageSheetReference> imageSheetReferences;
 		for (const auto* node = element->firstChildElement("imagesheet"); node; node = node->nextSiblingElement("imagesheet"))

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -134,11 +134,6 @@ namespace
 	}
 
 
-	/**
-	 * Parses a Sprite XML Definition File.
-	 *
-	 * \param filePath	File path of the sprite XML definition file.
-	 */
 	AnimationFileIndexedData readAndIndexAnimationFile(std::string_view filePath, ImageCache& imageCache)
 	{
 		try
@@ -187,10 +182,6 @@ namespace
 			throwLoadError("Unsupported version: Expected: " + std::string{SpriteVersion} + " Actual: " + version, spriteElement);
 		}
 
-		// Note:
-		// Here instead of going through each element and calling a processing function to handle
-		// it, we just iterate through all nodes to find sprite sheets. This allows us to define
-		// image sheets anywhere in the sprite file.
 		return {
 			readImageSheetReferences(spriteElement),
 			readActions(spriteElement),
@@ -198,14 +189,6 @@ namespace
 	}
 
 
-	/**
-	 * Iterates through all elements of a Sprite XML definition looking
-	 * for 'imagesheet' elements and processes them.
-	 *
-	 * \note	Since 'imagesheet' elements are processed before any other
-	 *			element in a sprite definition, these elements can appear
-	 *			anywhere in a Sprite XML definition.
-	 */
 	std::vector<AnimationImageSheetReference> readImageSheetReferences(const Xml::XmlElement* element)
 	{
 		std::vector<AnimationImageSheetReference> imageSheetReferences;
@@ -249,10 +232,6 @@ namespace
 	}
 
 
-	/**
-	 * Iterates through all elements of a Sprite XML definition looking
-	 * for 'action' elements and processes them.
-	 */
 	std::vector<AnimationAction> readActions(const Xml::XmlElement* element)
 	{
 		std::vector<AnimationAction> actionDefinitions;
@@ -294,9 +273,6 @@ namespace
 	}
 
 
-	/**
-	 * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
-	 */
 	std::vector<AnimationFrameData> readFrames(const Xml::XmlElement* element)
 	{
 		std::vector<AnimationFrameData> frameDefinitions;

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -75,7 +75,7 @@ namespace
 	};
 
 	[[noreturn]] void throwLoadError(std::string_view message, const Xml::XmlNode* node);
-	AnimationFileIndexedData processXml(std::string_view filePath, ImageCache& imageCache);
+	AnimationFileIndexedData readAndIndexAnimationFile(std::string_view filePath, ImageCache& imageCache);
 	AnimationFileData readAnimationFileData(std::string_view fileData);
 	std::vector<AnimationImageSheetReference> processImageSheets(const Xml::XmlElement* element);
 	ImageSheets loadImages(const std::vector<AnimationImageSheetReference>& imageSheetReferences, const std::string& basePath, ImageCache& imageCache);
@@ -96,7 +96,7 @@ AnimationSet::AnimationSet(std::string_view fileName, ImageCache& imageCache) :
 	mImageSheets{},
 	mActions{}
 {
-	auto [imageSheets, actions] = processXml(fileName, imageCache);
+	auto [imageSheets, actions] = readAndIndexAnimationFile(fileName, imageCache);
 	mImageSheets = std::move(imageSheets);
 	mActions = std::move(actions);
 }
@@ -139,7 +139,7 @@ namespace
 	 *
 	 * \param filePath	File path of the sprite XML definition file.
 	 */
-	AnimationFileIndexedData processXml(std::string_view filePath, ImageCache& imageCache)
+	AnimationFileIndexedData readAndIndexAnimationFile(std::string_view filePath, ImageCache& imageCache)
 	{
 		try
 		{

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -62,14 +62,14 @@ namespace
 		std::vector<AnimationFrameData> frames;
 	};
 
-	struct AnimationFileData
+	struct AnimationFileIndexedData
 	{
 		ImageSheets imageSheets;
 		Actions actions;
 	};
 
 	[[noreturn]] void throwLoadError(std::string_view message, const Xml::XmlNode* node);
-	AnimationFileData processXml(std::string_view filePath, ImageCache& imageCache);
+	AnimationFileIndexedData processXml(std::string_view filePath, ImageCache& imageCache);
 	std::vector<AnimationImageSheetReference> processImageSheets(const Xml::XmlElement* element);
 	ImageSheets loadImages(const std::vector<AnimationImageSheetReference>& imageSheetReferences, const std::string& basePath, ImageCache& imageCache);
 	std::vector<AnimationAction> processActions(const Xml::XmlElement* element);
@@ -132,7 +132,7 @@ namespace
 	 *
 	 * \param filePath	File path of the sprite XML definition file.
 	 */
-	AnimationFileData processXml(std::string_view filePath, ImageCache& imageCache)
+	AnimationFileIndexedData processXml(std::string_view filePath, ImageCache& imageCache)
 	{
 		try
 		{

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -81,7 +81,7 @@ namespace
 	ImageSheets loadImages(const std::vector<AnimationImageSheetReference>& imageSheetReferences, const std::string& basePath, ImageCache& imageCache);
 	std::vector<AnimationAction> readActions(const Xml::XmlElement* element);
 	Actions indexActions(const std::vector<AnimationAction>& actionDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache);
-	std::vector<AnimationFrameData> processFrames(const Xml::XmlElement* element);
+	std::vector<AnimationFrameData> readFrames(const Xml::XmlElement* element);
 	AnimationSequence buildAnimationSequences(std::vector<AnimationFrameData> frameDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache);
 }
 
@@ -261,7 +261,7 @@ namespace
 			const auto dictionary = attributesToDictionary(*action);
 			const auto& actionDefinition = actionDefinitions.emplace_back(
 				dictionary.get("name"),
-				processFrames(action)
+				readFrames(action)
 			);
 
 			if (actionDefinition.name.empty())
@@ -297,7 +297,7 @@ namespace
 	/**
 	 * Parses through all <frame> tags within an <action> tag in a Sprite Definition.
 	 */
-	std::vector<AnimationFrameData> processFrames(const Xml::XmlElement* element)
+	std::vector<AnimationFrameData> readFrames(const Xml::XmlElement* element)
 	{
 		std::vector<AnimationFrameData> frameDefinitions;
 		for (const auto* frame = element->firstChildElement("frame"); frame; frame = frame->nextSiblingElement("frame"))

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -79,7 +79,7 @@ namespace
 	AnimationFileData readAnimationFileData(std::string_view fileData);
 	std::vector<AnimationImageSheetReference> readImageSheetReferences(const Xml::XmlElement* element);
 	ImageSheets loadImages(const std::vector<AnimationImageSheetReference>& imageSheetReferences, const std::string& basePath, ImageCache& imageCache);
-	std::vector<AnimationAction> processActions(const Xml::XmlElement* element);
+	std::vector<AnimationAction> readActions(const Xml::XmlElement* element);
 	Actions indexActions(const std::vector<AnimationAction>& actionDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache);
 	std::vector<AnimationFrameData> processFrames(const Xml::XmlElement* element);
 	AnimationSequence buildAnimationSequences(std::vector<AnimationFrameData> frameDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache);
@@ -193,7 +193,7 @@ namespace
 		// image sheets anywhere in the sprite file.
 		return {
 			readImageSheetReferences(spriteElement),
-			processActions(spriteElement),
+			readActions(spriteElement),
 		};
 	}
 
@@ -253,7 +253,7 @@ namespace
 	 * Iterates through all elements of a Sprite XML definition looking
 	 * for 'action' elements and processes them.
 	 */
-	std::vector<AnimationAction> processActions(const Xml::XmlElement* element)
+	std::vector<AnimationAction> readActions(const Xml::XmlElement* element)
 	{
 		std::vector<AnimationAction> actionDefinitions;
 		for (const auto* action = element->firstChildElement("action"); action; action = action->nextSiblingElement("action"))


### PR DESCRIPTION
Refactor `AnimationSet` file loading to first load data into structs in a raw untranslated form, and than later error check and convert to the indexed structures used by `AnimationSet`.

Related:
- Issue #991
- PR #1344
- PR #1343
- PR #1342
- PR #1340
