### PR TITLE
Refactor `AnimationSet` load - move functions

### DIFF
--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -75,13 +75,14 @@ namespace
 	};
 
 	[[noreturn]] void throwLoadError(std::string_view message, const Xml::XmlNode* node);
-	AnimationFileIndexedData readAndIndexAnimationFile(std::string_view filePath, ImageCache& imageCache);
 	AnimationFileData readAnimationFileData(std::string_view fileData);
 	std::vector<AnimationImageSheetReference> readImageSheetReferences(const Xml::XmlElement* element);
-	ImageSheets loadImages(const std::vector<AnimationImageSheetReference>& imageSheetReferences, const std::string& basePath, ImageCache& imageCache);
 	std::vector<AnimationAction> readActions(const Xml::XmlElement* element);
-	Actions indexActions(const std::vector<AnimationAction>& actionDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache);
 	std::vector<AnimationFrameData> readFrames(const Xml::XmlElement* element);
+
+	AnimationFileIndexedData readAndIndexAnimationFile(std::string_view filePath, ImageCache& imageCache);
+	ImageSheets loadImages(const std::vector<AnimationImageSheetReference>& imageSheetReferences, const std::string& basePath, ImageCache& imageCache);
+	Actions indexActions(const std::vector<AnimationAction>& actionDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache);
 	AnimationSequence buildAnimationSequences(std::vector<AnimationFrameData> frameDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache);
 }
 
@@ -131,28 +132,6 @@ namespace
 	void throwLoadError(std::string_view message, const Xml::XmlNode* node)
 	{
 		throw std::runtime_error(message + " (Line: " + std::to_string(node->row()) + ")");
-	}
-
-
-	AnimationFileIndexedData readAndIndexAnimationFile(std::string_view filePath, ImageCache& imageCache)
-	{
-		try
-		{
-			auto& filesystem = Utility<Filesystem>::get();
-			const auto basePath = Filesystem::parentPath(filePath);
-
-			const auto animationFileData = readAnimationFileData(filesystem.readFile(VirtualPath{filePath}));
-			auto imageSheets = loadImages(animationFileData.imageSheetReferences, basePath, imageCache);
-			auto actions = indexActions(animationFileData.actions, imageSheets, imageCache);
-			return {
-				std::move(imageSheets),
-				std::move(actions)
-			};
-		}
-		catch (const std::runtime_error& error)
-		{
-			throw std::runtime_error("Error loading Sprite file: " + filePath + "\n" + error.what());
-		}
 	}
 
 
@@ -214,24 +193,6 @@ namespace
 	}
 
 
-	ImageSheets loadImages(const std::vector<AnimationImageSheetReference>& imageSheetReferences, const std::string& basePath, ImageCache& imageCache)
-	{
-		ImageSheets imageSheets;
-		for (const auto& imageSheetReference : imageSheetReferences)
-		{
-			if (imageSheets.contains(imageSheetReference.id))
-			{
-				throw std::runtime_error("Image sheet redefinition: id: " + imageSheetReference.id);
-			}
-
-			const auto imagePath = basePath + imageSheetReference.filePath;
-			imageSheets.try_emplace(imageSheetReference.id, imagePath);
-			imageCache.load(imagePath);
-		}
-		return imageSheets;
-	}
-
-
 	std::vector<AnimationAction> readActions(const Xml::XmlElement* element)
 	{
 		std::vector<AnimationAction> actionDefinitions;
@@ -249,27 +210,6 @@ namespace
 			}
 		}
 		return actionDefinitions;
-	}
-
-
-	Actions indexActions(const std::vector<AnimationAction>& actionDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache)
-	{
-		Actions actions;
-		for (const auto& action : actionDefinitions)
-		{
-			if (actions.contains(action.name))
-			{
-				throw std::runtime_error("Action redefinition: " + action.name);
-			}
-
-			actions.try_emplace(action.name, buildAnimationSequences(action.frames, imageSheets, imageCache));
-
-			if (actions.at(action.name).empty())
-			{
-				throw std::runtime_error("Action contains no valid frames: " + action.name);
-			}
-		}
-		return actions;
 	}
 
 
@@ -306,6 +246,67 @@ namespace
 			}
 		}
 		return frameDefinitions;
+	}
+
+
+	AnimationFileIndexedData readAndIndexAnimationFile(std::string_view filePath, ImageCache& imageCache)
+	{
+		try
+		{
+			auto& filesystem = Utility<Filesystem>::get();
+			const auto basePath = Filesystem::parentPath(filePath);
+
+			const auto animationFileData = readAnimationFileData(filesystem.readFile(VirtualPath{filePath}));
+			auto imageSheets = loadImages(animationFileData.imageSheetReferences, basePath, imageCache);
+			auto actions = indexActions(animationFileData.actions, imageSheets, imageCache);
+			return {
+				std::move(imageSheets),
+				std::move(actions)
+			};
+		}
+		catch (const std::runtime_error& error)
+		{
+			throw std::runtime_error("Error loading Sprite file: " + filePath + "\n" + error.what());
+		}
+	}
+
+
+	ImageSheets loadImages(const std::vector<AnimationImageSheetReference>& imageSheetReferences, const std::string& basePath, ImageCache& imageCache)
+	{
+		ImageSheets imageSheets;
+		for (const auto& imageSheetReference : imageSheetReferences)
+		{
+			if (imageSheets.contains(imageSheetReference.id))
+			{
+				throw std::runtime_error("Image sheet redefinition: id: " + imageSheetReference.id);
+			}
+
+			const auto imagePath = basePath + imageSheetReference.filePath;
+			imageSheets.try_emplace(imageSheetReference.id, imagePath);
+			imageCache.load(imagePath);
+		}
+		return imageSheets;
+	}
+
+
+	Actions indexActions(const std::vector<AnimationAction>& actionDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache)
+	{
+		Actions actions;
+		for (const auto& action : actionDefinitions)
+		{
+			if (actions.contains(action.name))
+			{
+				throw std::runtime_error("Action redefinition: " + action.name);
+			}
+
+			actions.try_emplace(action.name, buildAnimationSequences(action.frames, imageSheets, imageCache));
+
+			if (actions.at(action.name).empty())
+			{
+				throw std::runtime_error("Action contains no valid frames: " + action.name);
+			}
+		}
+		return actions;
 	}
 
 

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -84,51 +84,8 @@ namespace
 	ImageSheets loadImages(const std::vector<AnimationImageSheetReference>& imageSheetReferences, const std::string& basePath, ImageCache& imageCache);
 	Actions indexActions(const std::vector<AnimationAction>& actionDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache);
 	AnimationSequence buildAnimationSequences(std::vector<AnimationFrameData> frameDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache);
-}
 
 
-AnimationSet::AnimationSet(std::string_view fileName) :
-	AnimationSet{fileName, animationImageCache}
-{
-}
-
-
-AnimationSet::AnimationSet(std::string_view fileName, ImageCache& imageCache) :
-	mImageSheets{},
-	mActions{}
-{
-	auto [imageSheets, actions] = readAndIndexAnimationFile(fileName, imageCache);
-	mImageSheets = std::move(imageSheets);
-	mActions = std::move(actions);
-}
-
-
-AnimationSet::AnimationSet(ImageSheets imageSheets, Actions actions) :
-	mImageSheets{std::move(imageSheets)},
-	mActions{std::move(actions)}
-{
-}
-
-
-std::vector<std::string> AnimationSet::actionNames() const
-{
-	return getKeys(mActions);
-}
-
-
-const AnimationSequence& AnimationSet::frames(const std::string& actionName) const
-{
-	if (!mActions.contains(actionName))
-	{
-		throw std::runtime_error("AnimationSet::frames called on undefined action: " + actionName);
-	}
-
-	return mActions.at(actionName);
-}
-
-
-namespace
-{
 	void throwLoadError(std::string_view message, const Xml::XmlNode* node)
 	{
 		throw std::runtime_error(message + " (Line: " + std::to_string(node->row()) + ")");
@@ -333,4 +290,44 @@ namespace
 		}
 		return {frameList};
 	}
+}
+
+
+AnimationSet::AnimationSet(std::string_view fileName) :
+	AnimationSet{fileName, animationImageCache}
+{
+}
+
+
+AnimationSet::AnimationSet(std::string_view fileName, ImageCache& imageCache) :
+	mImageSheets{},
+	mActions{}
+{
+	auto [imageSheets, actions] = readAndIndexAnimationFile(fileName, imageCache);
+	mImageSheets = std::move(imageSheets);
+	mActions = std::move(actions);
+}
+
+
+AnimationSet::AnimationSet(ImageSheets imageSheets, Actions actions) :
+	mImageSheets{std::move(imageSheets)},
+	mActions{std::move(actions)}
+{
+}
+
+
+std::vector<std::string> AnimationSet::actionNames() const
+{
+	return getKeys(mActions);
+}
+
+
+const AnimationSequence& AnimationSet::frames(const std::string& actionName) const
+{
+	if (!mActions.contains(actionName))
+	{
+		throw std::runtime_error("AnimationSet::frames called on undefined action: " + actionName);
+	}
+
+	return mActions.at(actionName);
 }


### PR DESCRIPTION
Re-order functions to group XML process code, and consolidate unnamed namespace code.

There's a lot of diff noise from the moved code, with no real changes, so I wanted to keep this separate from the other related PRs.

Related:
- Issue #991
- PR #1345
- PR #1344
- PR #1343
- PR #1342
- PR #1340
