### PR TITLE
Distinct path type construction

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -78,7 +78,7 @@ void Configuration::load(const std::string& filePath)
 		try
 		{
 			// Read in the Config File.
-			auto xmlData = filesystem.readFile(filePath);
+			auto xmlData = filesystem.readFile(VirtualPath{filePath});
 			loadData(xmlData);
 		}
 		catch (const std::runtime_error& e)

--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -73,7 +73,7 @@ void Configuration::loadData(const std::string& fileData)
 void Configuration::load(const std::string& filePath)
 {
 	const auto& filesystem = Utility<Filesystem>::get();
-	if (filesystem.exists(filePath))
+	if (filesystem.exists(VirtualPath{filePath}))
 	{
 		try
 		{
@@ -105,7 +105,7 @@ void Configuration::save(const std::string& filePath) const
 {
 	try
 	{
-		Utility<Filesystem>::get().writeFile(filePath, saveData());
+		Utility<Filesystem>::get().writeFile(VirtualPath{filePath}, saveData());
 	}
 	catch (const std::runtime_error& e)
 	{

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -182,7 +182,7 @@ RealPath Filesystem::findInParents(const RealPath& path, const RealPath& startPa
 		const auto checkPath = currentPath / path.string();
 		if (std::filesystem::exists(std::string{checkPath}))
 		{
-			return checkPath.string();
+			return RealPath{checkPath.string()};
 		}
 	}
 	return {};
@@ -278,7 +278,7 @@ std::vector<VirtualPath> Filesystem::directoryList(const VirtualPath& dir, const
 				const auto& filePath = dirEntry.path().filename().generic_string();
 				if (hasFileSuffix(filePath, filter))
 				{
-					fileList.push_back(filePath);
+					fileList.push_back(VirtualPath{filePath});
 				}
 			}
 		}

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -19,10 +19,6 @@
 
 namespace NAS2D
 {
-	struct RealPath : public FilesystemPath {};
-	struct VirtualPath : public FilesystemPath {};
-
-
 	class Filesystem
 	{
 	public:

--- a/NAS2D/Filesystem.h
+++ b/NAS2D/Filesystem.h
@@ -19,8 +19,8 @@
 
 namespace NAS2D
 {
-	using RealPath = FilesystemPath;
-	using VirtualPath = FilesystemPath;
+	struct RealPath : public FilesystemPath {};
+	struct VirtualPath : public FilesystemPath {};
 
 
 	class Filesystem

--- a/NAS2D/FilesystemPath.h
+++ b/NAS2D/FilesystemPath.h
@@ -31,6 +31,10 @@ namespace NAS2D
 	};
 
 
+	struct RealPath : public FilesystemPath {};
+	struct VirtualPath : public FilesystemPath {};
+
+
 	std::string operator+(const char* string, const FilesystemPath& path);
 	std::string operator+(const FilesystemPath& path, const char* string);
 }

--- a/NAS2D/Game.cpp
+++ b/NAS2D/Game.cpp
@@ -81,8 +81,8 @@ Game::Game(const std::string& title, const std::string& appName, const std::stri
 	SDL_Init(0);
 
 	auto& fs = Utility<Filesystem>::init<Filesystem>(appName, organizationName);
-	fs.mountSoftFail(dataPath);
-	fs.mountSoftFail(fs.findInParents(dataPath, fs.basePath()));
+	fs.mountSoftFail(RealPath{dataPath});
+	fs.mountSoftFail(fs.findInParents(RealPath{dataPath}, fs.basePath()));
 	fs.mountReadWrite(fs.prefPath());
 
 	Configuration& configuration = Utility<Configuration>::init(defaultConfig());
@@ -127,7 +127,7 @@ Game::~Game()
  */
 void Game::mount(const std::string& path)
 {
-	Utility<Filesystem>::get().mount(path);
+	Utility<Filesystem>::get().mount(RealPath{path});
 }
 
 
@@ -141,7 +141,7 @@ void Game::mount(const std::string& path)
 void Game::mountFindFromBase(const std::string& path)
 {
 	auto& filesystem = Utility<Filesystem>::get();
-	filesystem.mount(filesystem.findInParents(path, filesystem.basePath()));
+	filesystem.mount(filesystem.findInParents(RealPath{path}, filesystem.basePath()));
 }
 
 

--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -196,7 +196,7 @@ DisplayDesc Window::getClosestMatchingDisplayMode(const DisplayDesc& preferredDi
 
 void Window::window_icon(const std::string& path)
 {
-	auto iconData = Utility<Filesystem>::get().readFile(path);
+	auto iconData = Utility<Filesystem>::get().readFile(VirtualPath{path});
 	SDL_Surface* icon = IMG_Load_RW(SDL_RWFromConstMem(iconData.c_str(), static_cast<int>(iconData.size())), 1);
 	if (!icon)
 	{
@@ -216,7 +216,7 @@ void Window::showSystemPointer(bool _b)
 
 void Window::addCursor(CursorId cursorId, const std::string& filePath, Vector<int> hotOffset)
 {
-	auto imageData = Utility<Filesystem>::get().readFile(filePath);
+	auto imageData = Utility<Filesystem>::get().readFile(VirtualPath{filePath});
 	if (imageData.size() == 0)
 	{
 		throw std::runtime_error("Cursor file is empty: " + filePath);

--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -246,7 +246,7 @@ namespace
 			}
 		}
 
-		auto fontBuffer = Utility<Filesystem>::get().readFile(path);
+		auto fontBuffer = Utility<Filesystem>::get().readFile(VirtualPath{path});
 		if (fontBuffer.empty())
 		{
 			throw std::runtime_error("Font file is empty: " + path);
@@ -284,7 +284,7 @@ namespace
 	 */
 	Font::FontInfo loadBitmap(std::string_view path)
 	{
-		auto fontBuffer = Utility<Filesystem>::get().readFile(path);
+		auto fontBuffer = Utility<Filesystem>::get().readFile(VirtualPath{path});
 		if (fontBuffer.empty())
 		{
 			throw std::runtime_error("Font file is empty: " + path);

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -47,7 +47,7 @@ namespace
 
 SDL_Surface* Image::fileToSdlSurface(std::string_view filePath)
 {
-	const auto& data = Utility<Filesystem>::get().readFile(filePath);
+	const auto& data = Utility<Filesystem>::get().readFile(VirtualPath{filePath});
 
 	if (data.size() == 0)
 	{

--- a/NAS2D/Resource/Music.cpp
+++ b/NAS2D/Resource/Music.cpp
@@ -22,7 +22,7 @@ using namespace NAS2D;
 
 
 Music::Music(std::string_view filePath) :
-	mBuffer{Utility<Filesystem>::get().readFile(filePath)}
+	mBuffer{Utility<Filesystem>::get().readFile(VirtualPath{filePath})}
 {
 	if (mBuffer.empty())
 	{

--- a/NAS2D/Resource/Sound.cpp
+++ b/NAS2D/Resource/Sound.cpp
@@ -32,7 +32,7 @@ using namespace NAS2D;
  */
 Sound::Sound(std::string_view filePath)
 {
-	auto data = Utility<Filesystem>::get().readFile(filePath);
+	auto data = Utility<Filesystem>::get().readFile(VirtualPath{filePath});
 	if (data.empty())
 	{
 		throw std::runtime_error("Sound file is empty: " + filePath);

--- a/demoGraphics/DemoGraphics.cpp
+++ b/demoGraphics/DemoGraphics.cpp
@@ -23,7 +23,7 @@ namespace
 		static const std::string fileName = "fonts/opensans.ttf";
 
 		const auto& filesystem = NAS2D::Utility<NAS2D::Filesystem>::get();
-		if (filesystem.exists(fileName))
+		if (filesystem.exists(NAS2D::VirtualPath{fileName}))
 		{
 			return NAS2D::Font{fileName, 16};
 		}

--- a/test/Filesystem.test.cpp
+++ b/test/Filesystem.test.cpp
@@ -46,7 +46,7 @@ namespace {
 			fs(AppName, OrganizationName)
 		{
 			fs.mount(fs.basePath());
-			fs.mount(fs.findInParents("test/data/", fs.basePath()));
+			fs.mount(fs.findInParents(NAS2D::RealPath{"test/data/"}, fs.basePath()));
 			fs.mountReadWrite(fs.prefPath());
 		}
 
@@ -70,17 +70,17 @@ TEST_F(Filesystem, prefPath) {
 
 TEST_F(Filesystem, findInParentsExist) {
 	// Try to find the unit test project folder
-	const auto folder = "test/";
+	const auto folder = NAS2D::RealPath{"test/"};
 	EXPECT_THAT(fs.findInParents(folder, fs.basePath()), testing::EndsWith(folder));
 	EXPECT_THAT(fs.findInParents(folder, fs.basePath(), 4), testing::EndsWith(folder));
 }
 
 TEST_F(Filesystem, findInParentsNotExist) {
-	EXPECT_EQ("", fs.findInParents("FolderThatDoesNotExist/", fs.basePath(), 0));
-	EXPECT_EQ("", fs.findInParents("FolderThatDoesNotExist/", fs.basePath(), 1));
-	EXPECT_EQ("", fs.findInParents("FolderThatDoesNotExist/", fs.basePath(), 2));
-	EXPECT_EQ("", fs.findInParents("FolderThatDoesNotExist/", fs.basePath(), 3));
-	EXPECT_EQ("", fs.findInParents("FolderThatDoesNotExist/", fs.basePath(), 4));
+	EXPECT_EQ("", fs.findInParents(NAS2D::RealPath{"FolderThatDoesNotExist/"}, fs.basePath(), 0));
+	EXPECT_EQ("", fs.findInParents(NAS2D::RealPath{"FolderThatDoesNotExist/"}, fs.basePath(), 1));
+	EXPECT_EQ("", fs.findInParents(NAS2D::RealPath{"FolderThatDoesNotExist/"}, fs.basePath(), 2));
+	EXPECT_EQ("", fs.findInParents(NAS2D::RealPath{"FolderThatDoesNotExist/"}, fs.basePath(), 3));
+	EXPECT_EQ("", fs.findInParents(NAS2D::RealPath{"FolderThatDoesNotExist/"}, fs.basePath(), 4));
 }
 
 TEST_F(Filesystem, searchPath) {
@@ -93,31 +93,31 @@ TEST_F(Filesystem, searchPath) {
 }
 
 TEST_F(Filesystem, directoryList) {
-	auto pathList = fs.directoryList("");
+	auto pathList = fs.directoryList(NAS2D::VirtualPath{""});
 	EXPECT_LE(1u, pathList.size());
 	EXPECT_THAT(pathList, testing::Contains(NAS2D::VirtualPath{"file.txt"}));
 }
 
 TEST_F(Filesystem, directoryListWithFilter) {
-	auto pathList = fs.directoryList("", "txt");
+	auto pathList = fs.directoryList(NAS2D::VirtualPath{""}, "txt");
 	EXPECT_LE(1u, pathList.size());
 	EXPECT_THAT(pathList, testing::Contains(NAS2D::VirtualPath{"file.txt"}));
 }
 
 TEST_F(Filesystem, exists) {
-	EXPECT_TRUE(fs.exists("file.txt"));
+	EXPECT_TRUE(fs.exists(NAS2D::VirtualPath{"file.txt"}));
 }
 
 TEST_F(Filesystem, read) {
-	const auto data = fs.readFile("file.txt");
+	const auto data = fs.readFile(NAS2D::VirtualPath{"file.txt"});
 	EXPECT_THAT(data, testing::StartsWith("Test data"));
 
-	EXPECT_THROW(fs.readFile("FileDoesNotExist.txt"), std::runtime_error);
+	EXPECT_THROW(fs.readFile(NAS2D::VirtualPath{"FileDoesNotExist.txt"}), std::runtime_error);
 }
 
 // Test a few related methods. Some don't test well standalone.
 TEST_F(Filesystem, writeReadDeleteExists) {
-	const std::string testFilename = "TestFile.txt";
+	const auto testFilename = NAS2D::VirtualPath{"TestFile.txt"};
 	const std::string testData = "Test file contents";
 
 	EXPECT_NO_THROW(fs.writeFile(testFilename, testData));
@@ -137,8 +137,8 @@ TEST_F(Filesystem, writeReadDeleteExists) {
 }
 
 TEST_F(Filesystem, isDirectoryMakeDirectory) {
-	const std::string fileName = "file.txt";
-	const std::string folderName = "subfolder/";
+	const auto fileName = NAS2D::VirtualPath{"file.txt"};
+	const auto folderName = NAS2D::VirtualPath{"subfolder/"};
 
 	EXPECT_TRUE(fs.exists(fileName));
 	EXPECT_FALSE(fs.isDirectory(fileName));
@@ -153,8 +153,8 @@ TEST_F(Filesystem, isDirectoryMakeDirectory) {
 }
 
 TEST_F(Filesystem, mountUnmount) {
-	const auto extraMount = fs.findInParents("test/data/extraData/", fs.basePath());
-	const std::string extraFile = "extraFile.txt";
+	const auto extraMount = fs.findInParents(NAS2D::RealPath{"test/data/extraData/"}, fs.basePath());
+	const auto extraFile = NAS2D::VirtualPath{"extraFile.txt"};
 
 	EXPECT_FALSE(fs.exists(extraFile));
 	EXPECT_NO_THROW(fs.mount(extraMount));
@@ -164,5 +164,5 @@ TEST_F(Filesystem, mountUnmount) {
 	EXPECT_NO_THROW(fs.unmount(extraMount));
 	EXPECT_FALSE(fs.exists(extraFile));
 
-	EXPECT_THROW(fs.mount("nonExistentPath/"), std::runtime_error);
+	EXPECT_THROW(fs.mount(NAS2D::RealPath{"nonExistentPath/"}), std::runtime_error);
 }


### PR DESCRIPTION
Use `struct` sub-types to make `RealPath` and `VirtualPath` distinct types.

Using distinct types prevents swapping path types in API calls. With a `using` alias there is no new type created, so anything aliased to the same type will be interchangeable with each other. By using `struct` we create new types, and so are forced to use the exact type, rather than an equivalent name. As such we now get errors if a `RealPath` is passed where a `VirtualPath` is expected, or a `VirtualPath` is passed where a `RealPath` is expected.

Related:
- Issue #1348
