### PR TITLE
Refactor for explicit `FilesystemPath` constructors

### DIFF
--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -216,7 +216,7 @@ void Filesystem::mount(const RealPath& path)
 {
 	if (mountSoftFail(path) == 0)
 	{
-		throw std::runtime_error("Error mounting search path: " + path + " : " + errorDescription());
+		throw std::runtime_error("Error mounting search path: " + path.string() + " : " + errorDescription());
 	}
 }
 
@@ -336,7 +336,7 @@ void Filesystem::del(const VirtualPath& filename)
 	const auto& filePath = mWritePath / filename;
 	if (!std::filesystem::remove(std::string{filePath}))
 	{
-		throw std::runtime_error("Error deleting file: " + filename + " : " + errorDescription());
+		throw std::runtime_error("Error deleting file: " + filename.string() + " : " + errorDescription());
 	}
 }
 
@@ -346,13 +346,13 @@ std::string Filesystem::readFile(const VirtualPath& filename) const
 	const auto& filePath = findFirstPath(filename, mSearchPaths);
 	if (filePath.empty())
 	{
-		throw std::runtime_error("Error opening file: " + filename + " : File does not exist");
+		throw std::runtime_error("Error opening file: " + filename.string() + " : File does not exist");
 	}
 
 	std::ifstream file{filePath, std::ios::in | std::ios::binary};
 	if (!file)
 	{
-		throw std::runtime_error("Error opening file: " + filename + " : " + errorDescription());
+		throw std::runtime_error("Error opening file: " + filename.string() + " : " + errorDescription());
 	}
 
 	const auto fileSize = std::filesystem::file_size(filePath);
@@ -364,7 +364,7 @@ std::string Filesystem::readFile(const VirtualPath& filename) const
 	file.read(fileBuffer.data(), static_cast<std::streamsize>(bufferSize));
 	if (!file)
 	{
-		throw std::runtime_error("Error reading file: " + filename + " : " + errorDescription());
+		throw std::runtime_error("Error reading file: " + filename.string() + " : " + errorDescription());
 	}
 
 	return fileBuffer;
@@ -375,19 +375,19 @@ void Filesystem::writeFile(const VirtualPath& filename, const std::string& data,
 {
 	if (flags != WriteFlags::Overwrite && exists(filename))
 	{
-		throw std::runtime_error("Overwrite flag not specified and file already exists: " + filename);
+		throw std::runtime_error("Overwrite flag not specified and file already exists: " + filename.string());
 	}
 
 	const auto& filePath = mWritePath / filename;
 	std::ofstream file{filePath.string(), std::ios::out | std::ios::binary};
 	if (!file)
 	{
-		throw std::runtime_error("Error opening file for writing: " + filename + " : " + errorDescription());
+		throw std::runtime_error("Error opening file for writing: " + filename.string() + " : " + errorDescription());
 	}
 
 	file << data;
 	if (!file)
 	{
-		throw std::runtime_error("Error writing file: " + filename + " : " + errorDescription());
+		throw std::runtime_error("Error writing file: " + filename.string() + " : " + errorDescription());
 	}
 }

--- a/NAS2D/Filesystem.cpp
+++ b/NAS2D/Filesystem.cpp
@@ -179,7 +179,7 @@ RealPath Filesystem::findInParents(const RealPath& path, const RealPath& startPa
 {
 	for (const auto& currentPath : FilesystemPathParents(startPath, maxLevels))
 	{
-		const auto checkPath = currentPath / path.string();
+		const auto checkPath = currentPath / path;
 		if (std::filesystem::exists(std::string{checkPath}))
 		{
 			return RealPath{checkPath.string()};

--- a/NAS2D/FilesystemPath.cpp
+++ b/NAS2D/FilesystemPath.cpp
@@ -52,7 +52,7 @@ bool FilesystemPath::operator<(const FilesystemPath& other) const
 
 FilesystemPath FilesystemPath::operator/(const FilesystemPath& path) const
 {
-	return (std::filesystem::path{mPath} / std::filesystem::path{std::string{path}}).string();
+	return FilesystemPath{(std::filesystem::path{mPath} / std::filesystem::path{std::string{path}}).string()};
 }
 
 
@@ -73,7 +73,7 @@ std::size_t FilesystemPath::componentCount() const
 
 FilesystemPath FilesystemPath::absolute() const
 {
-	return std::filesystem::absolute(mPath).string();
+	return FilesystemPath{std::filesystem::absolute(mPath).string()};
 }
 
 
@@ -81,13 +81,13 @@ FilesystemPath FilesystemPath::parent() const
 {
 	// Keep the trailing "/" as part of the folder name
 	// This is contrary to how <filesystem> behaves, which strips the trailing "/"
-	return ((std::filesystem::path{mPath} / "").parent_path().remove_filename()).string();
+	return FilesystemPath{((std::filesystem::path{mPath} / "").parent_path().remove_filename()).string()};
 }
 
 
 FilesystemPath FilesystemPath::stem() const
 {
-	return std::filesystem::path{mPath}.stem().string();
+	return FilesystemPath{std::filesystem::path{mPath}.stem().string()};
 }
 
 

--- a/NAS2D/FilesystemPathParents.cpp
+++ b/NAS2D/FilesystemPathParents.cpp
@@ -56,7 +56,7 @@ namespace NAS2D
 
 
 	FilesystemPathParents::Iterator::Iterator() :
-		FilesystemPathParents::Iterator::Iterator("", 0)
+		FilesystemPathParents::Iterator::Iterator(FilesystemPath{}, 0)
 	{
 	}
 

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -95,7 +95,7 @@ namespace
 
 	void throwLoadError(std::string_view message, const Xml::XmlNode* node)
 	{
-		throw std::runtime_error(message + " (Line: " + std::to_string(node->row()) + ")");
+		throw std::runtime_error(std::string{message} + " (Line: " + std::to_string(node->row()) + ")");
 	}
 
 
@@ -237,7 +237,7 @@ namespace
 		}
 		catch (const std::runtime_error& error)
 		{
-			throw std::runtime_error("Error loading Sprite file: " + filePath + "\n" + error.what());
+			throw std::runtime_error("Error loading Sprite file: " + std::string{filePath} + "\n" + error.what());
 		}
 	}
 

--- a/NAS2D/Resource/Font.cpp
+++ b/NAS2D/Resource/Font.cpp
@@ -249,7 +249,7 @@ namespace
 		auto fontBuffer = Utility<Filesystem>::get().readFile(VirtualPath{path});
 		if (fontBuffer.empty())
 		{
-			throw std::runtime_error("Font file is empty: " + path);
+			throw std::runtime_error("Font file is empty: " + std::string{path});
 		}
 
 		auto* font = TTF_OpenFontRW(SDL_RWFromConstMem(fontBuffer.c_str(), static_cast<int>(fontBuffer.size())), 1, static_cast<int>(ptSize));
@@ -287,7 +287,7 @@ namespace
 		auto fontBuffer = Utility<Filesystem>::get().readFile(VirtualPath{path});
 		if (fontBuffer.empty())
 		{
-			throw std::runtime_error("Font file is empty: " + path);
+			throw std::runtime_error("Font file is empty: " + std::string{path});
 		}
 
 		SDL_Surface* fontSurface = IMG_Load_RW(SDL_RWFromConstMem(fontBuffer.c_str(), static_cast<int>(fontBuffer.size())), 1);

--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -51,7 +51,7 @@ SDL_Surface* Image::fileToSdlSurface(std::string_view filePath)
 
 	if (data.size() == 0)
 	{
-		throw std::runtime_error("Image file is empty: " + filePath);
+		throw std::runtime_error("Image file is empty: " + std::string{filePath});
 	}
 
 	return dataToSdlSurface(data);

--- a/NAS2D/Resource/Music.cpp
+++ b/NAS2D/Resource/Music.cpp
@@ -26,7 +26,7 @@ Music::Music(std::string_view filePath) :
 {
 	if (mBuffer.empty())
 	{
-		throw std::runtime_error("Music file is empty: " + filePath);
+		throw std::runtime_error("Music file is empty: " + std::string{filePath});
 	}
 
 	mMusic = Mix_LoadMUS_RW(SDL_RWFromConstMem(mBuffer.c_str(), static_cast<int>(mBuffer.size())), 1);

--- a/NAS2D/Resource/Sound.cpp
+++ b/NAS2D/Resource/Sound.cpp
@@ -35,13 +35,13 @@ Sound::Sound(std::string_view filePath)
 	auto data = Utility<Filesystem>::get().readFile(VirtualPath{filePath});
 	if (data.empty())
 	{
-		throw std::runtime_error("Sound file is empty: " + filePath);
+		throw std::runtime_error("Sound file is empty: " + std::string{filePath});
 	}
 
 	mMixChunk = Mix_LoadWAV_RW(SDL_RWFromConstMem(data.c_str(), static_cast<int>(data.size())), 1);
 	if (!mMixChunk)
 	{
-		throw std::runtime_error("Sound file could not be loaded: " + filePath + " : " + std::string{Mix_GetError()});
+		throw std::runtime_error("Sound file could not be loaded: " + std::string{filePath} + " : " + std::string{Mix_GetError()});
 	}
 }
 


### PR DESCRIPTION
Some refactoring to prepare for `explicit` constructors in `FilesystemPath`.

Related:
- Issue #1348
- PR #1349
