### PR TITLE
Explicit `FilesystemPath` constructors

### DIFF
--- a/NAS2D/FilesystemPath.h
+++ b/NAS2D/FilesystemPath.h
@@ -31,14 +31,16 @@ namespace NAS2D
 	};
 
 
-	struct RealPath : public FilesystemPath
+	class RealPath : public FilesystemPath
 	{
+	public:
 		using FilesystemPath::FilesystemPath;
 	};
 
 
-	struct VirtualPath : public FilesystemPath
+	class VirtualPath : public FilesystemPath
 	{
+	public:
 		using FilesystemPath::FilesystemPath;
 	};
 


### PR DESCRIPTION
Mark `FilesystemPath` constructors as `explicit`.

Closes #1348

Related:
- Issue #1348
- PR #1351
- PR #1350
- PR #1349
