### PR TITLE
Convert `AnimationFile` from `struct` to `class`

### DIFF
--- a/NAS2D/Resource/AnimationFile.cpp
+++ b/NAS2D/Resource/AnimationFile.cpp
@@ -1,5 +1,10 @@
 #include "AnimationFile.h"
 
+#include "AnimationFrame.h"
+#include "AnimationSequence.h"
+#include "Image.h"
+#include "ResourceCache.h"
+
 #include "../Utility.h"
 #include "../Filesystem.h"
 #include "../ParserHelper.h"
@@ -192,6 +197,83 @@ const std::vector<AnimationImageSheetReference>& AnimationFile::imageSheetRefere
 const std::vector<AnimationAction>& AnimationFile::actions() const
 {
 	return mActions;
+}
+
+
+std::size_t AnimationFile::imageSheetReferenceCount() const
+{
+	return mImageSheetReferences.size();
+}
+
+
+std::size_t AnimationFile::actionCount() const
+{
+	return mActions.size();
+}
+
+
+std::size_t AnimationFile::imageSheetReferenceIndex(const std::string& id) const
+{
+	for (std::size_t index = 0; index < mImageSheetReferences.size(); ++index)
+	{
+		if (mImageSheetReferences[index].id == id)
+		{
+			return index;
+		}
+	}
+	throw std::runtime_error("Image sheet not found: " + id);
+}
+
+
+std::size_t AnimationFile::actionIndex(const std::string& name) const
+{
+	for (std::size_t index = 0; index < mActions.size(); ++index)
+	{
+		if (mActions[index].name == name)
+		{
+			return index;
+		}
+	}
+	throw std::runtime_error("Action not found: " + name);
+}
+
+
+const AnimationImageSheetReference& AnimationFile::imageSheetReference(std::size_t index) const
+{
+	return mImageSheetReferences.at(index);
+}
+
+
+const AnimationAction& AnimationFile::action(std::size_t index) const
+{
+	return mActions.at(index);
+}
+
+
+AnimationSequence AnimationFile::animationSequence(std::size_t actionIndex, ImageCache& imageCache) const
+{
+	const auto& action = mActions.at(actionIndex);
+	if (action.frames.empty())
+	{
+		throw std::runtime_error("Action contains no valid frames: " + action.name);
+	}
+
+	std::vector<AnimationFrame> frameList;
+	for (const auto& animationFrameData : action.frames)
+	{
+		const auto imageSheetIndex = imageSheetReferenceIndex(animationFrameData.id);
+		const auto& filePath = mBasePath + mImageSheetReferences[imageSheetIndex].filePath;
+		const auto& image = imageCache.load(filePath);
+
+		const auto imageRect = Rectangle{{0, 0}, image.size()};
+		if (!imageRect.contains(animationFrameData.imageBounds))
+		{
+			throw std::runtime_error("Frame bounds exceeds image sheet bounds: " + animationFrameData.id + " : " + stringFrom(animationFrameData.imageBounds));
+		}
+
+		frameList.emplace_back(image, animationFrameData.imageBounds, animationFrameData.anchorOffset, animationFrameData.frameDelay);
+	}
+	return AnimationSequence{std::move(frameList)};
 }
 
 

--- a/NAS2D/Resource/AnimationFile.cpp
+++ b/NAS2D/Resource/AnimationFile.cpp
@@ -7,6 +7,7 @@
 #include "../Xml/XmlElement.h"
 #include "../Xml/XmlDocument.h"
 
+#include <utility>
 #include <stdexcept>
 
 
@@ -154,6 +155,43 @@ namespace
 		}
 		return frameDefinitions;
 	}
+}
+
+
+AnimationFile::AnimationFile(std::string_view filePath) :
+	AnimationFile{readAnimationFile(filePath)}
+{
+}
+
+
+AnimationFile::AnimationFile(std::string basePath, AnimationFileData animationFileData) :
+	mBasePath{std::move(basePath)},
+	mImageSheetReferences{std::move(animationFileData.imageSheetReferences)},
+	mActions{std::move(animationFileData.actions)}
+{
+}
+
+
+AnimationFile::~AnimationFile()
+{
+}
+
+
+const std::string& AnimationFile::basePath() const
+{
+	return mBasePath;
+}
+
+
+const std::vector<AnimationImageSheetReference>& AnimationFile::imageSheetReferences() const
+{
+	return mImageSheetReferences;
+}
+
+
+const std::vector<AnimationAction>& AnimationFile::actions() const
+{
+	return mActions;
 }
 
 

--- a/NAS2D/Resource/AnimationFile.h
+++ b/NAS2D/Resource/AnimationFile.h
@@ -37,10 +37,24 @@ namespace NAS2D
 		std::vector<AnimationAction> actions;
 	};
 
-	struct AnimationFile
+
+	class AnimationFile
 	{
-		std::string basePath;
-		AnimationFileData animationFileData;
+	public:
+		explicit AnimationFile(std::string_view filePath);
+		AnimationFile(std::string basePath, AnimationFileData animationFileData);
+		AnimationFile(const AnimationFile&) = default;
+		AnimationFile(AnimationFile&&) = default;
+		~AnimationFile();
+
+		const std::string& basePath() const;
+		const std::vector<AnimationImageSheetReference>& imageSheetReferences() const;
+		const std::vector<AnimationAction>& actions() const;
+
+	private:
+		std::string mBasePath;
+		std::vector<AnimationImageSheetReference> mImageSheetReferences;
+		std::vector<AnimationAction> mActions;
 	};
 
 

--- a/NAS2D/Resource/AnimationFile.h
+++ b/NAS2D/Resource/AnimationFile.h
@@ -11,6 +11,12 @@
 
 namespace NAS2D
 {
+	class AnimationSequence;
+	class Image;
+	template <typename Resource, typename... Params> class ResourceCache;
+	using ImageCache = ResourceCache<Image, std::string>;
+
+
 	struct AnimationImageSheetReference
 	{
 		std::string id;
@@ -50,6 +56,17 @@ namespace NAS2D
 		const std::string& basePath() const;
 		const std::vector<AnimationImageSheetReference>& imageSheetReferences() const;
 		const std::vector<AnimationAction>& actions() const;
+
+		std::size_t imageSheetReferenceCount() const;
+		std::size_t actionCount() const;
+
+		std::size_t imageSheetReferenceIndex(const std::string& id) const;
+		std::size_t actionIndex(const std::string& name) const;
+
+		const AnimationImageSheetReference& imageSheetReference(std::size_t index) const;
+		const AnimationAction& action(std::size_t index) const;
+
+		AnimationSequence animationSequence(std::size_t actionIndex, ImageCache& imageCache) const;
 
 	private:
 		std::string mBasePath;

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -41,6 +41,7 @@ namespace
 		Actions actions;
 	};
 
+
 	AnimationFileIndexedData readAndIndexAnimationFile(std::string_view filePath, ImageCache& imageCache);
 	ImageSheets loadImages(const std::vector<AnimationImageSheetReference>& imageSheetReferences, const std::string& basePath, ImageCache& imageCache);
 	Actions indexActions(const std::vector<AnimationAction>& actionDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache);
@@ -51,9 +52,9 @@ namespace
 	{
 		try
 		{
-			const auto& [basePath, animationFileData] = loadAnimationFile(filePath);
-			auto imageSheets = loadImages(animationFileData.imageSheetReferences, basePath, imageCache);
-			auto actions = indexActions(animationFileData.actions, imageSheets, imageCache);
+			const auto animationFile = AnimationFile{filePath};
+			auto imageSheets = loadImages(animationFile.imageSheetReferences(), animationFile.basePath(), imageCache);
+			auto actions = indexActions(animationFile.actions(), imageSheets, imageCache);
 			return {
 				std::move(imageSheets),
 				std::move(actions)

--- a/NAS2D/Resource/AnimationSet.cpp
+++ b/NAS2D/Resource/AnimationSet.cpp
@@ -16,8 +16,6 @@
 #include "Image.h"
 #include "ResourceCache.h"
 #include "../ContainerUtils.h"
-#include "../StringFrom.h"
-#include "../Math/Rectangle.h"
 
 #include <utility>
 #include <stdexcept>
@@ -44,8 +42,7 @@ namespace
 
 	AnimationFileIndexedData readAndIndexAnimationFile(std::string_view filePath, ImageCache& imageCache);
 	ImageSheets loadImages(const std::vector<AnimationImageSheetReference>& imageSheetReferences, const std::string& basePath, ImageCache& imageCache);
-	Actions indexActions(const std::vector<AnimationAction>& actionDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache);
-	AnimationSequence buildAnimationSequences(std::vector<AnimationFrameData> frameDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache);
+	Actions indexActions(const AnimationFile& animationFile, ImageCache& imageCache);
 
 
 	AnimationFileIndexedData readAndIndexAnimationFile(std::string_view filePath, ImageCache& imageCache)
@@ -54,7 +51,7 @@ namespace
 		{
 			const auto animationFile = AnimationFile{filePath};
 			auto imageSheets = loadImages(animationFile.imageSheetReferences(), animationFile.basePath(), imageCache);
-			auto actions = indexActions(animationFile.actions(), imageSheets, imageCache);
+			auto actions = indexActions(animationFile, imageCache);
 			return {
 				std::move(imageSheets),
 				std::move(actions)
@@ -85,49 +82,20 @@ namespace
 	}
 
 
-	Actions indexActions(const std::vector<AnimationAction>& actionDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache)
+	Actions indexActions(const AnimationFile& animationFile, ImageCache& imageCache)
 	{
 		Actions actions;
-		for (const auto& action : actionDefinitions)
+		for (std::size_t actionIndex = 0; actionIndex < animationFile.actionCount(); ++actionIndex)
 		{
+			const auto& action = animationFile.action(actionIndex);
 			if (actions.contains(action.name))
 			{
 				throw std::runtime_error("Action redefinition: " + action.name);
 			}
 
-			actions.try_emplace(action.name, buildAnimationSequences(action.frames, imageSheets, imageCache));
-
-			if (actions.at(action.name).empty())
-			{
-				throw std::runtime_error("Action contains no valid frames: " + action.name);
-			}
+			actions.try_emplace(action.name, animationFile.animationSequence(actionIndex, imageCache));
 		}
 		return actions;
-	}
-
-
-	AnimationSequence buildAnimationSequences(std::vector<AnimationFrameData> frameDefinitions, const ImageSheets& imageSheets, ImageCache& imageCache)
-	{
-		std::vector<AnimationFrame> frameList;
-		for (const auto& animationFrameData : frameDefinitions)
-		{
-			if (!imageSheets.contains(animationFrameData.id))
-			{
-				throw std::runtime_error("Frame definition references undefined imagesheet: " + animationFrameData.id);
-			}
-
-			const auto& filePath = imageSheets.at(animationFrameData.id);
-			const auto& image = imageCache.load(filePath);
-
-			const auto imageRect = Rectangle{{0, 0}, image.size()};
-			if (!imageRect.contains(animationFrameData.imageBounds))
-			{
-				throw std::runtime_error("Frame bounds exceeds image sheet bounds: " + animationFrameData.id + " : " + stringFrom(animationFrameData.imageBounds));
-			}
-
-			frameList.push_back(AnimationFrame{image, animationFrameData.imageBounds, animationFrameData.anchorOffset, animationFrameData.frameDelay});
-		}
-		return {frameList};
 	}
 }
 


### PR DESCRIPTION
Convert `AnimationFile` from `struct` to `class` and use new methods to construct `AnimationSequence` instances.

Related:
- Issue #991
- PR #1347
- PR #1353
