### PR TITLE
Update `AnimatedImage` - New methods, `const` correctness

### DIFF
--- a/NAS2D/Resource/AnimatedImage.cpp
+++ b/NAS2D/Resource/AnimatedImage.cpp
@@ -66,13 +66,13 @@ void AnimatedImage::advanceFrame()
 }
 
 
-void AnimatedImage::draw(Renderer& renderer, Point<int> position)
+void AnimatedImage::draw(Renderer& renderer, Point<int> position) const
 {
 	draw(renderer, position, Color::White);
 }
 
 
-void AnimatedImage::draw(Renderer& renderer, Point<int> position, Color tintColor)
+void AnimatedImage::draw(Renderer& renderer, Point<int> position, Color tintColor) const
 {
 	const auto& frame = mAnimationSequence->frame(mFrameIndex);
 	const auto drawPosition = position - frame.anchorOffset;
@@ -81,7 +81,7 @@ void AnimatedImage::draw(Renderer& renderer, Point<int> position, Color tintColo
 }
 
 
-void AnimatedImage::draw(Renderer& renderer, Point<int> position, Color tintColor, Angle rotation)
+void AnimatedImage::draw(Renderer& renderer, Point<int> position, Color tintColor, Angle rotation) const
 {
 	const auto& frame = mAnimationSequence->frame(mFrameIndex);
 	const auto drawPosition = position - frame.anchorOffset;

--- a/NAS2D/Resource/AnimatedImage.cpp
+++ b/NAS2D/Resource/AnimatedImage.cpp
@@ -24,6 +24,18 @@ AnimatedImage::AnimatedImage(const AnimationSequence& animationSequence) :
 }
 
 
+const AnimationSequence& AnimatedImage::sequence() const
+{
+	return *mAnimationSequence;
+}
+
+
+const AnimationFrame& AnimatedImage::frame() const
+{
+	return mAnimationSequence->frame(mFrameIndex);
+}
+
+
 std::size_t AnimatedImage::frameCount() const
 {
 	return mAnimationSequence->frameCount();

--- a/NAS2D/Resource/AnimatedImage.cpp
+++ b/NAS2D/Resource/AnimatedImage.cpp
@@ -48,6 +48,12 @@ std::size_t AnimatedImage::frameIndex() const
 }
 
 
+void AnimatedImage::setFrame(std::size_t frameIndex)
+{
+	mFrameIndex = frameIndex % mAnimationSequence->frameCount();
+}
+
+
 void AnimatedImage::advanceFrame()
 {
 	if (mAnimationSequence->frame(mFrameIndex).isStopFrame()) { return; }

--- a/NAS2D/Resource/AnimatedImage.h
+++ b/NAS2D/Resource/AnimatedImage.h
@@ -24,6 +24,7 @@ namespace NAS2D
 		std::size_t frameCount() const;
 		std::size_t frameIndex() const;
 
+		void setFrame(std::size_t frameIndex);
 		void advanceFrame();
 		void draw(Renderer& renderer, Point<int> position);
 		void draw(Renderer& renderer, Point<int> position, Color tintColor);

--- a/NAS2D/Resource/AnimatedImage.h
+++ b/NAS2D/Resource/AnimatedImage.h
@@ -17,9 +17,6 @@ namespace NAS2D
 	public:
 		explicit AnimatedImage(const AnimationSequence& animationSequence);
 
-		AnimatedImage(const AnimatedImage&) = default;
-		AnimatedImage& operator=(const AnimatedImage&) = default;
-
 		std::size_t frameCount() const;
 		std::size_t frameIndex() const;
 

--- a/NAS2D/Resource/AnimatedImage.h
+++ b/NAS2D/Resource/AnimatedImage.h
@@ -6,6 +6,7 @@
 namespace NAS2D
 {
 	struct Color;
+	struct AnimationFrame;
 	class AnimationSequence;
 	class Renderer;
 	class Angle;
@@ -16,6 +17,9 @@ namespace NAS2D
 	{
 	public:
 		explicit AnimatedImage(const AnimationSequence& animationSequence);
+
+		const AnimationSequence& sequence() const;
+		const AnimationFrame& frame() const;
 
 		std::size_t frameCount() const;
 		std::size_t frameIndex() const;

--- a/NAS2D/Resource/AnimatedImage.h
+++ b/NAS2D/Resource/AnimatedImage.h
@@ -26,9 +26,10 @@ namespace NAS2D
 
 		void setFrame(std::size_t frameIndex);
 		void advanceFrame();
-		void draw(Renderer& renderer, Point<int> position);
-		void draw(Renderer& renderer, Point<int> position, Color tintColor);
-		void draw(Renderer& renderer, Point<int> position, Color tintColor, Angle rotation);
+
+		void draw(Renderer& renderer, Point<int> position) const;
+		void draw(Renderer& renderer, Point<int> position, Color tintColor) const;
+		void draw(Renderer& renderer, Point<int> position, Color tintColor, Angle rotation) const;
 
 	private:
 		const AnimationSequence* mAnimationSequence;

--- a/test/Resource/AnimatedImage.test.cpp
+++ b/test/Resource/AnimatedImage.test.cpp
@@ -56,3 +56,17 @@ TEST(AnimatedImage, animateFrameFrameStop) {
 	animatedImage.advanceFrame();
 	EXPECT_EQ(1, animatedImage.frameIndex());
 }
+
+TEST(AnimatedImage, setFrame) {
+	auto animatedImage = NAS2D::AnimatedImage{sequenceFrameFrameLoop};
+	animatedImage.setFrame(0);
+	EXPECT_EQ(0, animatedImage.frameIndex());
+	animatedImage.setFrame(1);
+	EXPECT_EQ(1, animatedImage.frameIndex());
+}
+
+TEST(AnimatedImage, setFrameWrap) {
+	auto animatedImage = NAS2D::AnimatedImage{sequenceFrameFrameLoop};
+	animatedImage.setFrame(2);
+	EXPECT_EQ(0, animatedImage.frameIndex());
+}


### PR DESCRIPTION
A few extensions and fixes for the recently added `AnimatedImage` class.
- Remove explicit `default` of copy operations
- Add accessor methods for `AnimationSequence` and `AnimationFrame`
- Add setter method for the frame index
- Mark `draw` methods as `const`

----

Related:
- Issue #991
- PR #1357
