### PR TITLE
Convert `Sprite` to use `AnimatedImage`

### DIFF
--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -93,13 +93,13 @@ void Sprite::update()
 }
 
 
-void Sprite::draw(Point<float> position) const
+void Sprite::draw(Point<int> position) const
 {
 	mAnimatedImage.draw(Utility<Renderer>::get(), position, mTintColor);
 }
 
 
-void Sprite::draw(Point<float> position, Angle rotation) const
+void Sprite::draw(Point<int> position, Angle rotation) const
 {
 	mAnimatedImage.draw(Utility<Renderer>::get(), position, mTintColor, rotation);
 }

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "AnimatedImage.h"
 #include "../Timer.h"
 #include "../Renderer/Color.h"
 
@@ -20,7 +21,6 @@
 namespace NAS2D
 {
 	struct Duration;
-	class AnimationSequence;
 	class AnimationSet;
 	class Angle;
 	template <typename BaseType> struct Point;
@@ -66,8 +66,7 @@ namespace NAS2D
 
 	private:
 		const AnimationSet& mAnimationSet;
-		const AnimationSequence* mCurrentAction;
-		std::size_t mCurrentFrame;
+		AnimatedImage mAnimatedImage;
 
 		bool mPaused;
 		Timer mTimer;

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -53,8 +53,8 @@ namespace NAS2D
 		void setFrame(std::size_t frameIndex);
 
 		void update();
-		void draw(Point<float> position) const;
-		void draw(Point<float> position, Angle rotation) const;
+		void draw(Point<int> position) const;
+		void draw(Point<int> position, Angle rotation) const;
 
 		void alpha(uint8_t alpha);
 		uint8_t alpha() const;

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -14,7 +14,6 @@
 #include "../Timer.h"
 #include "../Renderer/Color.h"
 
-#include <vector>
 #include <string>
 
 


### PR DESCRIPTION
Might as well make use of the new `AnimatedImage` class to within `Sprite` and reduce some of the code duplication between them.

This conversion revealed the `const` correctness issue and need for additional methods that was fixed in the followup PR after `AnimatedImage` was added.

The removal of `<vector>` from the `Sprite` header will need downstream changes due to careless use of transitive includes.

Related:
- Issue #991
- PR #1358
- PR #1357
