### PR TITLE
Update `makefile` rule for `cppinclude`

### DIFF
--- a/makefile
+++ b/makefile
@@ -237,6 +237,10 @@ cppclean:
 
 .PHONY: cppinclude
 cppinclude:
+	cppinclude --show_details=false --report_limit=30
+
+.PHONY: cppinclude-detailed
+cppinclude-detailed:
 	cppinclude
 
 .PHONY: format


### PR DESCRIPTION
Show less detailed summary by default.

Related:
- PR https://github.com/OutpostUniverse/OPHD/pull/2043
