### PR TITLE
Add `AnimatedImage::advanceFrame` overload with `Duration`

### DIFF
--- a/NAS2D/Resource/AnimatedImage.cpp
+++ b/NAS2D/Resource/AnimatedImage.cpp
@@ -2,6 +2,7 @@
 
 #include "AnimationSequence.h"
 #include "AnimationFrame.h"
+#include "../Duration.h"
 #include "../Math/Point.h"
 #include "../Math/Angle.h"
 #include "../Renderer/Color.h"
@@ -62,6 +63,32 @@ void AnimatedImage::advanceFrame()
 	if (mFrameIndex >= mAnimationSequence->frameCount())
 	{
 		mFrameIndex = 0;
+	}
+}
+
+
+// Returns the `Duration` consumed by advancing frames
+// The final frame may be part way through it's `Duration` so does not consume it
+Duration AnimatedImage::advanceFrame(Duration timeDelta)
+{
+	Duration accumulator{0};
+
+	for (;;)
+	{
+		const auto& frame = this->frame();
+
+		if (frame.isStopFrame())
+		{
+			return accumulator;
+		}
+
+		if (timeDelta - accumulator < frame.frameDelay)
+		{
+			return accumulator;
+		}
+
+		accumulator += frame.frameDelay;
+		advanceFrame();
 	}
 }
 

--- a/NAS2D/Resource/AnimatedImage.h
+++ b/NAS2D/Resource/AnimatedImage.h
@@ -6,6 +6,7 @@
 namespace NAS2D
 {
 	struct Color;
+	struct Duration;
 	struct AnimationFrame;
 	class AnimationSequence;
 	class Renderer;
@@ -26,6 +27,7 @@ namespace NAS2D
 
 		void setFrame(std::size_t frameIndex);
 		void advanceFrame();
+		Duration advanceFrame(Duration timeDelta);
 
 		void draw(Renderer& renderer, Point<int> position) const;
 		void draw(Renderer& renderer, Point<int> position, Color tintColor) const;

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -89,6 +89,7 @@ void Sprite::setFrame(std::size_t frameIndex)
 
 void Sprite::update()
 {
+	if (mPaused) { return; }
 	mTimer.adjustStartTick(advanceByTimeDelta(mTimer.elapsedTicks()));
 }
 
@@ -133,18 +134,12 @@ Duration Sprite::advanceByTimeDelta(Duration timeDelta)
 {
 	Duration accumulator{0};
 
-	if (mPaused)
-	{
-		return accumulator;
-	}
-
 	for (;;)
 	{
 		const auto& frame = mAnimatedImage.frame();
 
 		if (frame.isStopFrame())
 		{
-			mPaused = true;
 			return accumulator;
 		}
 

--- a/NAS2D/Resource/Sprite.cpp
+++ b/NAS2D/Resource/Sprite.cpp
@@ -90,7 +90,7 @@ void Sprite::setFrame(std::size_t frameIndex)
 void Sprite::update()
 {
 	if (mPaused) { return; }
-	mTimer.adjustStartTick(advanceByTimeDelta(mTimer.elapsedTicks()));
+	mTimer.adjustStartTick(mAnimatedImage.advanceFrame(mTimer.elapsedTicks()));
 }
 
 
@@ -127,28 +127,4 @@ void Sprite::color(Color color)
 Color Sprite::color() const
 {
 	return mTintColor;
-}
-
-
-Duration Sprite::advanceByTimeDelta(Duration timeDelta)
-{
-	Duration accumulator{0};
-
-	for (;;)
-	{
-		const auto& frame = mAnimatedImage.frame();
-
-		if (frame.isStopFrame())
-		{
-			return accumulator;
-		}
-
-		if (timeDelta - accumulator < frame.frameDelay)
-		{
-			return accumulator;
-		}
-
-		accumulator += frame.frameDelay;
-		mAnimatedImage.advanceFrame();
-	}
 }

--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -60,9 +60,6 @@ namespace NAS2D
 		void color(Color color);
 		Color color() const;
 
-	protected:
-		Duration advanceByTimeDelta(Duration timeDelta);
-
 	private:
 		const AnimationSet& mAnimationSet;
 		AnimatedImage mAnimatedImage;

--- a/test/Resource/AnimatedImage.test.cpp
+++ b/test/Resource/AnimatedImage.test.cpp
@@ -70,3 +70,12 @@ TEST(AnimatedImage, setFrameWrap) {
 	animatedImage.setFrame(2);
 	EXPECT_EQ(0, animatedImage.frameIndex());
 }
+
+TEST(AnimatedImage, advanceFrameTimeDelta) {
+	auto animatedImage = NAS2D::AnimatedImage{sequenceFrameFrameLoop};
+	EXPECT_EQ(NAS2D::Duration{0u}, animatedImage.advanceFrame(NAS2D::Duration{0u}));
+	EXPECT_EQ(NAS2D::Duration{0u}, animatedImage.advanceFrame(NAS2D::Duration{1u}));
+	EXPECT_EQ(NAS2D::Duration{2u}, animatedImage.advanceFrame(NAS2D::Duration{2u}));
+	EXPECT_EQ(NAS2D::Duration{2u}, animatedImage.advanceFrame(NAS2D::Duration{3u}));
+	EXPECT_EQ(NAS2D::Duration{4u}, animatedImage.advanceFrame(NAS2D::Duration{4u}));
+}

--- a/test/Resource/Sprite.test.cpp
+++ b/test/Resource/Sprite.test.cpp
@@ -13,16 +13,6 @@
 namespace {
 	class Sprite : public ::testing::Test {
 	protected:
-		// Use a derived class to access protected methods
-		class SpriteDerived : public NAS2D::Sprite {
-		public:
-			SpriteDerived(const NAS2D::AnimationSet& animationSet, const std::string& initialAction) :
-				Sprite{animationSet, initialAction}
-			{}
-			// Re-export protected method as public
-			using Sprite::advanceByTimeDelta;
-		};
-
 		static constexpr NAS2D::Vector imageSize{1, 1};
 		static constexpr NAS2D::Rectangle imageRect{{0, 0}, imageSize};
 		static constexpr NAS2D::Vector anchorOffset{0, 0};
@@ -31,7 +21,7 @@ namespace {
 		NAS2D::AnimationFrame frame{image, imageRect, anchorOffset, {2}};
 		NAS2D::AnimationFrame frameStop{image, imageRect, anchorOffset, {0}};
 		NAS2D::AnimationSet testAnimationSet{{{"defaultAction", {{frame}}}, {"frameStopAction", {{frameStop}}}}};
-		SpriteDerived sprite{testAnimationSet, "defaultAction"};
+		NAS2D::Sprite sprite{testAnimationSet, "defaultAction"};
 	};
 }
 
@@ -47,12 +37,4 @@ TEST_F(Sprite, isPaused) {
 TEST_F(Sprite, isPausedStopAnimation) {
 	sprite.play("frameStopAction");
 	EXPECT_TRUE(sprite.isPaused());
-}
-
-TEST_F(Sprite, advanceByTimeDelta) {
-	EXPECT_EQ(NAS2D::Duration{0u}, sprite.advanceByTimeDelta(NAS2D::Duration{0u}));
-	EXPECT_EQ(NAS2D::Duration{0u}, sprite.advanceByTimeDelta(NAS2D::Duration{1u}));
-	EXPECT_EQ(NAS2D::Duration{2u}, sprite.advanceByTimeDelta(NAS2D::Duration{2u}));
-	EXPECT_EQ(NAS2D::Duration{2u}, sprite.advanceByTimeDelta(NAS2D::Duration{3u}));
-	EXPECT_EQ(NAS2D::Duration{4u}, sprite.advanceByTimeDelta(NAS2D::Duration{4u}));
 }


### PR DESCRIPTION
Add `AnimatedImage::advanceFrame` overload with `Duration` parameter, and use it to replace `Sprite::advanceByTimeDelta`.

Related:
- Issue #991
- PR #1359
