### PR TITLE
Rename method to `Window::windowIcon`

### DIFF
--- a/NAS2D/Renderer/Window.cpp
+++ b/NAS2D/Renderer/Window.cpp
@@ -194,7 +194,7 @@ DisplayDesc Window::getClosestMatchingDisplayMode(const DisplayDesc& preferredDi
 }
 
 
-void Window::window_icon(const std::string& path)
+void Window::windowIcon(const std::string& path)
 {
 	auto iconData = Utility<Filesystem>::get().readFile(VirtualPath{path});
 	SDL_Surface* icon = IMG_Load_RW(SDL_RWFromConstMem(iconData.c_str(), static_cast<int>(iconData.size())), 1);

--- a/NAS2D/Renderer/Window.h
+++ b/NAS2D/Renderer/Window.h
@@ -41,7 +41,7 @@ namespace NAS2D
 		const std::string& title() const;
 		void title(const std::string& title);
 
-		virtual void window_icon(const std::string& path);
+		virtual void windowIcon(const std::string& path);
 
 		virtual void showSystemPointer(bool);
 		virtual void addCursor(CursorId cursorId, const std::string& filePath, Vector<int> hotOffset);


### PR DESCRIPTION
Remove underscore and use camelCase to be consistent with all the other methods.
