### PR TITLE
Use lowerCamelCase for `receiveCopy` in `Delegate` unit test

### DIFF
--- a/test/Signal/Delegate.test.cpp
+++ b/test/Signal/Delegate.test.cpp
@@ -80,11 +80,11 @@ TEST(Delegate, ForwardWithoutCopy) {
 	};
 
 	struct CopyReceiver {
-		int ReceiveCopy(CopyCounter copyCounter) { return copyCounter.numCopies; }
+		int receiveCopy(CopyCounter copyCounter) { return copyCounter.numCopies; }
 	};
 
 	CopyReceiver copyReceiver;
-	auto delegate = NAS2D::Delegate{&copyReceiver, &CopyReceiver::ReceiveCopy};
+	auto delegate = NAS2D::Delegate{&copyReceiver, &CopyReceiver::receiveCopy};
 
 	CopyCounter copyCounter;
 	EXPECT_EQ(1, delegate(copyCounter));


### PR DESCRIPTION
Small correction to previous PR.

Related:
- PR #1368
- Issue #1366
