### PR TITLE
Decouple `AnimationFile` from `ResourceCache`

### DIFF
--- a/NAS2D/Resource/AnimationFile.cpp
+++ b/NAS2D/Resource/AnimationFile.cpp
@@ -4,7 +4,6 @@
 #include "AnimationFrame.h"
 #include "AnimationSequence.h"
 #include "Image.h"
-#include "ResourceCache.h"
 
 #include "../Utility.h"
 #include "../Filesystem.h"
@@ -12,6 +11,7 @@
 #include "../Xml/XmlNode.h"
 #include "../Xml/XmlElement.h"
 #include "../Xml/XmlDocument.h"
+#include "../Signal/Delegate.h"
 
 #include <utility>
 #include <stdexcept>
@@ -257,7 +257,7 @@ const std::string& AnimationFile::actionName(std::size_t index) const
 }
 
 
-AnimationSequence AnimationFile::animationSequence(std::size_t actionIndex, ImageCache& imageCache) const
+AnimationSequence AnimationFile::animationSequence(std::size_t actionIndex, ImageLoader& imageLoader) const
 {
 	const auto& action = mActions.at(actionIndex);
 	if (action.frames.empty())
@@ -269,7 +269,7 @@ AnimationSequence AnimationFile::animationSequence(std::size_t actionIndex, Imag
 	for (const auto& animationFrameData : action.frames)
 	{
 		const auto imageSheetIndex = imageSheetReferenceIndex(animationFrameData.id);
-		const auto& image = imageCache.load(mBasePath + mImageSheetReferences[imageSheetIndex].filePath);
+		const auto& image = imageLoader(mBasePath + mImageSheetReferences[imageSheetIndex].filePath);
 
 		const auto imageRect = Rectangle{{0, 0}, image.size()};
 		if (!imageRect.contains(animationFrameData.imageBounds))

--- a/NAS2D/Resource/AnimationFile.h
+++ b/NAS2D/Resource/AnimationFile.h
@@ -12,8 +12,8 @@ namespace NAS2D
 	struct AnimationFileData;
 	class AnimationSequence;
 	class Image;
-	template <typename Resource, typename... Params> class ResourceCache;
-	using ImageCache = ResourceCache<Image, std::string>;
+	template <typename Signature> class Delegate;
+	using ImageLoader = Delegate<const Image&(std::string filePath)>;
 
 
 	class AnimationFile
@@ -39,7 +39,7 @@ namespace NAS2D
 		const AnimationAction& action(std::size_t index) const;
 		const std::string& actionName(std::size_t index) const;
 
-		AnimationSequence animationSequence(std::size_t actionIndex, ImageCache& imageCache) const;
+		AnimationSequence animationSequence(std::size_t actionIndex, ImageLoader& imageLoader) const;
 
 	private:
 		std::string mBasePath;


### PR DESCRIPTION
Use a `Delegate` to decouple `AnimationFile` from `ResourceCache`.

This enables loading images using an alternate source. It also isolates `AnimationFile` from the details of `ResourceCache`. In particular, `AnimationFile` no longer depends on a specific template instantiation of `ResourceCache`, which may matter if factory functions get included in the `ResourceCache` type information.

Related:
- Issue #972
- Issue #1366
- Issue #991
