### PR TITLE
Add MacOS specific header paths to `cppinclude` ignore set

### DIFF
--- a/.cppinclude.json
+++ b/.cppinclude.json
@@ -2,5 +2,5 @@
 	"project_dir": "NAS2D",
 	"include_dirs": ["/usr/include"],
 	"ignore_dirs": [],
-	"ignore_files": ["windows.h"]
+	"ignore_files": ["windows.h", "SDL2_image/SDL_image.h", "SDL2_mixer/SDL_mixer.h", "SDL2_ttf/SDL_ttf.h", "GLEW/GLEW.h"]
 }


### PR DESCRIPTION
The `cppinclude` utility ignores the `#define` guards around the MacOS includes, and reports the `#include` headers from within as unresolved (on Linux). Since `cppinclude` is mainly being used from Linux, it's perhaps easiest to just ignore the MacOS specific paths. We are already ignoring the Windows specific header `windows.h`.

Example warning from before this change:

> Unresolved files:
> 1 : "SDL2_image/SDL_image.h" isn't resolved
> 2 : "GLEW/GLEW.h" isn't resolved
> 3 : "SDL2_mixer/SDL_mixer.h" isn't resolved
> 4 : "SDL2_ttf/SDL_ttf.h" isn't resolved

Related:
- Issue #1245
