### PR TITLE
Add custom `forward` implementation

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -257,6 +257,7 @@
     <ClInclude Include="Resource\Sprite.h" />
     <ClInclude Include="Signal/SignalConnection.h" />
     <ClInclude Include="Signal/Delegate.h" />
+    <ClInclude Include="Signal/Forward.h" />
     <ClInclude Include="Signal/Signal.h" />
     <ClInclude Include="Signal/SignalSource.h" />
     <ClInclude Include="State.h" />

--- a/NAS2D/NAS2D.vcxproj.filters
+++ b/NAS2D/NAS2D.vcxproj.filters
@@ -371,6 +371,9 @@
     <ClInclude Include="Signal/Delegate.h">
       <Filter>Header Files\Signal</Filter>
     </ClInclude>
+    <ClInclude Include="Signal/Forward.h">
+      <Filter>Header Files\Signal</Filter>
+    </ClInclude>
     <ClInclude Include="Signal/Signal.h">
       <Filter>Header Files\Signal</Filter>
     </ClInclude>

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -24,8 +24,9 @@
 
 #pragma once
 
+#include "Forward.h"
+
 #include <cstring>
-#include <utility>
 
 
 // Compiler identification. It's not easy to identify Visual C++ because many vendors
@@ -409,7 +410,7 @@ namespace NAS2D
 
 		RetType operator()(Params... params) const
 		{
-			return (m_Closure.GetClosureThis()->*(m_Closure.GetClosureMemPtr()))(std::forward<Params>(params)...);
+			return (m_Closure.GetClosureThis()->*(m_Closure.GetClosureMemPtr()))(NAS2D::forward<Params>(params)...);
 		}
 
 	private:
@@ -435,7 +436,7 @@ namespace NAS2D
 	private:
 		RetType InvokeStaticFunction(Params... params) const
 		{
-			return (*(m_Closure.GetStaticFunction()))(std::forward<Params>(params)...);
+			return (*(m_Closure.GetStaticFunction()))(NAS2D::forward<Params>(params)...);
 		}
 	};
 

--- a/NAS2D/Signal/Forward.h
+++ b/NAS2D/Signal/Forward.h
@@ -1,0 +1,25 @@
+#pragma once
+
+
+namespace NAS2D
+{
+	template <typename T> inline constexpr bool isLvalueRef = false;
+	template <typename T> inline constexpr bool isLvalueRef<T&> = true;
+
+
+	template <typename T> struct removeReference { using type = T; };
+	template <typename T> struct removeReference<T&> { using type = T; };
+	template <typename T> struct removeReference<T&&> { using type = T; };
+
+
+	template <typename T> [[nodiscard]] inline constexpr T&& forward(typename removeReference<T>::type& value) noexcept
+	{
+		return static_cast<T&&>(value);
+	}
+
+	template <typename T> [[nodiscard]] inline constexpr T&& forward(typename removeReference<T>::type&& value) noexcept
+	{
+		static_assert(!isLvalueRef<T>, "Bad use of foward to convert rvalue to lvalue");
+		return static_cast<T&&>(value);
+	}
+}

--- a/NAS2D/Utility.h
+++ b/NAS2D/Utility.h
@@ -9,8 +9,9 @@
 // ==================================================================================
 #pragma once
 
+#include "Signal/Forward.h"
+
 #include <memory>
-#include <utility>
 #include <type_traits>
 #include <stdexcept>
 
@@ -131,7 +132,7 @@ namespace NAS2D
 		template <typename Type = T, typename... Args>
 		static Type& init(Args&&... args)
 		{
-			auto newInstance = std::make_unique<Type>(std::forward<Args>(args)...);
+			auto newInstance = std::make_unique<Type>(NAS2D::forward<Args>(args)...);
 			// The new instance may be a sub-type of T, so return as sub-type
 			auto typedNewInstance = newInstance.release();
 			mInstance.reset(typedNewInstance);


### PR DESCRIPTION
A custom implementation means we can include a file with about 25 lines, rather than `<utility>` which brings in over 4,000 lines.

Related:
- Issue #1366
- Issue #1245
