### PR TITLE
Remove `make package` step for Arch Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,6 @@ jobs:
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" test
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" check
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" demoGraphics
-    - run: make package
 
   linux-arm:
     runs-on: ubuntu-24.04-arm


### PR DESCRIPTION
We don't provide any release packages for Linux, and doing this for every run is probably just a waste of time.
