### PR TITLE
Remove Codacy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/lairworks/nas2d-core?branch=master&svg=true)](https://ci.appveyor.com/project/OPU/nas2d-core)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/lairworks/nas2d-core/tree/main.svg?style=shield )](https://dl.circleci.com/status-badge/redirect/gh/lairworks/nas2d-core/tree/main)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/5537c92504e84f1499c99396713cbd86)](https://app.codacy.com/gh/lairworks/nas2d-core/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 *NAS2D* is an open source, object oriented 2D game development framework written in portable C++. It was designed to make the development of games and other applications that needed a 2D interface easier by providing a high-level interface. It handles the low-level tasks of setting up the video display, input, sound mixing, file loading, etc.
 


### PR DESCRIPTION
We stopped building with Codacy a little while ago. The badge no longer shows up properly. Hence why we should remove it.
