### PR TITLE
Update `Package.bat` for recent build folder change

### DIFF
--- a/Package.bat
+++ b/Package.bat
@@ -8,7 +8,7 @@ set "ProjectName=NAS2D"
 set "OutputFolder=.build\"
 set "PackageFolder=%OutputFolder%Package\"
 
-if "%TargetPath%" == "" (set "TargetPath=%OutputFolder%%Configuration%_%Platform%_%ProjectName%\%ProjectName%.lib")
+if "%TargetPath%" == "" (set "TargetPath=%OutputFolder%%Configuration%_%Platform%\%ProjectName%\%ProjectName%.lib")
 
 for /f %%i in ('git describe --tags --dirty') do set Version=%%i
 


### PR DESCRIPTION
Small fix for recent change in PR #1389.

Looks like restoring the incremental build cache allowed the workflow runs of the previous PR to succeed, though once merged to `main` a fresh build is done, which revealed the problem.

Related:
- PR #1389
- Issue #1385
