### PR TITLE
Set `mForceStopAudio` default to `false`

### DIFF
--- a/NAS2D/StateManager.h
+++ b/NAS2D/StateManager.h
@@ -43,6 +43,6 @@ namespace NAS2D
 
 		std::unique_ptr<State> mActiveState;
 		bool mActive;
-		bool mForceStopAudio = true;
+		bool mForceStopAudio = false;
 	};
 }


### PR DESCRIPTION
This feature is likely to be removed. For now, set the default so this feature is not used unless explicitly requested.

Related:
- Issue #1388
