### PR TITLE
Move template methods out of `ParserHelper.h`

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -14,11 +14,68 @@
 #include "Filesystem.h"
 #include "Utility.h"
 
+#include "Xml/XmlDocument.h"
+#include "Xml/XmlMemoryBuffer.h"
+#include "Xml/XmlComment.h"
+#include "Xml/XmlElement.h"
+
 #include <algorithm>
 #include <utility>
 #include <stdexcept>
 
+
 using namespace NAS2D;
+
+
+namespace
+{
+	template <typename ReturnType, ReturnType fileFormatParser(const Xml::XmlElement& element) = subTagsToDictionaryMap>
+	auto parseXmlFileData(const std::string& xmlString, const std::string& sectionName = "", const std::string& requiredVersion = "")
+	{
+		Xml::XmlDocument xmlDocument;
+		xmlDocument.parse(xmlString.c_str());
+
+		if (xmlDocument.error())
+		{
+			throw std::runtime_error("Error parsing XML file on (Row " + std::to_string(xmlDocument.errorRow()) + ", Column " + std::to_string(xmlDocument.errorCol()) + "): " + xmlDocument.errorDesc());
+		}
+
+		auto* root = !sectionName.empty() ? xmlDocument.firstChildElement(sectionName) : xmlDocument.rootElement();
+		if (!root)
+		{
+			throw std::runtime_error("XML file does not contain tag: " + (!sectionName.empty() ? sectionName : "(root element)"));
+		}
+
+		if (!requiredVersion.empty())
+		{
+			const auto actualVersion = root->attribute("version");
+			if (actualVersion != requiredVersion)
+			{
+				throw std::runtime_error("Version mismatch. Expected: " + std::string{requiredVersion} + " Actual: " + actualVersion);
+			}
+		}
+
+		return fileFormatParser(*root);
+	}
+
+	template <typename Data, Xml::XmlElement* dataFormatter(const std::string& tagName, const Data& data) = dictionaryMapToElement>
+	std::string formatXmlData(const Data& data, const std::string& tagName, const std::string& comment = "")
+	{
+		Xml::XmlDocument doc;
+
+		if (!comment.empty())
+		{
+			doc.linkEndChild(new Xml::XmlComment(comment));
+		}
+		doc.linkEndChild(dataFormatter(tagName, data));
+
+		// Write out the XML file.
+		Xml::XmlMemoryBuffer buff;
+		doc.accept(&buff);
+
+		return buff.buffer();
+	}
+}
 
 
 Configuration::Configuration(std::map<std::string, Dictionary> defaults) :

--- a/NAS2D/ParserHelper.cpp
+++ b/NAS2D/ParserHelper.cpp
@@ -14,6 +14,9 @@
 #include "ContainerUtils.h"
 
 #include "Xml/XmlNode.h"
+#include "Xml/XmlElement.h"
+
+#include <stdexcept>
 
 
 namespace NAS2D

--- a/NAS2D/ParserHelper.h
+++ b/NAS2D/ParserHelper.h
@@ -11,19 +11,20 @@
 #pragma once
 
 #include "Dictionary.h"
-#include "Xml/XmlDocument.h"
-#include "Xml/XmlMemoryBuffer.h"
-#include "Xml/XmlComment.h"
-#include "Xml/XmlElement.h"
 
 #include <string>
 #include <vector>
 #include <map>
-#include <stdexcept>
 
 
 namespace NAS2D
 {
+	namespace Xml
+	{
+		class XmlElement;
+	}
+
+
 	void reportMissingOrUnexpected(const std::vector<std::string>& missing, const std::vector<std::string>& unexpected);
 	void reportMissingOrUnexpected(const std::vector<std::string>& names, const std::vector<std::string>& required, const std::vector<std::string>& optional);
 
@@ -32,51 +33,4 @@ namespace NAS2D
 
 	Xml::XmlElement* dictionaryToAttributes(const std::string& tagName, const Dictionary& dictionary);
 	Xml::XmlElement* dictionaryMapToElement(const std::string& tagName, const std::map<std::string, Dictionary>& sections);
-
-	template <typename ReturnType, ReturnType fileFormatParser(const Xml::XmlElement& element) = subTagsToDictionaryMap>
-	auto parseXmlFileData(const std::string& xmlString, const std::string& sectionName = "", const std::string& requiredVersion = "")
-	{
-		Xml::XmlDocument xmlDocument;
-		xmlDocument.parse(xmlString.c_str());
-
-		if (xmlDocument.error())
-		{
-			throw std::runtime_error("Error parsing XML file on (Row " + std::to_string(xmlDocument.errorRow()) + ", Column " + std::to_string(xmlDocument.errorCol()) + "): " + xmlDocument.errorDesc());
-		}
-
-		auto* root = !sectionName.empty() ? xmlDocument.firstChildElement(sectionName) : xmlDocument.rootElement();
-		if (!root)
-		{
-			throw std::runtime_error("XML file does not contain tag: " + (!sectionName.empty() ? sectionName : "(root element)"));
-		}
-
-		if (!requiredVersion.empty())
-		{
-			const auto actualVersion = root->attribute("version");
-			if (actualVersion != requiredVersion)
-			{
-				throw std::runtime_error("Version mismatch. Expected: " + std::string{requiredVersion} + " Actual: " + actualVersion);
-			}
-		}
-
-		return fileFormatParser(*root);
-	}
-
-	template <typename Data, Xml::XmlElement* dataFormatter(const std::string& tagName, const Data& data) = dictionaryMapToElement>
-	std::string formatXmlData(const Data& data, const std::string& tagName, const std::string& comment = "")
-	{
-		Xml::XmlDocument doc;
-
-		if (!comment.empty())
-		{
-			doc.linkEndChild(new Xml::XmlComment(comment));
-		}
-		doc.linkEndChild(dataFormatter(tagName, data));
-
-		// Write out the XML file.
-		Xml::XmlMemoryBuffer buff;
-		doc.accept(&buff);
-
-		return buff.buffer();
-	}
 }


### PR DESCRIPTION
These templates methods are only used in `Configuration`. Further, we probably won't be pursuing more general use of these template methods, so it makes sense to limit their visibility. One issue with template methods is they are implemented in header files, and require those header files to include anything needed for the function implementation. The added transitive includes can have a negative impact on compile times.

Related:
- Issue #797
- Issue #1245
- PR https://github.com/OutpostUniverse/OPHD/pull/2170
