### PR TITLE
Remove config file comment

### DIFF
--- a/NAS2D/Configuration.cpp
+++ b/NAS2D/Configuration.cpp
@@ -16,7 +16,6 @@
 
 #include "Xml/XmlDocument.h"
 #include "Xml/XmlMemoryBuffer.h"
-#include "Xml/XmlComment.h"
 #include "Xml/XmlElement.h"
 
 #include <algorithm>
@@ -59,14 +58,10 @@ namespace
 	}
 
 	template <typename Data, Xml::XmlElement* dataFormatter(const std::string& tagName, const Data& data) = dictionaryMapToElement>
-	std::string formatXmlData(const Data& data, const std::string& tagName, const std::string& comment = "")
+	std::string formatXmlData(const Data& data, const std::string& tagName)
 	{
 		Xml::XmlDocument doc;
 
-		if (!comment.empty())
-		{
-			doc.linkEndChild(new Xml::XmlComment(comment));
-		}
 		doc.linkEndChild(dataFormatter(tagName, data));
 
 		// Write out the XML file.


### PR DESCRIPTION
The comment doesn't really say anything important. Further, if we switch to JSON, there isn't really a standard comment format in JSON, so not writing any comments would simplify such a transition.

Related:
- Issue #797
- Issue #1245
