### PR TITLE
Remove unused `Duration` forward declare from `Sprite`

### DIFF
--- a/NAS2D/Resource/Sprite.h
+++ b/NAS2D/Resource/Sprite.h
@@ -19,7 +19,6 @@
 
 namespace NAS2D
 {
-	struct Duration;
 	class AnimationSet;
 	class Angle;
 	template <typename BaseType> struct Point;


### PR DESCRIPTION
Due to API changes, `Duration` is no longer directly used by `Sprite`. These changes happened a little while ago, though the forward declaration was forgotten about.

Related:
- PR #1361
- Issue #991
