### PR TITLE
Use OpenGL Compatibility Profile instead of Core Profile

### DIFF
--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -607,7 +607,7 @@ void RendererOpenGL::initSdl(Vector<int> resolution, bool fullscreen)
 
 void RendererOpenGL::initSdlGL(bool vsync)
 {
-	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
 	SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 4);


### PR DESCRIPTION
The renderer currently uses legacy fixed-function OpenGL (glColor4ub, glPushMatrix, glVertexPointer, etc.) which requires Compatibility Profile.

Core Profile 3.2+ removed these functions, causing rendering failure on macOS which strictly enforces profile restrictions.

Further details about the issue, links to the documentation describing the deprecated function, etc, are described in OutpostUniverse/OPHD#2173.