### PR TITLE
Pass `Configuration` data explicitly in `Application` init

### DIFF
--- a/NAS2D/Application.cpp
+++ b/NAS2D/Application.cpp
@@ -91,11 +91,13 @@ Application::Application(const std::string& title, const std::string& appName, c
 
 	Utility<EventHandler>::get();
 
-	Utility<Renderer>::init<RendererOpenGL>(title);
+	const auto rendererOptions = RendererOpenGL::ReadConfigurationOptions(configuration);
+	Utility<Renderer>::init<RendererOpenGL>(title, rendererOptions);
 
 	try
 	{
-		Utility<Mixer>::init<MixerSDL>();
+		const auto mixerOptions = MixerSDL::InvalidToDefault(MixerSDL::ReadConfigurationOptions(configuration));
+		Utility<Mixer>::init<MixerSDL>(mixerOptions);
 	}
 	catch (std::exception& /*exception*/)
 	{


### PR DESCRIPTION
Avoid using the methods that need to use `Utility` internally to gain access to `Configuration` data.

Related:
- Issue #1305
- PR #1403
