### PR TITLE
Use explicit non-virtual calls from constructors

### DIFF
--- a/NAS2D/Mixer/MixerSDL.cpp
+++ b/NAS2D/Mixer/MixerSDL.cpp
@@ -125,8 +125,8 @@ MixerSDL::MixerSDL(const Options& options)
 		throw std::runtime_error(std::string{"Error opening audio mixer: "} + Mix_GetError());
 	}
 
-	soundVolume(options.sfxVolume);
-	musicVolume(options.musicVolume);
+	MixerSDL::soundVolume(options.sfxVolume);
+	MixerSDL::musicVolume(options.musicVolume);
 
 	musicFinished = Delegate{this, &MixerSDL::onMusicFinished};
 	Mix_HookMusicFinished(&::onMusicFinished);

--- a/NAS2D/Renderer/RendererOpenGL.cpp
+++ b/NAS2D/Renderer/RendererOpenGL.cpp
@@ -586,7 +586,7 @@ void RendererOpenGL::initGL()
 
 	glTexCoordPointer(2, GL_FLOAT, 0, DefaultTextureCoords.data());
 
-	onResize(size());
+	RendererOpenGL::onResize(size());
 }
 
 


### PR DESCRIPTION
Found using `cppcheck --enable=all`.

Related:
- PR #1406
- PR #1405
- Issue #528
