### PR TITLE
Improve re-run time of `cppcheck` make target

### DIFF
--- a/makefile
+++ b/makefile
@@ -227,9 +227,11 @@ show-warnings:
 .PHONY: lint
 lint: cppcheck cppclean cppinclude
 
+CppCheckBuildDir := $(ROOTBUILDDIR)/cppcheck
 .PHONY: cppcheck
 cppcheck:
-	cppcheck --quiet "$(SRCDIR)"
+	@mkdir -p "$(CppCheckBuildDir)"
+	cppcheck --cppcheck-build-dir="$(CppCheckBuildDir)" --quiet "$(SRCDIR)"
 
 .PHONY: cppclean
 cppclean:


### PR DESCRIPTION
Store analysis results in sub-folder of `.build` so re-runs are faster.

Related:
- PR #1405
- PR #1406
- PR #1407
- Issue #528
