### PR TITLE
Refactor delegate type conversion names

### DIFF
--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -41,7 +41,7 @@ namespace NAS2D
 	namespace detail
 	{
 		template <typename OutputType, typename InputType>
-		union horribleUnion
+		union HorribleUnion
 		{
 			OutputType out;
 			InputType in;
@@ -50,7 +50,7 @@ namespace NAS2D
 		template <typename OutputType, typename InputType>
 		inline OutputType horribleCast(const InputType input)
 		{
-			horribleUnion<OutputType, InputType> u;
+			HorribleUnion<OutputType, InputType> u;
 			static_assert(sizeof(InputType) == sizeof(u) && sizeof(InputType) == sizeof(OutputType), "Can't use horrible cast");
 			u.in = input;
 			return u.out;

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -43,8 +43,8 @@ namespace NAS2D
 		template <typename OutputType, typename InputType>
 		union HorribleUnion
 		{
-			OutputType out;
-			InputType in;
+			OutputType output;
+			InputType input;
 		};
 
 		template <typename OutputType, typename InputType>
@@ -52,8 +52,8 @@ namespace NAS2D
 		{
 			HorribleUnion<OutputType, InputType> u;
 			static_assert(sizeof(InputType) == sizeof(u) && sizeof(InputType) == sizeof(OutputType), "Can't use horrible cast");
-			u.in = input;
-			return u.out;
+			u.input = input;
+			return u.output;
 		}
 
 

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -40,18 +40,18 @@ namespace NAS2D
 {
 	namespace detail
 	{
-		template <typename OutputClass, typename InputClass>
+		template <typename OutputType, typename InputType>
 		union horribleUnion
 		{
-			OutputClass out;
-			InputClass in;
+			OutputType out;
+			InputType in;
 		};
 
-		template <typename OutputClass, typename InputClass>
-		inline OutputClass horribleCast(const InputClass input)
+		template <typename OutputType, typename InputType>
+		inline OutputType horribleCast(const InputType input)
 		{
-			horribleUnion<OutputClass, InputClass> u;
-			static_assert(sizeof(InputClass) == sizeof(u) && sizeof(InputClass) == sizeof(OutputClass), "Can't use horrible cast");
+			horribleUnion<OutputType, InputType> u;
+			static_assert(sizeof(InputType) == sizeof(u) && sizeof(InputType) == sizeof(OutputType), "Can't use horrible cast");
 			u.in = input;
 			return u.out;
 		}

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -48,7 +48,7 @@ namespace NAS2D
 		};
 
 		template <typename OutputClass, typename InputClass>
-		inline OutputClass horrible_cast(const InputClass input)
+		inline OutputClass horribleCast(const InputClass input)
 		{
 			horribleUnion<OutputClass, InputClass> u;
 			static_assert(sizeof(InputClass) == sizeof(u) && sizeof(InputClass) == sizeof(OutputClass), "Can't use horrible cast");
@@ -284,17 +284,17 @@ namespace NAS2D
 				{
 					bindMemFunc(targetObjectProxy, staticFunctionInvoker);
 				}
-				mTargetObject = horrible_cast<GenericClass*>(targetStaticFunction);
+				mTargetObject = horribleCast<GenericClass*>(targetStaticFunction);
 			}
 
 			inline StaticFuncPtr GetStaticFunction() const
 			{
-				return horrible_cast<StaticFuncPtr>(this);
+				return horribleCast<StaticFuncPtr>(this);
 			}
 
 			inline bool IsEqualToStaticFuncPtr(StaticFuncPtr funcptr) const
 			{
-				return (!funcptr) ? operator!() : (funcptr == horrible_cast<StaticFuncPtr>(mTargetObject));
+				return (!funcptr) ? operator!() : (funcptr == horribleCast<StaticFuncPtr>(mTargetObject));
 			}
 		};
 	}

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -50,10 +50,10 @@ namespace NAS2D
 		template <typename OutputType, typename InputType>
 		inline OutputType horribleCast(const InputType input)
 		{
-			HorribleUnion<OutputType, InputType> u;
-			static_assert(sizeof(InputType) == sizeof(u) && sizeof(InputType) == sizeof(OutputType), "Can't use horrible cast");
-			u.input = input;
-			return u.output;
+			HorribleUnion<OutputType, InputType> horribleUnion;
+			static_assert(sizeof(InputType) == sizeof(horribleUnion) && sizeof(InputType) == sizeof(OutputType), "Can't use horrible cast");
+			horribleUnion.input = input;
+			return horribleUnion.output;
 		}
 
 

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -41,7 +41,7 @@ namespace NAS2D
 	namespace detail
 	{
 		template <typename OutputClass, typename InputClass>
-		union horrible_union
+		union horribleUnion
 		{
 			OutputClass out;
 			InputClass in;
@@ -50,7 +50,7 @@ namespace NAS2D
 		template <typename OutputClass, typename InputClass>
 		inline OutputClass horrible_cast(const InputClass input)
 		{
-			horrible_union<OutputClass, InputClass> u;
+			horribleUnion<OutputClass, InputClass> u;
 			static_assert(sizeof(InputClass) == sizeof(u) && sizeof(InputClass) == sizeof(OutputClass), "Can't use horrible cast");
 			u.in = input;
 			return u.out;

--- a/NAS2D/Signal/Delegate.h
+++ b/NAS2D/Signal/Delegate.h
@@ -58,13 +58,13 @@ namespace NAS2D
 
 
 		template <typename GenericMemFuncType, typename XFuncType>
-		GenericMemFuncType CastMemFuncPtr(XFuncType function_to_bind)
+		GenericMemFuncType CastMemFuncPtr(XFuncType targetMemberFunction)
 		{
 #if __GNUC__
 	#pragma GCC diagnostic push
 	#pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
-			return reinterpret_cast<GenericMemFuncType>(function_to_bind);
+			return reinterpret_cast<GenericMemFuncType>(targetMemberFunction);
 #if __GNUC__
 	#pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
Use consistent naming style for helper functions used to cast function pointer types.

Related:
- Issue #1423
