### PR TITLE
Update GoogleMock macro usage

### DIFF
--- a/test/Signal/Delegate.test.cpp
+++ b/test/Signal/Delegate.test.cpp
@@ -12,8 +12,8 @@ namespace {
 
 	class MockHandler {
 	public:
-		MOCK_CONST_METHOD1(MockMethod, void(int value));
-		MOCK_CONST_METHOD1(MockMethod2, void(int value));
+		MOCK_METHOD(void, MockMethod, (int value), (const));
+		MOCK_METHOD(void, MockMethod2, (int value), (const));
 	};
 }
 

--- a/test/Signal/Signal.test.cpp
+++ b/test/Signal/Signal.test.cpp
@@ -7,7 +7,7 @@
 namespace {
 	class MockHandler {
 	public:
-		MOCK_CONST_METHOD0(MockMethod, void());
+		MOCK_METHOD(void, MockMethod, (), (const));
 	};
 
 	struct CopyCounter {

--- a/test/Signal/SignalConnection.test.cpp
+++ b/test/Signal/SignalConnection.test.cpp
@@ -8,7 +8,7 @@
 namespace {
 	class MockHandler {
 	public:
-		MOCK_CONST_METHOD0(MockMethod, void());
+		MOCK_METHOD(void, MockMethod, (), (const));
 	};
 }
 

--- a/test/Signal/SignalSource.test.cpp
+++ b/test/Signal/SignalSource.test.cpp
@@ -7,7 +7,7 @@
 namespace {
 	class MockHandler {
 	public:
-		MOCK_CONST_METHOD0(MockMethod, void());
+		MOCK_METHOD(void, MockMethod, (), (const));
 	};
 }
 


### PR DESCRIPTION
Use the newer `MOCK_METHOD` macro, rather than the older style `MOCK_CONST_METHOD1` macro.

As a bonus, this seems to have fixed the Clang warnings `-Wunused-member-function` that were generated by the older GoogleMock macros.

Related:
- Issue #1442
- Issue #528

Closes #1442
