### PR TITLE
Update GitHub actions for `Node.js` 20 deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.3.2
+      uses: microsoft/setup-msbuild@v3
 
     - name: Integrate vcpkg
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       VcpkgManifestInstall: false
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.3.2
@@ -113,7 +113,7 @@ jobs:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" test
@@ -126,7 +126,7 @@ jobs:
     steps:
     - run: sudo apt update && sudo apt --yes install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev libgtest-dev libgmock-dev
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         vcpkg integrate install
 
     - name: Restore vcpkg dependency cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       id: cacheRestoreVcpkg
       with:
         path: vcpkg_installed
@@ -42,14 +42,14 @@ jobs:
         msbuild . /target:VcpkgInstallManifestDependencies
 
     - name: Save vcpkg dependency cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       if: steps.cacheRestoreVcpkg.outputs.cache-hit != 'true'
       with:
         path: vcpkg_installed
         key: ${{ steps.cacheRestoreVcpkg.outputs.cache-primary-key }}
 
     - name: Restore incremental build cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
       with:
         path: .build
@@ -90,7 +90,7 @@ jobs:
         msbuild . /maxCpuCount /warnAsError /property:RunCodeAnalysis=true
 
     - name: Save incremental build cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: .build
         key: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ github.sha }}

--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -27,7 +27,7 @@ jobs:
       defaultBranch: ${{ github.event.repository.default_branch }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fetch default branch
         run: |


### PR DESCRIPTION
This should address the warnings on the run summary page:
> Node.js 20 actions are deprecated.

----

Noticed these warnings while looking into compiler warning flags.

Related:
- Issue #528
