### PR TITLE
Add MSVC CI `Debug` build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       run: ../.build/${{env.Configuration}}_${{env.Platform}}_test/test.exe
 
     - name: Package
-      run: ./Package.bat "${{env.Configuration}}" "${{matrix.platform}}"
+      run: ./Package.bat "${{env.Configuration}}" "${{env.Platform}}"
 
   linux:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         platform: [x86, x64]
+        configuration: [Release]
     runs-on: windows-2025
     env:
       Platform: ${{ matrix.platform }}
-      Configuration: Release
+      Configuration: ${{ matrix.configuration }}
       VcpkgManifestInstall: false
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [x86, x64]
-        configuration: [Release]
+        configuration: [Debug, Release]
     runs-on: windows-2025
     env:
       Platform: ${{ matrix.platform }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,8 @@ jobs:
       if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
       with:
         path: .build
-        key: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ github.sha }}
-        restore-keys: buildCache-${{ runner.os }}-${{ matrix.platform }}-
+        key: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.configuration }}-${{ github.sha }}
+        restore-keys: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.configuration }}-
 
     - name: Set modification times
       if: ${{ hashFiles('.build/lastBuildSha.txt') != '' }}
@@ -94,7 +94,7 @@ jobs:
       uses: actions/cache/save@v5
       with:
         path: .build
-        key: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ github.sha }}
+        key: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.configuration }}-${{ github.sha }}
 
     - name: Test
       working-directory: ./test/


### PR DESCRIPTION
Related:
- Issue #1447

Note that when the `vcpkg` cache needs to be rebuilt, both the `Debug` and `Release` runs (of the same `Platform`) will attempt to build the same `vcpkg` cache. Whichever one is fastest will write the cache. The slower run will issue a warning about not being able to write the cache because the key already exists.

The `vcpkg` cache design leads to wasted effort rebuilding caches twice in parallel (when they need to be rebuilt), though does not result in wasted cache space, and also didn't require extensive rewrites to the pipeline to have two configurations share a single run to build the cache, and any associated lag time to start new runners and transfer a hot cache to fresh runners. Effectively there was bound to be some waste somewhere. I figured the CPU time spent by two parallel runners was the least intrusive waste.
