### PR TITLE
Remove `VcpkgConfiguration` custom setting

### DIFF
--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -27,6 +27,12 @@
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
     <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\Intermediate\</IntDir>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -43,12 +43,6 @@
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
   </PropertyGroup>
-  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <VcpkgConfiguration>Debug</VcpkgConfiguration>
-  </PropertyGroup>
-  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <VcpkgConfiguration>Debug</VcpkgConfiguration>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>


### PR DESCRIPTION
Set `UseDebugLibraries` like the other project files, and remove the custom setting for `VcpkgConfiguration`.

The `VcpkgConfiguration` setting will default to `Debug` when `UseDebugLibraries` is set to `true`, which should be the case for `Debug` configurations.

----

Verify the settings work as expected from the build output:

When running `link.exe` for `Debug` configurations, we should expect to see `/LIBPATH` options with a "debug" folder component, such as:
> /LIBPATH:"D:\a\nas2d-core\nas2d-core\vcpkg_installed\x64-windows\x64-windows\debug\lib"
> /LIBPATH:"D:\a\nas2d-core\nas2d-core\vcpkg_installed\x64-windows\x64-windows\debug\lib\manual-link"

This is in contrast to the `Release` configurations, which should have similar paths, but without the "debug" component in the path:
> /LIBPATH:"D:\a\nas2d-core\nas2d-core\vcpkg_installed\x64-windows\x64-windows\lib"
> /LIBPATH:"D:\a\nas2d-core\nas2d-core\vcpkg_installed\x64-windows\x64-windows\lib\manual-link"

Additionally, we should expect the unit test project to compile, run, and produce output for all the tests. Failure might mean errors linking, unit tests that crash, or the unit tests running and showing no test and no results. (See Issue #1101 for details).

----

Related:
- Issue #1447
- PR #1448
- PR #1117
- Issue #1101

Closes #1447
