### PR TITLE
Keep more recent caches when cleaning caches

### DIFF
--- a/makefile
+++ b/makefile
@@ -338,7 +338,7 @@ cache-list-branch:
 	$(GhCacheListBranch)
 
 cache-delete-main-stale:
-	$(GhCacheListMain) | jq '.[0:-2] | .[] .id' | $(GhCacheDeleteIds)
+	$(GhCacheListMain) | jq '.[0:-4] | .[] .id' | $(GhCacheDeleteIds)
 
 cache-delete-branch:
 	$(GhCacheListBranch) | jq '.id' | $(GhCacheDeleteIds)


### PR DESCRIPTION
Since the `Debug` configuration builds were added, we've doubled the number of caches generated. Hence we need to keep the most recent 4 caches in order to preserve the most recent cache for each build configuration.

----

Noticed this while cleaning caches to properly test PR #1449

Related:
- PR #1448
- PR #1449
- Issue #1447
