### PR TITLE
Fix `pitch` setting in `Image` constructor

### DIFF
--- a/NAS2D/Resource/Image.cpp
+++ b/NAS2D/Resource/Image.cpp
@@ -81,7 +81,7 @@ SDL_Surface* Image::dataToSdlSurface(void* buffer, int bytesPerPixel, Vector<int
 		throw std::runtime_error("Image bit-depth unsupported with bytesPerPixel: " + std::to_string(bytesPerPixel));
 	}
 
-	auto* surface = SDL_CreateRGBSurfaceFrom(buffer, size.x, size.y, bytesPerPixel * 8, 0, 0, 0, 0, isBigEndian ? 0x000000FF : 0xFF000000);
+	auto* surface = SDL_CreateRGBSurfaceFrom(buffer, size.x, size.y, bytesPerPixel * 8, bytesPerPixel * size.x, 0, 0, 0, isBigEndian ? 0x000000FF : 0xFF000000);
 
 	if (!surface)
 	{


### PR DESCRIPTION
According to the source code in `SDL_CreateSurfaceFrom`, which is called by `SDL_CreateRGBSurfaceFrom`, the `pitch` value should be set to a valid value if the `pixel` data buffer pointer is valid (not `nullptr`).

https://github.com/libsdl-org/SDL/blob/01a7588f8e593b93c75ca7adbc6ec595e84e9bce/src/video/SDL_surface.c#L253

----

Related:
- Issue #1453
- PR #1454
