### PR TITLE
Update Arch Linux build environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - "build-env-nas2d-arch:1.5"
+        - "build-env-nas2d-arch:1.6"
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"

--- a/dockerBuildEnv/nas2d-arch.Dockerfile
+++ b/dockerBuildEnv/nas2d-arch.Dockerfile
@@ -24,4 +24,6 @@ RUN pacman --sync --refresh --noconfirm \
     sdl2_ttf \
   && rm -rf /var/cache/pacman/pkg
 
+RUN useradd --create-home user
+
 CMD ["make", "--keep-going", "check"]

--- a/dockerBuildEnv/nas2d-arch.Dockerfile
+++ b/dockerBuildEnv/nas2d-arch.Dockerfile
@@ -1,6 +1,6 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM archlinux:base-20240811.0.253648
+FROM archlinux:base-20260419.0.517065
 
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages

--- a/dockerBuildEnv/nas2d-arch.version.mk
+++ b/dockerBuildEnv/nas2d-arch.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_arch := 1.5
+ImageVersion_arch := 1.6


### PR DESCRIPTION
Fix Arch Linux Docker container for local use so the `Filesystem` unit tests don't fail, and update the base Docker image to the most recent available Arch Linux image.

Related:
- Issue #1457
- Issue #1431

Closes #1457

----

To ease use for local builds, a local `user` account was added to the Arch Linux image. This isn't a great solution, since there's an implied assumption the generated user account (uid 1000) matches the uid on the host system of the user running the image. For a single user system, there's a pretty good change it will match, and so this typically works. Additionally, it matches with the Ubuntu images that have an `ubuntu` user (uid 1000).

Another solution might involve using a `--mount` option to ensure a writable folder owned by the host system uid, though that may involve cleanup on the host system for any generated files.

Yet another solution might be to use the temp filesystem for the `HOME` folder. Perhaps by starting the container using `-e HOME=/tmp`. It's a bit strange to use `/tmp` as a `HOME` folder, though it would work in this case, and the generated output files are all ephemeral in nature. One downside to such a solution is it doesn't work across all other supported build environments, namely the `mingw` build image with give errors with a modified `HOME` because `wine` refuses to create the `.wine` folder under a location not owned by the current user. As such I wanted to avoid this solution as it creates an inconsistency between environments.

----

Another point is maybe we should revisit the `Filesystem` unit tests, which maybe shouldn't really be considered unit tests due to the junk they can generate in the filesystem, which can persist past the end of the tests.
