### PR TITLE
Fix `vcpkg` cache for `platform` change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       id: cacheRestoreVcpkg
       with:
         path: vcpkg_installed
-        key: vcpkgCache-${{ runner.os }}-${{ matrix.architecture.platform }}-${{ hashFiles('vcpkg.json') }}
+        key: vcpkgCache-${{ runner.os }}-${{ env.Platform }}-${{ hashFiles('vcpkg.json') }}
 
     - name: Install vcpkg dependencies
       if: steps.cacheRestoreVcpkg.outputs.cache-hit != 'true'
@@ -58,8 +58,8 @@ jobs:
       if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
       with:
         path: .build
-        key: buildCache-${{ runner.os }}-${{ matrix.architecture.platform }}-${{ matrix.configuration }}-${{ github.sha }}
-        restore-keys: buildCache-${{ runner.os }}-${{ matrix.architecture.platform }}-${{ matrix.configuration }}-
+        key: buildCache-${{ runner.os }}-${{ env.Platform }}-${{ env.Configuration }}-${{ github.sha }}
+        restore-keys: buildCache-${{ runner.os }}-${{ env.Platform }}-${{ env.Configuration }}-
 
     - name: Set modification times
       if: ${{ hashFiles('.build/lastBuildSha.txt') != '' }}
@@ -98,7 +98,7 @@ jobs:
       uses: actions/cache/save@v5
       with:
         path: .build
-        key: buildCache-${{ runner.os }}-${{ matrix.architecture.platform }}-${{ matrix.configuration }}-${{ github.sha }}
+        key: buildCache-${{ runner.os }}-${{ env.Platform }}-${{ env.Configuration }}-${{ github.sha }}
 
     - name: Test
       working-directory: test/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       id: cacheRestoreVcpkg
       with:
         path: vcpkg_installed
-        key: vcpkgCache-${{ runner.os }}-${{ matrix.platform }}-${{ hashFiles('vcpkg.json') }}
+        key: vcpkgCache-${{ runner.os }}-${{ matrix.architecture.platform }}-${{ hashFiles('vcpkg.json') }}
 
     - name: Install vcpkg dependencies
       if: steps.cacheRestoreVcpkg.outputs.cache-hit != 'true'
@@ -58,8 +58,8 @@ jobs:
       if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
       with:
         path: .build
-        key: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.configuration }}-${{ github.sha }}
-        restore-keys: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.configuration }}-
+        key: buildCache-${{ runner.os }}-${{ matrix.architecture.platform }}-${{ matrix.configuration }}-${{ github.sha }}
+        restore-keys: buildCache-${{ runner.os }}-${{ matrix.architecture.platform }}-${{ matrix.configuration }}-
 
     - name: Set modification times
       if: ${{ hashFiles('.build/lastBuildSha.txt') != '' }}
@@ -98,7 +98,7 @@ jobs:
       uses: actions/cache/save@v5
       with:
         path: .build
-        key: buildCache-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.configuration }}-${{ github.sha }}
+        key: buildCache-${{ runner.os }}-${{ matrix.architecture.platform }}-${{ matrix.configuration }}-${{ github.sha }}
 
     - name: Test
       working-directory: test/


### PR DESCRIPTION
Fix references to updated name `matrix.architecture.platform`.

Getting this name wrong would break caching on subsequent runs.

Update cache keys to use the environment variable equivalents `env.Platform` and `env.Configuration`. The step outputs are sensitive to the environment variable values, so we should depend on the environment variables directly to ensure consistency, rather than try to re-derive the values from some source which may introduce skew when things are updated.

Related:
- Issue #1309
- PR #1467
