### PR TITLE
Use `msbuild` to run unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,8 +101,7 @@ jobs:
         key: buildCache-${{ runner.os }}-${{ env.Platform }}-${{ env.Configuration }}-${{ github.sha }}
 
     - name: Test
-      working-directory: test/
-      run: ../.build/${{env.Configuration}}_${{env.Platform}}_test/test.exe
+      run: msbuild /target:test:Run
 
     - name: Package
       run: ./Package.bat "${{env.Configuration}}" "${{env.Platform}}"


### PR DESCRIPTION
We no longer need to worry about changes to `OutDir` or the target filename. Knowing just the project name is enough. We also don't need to worry about setting the `working-directory`.

Related:
- Issue #1309
- Issue https://github.com/OutpostUniverse/OPHD/issues/1860
  - https://github.com/OutpostUniverse/OPHD/issues/1860#issuecomment-4529074927
  - https://github.com/OutpostUniverse/OPHD/issues/1860#issuecomment-4529159076