### PR TITLE
Remove `RunCodeAnalysis` setting

### DIFF
--- a/demoGraphics/demoGraphics.vcxproj
+++ b/demoGraphics/demoGraphics.vcxproj
@@ -104,7 +104,6 @@
     <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\Intermediate\</IntDir>
     <OutDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\</OutDir>
     <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -60,7 +60,6 @@
     <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\Intermediate\</IntDir>
     <OutDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\</OutDir>
     <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>


### PR DESCRIPTION
For local builds, let this be done on demand through the Visual Studio menu: Build -> Run Code Analysis on Solution (Alt+F11)

For CI builds, this is done by calling `msbuild` with the flag `/property:RunCodeAnalysis=true`.

----

The NAS2D library project doesn't have a `RunCodeAnalysis` setting. The unit test project and demo graphics projects did.

----

Related:
- Issue #1452
