### PR TITLE
Fix `makefile` target for GitHub Actions cache cleaning

### DIFF
--- a/makefile
+++ b/makefile
@@ -338,7 +338,7 @@ cache-list-branch:
 	$(GhCacheListBranch)
 
 cache-delete-main-stale:
-	$(GhCacheListMain) | jq '.[0:-6] | .[] .id' | $(GhCacheDeleteIds)
+	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"$(shell git rev-parse origin/main)\") | not) | .[] .id" | $(GhCacheDeleteIds)
 
 cache-delete-branch:
 	$(GhCacheListBranch) | jq '.id' | $(GhCacheDeleteIds)

--- a/makefile
+++ b/makefile
@@ -338,7 +338,7 @@ cache-list-branch:
 	$(GhCacheListBranch)
 
 cache-delete-main-stale:
-	$(GhCacheListMain) | jq '.[0:-4] | .[] .id' | $(GhCacheDeleteIds)
+	$(GhCacheListMain) | jq '.[0:-6] | .[] .id' | $(GhCacheDeleteIds)
 
 cache-delete-branch:
 	$(GhCacheListBranch) | jq '.id' | $(GhCacheDeleteIds)

--- a/makefile
+++ b/makefile
@@ -319,7 +319,9 @@ circleci-build:
 
 
 ## GitHub ##
-.PHONY: cache-list-all cache-list-main cache-list-branch cache-delete-main-stale cache-delete-branch
+.PHONY: cache-list-all cache-list-main cache-list-current cache-list-stale cache-list-branch cache-delete-main-stale cache-delete-branch
+GhMain := origin/main
+GhMainSha = $(shell git rev-parse ${GhMain})
 GhCacheKeyIncremental := buildCache-
 GhCacheLimit := 100
 GhCacheFields := id,ref,key,version,sizeInBytes,createdAt,lastAccessedAt
@@ -334,11 +336,17 @@ cache-list-all:
 cache-list-main:
 	$(GhCacheListMain)
 
+cache-list-current:
+	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GitMainSha}\"))"
+
+cache-list-stale:
+	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GitMainSha}\") | not)"
+
 cache-list-branch:
 	$(GhCacheListBranch)
 
 cache-delete-main-stale:
-	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"$(shell git rev-parse origin/main)\") | not) | .[] .id" | $(GhCacheDeleteIds)
+	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GitMainSha}\") | not) | .[] .id" | $(GhCacheDeleteIds)
 
 cache-delete-branch:
 	$(GhCacheListBranch) | jq '.id' | $(GhCacheDeleteIds)


### PR DESCRIPTION
Since the addition of the `ARM64` builds, we now have more current caches, so we need to update the cache cleaning logic to clean only stale caches.

Since the current cache count can change as we add or remove builds, and it's easy to miss the cache cleaning code, it is more robust to instead check the SHA of the latest commit on `origin/main`, rather than trying to count how many current caches there should be, and hoping a date sorted list will put the current caches at one end of the list.

I'm not entirely pleased with the current code, since it makes assumptions about both the name `origin` and the name of the default branch being `main`. It could be made more generic, but perhaps isn't the priority right now. What exists now is certainly better than keeping a fixed number of entries at one end of a sorted list.

Related:
- Issue #1309
- PR #1467
- PR #1450
- PR #1271
