### PR TITLE
Fix `makefile` GitHub Actions cache cleaning

### DIFF
--- a/makefile
+++ b/makefile
@@ -346,7 +346,7 @@ cache-list-branch:
 	$(GhCacheListBranch)
 
 cache-delete-main-stale:
-	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GhMainSha}\") | not) | .[] .id" | $(GhCacheDeleteIds)
+	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GhMainSha}\") | not) | .id" | $(GhCacheDeleteIds)
 
 cache-delete-branch:
 	$(GhCacheListBranch) | jq '.id' | $(GhCacheDeleteIds)

--- a/makefile
+++ b/makefile
@@ -337,16 +337,16 @@ cache-list-main:
 	$(GhCacheListMain)
 
 cache-list-current:
-	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GitMainSha}\"))"
+	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GhMainSha}\"))"
 
 cache-list-stale:
-	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GitMainSha}\") | not)"
+	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GhMainSha}\") | not)"
 
 cache-list-branch:
 	$(GhCacheListBranch)
 
 cache-delete-main-stale:
-	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GitMainSha}\") | not) | .[] .id" | $(GhCacheDeleteIds)
+	$(GhCacheListMain) | jq ".[] | select(.key | endswith(\"${GhMainSha}\") | not) | .[] .id" | $(GhCacheDeleteIds)
 
 cache-delete-branch:
 	$(GhCacheListBranch) | jq '.id' | $(GhCacheDeleteIds)


### PR DESCRIPTION
Fixes for previous PR.

There weren't sufficient caches available to fully test the updated cache cleaning code, so naturally some of it was a bit wrong.

Related:
- PR #1475
