### PR TITLE
Remove explicit `LinkTimeCodeGeneration` setting

### DIFF
--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -170,7 +170,6 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -191,7 +190,6 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -212,7 +210,6 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -233,7 +230,6 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
We get automatic `LinkTimeCodeGeneration` settings when `WholeProgramOptimization` is enabled in a `PropertyGroup`. This is the case for the `Release` configurations where `LinkTimeCodeGeneration` was being used.

There will be a slight change in the linker flags from `/LTCG` to `/LTCG:incremental`. This may slightly improve linker performance.

Documentation:
https://learn.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-170

----

The `LinkTimeCodeGeneration` setting was only being set in the unit test project, so kind of stood out as being a bit odd.

----

The explicit `LinkTimeCodeGeneration` setting stems from earlier work to solve the following error:
> MSIL .netmodule or module compiled with /GL found; restarting link with /LTCG; add /LTCG to the link command line to improve linker performance

History:
- Issue #367
  - Warning message noted
- PR #374
  - Warning message fixed
  - Introduced `ClCompile` settings `WholeProgramOptimization` and `LinkTimeCodeGeneration`
  - Commit: b11a91c393b772e755146934f1324d82926a4798
- PR #1473
  - The `ClCompile` setting `WholeProgramOptimization` was replaced by a `PropertyGroup` setting of the same name
  - No changes made to the `LinkTimeCodeGeneration` setting
  - Commit: aa41afbcba07e920aa0a927ee92df20feaa87f93

----

Related:
- Issue #1452
  - Comment: https://github.com/lairworks/nas2d-core/issues/1452#issuecomment-4588009001