### PR TITLE
Remove `HOMEBREW_NO_AUTO_UPDATE` setting for MacOS builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
     macos:
       xcode: "26.5"
     environment:
-      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - checkout
       - brew-install


### PR DESCRIPTION
We seem to get a lot of MacOS build errors related to `brew` installing dependencies.

Related:
- Issue #1431
