### PR TITLE
Remove explicit default for `CodeAnalysisRuleSet`

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -74,7 +74,6 @@
   <PropertyGroup>
     <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)\$(ProjectName)\Intermediate\</IntDir>
     <OutDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)\$(ProjectName)\</OutDir>
-    <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>

--- a/demoGraphics/demoGraphics.vcxproj
+++ b/demoGraphics/demoGraphics.vcxproj
@@ -78,7 +78,6 @@
   <PropertyGroup>
     <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\Intermediate\</IntDir>
     <OutDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\</OutDir>
-    <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -72,7 +72,6 @@
   <PropertyGroup>
     <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\Intermediate\</IntDir>
     <OutDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\</OutDir>
-    <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>


### PR DESCRIPTION
The default `CodeAnalysisRuleSet` is set based on some condition checks:
- `'$(Language)'=='C++'`
- `'$(CLRSupport)'=='true'`
- `'$(CodeAnalysisVSSku)'=='Express'`

Depending on which set of conditions all hold, the default may be one of:
- `MixedMinimumRules.ruleset` (`C++` and `CLRSupport` and `Express`)
- `MixedRecommendedRules.ruleset` (`C++` and `CLRSupport`)
- `NativeMinimumRules.ruleset` (`C++` and `Express`)
- `NativeRecommendedRules.ruleset` (`C++`)
- `ManagedMinimumRules.ruleset` (`Express`)

According to those rules, we get a default of `NativeRecommendedRules.ruleset`.

----

Related:
- Issue #1452
