### PR TITLE
Normalize use of `CAExcludePath` across all projects

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -309,4 +309,7 @@
     <None Include="..\.clang-format" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <PropertyGroup Condition="'$(Language)'=='C++'">
+    <CAExcludePath>..\vcpkg_installed;$(CAExcludePath)</CAExcludePath>
+  </PropertyGroup>
 </Project>

--- a/demoGraphics/demoGraphics.vcxproj
+++ b/demoGraphics/demoGraphics.vcxproj
@@ -231,4 +231,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <PropertyGroup Condition="'$(Language)'=='C++'">
+    <CAExcludePath>..\vcpkg_installed;$(CAExcludePath)</CAExcludePath>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
The `CAExcludePath` property is not initialized with a default value until `Microsoft.CodeAnalysis.Targets`, so any override needs to happen after the `Import` of `Microsoft.Cpp.targets`.

Related:
- Issue #1452
