### PR TITLE
Default screen size to 16x9

### DIFF
--- a/NAS2D/Application.cpp
+++ b/NAS2D/Application.cpp
@@ -37,8 +37,8 @@ namespace
 	NAS2D::Dictionary defaultConfigGraphics()
 	{
 		return NAS2D::Dictionary{{
-			{"screenwidth", 1000},
-			{"screenheight", 700},
+			{"screenwidth", 1600},
+			{"screenheight", 900},
 			{"bitdepth", 32},
 			{"fullscreen", false},
 			{"vsync", true},


### PR DESCRIPTION
Changes the default screen size to 1600x900 instead of 1000x700.

The de-facto standard screen resolutions in 2026 are 16:9 aspect ratios. As such the minimum supported screen size of a monitor should be 1600x900.