### PR TITLE
Update `IntDir`, `OutDir` and `makefile` equivalent

### DIFF
--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -70,8 +70,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)\$(ProjectName)\Intermediate\</IntDir>
-    <OutDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)\$(ProjectName)\</OutDir>
+    <IntDir>$(ProjectDir)..\.build\$(PlatformShortName)_$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
+    <OutDir>$(ProjectDir)..\.build\$(PlatformShortName)_$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -70,8 +70,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <IntDir>$(ProjectDir)..\.build\$(PlatformShortName)_$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
-    <OutDir>$(ProjectDir)..\.build\$(PlatformShortName)_$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)_$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
+    <OutDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)_$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>

--- a/NAS2D/NAS2D.vcxproj
+++ b/NAS2D/NAS2D.vcxproj
@@ -70,8 +70,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <IntDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)_$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
-    <OutDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)_$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)\$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
+    <OutDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)\$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>

--- a/Package.bat
+++ b/Package.bat
@@ -8,7 +8,7 @@ set "ProjectName=NAS2D"
 set "OutputFolder=.build\"
 set "PackageFolder=%OutputFolder%Package\"
 
-if "%TargetPath%" == "" (set "TargetPath=%OutputFolder%Windows\%Platform%_%Configuration%\%ProjectName%\%ProjectName%.lib")
+if "%TargetPath%" == "" (set "TargetPath=%OutputFolder%Windows\%Platform%\%Configuration%\%ProjectName%\%ProjectName%.lib")
 
 for /f %%i in ('git describe --tags --dirty') do set Version=%%i
 

--- a/Package.bat
+++ b/Package.bat
@@ -8,7 +8,7 @@ set "ProjectName=NAS2D"
 set "OutputFolder=.build\"
 set "PackageFolder=%OutputFolder%Package\"
 
-if "%TargetPath%" == "" (set "TargetPath=%OutputFolder%%Platform%_%Configuration%\%ProjectName%\%ProjectName%.lib")
+if "%TargetPath%" == "" (set "TargetPath=%OutputFolder%Windows\%Platform%_%Configuration%\%ProjectName%\%ProjectName%.lib")
 
 for /f %%i in ('git describe --tags --dirty') do set Version=%%i
 

--- a/Package.bat
+++ b/Package.bat
@@ -8,7 +8,7 @@ set "ProjectName=NAS2D"
 set "OutputFolder=.build\"
 set "PackageFolder=%OutputFolder%Package\"
 
-if "%TargetPath%" == "" (set "TargetPath=%OutputFolder%%Configuration%_%Platform%\%ProjectName%\%ProjectName%.lib")
+if "%TargetPath%" == "" (set "TargetPath=%OutputFolder%%Platform%_%Configuration%\%ProjectName%\%ProjectName%.lib")
 
 for /f %%i in ('git describe --tags --dirty') do set Version=%%i
 

--- a/demoGraphics/demoGraphics.vcxproj
+++ b/demoGraphics/demoGraphics.vcxproj
@@ -70,8 +70,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)\$(ProjectName)\Intermediate\</IntDir>
-    <OutDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)\$(ProjectName)\</OutDir>
+    <IntDir>$(ProjectDir)..\.build\$(PlatformShortName)_$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
+    <OutDir>$(ProjectDir)..\.build\$(PlatformShortName)_$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>

--- a/demoGraphics/demoGraphics.vcxproj
+++ b/demoGraphics/demoGraphics.vcxproj
@@ -70,8 +70,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\Intermediate\</IntDir>
-    <OutDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\</OutDir>
+    <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)\$(ProjectName)\Intermediate\</IntDir>
+    <OutDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>

--- a/demoGraphics/demoGraphics.vcxproj
+++ b/demoGraphics/demoGraphics.vcxproj
@@ -70,8 +70,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <IntDir>$(ProjectDir)..\.build\$(PlatformShortName)_$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
-    <OutDir>$(ProjectDir)..\.build\$(PlatformShortName)_$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)_$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
+    <OutDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)_$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>

--- a/demoGraphics/demoGraphics.vcxproj
+++ b/demoGraphics/demoGraphics.vcxproj
@@ -70,8 +70,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <IntDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)_$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
-    <OutDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)_$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)\$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
+    <OutDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)\$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>

--- a/makefile
+++ b/makefile
@@ -65,7 +65,7 @@ RunPrefix := $($(TARGET_OS)RunPrefix)
 RunSuffixUnitTest := $($(TARGET_OS)RunSuffixUnitTest)
 
 ROOTBUILDDIR := .build
-BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(CONFIG)_Linux/
+BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(CONFIG)_$(TARGET_OS)/
 
 
 ## NAS2D project ##

--- a/makefile
+++ b/makefile
@@ -68,7 +68,7 @@ RunPrefix := $($(TARGET_OS)RunPrefix)
 RunSuffixUnitTest := $($(TARGET_OS)RunSuffixUnitTest)
 
 ROOTBUILDDIR := .build
-BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(TARGET_OS)/$(CONFIG)/
+BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(TARGET_OS)/$(TARGET_PLATFORM)/$(CONFIG)/
 
 
 ## NAS2D project ##

--- a/makefile
+++ b/makefile
@@ -65,7 +65,7 @@ RunPrefix := $($(TARGET_OS)RunPrefix)
 RunSuffixUnitTest := $($(TARGET_OS)RunSuffixUnitTest)
 
 ROOTBUILDDIR := .build
-BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(CONFIG)_$(TARGET_OS)/
+BUILDDIRPREFIX := $(ROOTBUILDDIR)/$(TARGET_OS)/$(CONFIG)/
 
 
 ## NAS2D project ##

--- a/makefile
+++ b/makefile
@@ -203,8 +203,8 @@ clean-all: | clean
 
 PACKAGEDIR := $(ROOTBUILDDIR)/package
 VERSION = $(shell git describe --tags --dirty)
-PLATFORM = $(shell uname -m)
-PACKAGE_NAME = $(PACKAGEDIR)/nas2d-$(VERSION)-$(TARGET_OS)-$(PLATFORM)-$(CONFIG).tar.gz
+TARGET_PLATFORM = $(shell uname -m)
+PACKAGE_NAME = $(PACKAGEDIR)/nas2d-$(VERSION)-$(TARGET_OS)-$(TARGET_PLATFORM)-$(CONFIG).tar.gz
 Darwin_TAR_RENAME_FLAG := -s '!^$(SRCDIR)/!include/\0!'
 Linux_TAR_RENAME_FLAG := --transform='s/^$(SRCDIR)/include\/\0/'
 TAR_RENAME_FLAG := $($(CURRENT_OS)_TAR_RENAME_FLAG)

--- a/makefile
+++ b/makefile
@@ -11,6 +11,9 @@ all: nas2d test demoGraphics
 CURRENT_OS := $(shell uname 2>/dev/null || echo Unknown)
 TARGET_OS ?= $(CURRENT_OS)
 
+CURRENT_PLATFORM = $(shell uname -m)
+TARGET_PLATFORM ?= $(CURRENT_PLATFORM)
+
 # Toolchain: gcc, clang, mingw, (or blank for environment default)
 Toolchain ?=
 
@@ -203,7 +206,6 @@ clean-all: | clean
 
 PACKAGEDIR := $(ROOTBUILDDIR)/package
 VERSION = $(shell git describe --tags --dirty)
-TARGET_PLATFORM = $(shell uname -m)
 PACKAGE_NAME = $(PACKAGEDIR)/nas2d-$(VERSION)-$(TARGET_OS)-$(TARGET_PLATFORM)-$(CONFIG).tar.gz
 Darwin_TAR_RENAME_FLAG := -s '!^$(SRCDIR)/!include/\0!'
 Linux_TAR_RENAME_FLAG := --transform='s/^$(SRCDIR)/include\/\0/'

--- a/makefile
+++ b/makefile
@@ -203,7 +203,7 @@ clean-all: | clean
 
 PACKAGEDIR := $(ROOTBUILDDIR)/package
 VERSION = $(shell git describe --tags --dirty)
-PLATFORM = x64
+PLATFORM = $(shell uname -m)
 PACKAGE_NAME = $(PACKAGEDIR)/nas2d-$(VERSION)-$(TARGET_OS)-$(PLATFORM)-$(CONFIG).tar.gz
 Darwin_TAR_RENAME_FLAG := -s '!^$(SRCDIR)/!include/\0!'
 Linux_TAR_RENAME_FLAG := --transform='s/^$(SRCDIR)/include\/\0/'

--- a/makefile
+++ b/makefile
@@ -204,7 +204,7 @@ clean-all: | clean
 PACKAGEDIR := $(ROOTBUILDDIR)/package
 VERSION = $(shell git describe --tags --dirty)
 PLATFORM = x64
-PACKAGE_NAME = $(PACKAGEDIR)/nas2d-$(VERSION)-$(TARGET_OS).$(PLATFORM)-$(CONFIG).tar.gz
+PACKAGE_NAME = $(PACKAGEDIR)/nas2d-$(VERSION)-$(TARGET_OS)-$(PLATFORM)-$(CONFIG).tar.gz
 Darwin_TAR_RENAME_FLAG := -s '!^$(SRCDIR)/!include/\0!'
 Linux_TAR_RENAME_FLAG := --transform='s/^$(SRCDIR)/include\/\0/'
 TAR_RENAME_FLAG := $($(CURRENT_OS)_TAR_RENAME_FLAG)

--- a/makefile
+++ b/makefile
@@ -203,8 +203,8 @@ clean-all: | clean
 
 PACKAGEDIR := $(ROOTBUILDDIR)/package
 VERSION = $(shell git describe --tags --dirty)
-PLATFORM = $(TARGET_OS).x64
-PACKAGE_NAME = $(PACKAGEDIR)/nas2d-$(VERSION)-$(PLATFORM)-$(CONFIG).tar.gz
+PLATFORM = x64
+PACKAGE_NAME = $(PACKAGEDIR)/nas2d-$(VERSION)-$(TARGET_OS).$(PLATFORM)-$(CONFIG).tar.gz
 Darwin_TAR_RENAME_FLAG := -s '!^$(SRCDIR)/!include/\0!'
 Linux_TAR_RENAME_FLAG := --transform='s/^$(SRCDIR)/include\/\0/'
 TAR_RENAME_FLAG := $($(CURRENT_OS)_TAR_RENAME_FLAG)

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -70,8 +70,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)\$(ProjectName)\Intermediate\</IntDir>
-    <OutDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)\$(ProjectName)\</OutDir>
+    <IntDir>$(ProjectDir)..\.build\$(PlatformShortName)_$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
+    <OutDir>$(ProjectDir)..\.build\$(PlatformShortName)_$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -70,8 +70,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\Intermediate\</IntDir>
-    <OutDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)_$(ProjectName)\</OutDir>
+    <IntDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)\$(ProjectName)\Intermediate\</IntDir>
+    <OutDir>$(ProjectDir)..\.build\$(Configuration)_$(PlatformShortName)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -70,8 +70,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <IntDir>$(ProjectDir)..\.build\$(PlatformShortName)_$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
-    <OutDir>$(ProjectDir)..\.build\$(PlatformShortName)_$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)_$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
+    <OutDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)_$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -70,8 +70,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <IntDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)_$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
-    <OutDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)_$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)\$(Configuration)\$(ProjectName)\Intermediate\</IntDir>
+    <OutDir>$(ProjectDir)..\.build\Windows\$(PlatformShortName)\$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>


### PR DESCRIPTION
Make output locations of all projects consistent, and rename for better organization of multi platform builds from a common folder, and the potential for cross compiling to different architectures.

Related:
- Issue #1452
- Issue #1385
