### PR TITLE
Remove obsolete `CAExcludePath`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,5 @@
   <PropertyGroup>
     <ForceImportAfterCppDefaultProps>$(MSBuildThisFileDirectory)/MsvcDefaults/PropertyDefaults.props</ForceImportAfterCppDefaultProps>
     <ForceImportAfterCppProps>$(MSBuildThisFileDirectory)/MsvcDefaults/PropertyDerived.props</ForceImportAfterCppProps>
-    <ForceImportAfterCppTargets>$(MSBuildThisFileDirectory)/MsvcDefaults/TargetOverrides.targets</ForceImportAfterCppTargets>
   </PropertyGroup>
 </Project>

--- a/MsvcDefaults/TargetOverrides.targets
+++ b/MsvcDefaults/TargetOverrides.targets
@@ -1,5 +1,0 @@
-<Project>
-  <PropertyGroup Condition="'$(Language)'=='C++'">
-    <CAExcludePath>..\vcpkg_installed;$(CAExcludePath)</CAExcludePath>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
As part of `vcpkg` setup, `ExternalIncludePath` is set to contain the needed `include` folder. This makes the older `CAExcludePath` setting unnecessary for disabling warnings in external files.

Related:
- Issue #1452
  - Comment: https://github.com/lairworks/nas2d-core/issues/1452#issuecomment-4727523987
- PR #1501
- PR #1495
- PR #578
- PR #1119
- PR #1121
