### PR TITLE
Revert "Remove obsolete `CAExcludePath`"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <ForceImportAfterCppDefaultProps>$(MSBuildThisFileDirectory)/MsvcDefaults/PropertyDefaults.props</ForceImportAfterCppDefaultProps>
     <ForceImportAfterCppProps>$(MSBuildThisFileDirectory)/MsvcDefaults/PropertyDerived.props</ForceImportAfterCppProps>
+    <ForceImportAfterCppTargets>$(MSBuildThisFileDirectory)/MsvcDefaults/TargetOverrides.targets</ForceImportAfterCppTargets>
   </PropertyGroup>
 </Project>

--- a/MsvcDefaults/TargetOverrides.targets
+++ b/MsvcDefaults/TargetOverrides.targets
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup Condition="'$(Language)'=='C++'">
+    <CAExcludePath>..\vcpkg_installed;$(CAExcludePath)</CAExcludePath>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This reverts commit db74703d6ee40c8ed9b459c8ed07662fbbd9e0db.

It seems this is still needed. Without this setting the ARM builds fail with error:
> C:\a\nas2d-core\nas2d-core\vcpkg_installed\arm64-windows\arm64-windows\include\gtest\gtest-matchers.h(299): error C26439: This kind of function should not throw. Declare it 'noexcept' (f.6). [C:\a\nas2d-core\nas2d-core\test\test.vcxproj]
> C:\a\nas2d-core\nas2d-core\vcpkg_installed\arm64-windows\arm64-windows\include\gtest\gtest-matchers.h(304): error C26439: This kind of function should not throw. Declare it 'noexcept' (f.6). [C:\a\nas2d-core\nas2d-core\test\test.vcxproj]

----

The incremental build caching meant most of the build was skipped in PR #1503, so no error was shown then. The error did not appear until after merging to `main`, where a full build was done.

----

I have not yet looked much into why this is a problem, and why it only affects the ARM builds.

The relevant settings are passed using environment variables, so they don't appear in the build logs. We need to increase the verbosity level of the build logs in order to see the environment variables being set. Adding `/v:diag` to the `msbuild` line will do that. With this change, we can see the `EXTERNAL_INCLUDE` env var being set.

```
EXTERNAL_INCLUDE=...;C:\a\nas2d-core\nas2d-core\vcpkg_installed\arm64-windows\arm64-windows\include
```

This matches the `AdditionalIncludeDirectories` setting:
```
/I"C:\a\nas2d-core\nas2d-core\vcpkg_installed\arm64-windows\arm64-windows\include"
```

Given this, I'm not too sure why there is an issue. I wonder if this might be a bug in the Arm tooling, or the `vcpkg` integration with the Arm tooling.

----

Related:
- PR #1503
- Issue #1452
