### PR TITLE
Be explicit with `ProjectIsGoogleTestUnitTest`

### DIFF
--- a/MsvcDefaults/CompilerLinker.props
+++ b/MsvcDefaults/CompilerLinker.props
@@ -33,7 +33,6 @@
 
   <ItemDefinitionGroup Condition="'$(ProjectIsGoogleTestUnitTest)' == 'true'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>GTEST_LINKED_AS_SHARED_LIBRARY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>

--- a/MsvcDefaults/CompilerLinker.props
+++ b/MsvcDefaults/CompilerLinker.props
@@ -22,15 +22,6 @@
     </Link>
   </ItemDefinitionGroup>
 
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <AdditionalIncludeDirectories Condition="'$(ProjectAdditionalIncludeDirectories)' != ''">$(ProjectAdditionalIncludeDirectories);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <SubSystem Condition="'$(ProjectSubSystem)' != ''">$(ProjectSubSystem)</SubSystem>
-    </Link>
-  </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(ProjectIsGoogleTestUnitTest)' == 'true'">
     <ClCompile>
       <PreprocessorDefinitions>GTEST_LINKED_AS_SHARED_LIBRARY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -38,6 +29,15 @@
     <Link>
       <AdditionalDependencies>gmock_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories Condition="'$(ProjectAdditionalIncludeDirectories)' != ''">$(ProjectAdditionalIncludeDirectories);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem Condition="'$(ProjectSubSystem)' != ''">$(ProjectSubSystem)</SubSystem>
     </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/MsvcDefaults/CompilerLinker.props
+++ b/MsvcDefaults/CompilerLinker.props
@@ -31,7 +31,7 @@
     </Link>
   </ItemDefinitionGroup>
 
-  <ItemDefinitionGroup Condition="'$(IsGoogleTestUnitTestProject)' == 'true'">
+  <ItemDefinitionGroup Condition="'$(ProjectIsGoogleTestUnitTest)' == 'true'">
     <ClCompile>
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>GTEST_LINKED_AS_SHARED_LIBRARY;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/MsvcDefaults/PropertyDerived.props
+++ b/MsvcDefaults/PropertyDerived.props
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <PropertyGroup Label="AutoDetectGoogleTestUnitTestProject">
-    <IsGoogleTestUnitTestProject>false</IsGoogleTestUnitTestProject>
-    <IsGoogleTestUnitTestProject Condition="'$(AutoDetectGoogleTestUnitTestProject)' != 'false' AND $(MSBuildProjectName.StartsWith('test')) AND '$(ConfigurationType)' == 'Application'">true</IsGoogleTestUnitTestProject>
+    <ProjectIsGoogleTestUnitTest>false</ProjectIsGoogleTestUnitTest>
+    <ProjectIsGoogleTestUnitTest Condition="'$(AutoDetectGoogleTestUnitTestProject)' != 'false' AND $(MSBuildProjectName.StartsWith('test')) AND '$(ConfigurationType)' == 'Application'">true</ProjectIsGoogleTestUnitTest>
   </PropertyGroup>
 
   <Import Project="CompilerLinker.props" />

--- a/MsvcDefaults/PropertyDerived.props
+++ b/MsvcDefaults/PropertyDerived.props
@@ -8,10 +8,5 @@
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
   </PropertyGroup>
 
-  <PropertyGroup Label="AutoDetectGoogleTestUnitTestProject">
-    <ProjectIsGoogleTestUnitTest>false</ProjectIsGoogleTestUnitTest>
-    <ProjectIsGoogleTestUnitTest Condition="'$(AutoDetectGoogleTestUnitTestProject)' != 'false' AND $(MSBuildProjectName.StartsWith('test')) AND '$(ConfigurationType)' == 'Application'">true</ProjectIsGoogleTestUnitTest>
-  </PropertyGroup>
-
   <Import Project="CompilerLinker.props" />
 </Project>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -5,6 +5,9 @@
     <ConfigurationType>Application</ConfigurationType>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
+  <PropertyGroup Label="CustomProperties">
+    <ProjectIsGoogleTestUnitTest>true</ProjectIsGoogleTestUnitTest>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration" />

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <PropertyGroup Label="CustomProperties">
     <ProjectIsGoogleTestUnitTest>true</ProjectIsGoogleTestUnitTest>
+    <ProjectAdditionalIncludeDirectories>..</ProjectAdditionalIncludeDirectories>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration" />


### PR DESCRIPTION
Rename custom property to `ProjectIsGoogleTestUnitTest`, and make it an explicit setting, rather than an automatic setting based on some heuristic that could be wrong.

This makes the `ProjectIsGoogleTestUnitTest` setting more consistent with the recently added `ProjectAdditionalIncludeDirectories` and `ProjectSubSystem` custom settings for project wide defaults for all configurations.

Related:
- Issue #1452
- PR #1507
- PR #1506
