### PR TITLE
Add more `VectorSizeRange` tests

### DIFF
--- a/test/Math/VectorSizeRange.test.cpp
+++ b/test/Math/VectorSizeRange.test.cpp
@@ -60,6 +60,12 @@ TEST(VectorSizeRange, IterationMultiXOnly) {
 	EXPECT_EQ(fillByRangeFor(vectorRangeMultiWrap), (Items{{0, 0}, {1, 0}, {2, 0}}));
 }
 
+TEST(VectorSizeRange, IterationMultiYOnly) {
+	using Items = std::vector<NAS2D::Vector<int>>;
+	const auto vectorRangeMultiWrap = NAS2D::VectorSizeRange{NAS2D::Vector{1, 3}};
+	EXPECT_EQ(fillByRangeFor(vectorRangeMultiWrap), (Items{{0, 0}, {0, 1}, {0, 2}}));
+}
+
 TEST(VectorSizeRange, IterationMultiXAndY) {
 	using Items = std::vector<NAS2D::Vector<int>>;
 	const auto vectorRangeMultiWrap = NAS2D::VectorSizeRange{NAS2D::Vector{2, 3}};

--- a/test/Math/VectorSizeRange.test.cpp
+++ b/test/Math/VectorSizeRange.test.cpp
@@ -42,14 +42,20 @@ TEST(VectorSizeRange, EndDecrementIsLast) {
 	EXPECT_EQ((NAS2D::Vector{1, 2}), (*--NAS2D::VectorSizeRange{NAS2D::Vector{2, 3}}.end()));
 }
 
-TEST(VectorSizeRange, Iteration) {
+TEST(VectorSizeRange, IterationEmpty) {
 	using Items = std::vector<NAS2D::Vector<int>>;
+	const auto vectorRangeEmpty = NAS2D::VectorSizeRange{NAS2D::Vector{0, 0}};
+	EXPECT_EQ(fillByRangeFor(vectorRangeEmpty), (Items{}));
+}
 
-	const auto vectorRange1 = NAS2D::VectorSizeRange{NAS2D::Vector{0, 0}};
-	const auto vectorRange2 = NAS2D::VectorSizeRange{NAS2D::Vector{1, 1}};
-	const auto vectorRange3 = NAS2D::VectorSizeRange{NAS2D::Vector{2, 3}};
+TEST(VectorSizeRange, IterationSingle) {
+	using Items = std::vector<NAS2D::Vector<int>>;
+	const auto vectorRangeSingle = NAS2D::VectorSizeRange{NAS2D::Vector{1, 1}};
+	EXPECT_EQ(fillByRangeFor(vectorRangeSingle), (Items{{0, 0}}));
+}
 
-	EXPECT_EQ(fillByRangeFor(vectorRange1), (Items{}));
-	EXPECT_EQ(fillByRangeFor(vectorRange2), (Items{{0, 0}}));
-	EXPECT_EQ(fillByRangeFor(vectorRange3), (Items{{0, 0}, {1, 0}, {0, 1}, {1, 1}, {0, 2}, {1, 2}}));
+TEST(VectorSizeRange, IterationMultiWrap) {
+	using Items = std::vector<NAS2D::Vector<int>>;
+	const auto vectorRangeMultiWrap = NAS2D::VectorSizeRange{NAS2D::Vector{2, 3}};
+	EXPECT_EQ(fillByRangeFor(vectorRangeMultiWrap), (Items{{0, 0}, {1, 0}, {0, 1}, {1, 1}, {0, 2}, {1, 2}}));
 }

--- a/test/Math/VectorSizeRange.test.cpp
+++ b/test/Math/VectorSizeRange.test.cpp
@@ -49,11 +49,6 @@ TEST(VectorSizeRange, Iteration) {
 	const auto vectorRange2 = NAS2D::VectorSizeRange{NAS2D::Vector{1, 1}};
 	const auto vectorRange3 = NAS2D::VectorSizeRange{NAS2D::Vector{2, 3}};
 
-	// Dereference produces the expected starting value
-	// (Later tests also proves the range is restartable)
-	EXPECT_EQ((NAS2D::Vector{0, 0}), *vectorRange2.begin());
-	EXPECT_EQ((NAS2D::Vector{0, 0}), *vectorRange3.begin());
-
 	EXPECT_EQ(fillByRangeFor(vectorRange1), (Items{}));
 	EXPECT_EQ(fillByRangeFor(vectorRange2), (Items{{0, 0}}));
 	EXPECT_EQ(fillByRangeFor(vectorRange3), (Items{{0, 0}, {1, 0}, {0, 1}, {1, 1}, {0, 2}, {1, 2}}));

--- a/test/Math/VectorSizeRange.test.cpp
+++ b/test/Math/VectorSizeRange.test.cpp
@@ -5,6 +5,18 @@
 #include <vector>
 
 
+namespace {
+	template <typename BaseType>
+	auto fillByRangeFor(NAS2D::VectorSizeRange<BaseType> vectorRange) -> std::vector<NAS2D::Vector<BaseType>> {
+		std::vector<NAS2D::Vector<BaseType>> collection;
+		for (const auto vector : vectorRange) {
+			collection.push_back(vector);
+		}
+		return collection;
+	};
+}
+
+
 TEST(VectorSizeRange, EmptyRangeBeginIsEnd) {
 	const auto vectorRangeEmpty = NAS2D::VectorSizeRange{NAS2D::Vector{0, 0}};
 	EXPECT_EQ(vectorRangeEmpty.begin(), vectorRangeEmpty.end());
@@ -42,14 +54,6 @@ TEST(VectorSizeRange, Iteration) {
 	EXPECT_EQ((NAS2D::Vector{0, 0}), *vectorRange2.begin());
 	EXPECT_EQ((NAS2D::Vector{0, 0}), *vectorRange3.begin());
 
-	// Range-for syntax is supported
-	const auto fillByRangeFor = [](auto vectorRange) {
-		Items collection;
-		for (const auto vector : vectorRange) {
-			collection.push_back(vector);
-		}
-		return collection;
-	};
 	EXPECT_EQ(fillByRangeFor(vectorRange1), (Items{}));
 	EXPECT_EQ(fillByRangeFor(vectorRange2), (Items{{0, 0}}));
 	EXPECT_EQ(fillByRangeFor(vectorRange3), (Items{{0, 0}, {1, 0}, {0, 1}, {1, 1}, {0, 2}, {1, 2}}));

--- a/test/Math/VectorSizeRange.test.cpp
+++ b/test/Math/VectorSizeRange.test.cpp
@@ -5,6 +5,31 @@
 #include <vector>
 
 
+TEST(VectorSizeRange, EmptyRangeBeginIsEnd) {
+	const auto vectorRangeEmpty = NAS2D::VectorSizeRange{NAS2D::Vector{0, 0}};
+	EXPECT_EQ(vectorRangeEmpty.begin(), vectorRangeEmpty.end());
+}
+
+TEST(VectorSizeRange, EndIsEnd) {
+	const auto vectorRangeSingleElement = NAS2D::VectorSizeRange{NAS2D::Vector{1, 1}};
+	EXPECT_EQ(vectorRangeSingleElement.end(), vectorRangeSingleElement.end());
+}
+
+TEST(VectorSizeRange, BeginToEnd) {
+	const auto vectorRangeSingleElement = NAS2D::VectorSizeRange{NAS2D::Vector{1, 1}};
+	EXPECT_EQ(vectorRangeSingleElement.end(), ++vectorRangeSingleElement.begin());
+}
+
+TEST(VectorSizeRange, BeginIsOrigin) {
+	EXPECT_EQ((NAS2D::Vector{0, 0}), (*NAS2D::VectorSizeRange{NAS2D::Vector{1, 1}}.begin()));
+	EXPECT_EQ((NAS2D::Vector{0, 0}), (*NAS2D::VectorSizeRange{NAS2D::Vector{2, 3}}.begin()));
+}
+
+TEST(VectorSizeRange, EndDecrementIsLast) {
+	EXPECT_EQ((NAS2D::Vector{0, 0}), (*--NAS2D::VectorSizeRange{NAS2D::Vector{1, 1}}.end()));
+	EXPECT_EQ((NAS2D::Vector{1, 2}), (*--NAS2D::VectorSizeRange{NAS2D::Vector{2, 3}}.end()));
+}
+
 TEST(VectorSizeRange, Iteration) {
 	using Items = std::vector<NAS2D::Vector<int>>;
 

--- a/test/Math/VectorSizeRange.test.cpp
+++ b/test/Math/VectorSizeRange.test.cpp
@@ -54,13 +54,13 @@ TEST(VectorSizeRange, IterationSingle) {
 	EXPECT_EQ(fillByRangeFor(vectorRangeSingle), (Items{{0, 0}}));
 }
 
-TEST(VectorSizeRange, IterationMultiNoWrap) {
+TEST(VectorSizeRange, IterationMultiXOnly) {
 	using Items = std::vector<NAS2D::Vector<int>>;
 	const auto vectorRangeMultiWrap = NAS2D::VectorSizeRange{NAS2D::Vector{3, 1}};
 	EXPECT_EQ(fillByRangeFor(vectorRangeMultiWrap), (Items{{0, 0}, {1, 0}, {2, 0}}));
 }
 
-TEST(VectorSizeRange, IterationMultiWrap) {
+TEST(VectorSizeRange, IterationMultiXAndY) {
 	using Items = std::vector<NAS2D::Vector<int>>;
 	const auto vectorRangeMultiWrap = NAS2D::VectorSizeRange{NAS2D::Vector{2, 3}};
 	EXPECT_EQ(fillByRangeFor(vectorRangeMultiWrap), (Items{{0, 0}, {1, 0}, {0, 1}, {1, 1}, {0, 2}, {1, 2}}));

--- a/test/Math/VectorSizeRange.test.cpp
+++ b/test/Math/VectorSizeRange.test.cpp
@@ -14,7 +14,6 @@ TEST(VectorSizeRange, Iteration) {
 
 	// Dereference produces the expected starting value
 	// (Later tests also proves the range is restartable)
-	EXPECT_EQ((NAS2D::Vector{0, 0}), *vectorRange1.begin());
 	EXPECT_EQ((NAS2D::Vector{0, 0}), *vectorRange2.begin());
 	EXPECT_EQ((NAS2D::Vector{0, 0}), *vectorRange3.begin());
 

--- a/test/Math/VectorSizeRange.test.cpp
+++ b/test/Math/VectorSizeRange.test.cpp
@@ -54,6 +54,12 @@ TEST(VectorSizeRange, IterationSingle) {
 	EXPECT_EQ(fillByRangeFor(vectorRangeSingle), (Items{{0, 0}}));
 }
 
+TEST(VectorSizeRange, IterationMultiNoWrap) {
+	using Items = std::vector<NAS2D::Vector<int>>;
+	const auto vectorRangeMultiWrap = NAS2D::VectorSizeRange{NAS2D::Vector{3, 1}};
+	EXPECT_EQ(fillByRangeFor(vectorRangeMultiWrap), (Items{{0, 0}, {1, 0}, {2, 0}}));
+}
+
 TEST(VectorSizeRange, IterationMultiWrap) {
 	using Items = std::vector<NAS2D::Vector<int>>;
 	const auto vectorRangeMultiWrap = NAS2D::VectorSizeRange{NAS2D::Vector{2, 3}};


### PR DESCRIPTION
Increase the granularity by splitting tests into separate test cases, and increase the amount of testing.

----

When attempting to upgrade `PlatformToolset` to `v145` (VS2026) it was found that certain configurations would have failures in the `VectorSizeRange` test case.

It is generally good practice to split tests into separate test cases to increase the granularity and help to more quickly pinpoint the cause of failures.

Related:
- Issue #1393
