### PR TITLE
Add tests for `VectorSizeRange::Iterator`

### DIFF
--- a/test/Math/VectorSizeRange.test.cpp
+++ b/test/Math/VectorSizeRange.test.cpp
@@ -42,6 +42,36 @@ TEST(VectorSizeRange, EndDecrementIsLast) {
 	EXPECT_EQ((NAS2D::Vector{1, 2}), (*--NAS2D::VectorSizeRange{NAS2D::Vector{2, 3}}.end()));
 }
 
+TEST(VectorSizeRange, IteratorIncrementXOnly) {
+	const auto vectorRange = NAS2D::VectorSizeRange{NAS2D::Vector{3, 1}};
+	auto iterator = vectorRange.begin();
+	EXPECT_EQ((NAS2D::Vector{0, 0}), *iterator);
+	EXPECT_EQ((NAS2D::Vector{1, 0}), *++iterator);
+	EXPECT_EQ((NAS2D::Vector{2, 0}), *++iterator);
+	EXPECT_EQ(vectorRange.end(), ++iterator);
+}
+
+TEST(VectorSizeRange, IteratorIncrementYOnly) {
+	const auto vectorRange = NAS2D::VectorSizeRange{NAS2D::Vector{1, 3}};
+	auto iterator = vectorRange.begin();
+	EXPECT_EQ((NAS2D::Vector{0, 0}), *iterator);
+	EXPECT_EQ((NAS2D::Vector{0, 1}), *++iterator);
+	EXPECT_EQ((NAS2D::Vector{0, 2}), *++iterator);
+	EXPECT_EQ(vectorRange.end(), ++iterator);
+}
+
+TEST(VectorSizeRange, IteratorIncrementXAndY) {
+	const auto vectorRange = NAS2D::VectorSizeRange{NAS2D::Vector{2, 3}};
+	auto iterator = vectorRange.begin();
+	EXPECT_EQ((NAS2D::Vector{0, 0}), *iterator);
+	EXPECT_EQ((NAS2D::Vector{1, 0}), *++iterator);
+	EXPECT_EQ((NAS2D::Vector{0, 1}), *++iterator);
+	EXPECT_EQ((NAS2D::Vector{1, 1}), *++iterator);
+	EXPECT_EQ((NAS2D::Vector{0, 2}), *++iterator);
+	EXPECT_EQ((NAS2D::Vector{1, 2}), *++iterator);
+	EXPECT_EQ(vectorRange.end(), ++iterator);
+}
+
 TEST(VectorSizeRange, IterationEmpty) {
 	using Items = std::vector<NAS2D::Vector<int>>;
 	const auto vectorRangeEmpty = NAS2D::VectorSizeRange{NAS2D::Vector{0, 0}};


### PR DESCRIPTION
The range-for loops are seeing unit test failures with the new `PlatformToolset` set to `v145` for VS2026. Having separate `Iterator` tests allows the iterators to be verified without any complications from range-for loops. The range-for loops are syntax sugar for more complicated hidden code, which might be affected in unknown ways by updates to the optimizer, or from any undefined behavior that might be exhibited from the `Iterator` or the `VectorSizeRange` class.

----

Related:
- PR #1510
- Issue #1393
