### PR TITLE
Remove `const &` when passing `Vector`

### DIFF
--- a/NAS2D/Math/VectorSizeRange.h
+++ b/NAS2D/Math/VectorSizeRange.h
@@ -23,7 +23,7 @@ namespace NAS2D
 		class Iterator
 		{
 		public:
-			explicit Iterator(const Vector<BaseType>& size, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
+			explicit Iterator(Vector<BaseType> size, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
 				mCurrent(initial),
 				mSize(size)
 			{}


### PR DESCRIPTION
Be consistent with the other parameter, and other code, which passes `Vector` by-value.

----

Curiously this fixes one of the unit test failures seen when upgrading `PlatformToolset` to `v145` (VS2026). For some reason the `x86|Release` configuration starts passing again with this change. The `x64|Release` configuration still fails.

----

Related:
- PR #1511
- PR #1510
- Issue #1393
