### PR TITLE
Make `Vector`/`Rectangle` ranges `constexpr`

### DIFF
--- a/NAS2D/Math/PointInRectangleRange.h
+++ b/NAS2D/Math/PointInRectangleRange.h
@@ -26,36 +26,36 @@ namespace NAS2D
 		class Iterator
 		{
 		public:
-			explicit Iterator(const Rectangle<BaseType>& rect, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
+			constexpr explicit Iterator(const Rectangle<BaseType>& rect, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
 				mIterator(rect.size, initial),
 				mStartPoint(rect.position)
 			{}
-			Iterator(const Iterator& other) = default;
-			Iterator& operator=(const Iterator& other) = default;
+			constexpr Iterator(const Iterator& other) = default;
+			constexpr Iterator& operator=(const Iterator& other) = default;
 
-			Iterator& operator++()
+			constexpr Iterator& operator++()
 			{
 				++mIterator;
 				return *this;
 			}
 
-			Iterator& operator--()
+			constexpr Iterator& operator--()
 			{
 				--mIterator;
 				return *this;
 			}
 
-			bool operator==(const Iterator& other) const
+			constexpr bool operator==(const Iterator& other) const
 			{
 				return **this == *other;
 			}
 
-			bool operator!=(const Iterator& other) const
+			constexpr bool operator!=(const Iterator& other) const
 			{
 				return !(*this == other);
 			}
 
-			Point<BaseType> operator*() const
+			constexpr Point<BaseType> operator*() const
 			{
 				return mStartPoint + *mIterator;
 			}
@@ -66,16 +66,16 @@ namespace NAS2D
 		};
 
 
-		explicit PointInRectangleRange(Rectangle<BaseType> rect) :
+		constexpr explicit PointInRectangleRange(Rectangle<BaseType> rect) :
 			mRect(rect)
 		{}
 
-		Iterator begin() const
+		constexpr Iterator begin() const
 		{
 			return Iterator{mRect};
 		}
 
-		Iterator end() const
+		constexpr Iterator end() const
 		{
 			return Iterator{mRect, Vector<BaseType>{0, mRect.size.y}};
 		}

--- a/NAS2D/Math/PointInRectangleRange.h
+++ b/NAS2D/Math/PointInRectangleRange.h
@@ -62,7 +62,7 @@ namespace NAS2D
 
 		private:
 			typename VectorSizeRange<BaseType>::Iterator mIterator;
-			const Point<BaseType> mStartPoint;
+			Point<BaseType> mStartPoint;
 		};
 
 

--- a/NAS2D/Math/VectorSizeRange.h
+++ b/NAS2D/Math/VectorSizeRange.h
@@ -23,14 +23,14 @@ namespace NAS2D
 		class Iterator
 		{
 		public:
-			explicit Iterator(Vector<BaseType> size, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
+			constexpr explicit Iterator(Vector<BaseType> size, Vector<BaseType> initial = Vector<BaseType>{0, 0}) :
 				mCurrent(initial),
 				mSize(size)
 			{}
-			Iterator(const Iterator& other) = default;
-			Iterator& operator=(const Iterator& other) = default;
+			constexpr Iterator(const Iterator& other) = default;
+			constexpr Iterator& operator=(const Iterator& other) = default;
 
-			Iterator& operator++()
+			constexpr Iterator& operator++()
 			{
 				++mCurrent.x;
 				if (mCurrent.x >= mSize.x)
@@ -41,7 +41,7 @@ namespace NAS2D
 				return *this;
 			}
 
-			Iterator& operator--()
+			constexpr Iterator& operator--()
 			{
 				if (mCurrent.x <= 0)
 				{
@@ -52,17 +52,17 @@ namespace NAS2D
 				return *this;
 			}
 
-			bool operator==(const Iterator& other) const
+			constexpr bool operator==(const Iterator& other) const
 			{
 				return mCurrent == other.mCurrent;
 			}
 
-			bool operator!=(const Iterator& other) const
+			constexpr bool operator!=(const Iterator& other) const
 			{
 				return !(*this == other);
 			}
 
-			Vector<BaseType> operator*() const
+			constexpr Vector<BaseType> operator*() const
 			{
 				return mCurrent;
 			}
@@ -73,16 +73,16 @@ namespace NAS2D
 		};
 
 
-		explicit VectorSizeRange(Vector<BaseType> size) :
+		constexpr explicit VectorSizeRange(Vector<BaseType> size) :
 			mSize(size)
 		{}
 
-		Iterator begin() const
+		constexpr Iterator begin() const
 		{
 			return Iterator{mSize};
 		}
 
-		Iterator end() const
+		constexpr Iterator end() const
 		{
 			return Iterator{mSize, Vector<BaseType>{0, mSize.y}};
 		}

--- a/NAS2D/Math/VectorSizeRange.h
+++ b/NAS2D/Math/VectorSizeRange.h
@@ -69,7 +69,7 @@ namespace NAS2D
 
 		private:
 			Vector<BaseType> mCurrent;
-			const Vector<BaseType> mSize;
+			Vector<BaseType> mSize;
 		};
 
 


### PR DESCRIPTION
While looking over `VectorSizeRange` and `PointInRectangleRange` it was noted they could declare methods `constexpr` for use in compile time contexts.

Related:
- Issue #1393
- PR #1512
- PR #1511
- PR #1510
