### PR TITLE
Update `PointInRectangleRange` tests

### DIFF
--- a/test/Math/PointInRectangleRange.test.cpp
+++ b/test/Math/PointInRectangleRange.test.cpp
@@ -54,6 +54,12 @@ TEST(PointInRectangleRange, IterationSingle) {
 	EXPECT_EQ(fillByRangeFor(pointRangeSingle), (Items{{1, 1}}));
 }
 
+TEST(PointInRectangleRange, IterationMultiNoWrap) {
+	using Items = std::vector<NAS2D::Point<int>>;
+	const auto pointRangeMulti = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {3, 1}}};
+	EXPECT_EQ(fillByRangeFor(pointRangeMulti), (Items{{4, 5}, {5, 5}, {6, 5}}));
+}
+
 TEST(PointInRectangleRange, IterationMultiWrap) {
 	using Items = std::vector<NAS2D::Point<int>>;
 	const auto pointRangeMultiWrap = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {2, 3}}};

--- a/test/Math/PointInRectangleRange.test.cpp
+++ b/test/Math/PointInRectangleRange.test.cpp
@@ -5,6 +5,31 @@
 #include <vector>
 
 
+TEST(PointInRectangleRange, EmptyRangeBeginIsEnd) {
+	const auto pointRangeEmpty = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{0, 0}, {0, 0}}};
+	EXPECT_EQ(pointRangeEmpty.begin(), pointRangeEmpty.end());
+}
+
+TEST(PointInRectangleRange, EndIsEnd) {
+	const auto pointRangeSingleElement = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{1, 1}, {1, 1}}};
+	EXPECT_EQ(pointRangeSingleElement.end(), pointRangeSingleElement.end());
+}
+
+TEST(PointInRectangleRange, BeginToEnd) {
+	const auto pointRangeSingleElement = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{1, 1}, {1, 1}}};
+	EXPECT_EQ(pointRangeSingleElement.end(), ++pointRangeSingleElement.begin());
+}
+
+TEST(PointInRectangleRange, BeginIsOrigin) {
+	EXPECT_EQ((NAS2D::Point{1, 1}), (*NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{1, 1}, {1, 1}}}.begin()));
+	EXPECT_EQ((NAS2D::Point{4, 5}), (*NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {2, 3}}}.begin()));
+}
+
+TEST(PointInRectangleRange, EndDecrementIsLast) {
+	EXPECT_EQ((NAS2D::Point{1, 1}), (*--NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{1, 1}, {1, 1}}}.end()));
+	EXPECT_EQ((NAS2D::Point{5, 7}), (*--NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {2, 3}}}.end()));
+}
+
 TEST(PointInRectangleRange, Iteration) {
 	using Items = std::vector<NAS2D::Point<int>>;
 

--- a/test/Math/PointInRectangleRange.test.cpp
+++ b/test/Math/PointInRectangleRange.test.cpp
@@ -42,6 +42,36 @@ TEST(PointInRectangleRange, EndDecrementIsLast) {
 	EXPECT_EQ((NAS2D::Point{5, 7}), (*--NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {2, 3}}}.end()));
 }
 
+TEST(PointInRectangleRange, IteratorIncrementXOnly) {
+	const auto pointRange = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {3, 1}}};
+	auto iterator = pointRange.begin();
+	EXPECT_EQ((NAS2D::Point{4, 5}), *iterator);
+	EXPECT_EQ((NAS2D::Point{5, 5}), *++iterator);
+	EXPECT_EQ((NAS2D::Point{6, 5}), *++iterator);
+	EXPECT_EQ(pointRange.end(), ++iterator);
+}
+
+TEST(PointInRectangleRange, IteratorIncrementYOnly) {
+	const auto pointRange = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {1, 3}}};
+	auto iterator = pointRange.begin();
+	EXPECT_EQ((NAS2D::Point{4, 5}), *iterator);
+	EXPECT_EQ((NAS2D::Point{4, 6}), *++iterator);
+	EXPECT_EQ((NAS2D::Point{4, 7}), *++iterator);
+	EXPECT_EQ(pointRange.end(), ++iterator);
+}
+
+TEST(PointInRectangleRange, IteratorIncrementXAndY) {
+	const auto pointRange = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {2, 3}}};
+	auto iterator = pointRange.begin();
+	EXPECT_EQ((NAS2D::Point{4, 5}), *iterator);
+	EXPECT_EQ((NAS2D::Point{5, 5}), *++iterator);
+	EXPECT_EQ((NAS2D::Point{4, 6}), *++iterator);
+	EXPECT_EQ((NAS2D::Point{5, 6}), *++iterator);
+	EXPECT_EQ((NAS2D::Point{4, 7}), *++iterator);
+	EXPECT_EQ((NAS2D::Point{5, 7}), *++iterator);
+	EXPECT_EQ(pointRange.end(), ++iterator);
+}
+
 TEST(PointInRectangleRange, IterationEmpty) {
 	using Items = std::vector<NAS2D::Point<int>>;
 	const auto pointRangeEmpty = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{0, 0}, {0, 0}}};

--- a/test/Math/PointInRectangleRange.test.cpp
+++ b/test/Math/PointInRectangleRange.test.cpp
@@ -54,13 +54,13 @@ TEST(PointInRectangleRange, IterationSingle) {
 	EXPECT_EQ(fillByRangeFor(pointRangeSingle), (Items{{1, 1}}));
 }
 
-TEST(PointInRectangleRange, IterationMultiNoWrap) {
+TEST(PointInRectangleRange, IterationMultiXOnly) {
 	using Items = std::vector<NAS2D::Point<int>>;
 	const auto pointRangeMulti = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {3, 1}}};
 	EXPECT_EQ(fillByRangeFor(pointRangeMulti), (Items{{4, 5}, {5, 5}, {6, 5}}));
 }
 
-TEST(PointInRectangleRange, IterationMultiWrap) {
+TEST(PointInRectangleRange, IterationMultiXAndY) {
 	using Items = std::vector<NAS2D::Point<int>>;
 	const auto pointRangeMultiWrap = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {2, 3}}};
 	EXPECT_EQ(fillByRangeFor(pointRangeMultiWrap), (Items{{4, 5}, {5, 5}, {4, 6}, {5, 6}, {4, 7}, {5, 7}}));

--- a/test/Math/PointInRectangleRange.test.cpp
+++ b/test/Math/PointInRectangleRange.test.cpp
@@ -42,14 +42,20 @@ TEST(PointInRectangleRange, EndDecrementIsLast) {
 	EXPECT_EQ((NAS2D::Point{5, 7}), (*--NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {2, 3}}}.end()));
 }
 
-TEST(PointInRectangleRange, Iteration) {
+TEST(PointInRectangleRange, IterationEmpty) {
 	using Items = std::vector<NAS2D::Point<int>>;
+	const auto pointRangeEmpty = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{0, 0}, {0, 0}}};
+	EXPECT_EQ(fillByRangeFor(pointRangeEmpty), (Items{}));
+}
 
-	const auto pointRange1 = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{0, 0}, {0, 0}}};
-	const auto pointRange2 = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{1, 1}, {1, 1}}};
-	const auto pointRange3 = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {2, 3}}};
+TEST(PointInRectangleRange, IterationSingle) {
+	using Items = std::vector<NAS2D::Point<int>>;
+	const auto pointRangeSingle = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{1, 1}, {1, 1}}};
+	EXPECT_EQ(fillByRangeFor(pointRangeSingle), (Items{{1, 1}}));
+}
 
-	EXPECT_EQ(fillByRangeFor(pointRange1), (Items{}));
-	EXPECT_EQ(fillByRangeFor(pointRange2), (Items{{1, 1}}));
-	EXPECT_EQ(fillByRangeFor(pointRange3), (Items{{4, 5}, {5, 5}, {4, 6}, {5, 6}, {4, 7}, {5, 7}}));
+TEST(PointInRectangleRange, IterationMultiWrap) {
+	using Items = std::vector<NAS2D::Point<int>>;
+	const auto pointRangeMultiWrap = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {2, 3}}};
+	EXPECT_EQ(fillByRangeFor(pointRangeMultiWrap), (Items{{4, 5}, {5, 5}, {4, 6}, {5, 6}, {4, 7}, {5, 7}}));
 }

--- a/test/Math/PointInRectangleRange.test.cpp
+++ b/test/Math/PointInRectangleRange.test.cpp
@@ -49,12 +49,6 @@ TEST(PointInRectangleRange, Iteration) {
 	const auto pointRange2 = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{1, 1}, {1, 1}}};
 	const auto pointRange3 = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {2, 3}}};
 
-	// Test head of range for expected values
-	EXPECT_EQ((NAS2D::Point{4, 5}), *pointRange3.begin());
-	EXPECT_EQ((NAS2D::Point{5, 5}), *++pointRange3.begin());
-	EXPECT_EQ((NAS2D::Point{4, 6}), *++++pointRange3.begin());
-	EXPECT_EQ((NAS2D::Point{5, 6}), *++++++pointRange3.begin());
-
 	EXPECT_EQ(fillByRangeFor(pointRange1), (Items{}));
 	EXPECT_EQ(fillByRangeFor(pointRange2), (Items{{1, 1}}));
 	EXPECT_EQ(fillByRangeFor(pointRange3), (Items{{4, 5}, {5, 5}, {4, 6}, {5, 6}, {4, 7}, {5, 7}}));

--- a/test/Math/PointInRectangleRange.test.cpp
+++ b/test/Math/PointInRectangleRange.test.cpp
@@ -14,7 +14,6 @@ TEST(PointInRectangleRange, Iteration) {
 
 	// Dereference produces the expected starting value
 	// (Later tests also proves the range is restartable)
-	EXPECT_EQ((NAS2D::Point{0, 0}), *pointRange1.begin());
 	EXPECT_EQ((NAS2D::Point{1, 1}), *pointRange2.begin());
 	EXPECT_EQ((NAS2D::Point{4, 5}), *pointRange3.begin());
 

--- a/test/Math/PointInRectangleRange.test.cpp
+++ b/test/Math/PointInRectangleRange.test.cpp
@@ -60,6 +60,12 @@ TEST(PointInRectangleRange, IterationMultiXOnly) {
 	EXPECT_EQ(fillByRangeFor(pointRangeMulti), (Items{{4, 5}, {5, 5}, {6, 5}}));
 }
 
+TEST(PointInRectangleRange, IterationMultiYOnly) {
+	using Items = std::vector<NAS2D::Point<int>>;
+	const auto pointRangeMulti = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {1, 3}}};
+	EXPECT_EQ(fillByRangeFor(pointRangeMulti), (Items{{4, 5}, {4, 6}, {4, 7}}));
+}
+
 TEST(PointInRectangleRange, IterationMultiXAndY) {
 	using Items = std::vector<NAS2D::Point<int>>;
 	const auto pointRangeMultiWrap = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {2, 3}}};

--- a/test/Math/PointInRectangleRange.test.cpp
+++ b/test/Math/PointInRectangleRange.test.cpp
@@ -5,6 +5,18 @@
 #include <vector>
 
 
+namespace {
+	template <typename BaseType>
+	auto fillByRangeFor(NAS2D::PointInRectangleRange<BaseType> pointRange) -> std::vector<NAS2D::Point<BaseType>> {
+		std::vector<NAS2D::Point<BaseType>> collection;
+		for (const auto point : pointRange) {
+			collection.push_back(point);
+		}
+		return collection;
+	};
+}
+
+
 TEST(PointInRectangleRange, EmptyRangeBeginIsEnd) {
 	const auto pointRangeEmpty = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{0, 0}, {0, 0}}};
 	EXPECT_EQ(pointRangeEmpty.begin(), pointRangeEmpty.end());
@@ -48,14 +60,6 @@ TEST(PointInRectangleRange, Iteration) {
 	EXPECT_EQ((NAS2D::Point{4, 6}), *++++pointRange3.begin());
 	EXPECT_EQ((NAS2D::Point{5, 6}), *++++++pointRange3.begin());
 
-	// Range-for syntax is supported
-	const auto fillByRangeFor = [](auto pointRange) {
-		Items collection;
-		for (const auto point : pointRange) {
-			collection.push_back(point);
-		}
-		return collection;
-	};
 	EXPECT_EQ(fillByRangeFor(pointRange1), (Items{}));
 	EXPECT_EQ(fillByRangeFor(pointRange2), (Items{{1, 1}}));
 	EXPECT_EQ(fillByRangeFor(pointRange3), (Items{{4, 5}, {5, 5}, {4, 6}, {5, 6}, {4, 7}, {5, 7}}));

--- a/test/Math/PointInRectangleRange.test.cpp
+++ b/test/Math/PointInRectangleRange.test.cpp
@@ -49,11 +49,6 @@ TEST(PointInRectangleRange, Iteration) {
 	const auto pointRange2 = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{1, 1}, {1, 1}}};
 	const auto pointRange3 = NAS2D::PointInRectangleRange{NAS2D::Rectangle<int>{{4, 5}, {2, 3}}};
 
-	// Dereference produces the expected starting value
-	// (Later tests also proves the range is restartable)
-	EXPECT_EQ((NAS2D::Point{1, 1}), *pointRange2.begin());
-	EXPECT_EQ((NAS2D::Point{4, 5}), *pointRange3.begin());
-
 	// Test head of range for expected values
 	EXPECT_EQ((NAS2D::Point{4, 5}), *pointRange3.begin());
 	EXPECT_EQ((NAS2D::Point{5, 5}), *++pointRange3.begin());


### PR DESCRIPTION
Apply the recent updates on `VectorSizeRange` tests to `PointInRectangleRange` tests.

The test cases are pretty similar to each other, so should probably be updated in the same ways. This mostly involves splitting up the tests to better localize failures, and improving coverage.

Related:
- Issue #1393
- PR #1510
- PR #1511
