### PR TITLE
Support more custom MSVC project customizations

### DIFF
--- a/MsvcDefaults/CompilerLinker.props
+++ b/MsvcDefaults/CompilerLinker.props
@@ -35,6 +35,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories Condition="'$(ProjectAdditionalIncludeDirectories)' != ''">$(ProjectAdditionalIncludeDirectories);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <FavorSizeOrSpeed Condition="'$(ProjectFavorSizeOrSpeed)' != ''">$(ProjectFavorSizeOrSpeed)</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem Condition="'$(ProjectSubSystem)' != ''">$(ProjectSubSystem)</SubSystem>

--- a/MsvcDefaults/CompilerLinker.props
+++ b/MsvcDefaults/CompilerLinker.props
@@ -38,6 +38,7 @@
       <FavorSizeOrSpeed Condition="'$(ProjectFavorSizeOrSpeed)' != ''">$(ProjectFavorSizeOrSpeed)</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
+      <AdditionalDependencies Condition="'$(ProjectAdditionalDependencies)' != ''">$(ProjectAdditionalDependencies);%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem Condition="'$(ProjectSubSystem)' != ''">$(ProjectSubSystem)</SubSystem>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Add custom properties `ProjectFavorSizeOrSpeed` and `ProjectAdditionalDependencies` to easily set defaults for all configurations.

A `Condition` guard can be used to apply the properties to only certain configurations.

These can be used to support certain customizations in OPHD.

Related:
- Issue #1452
- Issue https://github.com/OutpostUniverse/OPHD/issues/2196
  - Comment https://github.com/OutpostUniverse/OPHD/issues/2196#issuecomment-4821714948
- PR #1506
- PR #1507
- PR #1508
