### PR TITLE
Retarget MSVC `PlatformToolset` to `v145` (VS2026)

### DIFF
--- a/MsvcDefaults/PropertyDefaults.props
+++ b/MsvcDefaults/PropertyDefaults.props
@@ -3,6 +3,10 @@
     <RootNamespace>$(MSBuildProjectName)</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Platform)'=='ARM' OR '$(Platform)'=='ARM64'">
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
 


### PR DESCRIPTION
Add an exception for `ARM` and `ARM64` which will continue using the older `v143` toolset. The currently available Arm runners have only just opened preview environments with Visual Studio 2026. The new environments are not scheduled to be officially supported until September. We can re-address the target `PlatformToolset` when support becomes official.

The `PlatformToolset` upgrade is perhaps most impactful regarding nag screens to upgrade for local Visual Studio users. Visual Studio 2026 can prompt the user to upgrade the projects when opening them. The upgrade should remove the nag screen. We don't actually need the new toolset for any features, or near term planned features.

----

The update will change the version string in the path to the tools, such as `CL.exe`:

Previous:
```cmd
C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Tools\MSVC\14.44.35207\bin\HostX86\x64\CL.exe
```

Updated:
```cmd
C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Tools\MSVC\14.51.36231\bin\HostX86\x64\CL.exe
```

----

Draft:
There is a compiler code gen bug in the latest toolset which causes some failures in the unit tests. We may want to wait for the fix to be packaged into a release before merging this change.

https://developercommunity.visualstudio.com/t/Bad-code-gen-for-x64x86-with-msvc-v/11112781

----

Related:
- Issue #1393
