### PR TITLE
Run Docker image build only on demand

### DIFF
--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -1,54 +1,32 @@
 name: Build Docker Build Env
 
 on:
-  push:
-    # Builds should happen on feature branches
-    # Only successfully tested builds should be merged to main
-    # We don't want to rebuild after testing and verifying
-    branches-ignore:
-      - 'main'
-    paths:
-      - '.github/workflows/buildDockerBuildEnv.yml'
-      - 'dockerBuildEnv/*'
   workflow_dispatch:
+    inputs:
+      buildEnv:
+        description: Image to rebuild
+        required: true
+        type: choice
+        options:
+          - arch
+          - clang
+          - gcc
+          - mingw
 
 jobs:
   dockerBuild:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-        - 'arch'
-        - 'clang'
-        - 'gcc'
-        - 'mingw'
     env:
-      buildEnv: ${{ matrix.platform }}
-      defaultBranch: ${{ github.event.repository.default_branch }}
+      buildEnv: ${{ inputs.buildEnv }}
 
     steps:
       - uses: actions/checkout@v6
 
-      - name: Fetch default branch
-        run: |
-          git remote set-branches --add origin "${defaultBranch}"
-          git fetch --depth 1 origin "${defaultBranch}"
-
-      - name: Check for changes
-        id: diff
-        run: |
-          set +e
-          git diff --exit-code --no-patch "origin/${defaultBranch}" dockerBuildEnv/nas2d-${{ env.buildEnv }}.* ; echo "modified=$?" >> $GITHUB_OUTPUT
-
       - name: Docker build
-        if: ${{ fromJSON(steps.diff.outputs.modified) }}
         run: make build-image-${{ env.buildEnv }}
 
       - name: Docker login
-        if: ${{ fromJSON(steps.diff.outputs.modified) }}
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username "${{ github.repository_owner }}" --password-stdin
 
       - name: Docker push
-        if: ${{ fromJSON(steps.diff.outputs.modified) }}
         run: make push-image-${{ env.buildEnv }}

--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -12,6 +12,11 @@ on:
           - clang
           - gcc
           - mingw
+  workflow_call:
+    inputs:
+      buildEnv:
+        required: true
+        type: string
 
 jobs:
   dockerBuild:

--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -24,6 +24,7 @@ jobs:
         - 'gcc'
         - 'mingw'
     env:
+      buildEnv: ${{ matrix.platform }}
       defaultBranch: ${{ github.event.repository.default_branch }}
 
     steps:
@@ -38,11 +39,11 @@ jobs:
         id: diff
         run: |
           set +e
-          git diff --exit-code --no-patch "origin/${defaultBranch}" dockerBuildEnv/nas2d-${{ matrix.platform }}.* ; echo "modified=$?" >> $GITHUB_OUTPUT
+          git diff --exit-code --no-patch "origin/${defaultBranch}" dockerBuildEnv/nas2d-${{ env.buildEnv }}.* ; echo "modified=$?" >> $GITHUB_OUTPUT
 
       - name: Docker build
         if: ${{ fromJSON(steps.diff.outputs.modified) }}
-        run: make build-image-${{ matrix.platform }}
+        run: make build-image-${{ env.buildEnv }}
 
       - name: Docker login
         if: ${{ fromJSON(steps.diff.outputs.modified) }}
@@ -50,4 +51,4 @@ jobs:
 
       - name: Docker push
         if: ${{ fromJSON(steps.diff.outputs.modified) }}
-        run: make push-image-${{ matrix.platform }}
+        run: make push-image-${{ env.buildEnv }}


### PR DESCRIPTION
This gives better control over when the workflow runs. It allows for re-runs to restore a missing image if the image is deleted, or the repository moves to another account. It prevents automatic workflow runs and rebuilds for trivial changes that don't warrant a new release.

If we wish to run on push, potentially we can use a new workflow that calls this one. A `workflow_call` trigger has been added.

----

Related:
- Issue #1525
