### PR TITLE
Build for Linux on GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,35 +22,8 @@ jobs:
       - checkout
       - brew-install
       - build-and-test
-  build-linux-gcc:
-    docker:
-      - image: ghcr.io/lairworks/build-env-nas2d-gcc:1.7
-    environment:
-      Toolchain: "gcc"
-    steps:
-      - checkout
-      - build-and-test
-  build-linux-clang:
-    docker:
-      - image: ghcr.io/lairworks/build-env-nas2d-clang:1.6
-    environment:
-      Toolchain: "clang"
-    steps:
-      - checkout
-      - build-and-test
-  build-linux-mingw:
-    docker:
-      - image: ghcr.io/lairworks/build-env-nas2d-mingw:1.16
-    environment:
-      Toolchain: "mingw"
-    steps:
-      - checkout
-      - build-and-test
 
 workflows:
   build_and_test:
     jobs:
       - build-macos
-      - build-linux-gcc
-      - build-linux-clang
-      - build-linux-mingw

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,9 @@ jobs:
       matrix:
         image:
         - "build-env-nas2d-arch:1.7"
+        - "build-env-nas2d-clang:1.6"
+        - "build-env-nas2d-gcc:1.7"
+        - "build-env-nas2d-mingw:1.16"
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"


### PR DESCRIPTION
GitHub Actions can access the GitHub Docker registry using the automatic `GITHUB_TOKEN`, so won't need the packages to be public.

This was surprisingly easy and straightforward to accomplish. The Arch Linux build on GitHub Actions was already setup for `matrix` builds where we could just add the other images. Didn't even need the custom `makefile` variable `Toolchain` to be set since all the Docker images set `CXX`. Moved things over and they just worked. The build steps even run faster on GitHub Actions, sometimes by 50%-100%, though that might be impacted by runner load, so should be careful about drawing conclusions from one run at one time of day.

Related:
- Issue #1527
