### PR TITLE
Set `Toolchain` in Docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         - "build-env-nas2d-arch:1.7"
         - "build-env-nas2d-clang:1.7"
         - "build-env-nas2d-gcc:1.8"
-        - "build-env-nas2d-mingw:1.16"
+        - "build-env-nas2d-mingw:1.17"
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
         image:
         - "build-env-nas2d-arch:1.7"
         - "build-env-nas2d-clang:1.7"
-        - "build-env-nas2d-gcc:1.7"
+        - "build-env-nas2d-gcc:1.8"
         - "build-env-nas2d-mingw:1.16"
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
       matrix:
         image:
         - "build-env-nas2d-arch:1.7"
-        - "build-env-nas2d-clang:1.6"
+        - "build-env-nas2d-clang:1.7"
         - "build-env-nas2d-gcc:1.7"
         - "build-env-nas2d-mingw:1.16"
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - "build-env-nas2d-arch:1.7"
+        - "build-env-nas2d-arch:1.8"
         - "build-env-nas2d-clang:1.7"
         - "build-env-nas2d-gcc:1.8"
         - "build-env-nas2d-mingw:1.17"

--- a/dockerBuildEnv/nas2d-arch.Dockerfile
+++ b/dockerBuildEnv/nas2d-arch.Dockerfile
@@ -26,4 +26,8 @@ RUN pacman --sync --refresh --noconfirm \
 
 RUN useradd --create-home user
 
+# Set custom variables for build script convenience
+# Activate appropriate Toolchain settings
+ENV Toolchain=gcc
+
 CMD ["make", "--keep-going", "check"]

--- a/dockerBuildEnv/nas2d-arch.version.mk
+++ b/dockerBuildEnv/nas2d-arch.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_arch := 1.7
+ImageVersion_arch := 1.8

--- a/dockerBuildEnv/nas2d-clang.Dockerfile
+++ b/dockerBuildEnv/nas2d-clang.Dockerfile
@@ -31,4 +31,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsdl2-ttf-dev=2.24.0+* \
   && rm -rf /var/lib/apt/lists/*
 
+ENV Toolchain=clang
+
 CMD ["make", "--keep-going", "check"]

--- a/dockerBuildEnv/nas2d-clang.Dockerfile
+++ b/dockerBuildEnv/nas2d-clang.Dockerfile
@@ -31,6 +31,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsdl2-ttf-dev=2.24.0+* \
   && rm -rf /var/lib/apt/lists/*
 
+# Set custom variables for build script convenience
+# Activate appropriate Toolchain settings
 ENV Toolchain=clang
 
 CMD ["make", "--keep-going", "check"]

--- a/dockerBuildEnv/nas2d-clang.version.mk
+++ b/dockerBuildEnv/nas2d-clang.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_clang := 1.6
+ImageVersion_clang := 1.7

--- a/dockerBuildEnv/nas2d-gcc.Dockerfile
+++ b/dockerBuildEnv/nas2d-gcc.Dockerfile
@@ -32,6 +32,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsdl2-ttf-dev=2.24.0+* \
   && rm -rf /var/lib/apt/lists/*
 
+# Set custom variables for build script convenience
+# Activate appropriate Toolchain settings
 ENV Toolchain=gcc
 
 CMD ["make", "--keep-going", "check"]

--- a/dockerBuildEnv/nas2d-gcc.Dockerfile
+++ b/dockerBuildEnv/nas2d-gcc.Dockerfile
@@ -32,4 +32,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsdl2-ttf-dev=2.24.0+* \
   && rm -rf /var/lib/apt/lists/*
 
+ENV Toolchain=gcc
+
 CMD ["make", "--keep-going", "check"]

--- a/dockerBuildEnv/nas2d-gcc.version.mk
+++ b/dockerBuildEnv/nas2d-gcc.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_gcc := 1.7
+ImageVersion_gcc := 1.8

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -122,8 +122,6 @@ ENV  CC=${CC64}
 # USER root
 
 # Set custom variables for build script convenience
-# Set default target OS
-ENV TARGET_OS=Windows
 # Set custom makefile parameter
 ENV Toolchain=mingw
 # Set a library search path to make rebuilding easier in a debug sessions

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -127,8 +127,6 @@ ENV TARGET_OS=Windows
 # Set default extra C pre-processor flags
 # This makes proper rebuilding easier in a debug session
 ENV CPPFLAGS_EXTRA=-D"GLEW_STATIC"
-# Disable warnings for redundant declarations of intrinsics, triggered by SDL2
-ENV WARN_EXTRA=-Wno-redundant-decls
 # Set custom makefile parameter
 ENV Toolchain=mingw
 # Set a library search path to make rebuilding easier in a debug sessions

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -113,14 +113,6 @@ ENV WINEPATH="${WINEPATH64}"
 ENV CXX=${CXX64}
 ENV  CC=${CC64}
 
-# Cache the result of `wineboot` for faster startup (or don't for smaller images)
-# USER user
-
-# Pre-setup Wine to save startup time later
-# RUN wineboot
-
-# USER root
-
 # Set custom variables for build script convenience
 # Activate appropriate Toolchain settings
 ENV Toolchain=mingw

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -124,9 +124,6 @@ ENV  CC=${CC64}
 # Set custom variables for build script convenience
 # Set default target OS
 ENV TARGET_OS=Windows
-# Set default extra C pre-processor flags
-# This makes proper rebuilding easier in a debug session
-ENV CPPFLAGS_EXTRA=-D"GLEW_STATIC"
 # Set custom makefile parameter
 ENV Toolchain=mingw
 # Set a library search path to make rebuilding easier in a debug sessions

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -122,9 +122,9 @@ ENV  CC=${CC64}
 # USER root
 
 # Set custom variables for build script convenience
-# Set custom makefile parameter
+# Activate appropriate Toolchain settings
 ENV Toolchain=mingw
-# Set a library search path to make rebuilding easier in a debug sessions
+# Set a library search path to use during linking
 ENV LDFLAGS_EXTRA="-L/usr/local/x86_64-w64-mingw32/lib"
 
 # Be explicit about the extra flags with the default command

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -25,9 +25,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     ca-certificates=* \
   && rm -rf /var/lib/apt/lists/*
 
-# Set custom variables for build script convenience
-# Set default target OS
-ENV TARGET_OS=Windows
 # Set architecture short names
 ENV ARCH64=x86_64-w64-mingw32
 # Set compiler short names
@@ -124,6 +121,9 @@ ENV  CC=${CC64}
 
 # USER root
 
+# Set custom variables for build script convenience
+# Set default target OS
+ENV TARGET_OS=Windows
 # Set default extra C pre-processor flags
 # This makes proper rebuilding easier in a debug session
 ENV CPPFLAGS_EXTRA=-D"GLEW_STATIC"

--- a/dockerBuildEnv/nas2d-mingw.version.mk
+++ b/dockerBuildEnv/nas2d-mingw.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_mingw := 1.16
+ImageVersion_mingw := 1.17

--- a/makefile
+++ b/makefile
@@ -53,7 +53,6 @@ CONFIG_CXX_FLAGS := $($(CONFIG)_CXX_FLAGS)
 
 # Target specific settings
 WindowsSpecialPreprocessorFlags = -DGLEW_STATIC
-WindowsSpecialWarnFlags = -Wno-redundant-decls
 WindowsExeSuffix := .exe
 WindowsRunPrefix := wine
 WindowsRunSuffixUnitTest := --gtest_color=yes | cat -


### PR DESCRIPTION
This makes it easier to automatically activate `Toolchain` specific settings that are appropriate for that environment.

In particular, the `Toolchain` setting activates more strict warning flags for the Clang, GCC, and Arch Linux builds.

Remove one warning disable (`-Wno-redundant-decls`) for `Toolchain=mingw`.

Related:
- PR #1528
- Issue #1527
- Issue #528
