### PR TITLE
Partial fix for Mingw unit test running

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         - "build-env-nas2d-arch:1.8"
         - "build-env-nas2d-clang:1.7"
         - "build-env-nas2d-gcc:1.8"
-        - "build-env-nas2d-mingw:1.17"
+        - "build-env-nas2d-mingw:1.18"
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -36,7 +36,7 @@ ENV  LD64=${ARCH64}-ld
 RUN curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
   echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/wine.list && \
   apt-get update && apt-get install -y --no-install-recommends \
-    wine64=10.0~repack-12ubuntu1 \
+    wine=10.0~repack-12ubuntu1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Set default install location for custom packages

--- a/dockerBuildEnv/nas2d-mingw.version.mk
+++ b/dockerBuildEnv/nas2d-mingw.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_mingw := 1.17
+ImageVersion_mingw := 1.18


### PR DESCRIPTION
Change the `apt` package from `wine64` to `wine` in the Mingw build environment.

This ensures we have the more generic `wine` shell script that can dispatch to either `wine64` or theoretically `wine32`.

This fixes the error:
> wine .build/Windows/x86_64/Debug/test/test.exe --gtest_color=yes | cat -
> /bin/sh: 1: wine: not found

----

This change reveals the second error, which is not fixed here:
> wine .build/Windows/x86_64/Debug/test/test.exe  --gtest_color=yes | cat -
> wine: '/github/home' is not owned by you, refusing to create a configuration directory there

This second error is probably not going to be a Mingw build image fix. The `uid` and `gid` as well as the `HOME` environment variable is not known until the container is started. It will be different for GitHub Actions runners versus local Docker runs. It may require adjustments to either the CI workflow or the `makefile` rules.

----

Related:
- Issue #1533
