### PR TITLE
Fix Mingw unit test running and failure reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"
+      options: --user=1001:1001
 
     steps:
     - uses: actions/checkout@v6

--- a/makefile
+++ b/makefile
@@ -55,7 +55,7 @@ CONFIG_CXX_FLAGS := $($(CONFIG)_CXX_FLAGS)
 WindowsSpecialPreprocessorFlags = -DGLEW_STATIC
 WindowsExeSuffix := .exe
 WindowsRunPrefix := wine
-WindowsRunSuffixUnitTest := --gtest_color=yes | cat -
+WindowsRunSuffixUnitTest := --gtest_color=yes > >(cat)
 
 DarwinIncludeSearchFlags = -isystem$(shell brew --prefix)/include
 
@@ -134,6 +134,7 @@ $(TESTOBJS): $(TESTINTDIR)/%.o : $(TESTDIR)/%.cpp $(TESTINTDIR)/%.dep
 
 
 .PHONY: check
+check: SHELL := bash
 check: | test
 	$(RunPrefix) $(TESTOUTPUT) $(GTEST_OPTIONS) $(RunSuffixUnitTest)
 


### PR DESCRIPTION
Run the GitHub Actions Docker job using custom `--user` option to match the host `runner` user. This allows the `wine` process `uid` to match the expected `uid` of the mounted home folder. This fixes the error:
> wine: '/github/home' is not owned by you, refusing to create a configuration directory there

Unfortunately the `runner` user having `uid` of `1001` is not documented. Though there was an issue for Larger Runners where they were modified so the `uid` of the `runner` user matches that of the Standard Runners. Hence they seem to care enough to make them match in various environments, even if they don't document the value. There is also no apparent way to read the value early enough to use it when starting a job container. The value can be obtained using `id --user` (and `id --group`) from within the container, though that would be too late to use starting the container.

Although undocumented, the `1001` value seems stable and predictable enough that we can probably get away with using it as a hardcoded value for the foreseeable future.

----

Fix unit test failure reporting by replace the use of a pipe with the `bash` feature for process substitution (not available in the default `sh`/`dash` of Ubuntu).

The problem with the pipe is the return code of the pipe is that of the last executable in the pipe. Hence the pipe was swallowing the return code trying to run `wine` for the unit tests, and returning the value from `cat`, which was always successful.

By using process substitution, we get the return code from trying to run the unit tests using `wine`. This means we get the success/failure return code that we care about.

----

Related:
- Issue #1533

Closes #1533
