### PR TITLE
Add local Docker package caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,10 +126,10 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - "build-env-nas2d-arch:1.8"
-        - "build-env-nas2d-clang:1.7"
-        - "build-env-nas2d-gcc:1.8"
-        - "build-env-nas2d-mingw:1.18"
+        - "build-env-nas2d-arch:2026-07-15"
+        - "build-env-nas2d-clang:2026-07-15"
+        - "build-env-nas2d-gcc:2026-07-15"
+        - "build-env-nas2d-mingw:2026-07-15"
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"

--- a/dockerBuildEnv/nas2d-arch.Dockerfile
+++ b/dockerBuildEnv/nas2d-arch.Dockerfile
@@ -5,7 +5,8 @@ FROM archlinux:base-20260628.0.549485
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages
 # Includes tools needed for primary CircleCI containers
-RUN pacman --sync --refresh --noconfirm \
+RUN \
+  pacman --sync --refresh --noconfirm \
     gcc \
     make \
     gtest \
@@ -16,7 +17,8 @@ RUN pacman --sync --refresh --noconfirm \
     ca-certificates \
   && rm -rf /var/cache/pacman/pkg
 
-RUN pacman --sync --refresh --noconfirm \
+RUN \
+  pacman --sync --refresh --noconfirm \
     glew \
     sdl2 \
     sdl2_image \

--- a/dockerBuildEnv/nas2d-arch.Dockerfile
+++ b/dockerBuildEnv/nas2d-arch.Dockerfile
@@ -6,6 +6,7 @@ FROM archlinux:base-20260628.0.549485
 # Includes tools to build download, unpack, and build source packages
 # Includes tools needed for primary CircleCI containers
 RUN \
+  --mount=type=cache,target=/var/cache/pacman/pkg,sharing=locked \
   pacman --sync --refresh --noconfirm \
     gcc \
     make \
@@ -14,17 +15,16 @@ RUN \
     openssh \
     tar \
     gzip \
-    ca-certificates \
-  && rm -rf /var/cache/pacman/pkg
+    ca-certificates
 
 RUN \
+  --mount=type=cache,target=/var/cache/pacman/pkg,sharing=locked \
   pacman --sync --refresh --noconfirm \
     glew \
     sdl2 \
     sdl2_image \
     sdl2_mixer \
-    sdl2_ttf \
-  && rm -rf /var/cache/pacman/pkg
+    sdl2_ttf
 
 RUN useradd --create-home user
 

--- a/dockerBuildEnv/nas2d-arch.version.mk
+++ b/dockerBuildEnv/nas2d-arch.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_arch := 1.8
+ImageVersion_arch := 2026-07-15

--- a/dockerBuildEnv/nas2d-clang.Dockerfile
+++ b/dockerBuildEnv/nas2d-clang.Dockerfile
@@ -6,7 +6,9 @@ FROM ubuntu:resolute-20260610
 # Includes tools to build download, unpack, and build source packages
 # Includes tools needed for primary CircleCI containers
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential=12.12* \
     clang=1:21.1.6-* \
     cmake=4.2.3-* \
@@ -23,7 +25,9 @@ ENV CXX=clang++
 ENV  CC=clang
 
 # Install NAS2D specific dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
     libglew-dev=2.2.0-* \
     libsdl2-dev=2.32.10+* \
     libsdl2-image-dev=2.8.8+* \

--- a/dockerBuildEnv/nas2d-clang.Dockerfile
+++ b/dockerBuildEnv/nas2d-clang.Dockerfile
@@ -2,11 +2,16 @@
 
 FROM ubuntu:resolute-20260610
 
+# Remove automatic apt package cleanup so a local cache mount can be used
+RUN rm /etc/apt/apt.conf.d/docker-clean
+
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages
 # Includes tools needed for primary CircleCI containers
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential=12.12* \
@@ -18,22 +23,22 @@ RUN \
     ssh=1:10.2p1-* \
     tar=1.35+* \
     gzip=1.14-* \
-    ca-certificates=* \
-  && rm -rf /var/lib/apt/lists/*
+    ca-certificates=*
 
 ENV CXX=clang++
 ENV  CC=clang
 
 # Install NAS2D specific dependencies
 RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     libglew-dev=2.2.0-* \
     libsdl2-dev=2.32.10+* \
     libsdl2-image-dev=2.8.8+* \
     libsdl2-mixer-dev=2.8.1+* \
-    libsdl2-ttf-dev=2.24.0+* \
-  && rm -rf /var/lib/apt/lists/*
+    libsdl2-ttf-dev=2.24.0+*
 
 # Set custom variables for build script convenience
 # Activate appropriate Toolchain settings

--- a/dockerBuildEnv/nas2d-clang.version.mk
+++ b/dockerBuildEnv/nas2d-clang.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_clang := 1.7
+ImageVersion_clang := 2026-07-15

--- a/dockerBuildEnv/nas2d-gcc.Dockerfile
+++ b/dockerBuildEnv/nas2d-gcc.Dockerfile
@@ -2,12 +2,17 @@
 
 FROM ubuntu:resolute-20260610
 
+# Remove automatic apt package cleanup so a local cache mount can be used
+RUN rm /etc/apt/apt.conf.d/docker-clean
+
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages
 # Includes tools needed for primary CircleCI containers
 # Install latest available GCC compiler (which may not be the default)
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     g++=4:15.2.0-* \
@@ -19,22 +24,22 @@ RUN \
     ssh=1:10.2p1-* \
     tar=1.35+* \
     gzip=1.14-* \
-    ca-certificates=* \
-  && rm -rf /var/lib/apt/lists/*
+    ca-certificates=*
 
 ENV CXX=g++
 ENV  CC=gcc
 
 # Install NAS2D specific dependencies
 RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     libglew-dev=2.2.0-* \
     libsdl2-dev=2.32.10+* \
     libsdl2-image-dev=2.8.8+* \
     libsdl2-mixer-dev=2.8.1+* \
-    libsdl2-ttf-dev=2.24.0+* \
-  && rm -rf /var/lib/apt/lists/*
+    libsdl2-ttf-dev=2.24.0+*
 
 # Set custom variables for build script convenience
 # Activate appropriate Toolchain settings

--- a/dockerBuildEnv/nas2d-gcc.Dockerfile
+++ b/dockerBuildEnv/nas2d-gcc.Dockerfile
@@ -7,7 +7,9 @@ FROM ubuntu:resolute-20260610
 # Includes tools needed for primary CircleCI containers
 # Install latest available GCC compiler (which may not be the default)
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     g++=4:15.2.0-* \
     make=4.4.1-* \
     cmake=4.2.3-* \
@@ -24,7 +26,9 @@ ENV CXX=g++
 ENV  CC=gcc
 
 # Install NAS2D specific dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
     libglew-dev=2.2.0-* \
     libsdl2-dev=2.32.10+* \
     libsdl2-image-dev=2.8.8+* \

--- a/dockerBuildEnv/nas2d-gcc.version.mk
+++ b/dockerBuildEnv/nas2d-gcc.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_gcc := 1.8
+ImageVersion_gcc := 2026-07-15

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -38,12 +38,15 @@ ENV CXX64=${ARCH64}-g++
 ENV  CC64=${ARCH64}-gcc
 ENV  LD64=${ARCH64}-ld
 
+# Install apt repository for wine
+RUN \
+  curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
+  echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/wine.list
+
 # Install wine so resulting unit test binaries can be run
 RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-  curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
-  echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/wine.list && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     wine=10.0~repack-12ubuntu1

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -7,7 +7,9 @@ FROM ubuntu:resolute-20260610
 # Includes tools needed for primary CircleCI containers
 # The lsb-release package is used to install wine
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     g++-mingw-w64-x86-64-win32=13.2.0-* \
     cmake=4.2.3-* \
     make=4.4.1-* \
@@ -33,9 +35,11 @@ ENV  CC64=${ARCH64}-gcc
 ENV  LD64=${ARCH64}-ld
 
 # Install wine so resulting unit test binaries can be run
-RUN curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
+RUN \
+  curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
   echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/wine.list && \
-  apt-get update && apt-get install -y --no-install-recommends \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
     wine=10.0~repack-12ubuntu1 \
   && rm -rf /var/lib/apt/lists/*
 

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -2,12 +2,17 @@
 
 FROM ubuntu:resolute-20260610
 
+# Remove automatic apt package cleanup so a local cache mount can be used
+RUN rm /etc/apt/apt.conf.d/docker-clean
+
 # Install base development tools
 # Includes tools to build download, unpack, and build source packages
 # Includes tools needed for primary CircleCI containers
 # The lsb-release package is used to install wine
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     g++-mingw-w64-x86-64-win32=13.2.0-* \
@@ -24,8 +29,7 @@ RUN \
     bzip2=1.0.8-* \
     gnupg=2.4.8-* \
     lsb-release=12.1-* \
-    ca-certificates=* \
-  && rm -rf /var/lib/apt/lists/*
+    ca-certificates=*
 
 # Set architecture short names
 ENV ARCH64=x86_64-w64-mingw32
@@ -36,12 +40,13 @@ ENV  LD64=${ARCH64}-ld
 
 # Install wine so resulting unit test binaries can be run
 RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
   echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/wine.list && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
-    wine=10.0~repack-12ubuntu1 \
-  && rm -rf /var/lib/apt/lists/*
+    wine=10.0~repack-12ubuntu1
 
 # Set default install location for custom packages
 ENV INSTALL_PREFIX=/usr/local/

--- a/dockerBuildEnv/nas2d-mingw.version.mk
+++ b/dockerBuildEnv/nas2d-mingw.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_mingw := 1.18
+ImageVersion_mingw := 2026-07-15


### PR DESCRIPTION
Switch to date based image tags, and add local caching of packages during Docker builds.

This makes it faster to rebuild and test images with different sets of packages. This helps speed up development and fixes for Docker environments.

Related:
- Issue #1524
- Issue #1525
- Issue #1536
- Issue #1537

Closes #1524
