### PR TITLE
Update Mingw Dockerfile for early default to 64-bit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         - "build-env-nas2d-arch:2026-07-15"
         - "build-env-nas2d-clang:2026-07-15"
         - "build-env-nas2d-gcc:2026-07-15"
-        - "build-env-nas2d-mingw:2026-07-16"
+        - "build-env-nas2d-mingw:2026-07-20"
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -56,7 +56,7 @@ ENV INSTALL_PREFIX=/usr/local/
 ENV INSTALL64=${INSTALL_PREFIX}${ARCH}/
 
 # Custom variables for install locations
-ENV LIB64=${INSTALL64}lib;/usr/${ARCH}/lib
+ENV LIB64=${INSTALL64}lib
 ENV BIN64=${INSTALL64}bin/
 
 # Setup compiler and tooling default folders
@@ -122,7 +122,7 @@ RUN glewVersion="2.3.1" && \
 # Activate appropriate Toolchain settings
 ENV Toolchain=mingw
 # Set a library search path to use during linking
-ENV LDFLAGS_EXTRA="-L/usr/local/${ARCH}/lib"
+ENV LDFLAGS_EXTRA="-L${LIB64}"
 
 # Be explicit about the extra flags with the default command
 CMD ["make", "--keep-going", "check"]

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -71,7 +71,6 @@ ENV WINEPATH64=${BIN64};/usr/lib/gcc/${ARCH64}/13-win32/
 
 # Setup compiler and tooling default folders
 ENV CPLUS_INCLUDE_PATH="${INCLUDE64}"
-ENV LIBRARY_PATH="${LIB64}"
 ENV PATH="${PATH64}"
 ENV WINEPATH="${WINEPATH64}"
 

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -16,8 +16,8 @@ RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     g++-mingw-w64-x86-64-win32=13.2.0-* \
-    cmake=4.2.3-* \
     make=4.4.1-* \
+    cmake=4.2.3-* \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-* \
     git=1:2.53.0-* \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -126,7 +126,7 @@ RUN sdlTtfVersion="2.24.0" && \
 # Install dependencies from source packages
 RUN glewVersion="2.3.1" && \
   curl --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | tar -xz && \
-  make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 WARN="-Wno-cast-function-type" GLEW_DEST="${INSTALL64}" install && \
+  make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 WARN="-Wno-cast-function-type" install && \
   rm -rf glew-${glewVersion}/ glew.*
 
 # Set custom variables for build script convenience

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -125,7 +125,7 @@ RUN sdlTtfVersion="2.24.0" && \
 # Install dependencies from source packages
 RUN glewVersion="2.3.1" && \
   curl --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | tar -xz && \
-  make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 WARN="-Wno-cast-function-type" install && \
+  make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 install && \
   rm -rf glew-${glewVersion}/ glew.*
 
 # Set custom variables for build script convenience

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -56,16 +56,13 @@ ENV INSTALL_PREFIX=/usr/local/
 ENV INSTALL64=${INSTALL_PREFIX}${ARCH}/
 
 # Custom variables for install locations
-ENV INCLUDE64=${INSTALL64}include/
 ENV LIB64=${INSTALL64}lib;/usr/${ARCH}/lib
 ENV BIN64=${INSTALL64}bin/
-ENV PATH64="${PATH}:${BIN64}"
-ENV WINEPATH64=${BIN64};/usr/lib/gcc/${ARCH}/13-win32/
 
 # Setup compiler and tooling default folders
-ENV CPLUS_INCLUDE_PATH="${INCLUDE64}"
-ENV PATH="${PATH64}"
-ENV WINEPATH="${WINEPATH64}"
+ENV CPLUS_INCLUDE_PATH="${INSTALL64}include/"
+ENV PATH="${PATH}:${BIN64}"
+ENV WINEPATH="${BIN64};/usr/lib/gcc/${ARCH}/13-win32/"
 
 # Create directories for local install of libraries
 RUN mkdir --parents "${INSTALL64}"

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -30,13 +30,13 @@ RUN \
     ca-certificates=*
 
 # Set architecture short names
-ENV ARCH64=x86_64-w64-mingw32
+ENV ARCH=x86_64-w64-mingw32
 # Set compiler short names
-ENV CXX64=${ARCH64}-g++
-ENV  CC64=${ARCH64}-gcc
-ENV  LD64=${ARCH64}-ld
-ENV  AR64=${ARCH64}-ar
-ENV  STRIP64=${ARCH64}-strip
+ENV CXX64=${ARCH}-g++
+ENV  CC64=${ARCH}-gcc
+ENV  LD64=${ARCH}-ld
+ENV  AR64=${ARCH}-ar
+ENV  STRIP64=${ARCH}-strip
 
 # Set default compiler
 ENV CXX=${CXX64}
@@ -60,14 +60,14 @@ RUN \
 
 # Set default install location for custom packages
 ENV INSTALL_PREFIX=/usr/local/
-ENV INSTALL64=${INSTALL_PREFIX}${ARCH64}/
+ENV INSTALL64=${INSTALL_PREFIX}${ARCH}/
 
 # Custom variables for install locations
 ENV INCLUDE64=${INSTALL64}include/
-ENV LIB64=${INSTALL64}lib;/usr/${ARCH64}/lib
+ENV LIB64=${INSTALL64}lib;/usr/${ARCH}/lib
 ENV BIN64=${INSTALL64}bin/
 ENV PATH64="${PATH}:${BIN64}"
-ENV WINEPATH64=${BIN64};/usr/lib/gcc/${ARCH64}/13-win32/
+ENV WINEPATH64=${BIN64};/usr/lib/gcc/${ARCH}/13-win32/
 
 # Setup compiler and tooling default folders
 ENV CPLUS_INCLUDE_PATH="${INCLUDE64}"
@@ -81,11 +81,11 @@ RUN mkdir --parents "${INSTALL64}"
 RUN \
   mkdir --parents /tmp/gtest/ && \
   cd /tmp/gtest/ && \
-  cmake -H/usr/src/googletest/ -B"${ARCH64}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && make -C "${ARCH64}" && \
-  cmake -H/usr/src/googletest/ -B"${ARCH64}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON -DBUILD_SHARED_LIBS=ON && make -C "${ARCH64}" && \
+  cmake -H/usr/src/googletest/ -B"${ARCH}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && make -C "${ARCH}" && \
+  cmake -H/usr/src/googletest/ -B"${ARCH}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON -DBUILD_SHARED_LIBS=ON && make -C "${ARCH}" && \
   cp --parents -r \
-    "${ARCH64}/bin/" \
-    "${ARCH64}/lib/" \
+    "${ARCH}/bin/" \
+    "${ARCH}/lib/" \
     "${INSTALL_PREFIX}" && \
   mkdir -p \
     "${INSTALL_PREFIX}share/mingw-w64/" \
@@ -132,7 +132,7 @@ RUN glewVersion="2.3.1" && \
 # Activate appropriate Toolchain settings
 ENV Toolchain=mingw
 # Set a library search path to use during linking
-ENV LDFLAGS_EXTRA="-L/usr/local/${ARCH64}/lib"
+ENV LDFLAGS_EXTRA="-L/usr/local/${ARCH}/lib"
 
 # Be explicit about the extra flags with the default command
 CMD ["make", "--keep-going", "check"]

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -56,7 +56,7 @@ ENV INSTALL_PREFIX=/usr/local/
 ENV INSTALL64=${INSTALL_PREFIX}${ARCH}/
 
 # Custom variables for install locations
-ENV LIB64=${INSTALL64}lib
+ENV LIB64=${INSTALL64}lib/
 ENV BIN64=${INSTALL64}bin/
 
 # Setup compiler and tooling default folders

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -41,6 +41,7 @@ ENV  STRIP64=${ARCH64}-strip
 # Set default compiler
 ENV CXX=${CXX64}
 ENV  CC=${CC64}
+ENV  LD=${LD64}
 ENV  AR=${AR64}
 ENV  STRIP=${STRIP64}
 

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -51,21 +51,19 @@ RUN \
   apt-get install -y --no-install-recommends \
     wine=10.0~repack-12ubuntu1
 
-# Set default install location for custom packages
+# Set default install location for source built packages
 ENV INSTALL_PREFIX=/usr/local/
-ENV INSTALL64=${INSTALL_PREFIX}${ARCH}/
-
-# Custom variables for install locations
-ENV LIB64=${INSTALL64}lib/
-ENV BIN64=${INSTALL64}bin/
+ENV INSTALL_PREFIX_ARCH=${INSTALL_PREFIX}${ARCH}/
+ENV INSTALL_PREFIX_ARCH_LIB=${INSTALL_PREFIX_ARCH}lib/
+ENV INSTALL_PREFIX_ARCH_BIN=${INSTALL_PREFIX_ARCH}bin/
 
 # Setup compiler and tooling default folders
-ENV CPLUS_INCLUDE_PATH="${INSTALL64}include/"
-ENV PATH="${PATH}:${BIN64}"
-ENV WINEPATH="${BIN64};/usr/lib/gcc/${ARCH}/13-win32/"
+ENV CPLUS_INCLUDE_PATH="${INSTALL_PREFIX_ARCH}include/"
+ENV PATH="${PATH}:${INSTALL_PREFIX_ARCH_BIN}"
+ENV WINEPATH="${INSTALL_PREFIX_ARCH_BIN};/usr/lib/gcc/${ARCH}/13-win32/"
 
 # Create directories for local install of libraries
-RUN mkdir --parents "${INSTALL64}"
+RUN mkdir --parents "${INSTALL_PREFIX_ARCH}"
 
 # Download, compile, and install Google Test source package
 RUN \
@@ -79,13 +77,13 @@ RUN \
     "${INSTALL_PREFIX}" && \
   mkdir -p \
     "${INSTALL_PREFIX}share/mingw-w64/" \
-    "${INSTALL64}include/" && \
+    "${INSTALL_PREFIX_ARCH}include/" && \
   cp -r \
     /usr/src/googletest/googletest/include/ \
     /usr/src/googletest/googlemock/include/ \
     "${INSTALL_PREFIX}share/mingw-w64/" && \
-  ln -sf "${INSTALL_PREFIX}share/mingw-w64/include/gtest/" "${INSTALL64}include/" && \
-  ln -sf "${INSTALL_PREFIX}share/mingw-w64/include/gmock/" "${INSTALL64}include/" && \
+  ln -sf "${INSTALL_PREFIX}share/mingw-w64/include/gtest/" "${INSTALL_PREFIX_ARCH}include/" && \
+  ln -sf "${INSTALL_PREFIX}share/mingw-w64/include/gmock/" "${INSTALL_PREFIX_ARCH}include/" && \
   cp --parents -r \
     /usr/src/googletest/CMakeLists.txt \
     /usr/src/googletest/googletest/ \
@@ -122,7 +120,7 @@ RUN glewVersion="2.3.1" && \
 # Activate appropriate Toolchain settings
 ENV Toolchain=mingw
 # Set a library search path to use during linking
-ENV LDFLAGS_EXTRA="-L${LIB64}"
+ENV LDFLAGS_EXTRA="-L${INSTALL_PREFIX_ARCH_LIB}"
 
 # Be explicit about the extra flags with the default command
 CMD ["make", "--keep-going", "check"]

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -31,19 +31,12 @@ RUN \
 
 # Set architecture short names
 ENV ARCH=x86_64-w64-mingw32
-# Set compiler short names
-ENV CXX64=${ARCH}-g++
-ENV  CC64=${ARCH}-gcc
-ENV  LD64=${ARCH}-ld
-ENV  AR64=${ARCH}-ar
-ENV  STRIP64=${ARCH}-strip
-
-# Set default compiler
-ENV CXX=${CXX64}
-ENV  CC=${CC64}
-ENV  LD=${LD64}
-ENV  AR=${AR64}
-ENV  STRIP=${STRIP64}
+# Set default compiler tools
+ENV CXX=${ARCH}-g++
+ENV  CC=${ARCH}-gcc
+ENV  LD=${ARCH}-ld
+ENV  AR=${ARCH}-ar
+ENV  STRIP=${ARCH}-strip
 
 # Install apt repository for wine
 RUN \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -27,7 +27,6 @@ RUN \
     lsb-release=12.1-* \
     tar=1.35+* \
     gzip=1.14-* \
-    bzip2=1.0.8-* \
     ca-certificates=*
 
 # Set architecture short names

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -23,11 +23,11 @@ RUN \
     git=1:2.53.0-* \
     ssh=1:10.2p1-* \
     curl=8.18.0-* \
+    gnupg=2.4.8-* \
+    lsb-release=12.1-* \
     tar=1.35+* \
     gzip=1.14-* \
     bzip2=1.0.8-* \
-    gnupg=2.4.8-* \
-    lsb-release=12.1-* \
     ca-certificates=*
 
 # Set architecture short names

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -61,6 +61,19 @@ RUN \
 ENV INSTALL_PREFIX=/usr/local/
 ENV INSTALL64=${INSTALL_PREFIX}${ARCH64}/
 
+# Custom variables for install locations
+ENV INCLUDE64=${INSTALL64}include/
+ENV LIB64=${INSTALL64}lib;/usr/${ARCH64}/lib
+ENV BIN64=${INSTALL64}bin/
+ENV PATH64="${PATH}:${BIN64}"
+ENV WINEPATH64=${BIN64};/usr/lib/gcc/${ARCH64}/13-win32/
+
+# Setup compiler and tooling default folders
+ENV CPLUS_INCLUDE_PATH="${INCLUDE64}"
+ENV LIBRARY_PATH="${LIB64}"
+ENV PATH="${PATH64}"
+ENV WINEPATH="${WINEPATH64}"
+
 # Create directories for local install of libraries
 RUN mkdir --parents "${INSTALL64}"
 
@@ -114,19 +127,6 @@ RUN glewVersion="2.3.1" && \
   curl --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | tar -xz && \
   make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 CC="${CC64}" AR="${AR64}" STRIP="${STRIP64}" WARN="-Wno-cast-function-type" LD="${LD64}" LDFLAGS.EXTRA=-L"/usr/${ARCH64}/lib/" GLEW_DEST="${INSTALL64}" install && \
   rm -rf glew-${glewVersion}/ glew.*
-
-# Custom variables for install locations
-ENV INCLUDE64=${INSTALL64}include/
-ENV LIB64=${INSTALL64}lib;/usr/${ARCH64}/lib
-ENV BIN64=${INSTALL64}bin/
-ENV PATH64="${PATH}:${BIN64}"
-ENV WINEPATH64=${BIN64};/usr/lib/gcc/${ARCH64}/13-win32/
-
-# Setup compiler and tooling default folders
-ENV CPLUS_INCLUDE_PATH="${INCLUDE64}"
-ENV LIBRARY_PATH="${LIB64}"
-ENV PATH="${PATH64}"
-ENV WINEPATH="${WINEPATH64}"
 
 # Set custom variables for build script convenience
 # Activate appropriate Toolchain settings

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -38,6 +38,8 @@ ENV  LD=${ARCH}-ld
 ENV  AR=${ARCH}-ar
 ENV  STRIP=${ARCH}-strip
 
+ENV GCC_RUNTIME_PATH=/usr/lib/gcc/${ARCH}/13-win32/
+
 # Install apt repository for wine
 RUN \
   curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
@@ -60,7 +62,7 @@ ENV INSTALL_PREFIX_ARCH_BIN=${INSTALL_PREFIX_ARCH}bin/
 # Setup compiler and tooling default folders
 ENV CPLUS_INCLUDE_PATH="${INSTALL_PREFIX_ARCH}include/"
 ENV PATH="${PATH}:${INSTALL_PREFIX_ARCH_BIN}"
-ENV WINEPATH="${INSTALL_PREFIX_ARCH_BIN};/usr/lib/gcc/${ARCH}/13-win32/"
+ENV WINEPATH="${INSTALL_PREFIX_ARCH_BIN};${GCC_RUNTIME_PATH}"
 
 # Create directories for local install of libraries
 RUN mkdir --parents "${INSTALL_PREFIX_ARCH}"

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -38,6 +38,12 @@ ENV  LD64=${ARCH64}-ld
 ENV  AR64=${ARCH64}-ar
 ENV  STRIP64=${ARCH64}-strip
 
+# Set default compiler
+ENV CXX=${CXX64}
+ENV  CC=${CC64}
+ENV  AR=${AR64}
+ENV  STRIP=${STRIP64}
+
 # Install apt repository for wine
 RUN \
   curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
@@ -121,12 +127,6 @@ ENV CPLUS_INCLUDE_PATH="${INCLUDE64}"
 ENV LIBRARY_PATH="${LIB64}"
 ENV PATH="${PATH64}"
 ENV WINEPATH="${WINEPATH64}"
-
-# Set default compiler
-ENV CXX=${CXX64}
-ENV  CC=${CC64}
-ENV  AR=${AR64}
-ENV  STRIP=${STRIP64}
 
 # Set custom variables for build script convenience
 # Activate appropriate Toolchain settings

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -82,8 +82,8 @@ RUN mkdir --parents "${INSTALL64}"
 RUN \
   mkdir --parents /tmp/gtest/ && \
   cd /tmp/gtest/ && \
-  cmake -H/usr/src/googletest/ -B"${ARCH64}" -DCMAKE_CXX_COMPILER="${CXX64}" -DCMAKE_C_COMPILER="${CC64}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && make -C "${ARCH64}" && \
-  cmake -H/usr/src/googletest/ -B"${ARCH64}" -DCMAKE_CXX_COMPILER="${CXX64}" -DCMAKE_C_COMPILER="${CC64}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON -DBUILD_SHARED_LIBS=ON && make -C "${ARCH64}" && \
+  cmake -H/usr/src/googletest/ -B"${ARCH64}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && make -C "${ARCH64}" && \
+  cmake -H/usr/src/googletest/ -B"${ARCH64}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON -DBUILD_SHARED_LIBS=ON && make -C "${ARCH64}" && \
   cp --parents -r \
     "${ARCH64}/bin/" \
     "${ARCH64}/lib/" \
@@ -126,7 +126,7 @@ RUN sdlTtfVersion="2.24.0" && \
 # Install dependencies from source packages
 RUN glewVersion="2.3.1" && \
   curl --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | tar -xz && \
-  make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 CC="${CC64}" AR="${AR64}" STRIP="${STRIP64}" WARN="-Wno-cast-function-type" LD="${LD64}" LDFLAGS.EXTRA=-L"/usr/${ARCH64}/lib/" GLEW_DEST="${INSTALL64}" install && \
+  make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 WARN="-Wno-cast-function-type" LDFLAGS.EXTRA=-L"/usr/${ARCH64}/lib/" GLEW_DEST="${INSTALL64}" install && \
   rm -rf glew-${glewVersion}/ glew.*
 
 # Set custom variables for build script convenience

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -126,7 +126,7 @@ RUN sdlTtfVersion="2.24.0" && \
 # Install dependencies from source packages
 RUN glewVersion="2.3.1" && \
   curl --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | tar -xz && \
-  make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 WARN="-Wno-cast-function-type" LDFLAGS.EXTRA=-L"/usr/${ARCH64}/lib/" GLEW_DEST="${INSTALL64}" install && \
+  make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 WARN="-Wno-cast-function-type" GLEW_DEST="${INSTALL64}" install && \
   rm -rf glew-${glewVersion}/ glew.*
 
 # Set custom variables for build script convenience

--- a/dockerBuildEnv/nas2d-mingw.version.mk
+++ b/dockerBuildEnv/nas2d-mingw.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_mingw := 2026-07-16
+ImageVersion_mingw := 2026-07-20


### PR DESCRIPTION
Set compiler defaults earlier in the Dockerfile and use them to simplify installation of dependencies.

Earlier versions of the Mingw Dockerfile installed tools and dependencies for both 64-bit and 32-bit builds. We never really did 32-bit builds with Mingw. Effectively the 32-bit support was wasted bloat, in a Docker image that was already by far the largest. Recently 32-bit support was removed, greatly reducing the size of the Docker image. We no longer install 32-bit builds of dependencies, nor install 32-bit versions of `apt` packages, notably for running 32-bit binaries with Wine.

This change further removes some of the legacy of the early decision to support both 64-bit and 32-bit. For instance, a default compiler wasn't set until the end of the file, since it was assumed that might change, and putting it near the end reduced the number of Docker layers that would need to be rebuilt if it changed. This was unlike other build environments where env vars for the default compiler were setup right after the packages for the compiler and related tools were installed. Since removing the 32-builds of dependency libraries, this became much more evident. The remaining 64-bit builds all needed to explicitly specify tools that would have been defaults in other environments. By moving the compiler defaults up to right after installation, we can greatly simplify installation of dependencies.

Environment variables were renamed to drop the `64` suffix. They are now simply default tool values, unmarked with a bit size. If we later provide a 32-bit build environment, we can do so as a separate Dockerfile, copied from the 64-bit version, with a few modifications to some initial values. Everything would then flow from there to generate a 32-bit environment.

Some `apt` package sorting was also done to group related packages together. This makes it easier to find related tool packages when doing maintenance on a particular part of the Dockerfile.

Related:
- PR #1522
- PR #1521
- Issue #1431
- PR #1539
