### PR TITLE
Update Mingw Google Test install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         - "build-env-nas2d-arch:2026-07-15"
         - "build-env-nas2d-clang:2026-07-15"
         - "build-env-nas2d-gcc:2026-07-15"
-        - "build-env-nas2d-mingw:2026-07-20"
+        - "build-env-nas2d-mingw:2026-07-21"
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -71,7 +71,7 @@ RUN mkdir --parents "${INSTALL_PREFIX_ARCH}"
 RUN \
   mkdir --parents /tmp/gtest/ && \
   cd /tmp/gtest/ && \
-  cmake -B"${ARCH}" -H/usr/src/googletest/ -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && \
+  cmake -B"${ARCH}" -S/usr/src/googletest/ -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && \
   make -C "${ARCH}" && \
   cp --parents -r \
     "${ARCH}/bin/" \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -71,7 +71,8 @@ RUN mkdir --parents "${INSTALL_PREFIX_ARCH}"
 RUN \
   mkdir --parents /tmp/gtest/ && \
   cd /tmp/gtest/ && \
-  cmake -H/usr/src/googletest/ -B"${ARCH}" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && make -C "${ARCH}" && \
+  cmake -H/usr/src/googletest/ -B"${ARCH}" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && \
+  make -C "${ARCH}" && \
   cp --parents -r \
     "${ARCH}/bin/" \
     "${ARCH}/lib/" \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -72,7 +72,6 @@ RUN \
   mkdir --parents /tmp/gtest/ && \
   cd /tmp/gtest/ && \
   cmake -H/usr/src/googletest/ -B"${ARCH}" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && make -C "${ARCH}" && \
-  cmake -H/usr/src/googletest/ -B"${ARCH}" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON -DBUILD_SHARED_LIBS=ON && make -C "${ARCH}" && \
   cp --parents -r \
     "${ARCH}/bin/" \
     "${ARCH}/lib/" \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -64,9 +64,6 @@ ENV CPLUS_INCLUDE_PATH="${INSTALL_PREFIX_ARCH}include/"
 ENV PATH="${PATH}:${INSTALL_PREFIX_ARCH_BIN}"
 ENV WINEPATH="${INSTALL_PREFIX_ARCH_BIN};${GCC_RUNTIME_PATH}"
 
-# Create directories for local install of libraries
-RUN mkdir --parents "${INSTALL_PREFIX_ARCH}"
-
 # Download, compile, and install Google Test source package
 RUN \
   mkdir --parents /tmp/gtest/ && \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -72,7 +72,7 @@ RUN \
   mkdir --parents /tmp/gtest/ && \
   cd /tmp/gtest/ && \
   cmake -B"${ARCH}" -S/usr/src/googletest/ -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && \
-  make -C "${ARCH}" && \
+  cmake --build "${ARCH}" && \
   cp --parents -r \
     "${ARCH}/bin/" \
     "${ARCH}/lib/" \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -71,8 +71,8 @@ RUN mkdir --parents "${INSTALL_PREFIX_ARCH}"
 RUN \
   mkdir --parents /tmp/gtest/ && \
   cd /tmp/gtest/ && \
-  cmake -H/usr/src/googletest/ -B"${ARCH}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && make -C "${ARCH}" && \
-  cmake -H/usr/src/googletest/ -B"${ARCH}" -DCMAKE_CXX_FLAGS="-std=c++20" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON -DBUILD_SHARED_LIBS=ON && make -C "${ARCH}" && \
+  cmake -H/usr/src/googletest/ -B"${ARCH}" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && make -C "${ARCH}" && \
+  cmake -H/usr/src/googletest/ -B"${ARCH}" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON -DBUILD_SHARED_LIBS=ON && make -C "${ARCH}" && \
   cp --parents -r \
     "${ARCH}/bin/" \
     "${ARCH}/lib/" \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -85,11 +85,6 @@ RUN \
     "${INSTALL_PREFIX}share/mingw-w64/" && \
   ln -sf "${INSTALL_PREFIX}share/mingw-w64/include/gtest/" "${INSTALL_PREFIX_ARCH}include/" && \
   ln -sf "${INSTALL_PREFIX}share/mingw-w64/include/gmock/" "${INSTALL_PREFIX_ARCH}include/" && \
-  cp --parents -r \
-    /usr/src/googletest/CMakeLists.txt \
-    /usr/src/googletest/googletest/ \
-    /usr/src/googletest/googlemock/ \
-    "${INSTALL_PREFIX}src/" && \
   rm -rf /tmp/gtest/
 
 # Install NAS2D specific dependencies

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -71,7 +71,7 @@ RUN mkdir --parents "${INSTALL_PREFIX_ARCH}"
 RUN \
   mkdir --parents /tmp/gtest/ && \
   cd /tmp/gtest/ && \
-  cmake -H/usr/src/googletest/ -B"${ARCH}" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && \
+  cmake -B"${ARCH}" -H/usr/src/googletest/ -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && \
   make -C "${ARCH}" && \
   cp --parents -r \
     "${ARCH}/bin/" \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -66,11 +66,9 @@ ENV WINEPATH="${INSTALL_PREFIX_ARCH_BIN};${GCC_RUNTIME_PATH}"
 
 # Download, compile, and install Google Test source package
 RUN \
-  mkdir --parents /tmp/gtest/ && \
-  cd /tmp/gtest/ && \
-  cmake -B"${ARCH}" -S/usr/src/googletest/ -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX_ARCH}" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && \
-  cmake --build "${ARCH}" && \
-  cmake --install "${ARCH}" && \
+  cmake -B/tmp/gtest/ -S/usr/src/googletest/ -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX_ARCH}" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && \
+  cmake --build /tmp/gtest/ && \
+  cmake --install /tmp/gtest/ && \
   rm -rf /tmp/gtest/
 
 # Install NAS2D specific dependencies

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -71,21 +71,9 @@ RUN mkdir --parents "${INSTALL_PREFIX_ARCH}"
 RUN \
   mkdir --parents /tmp/gtest/ && \
   cd /tmp/gtest/ && \
-  cmake -B"${ARCH}" -S/usr/src/googletest/ -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && \
+  cmake -B"${ARCH}" -S/usr/src/googletest/ -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX_ARCH}" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && \
   cmake --build "${ARCH}" && \
-  cp --parents -r \
-    "${ARCH}/bin/" \
-    "${ARCH}/lib/" \
-    "${INSTALL_PREFIX}" && \
-  mkdir -p \
-    "${INSTALL_PREFIX}share/mingw-w64/" \
-    "${INSTALL_PREFIX_ARCH}include/" && \
-  cp -r \
-    /usr/src/googletest/googletest/include/ \
-    /usr/src/googletest/googlemock/include/ \
-    "${INSTALL_PREFIX}share/mingw-w64/" && \
-  ln -sf "${INSTALL_PREFIX}share/mingw-w64/include/gtest/" "${INSTALL_PREFIX_ARCH}include/" && \
-  ln -sf "${INSTALL_PREFIX}share/mingw-w64/include/gmock/" "${INSTALL_PREFIX_ARCH}include/" && \
+  cmake --install "${ARCH}" && \
   rm -rf /tmp/gtest/
 
 # Install NAS2D specific dependencies

--- a/dockerBuildEnv/nas2d-mingw.version.mk
+++ b/dockerBuildEnv/nas2d-mingw.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_mingw := 2026-07-20
+ImageVersion_mingw := 2026-07-21


### PR DESCRIPTION
Use newer `cmake` features to simplify the cross compile and install of the Google Test library.

Only build the static library, rather than both static and shared library. We only link one of them, and it reduces Docker image size and build time to only install one of them.

Remove install of Google Test source files. We don't need them or use them. Reduce Docker image size by not storing them.

Update `cmake` flags to use documented `-S` rather than earlier undocumented `-H` flag. Use newer `--build` and `--install` flags. Simplify creation and use of build and install folders.

Related:
- PR #1541
- PR #1539
- PR #1522
- Issue #1527
- Issue #1431
