### PR TITLE
Update Docker build environments - Remove unnecessary packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,10 +126,10 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - "build-env-nas2d-arch:2026-07-15"
-        - "build-env-nas2d-clang:2026-07-15"
-        - "build-env-nas2d-gcc:2026-07-15"
-        - "build-env-nas2d-mingw:2026-07-21"
+        - "build-env-nas2d-arch:2026-07-24"
+        - "build-env-nas2d-clang:2026-07-24"
+        - "build-env-nas2d-gcc:2026-07-24"
+        - "build-env-nas2d-mingw:2026-07-24"
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"

--- a/dockerBuildEnv/nas2d-arch.Dockerfile
+++ b/dockerBuildEnv/nas2d-arch.Dockerfile
@@ -8,11 +8,7 @@ RUN \
   pacman --sync --refresh --noconfirm \
     gcc \
     make \
-    gtest \
-    git \
-    tar \
-    gzip \
-    ca-certificates
+    gtest
 
 RUN \
   --mount=type=cache,target=/var/cache/pacman/pkg,sharing=locked \

--- a/dockerBuildEnv/nas2d-arch.Dockerfile
+++ b/dockerBuildEnv/nas2d-arch.Dockerfile
@@ -3,8 +3,6 @@
 FROM archlinux:base-20260628.0.549485
 
 # Install base development tools
-# Includes tools to build download, unpack, and build source packages
-# Includes tools needed for primary CircleCI containers
 RUN \
   --mount=type=cache,target=/var/cache/pacman/pkg,sharing=locked \
   pacman --sync --refresh --noconfirm \
@@ -12,7 +10,6 @@ RUN \
     make \
     gtest \
     git \
-    openssh \
     tar \
     gzip \
     ca-certificates

--- a/dockerBuildEnv/nas2d-arch.version.mk
+++ b/dockerBuildEnv/nas2d-arch.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_arch := 2026-07-15
+ImageVersion_arch := 2026-07-24

--- a/dockerBuildEnv/nas2d-clang.Dockerfile
+++ b/dockerBuildEnv/nas2d-clang.Dockerfile
@@ -6,12 +6,11 @@ FROM ubuntu:resolute-20260610
 RUN rm /etc/apt/apt.conf.d/docker-clean
 
 # Install base development tools
-# Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  apt-get install -y --no-install-recommends \
     clang=1:21.1.6-* \
     make=4.4.1-* \
     libgtest-dev=1.17.0-* \

--- a/dockerBuildEnv/nas2d-clang.Dockerfile
+++ b/dockerBuildEnv/nas2d-clang.Dockerfile
@@ -6,8 +6,6 @@ FROM ubuntu:resolute-20260610
 RUN rm /etc/apt/apt.conf.d/docker-clean
 
 # Install base development tools
-# Includes tools to build download, unpack, and build source packages
-# Includes tools needed for primary CircleCI containers
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -20,7 +18,6 @@ RUN \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-* \
     git=1:2.53.0-* \
-    ssh=1:10.2p1-* \
     tar=1.35+* \
     gzip=1.14-* \
     ca-certificates=*

--- a/dockerBuildEnv/nas2d-clang.Dockerfile
+++ b/dockerBuildEnv/nas2d-clang.Dockerfile
@@ -14,7 +14,6 @@ RUN \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential=12.12* \
     clang=1:21.1.6-* \
-    cmake=4.2.3-* \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-*
 

--- a/dockerBuildEnv/nas2d-clang.Dockerfile
+++ b/dockerBuildEnv/nas2d-clang.Dockerfile
@@ -12,8 +12,8 @@ RUN \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    build-essential=12.12* \
     clang=1:21.1.6-* \
+    make=4.4.1-* \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-*
 

--- a/dockerBuildEnv/nas2d-clang.Dockerfile
+++ b/dockerBuildEnv/nas2d-clang.Dockerfile
@@ -16,11 +16,7 @@ RUN \
     clang=1:21.1.6-* \
     cmake=4.2.3-* \
     libgtest-dev=1.17.0-* \
-    libgmock-dev=1.17.0-* \
-    git=1:2.53.0-* \
-    tar=1.35+* \
-    gzip=1.14-* \
-    ca-certificates=*
+    libgmock-dev=1.17.0-*
 
 ENV CXX=clang++
 ENV  CC=clang

--- a/dockerBuildEnv/nas2d-clang.version.mk
+++ b/dockerBuildEnv/nas2d-clang.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_clang := 2026-07-15
+ImageVersion_clang := 2026-07-24

--- a/dockerBuildEnv/nas2d-gcc.Dockerfile
+++ b/dockerBuildEnv/nas2d-gcc.Dockerfile
@@ -6,7 +6,6 @@ FROM ubuntu:resolute-20260610
 RUN rm /etc/apt/apt.conf.d/docker-clean
 
 # Install base development tools
-# Install latest available GCC compiler (which may not be the default)
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/dockerBuildEnv/nas2d-gcc.Dockerfile
+++ b/dockerBuildEnv/nas2d-gcc.Dockerfile
@@ -6,12 +6,11 @@ FROM ubuntu:resolute-20260610
 RUN rm /etc/apt/apt.conf.d/docker-clean
 
 # Install base development tools
-# Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  apt-get install -y --no-install-recommends \
     g++=4:15.2.0-* \
     make=4.4.1-* \
     libgtest-dev=1.17.0-* \

--- a/dockerBuildEnv/nas2d-gcc.Dockerfile
+++ b/dockerBuildEnv/nas2d-gcc.Dockerfile
@@ -17,11 +17,7 @@ RUN \
     make=4.4.1-* \
     cmake=4.2.3-* \
     libgtest-dev=1.17.0-* \
-    libgmock-dev=1.17.0-* \
-    git=1:2.53.0-* \
-    tar=1.35+* \
-    gzip=1.14-* \
-    ca-certificates=*
+    libgmock-dev=1.17.0-*
 
 ENV CXX=g++
 ENV  CC=gcc

--- a/dockerBuildEnv/nas2d-gcc.Dockerfile
+++ b/dockerBuildEnv/nas2d-gcc.Dockerfile
@@ -6,8 +6,6 @@ FROM ubuntu:resolute-20260610
 RUN rm /etc/apt/apt.conf.d/docker-clean
 
 # Install base development tools
-# Includes tools to build download, unpack, and build source packages
-# Includes tools needed for primary CircleCI containers
 # Install latest available GCC compiler (which may not be the default)
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN \
@@ -21,7 +19,6 @@ RUN \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-* \
     git=1:2.53.0-* \
-    ssh=1:10.2p1-* \
     tar=1.35+* \
     gzip=1.14-* \
     ca-certificates=*

--- a/dockerBuildEnv/nas2d-gcc.Dockerfile
+++ b/dockerBuildEnv/nas2d-gcc.Dockerfile
@@ -15,7 +15,6 @@ RUN \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     g++=4:15.2.0-* \
     make=4.4.1-* \
-    cmake=4.2.3-* \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-*
 

--- a/dockerBuildEnv/nas2d-gcc.version.mk
+++ b/dockerBuildEnv/nas2d-gcc.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_gcc := 2026-07-15
+ImageVersion_gcc := 2026-07-24

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -6,12 +6,11 @@ FROM ubuntu:resolute-20260610
 RUN rm /etc/apt/apt.conf.d/docker-clean
 
 # Install base development tools
-# Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  apt-get install -y --no-install-recommends \
     g++-mingw-w64-x86-64-win32=13.2.0-* \
     make=4.4.1-* \
     cmake=4.2.3-* \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -6,8 +6,6 @@ FROM ubuntu:resolute-20260610
 RUN rm /etc/apt/apt.conf.d/docker-clean
 
 # Install base development tools
-# Includes tools to build download, unpack, and build source packages
-# Includes tools needed for primary CircleCI containers
 # The lsb-release package is used to install wine
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN \
@@ -21,7 +19,6 @@ RUN \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-* \
     git=1:2.53.0-* \
-    ssh=1:10.2p1-* \
     curl=8.18.0-* \
     gnupg=2.4.8-* \
     lsb-release=12.1-* \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -18,7 +18,6 @@ RUN \
     cmake=4.2.3-* \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-* \
-    git=1:2.53.0-* \
     curl=8.18.0-* \
     gnupg=2.4.8-* \
     lsb-release=12.1-* \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -6,7 +6,6 @@ FROM ubuntu:resolute-20260610
 RUN rm /etc/apt/apt.conf.d/docker-clean
 
 # Install base development tools
-# The lsb-release package is used to install wine
 # Set DEBIAN_FRONTEND to prevent tzdata package install from prompting for timezone
 RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/dockerBuildEnv/nas2d-mingw.version.mk
+++ b/dockerBuildEnv/nas2d-mingw.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_mingw := 2026-07-21
+ImageVersion_mingw := 2026-07-24


### PR DESCRIPTION
Remove packages from Docker build environments that are no longer necessary, such as packages needed for a primary CircleCI container, or for dependencies that have been removed.

Now that we build on GitHub Actions rather than CircleCI we don't need to worry about installing packages that were necessary for a primary CircleCI container.

Some packages were previously installed for source builds of the Google Test library from back when the `apt` installed version wasn't new enough, or for a source build of the Physfs package, which is no longer a dependency.

Use smaller more targeted packages to install needed dependencies, rather than larger more generic packages with many dependencies which happen to satisfy installing the dependencies we need.

Remove the old `DEBIAN_FRONTEND=noninteractive` workaround that was necessary to prevent the `tzdata` package from prompting during install, and causing the package install steps to hang indefinitely waiting for input that could never come. Newer Ubuntu base images come with a UTC timezone pre-configured, so there is no need to prompt, plus `debconf` has better detection of non-interactive environments.

Remove outdated and low value comments.

Normalize package order a bit. These changes increase the Dockerfile consistency between environments, which helps make the real intended differences stand out better.

Related:
- PR #1542
- PR #1541
- PR #1539
- Issue #1537
- Issue #1527
- Issue #1431
