### PR TITLE
Update Mingw build environment - GTest `Release`, `lsb-release`, long form opts

### DIFF
--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -19,7 +19,6 @@ RUN \
     libgmock-dev=1.17.0-* \
     curl=8.18.0-* \
     gnupg=2.4.8-* \
-    lsb-release=12.1-* \
     tar=1.35+* \
     gzip=1.14-* \
     ca-certificates=*
@@ -37,7 +36,8 @@ ENV GCC_RUNTIME_PATH=/usr/lib/gcc/${ARCH}/13-win32/
 # Install apt repository for wine
 RUN \
   curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
-  echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/wine.list
+  . /etc/os-release && \
+  echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/wine.list
 
 # Install wine so resulting unit test binaries can be run
 RUN \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -23,15 +23,15 @@ RUN \
     gzip=1.14-* \
     ca-certificates=*
 
-ARG ARCH=x86_64-w64-mingw32
+ARG TARGET_TRIPLET=x86_64-w64-mingw32
 ENV \
-  CXX=${ARCH}-g++ \
-  CC=${ARCH}-gcc \
-  LD=${ARCH}-ld \
-  AR=${ARCH}-ar \
-  STRIP=${ARCH}-strip
+  CXX=${TARGET_TRIPLET}-g++ \
+  CC=${TARGET_TRIPLET}-gcc \
+  LD=${TARGET_TRIPLET}-ld \
+  AR=${TARGET_TRIPLET}-ar \
+  STRIP=${TARGET_TRIPLET}-strip
 
-ENV GCC_RUNTIME_PATH=/usr/lib/gcc/${ARCH}/13-win32/
+ENV GCC_RUNTIME_PATH=/usr/lib/gcc/${TARGET_TRIPLET}/13-win32/
 
 # Install apt repository for wine
 RUN \
@@ -49,7 +49,7 @@ RUN \
     wine=10.0~repack-12ubuntu1
 
 # Set default install location for source built packages
-ARG LOCAL_PACKAGE_PATH=/usr/local/${ARCH}/
+ARG LOCAL_PACKAGE_PATH=/usr/local/${TARGET_TRIPLET}/
 
 # Setup compiler and tooling default folders
 ENV WINEPATH="${LOCAL_PACKAGE_PATH}bin/;${GCC_RUNTIME_PATH}"

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -35,7 +35,8 @@ ENV GCC_RUNTIME_PATH=/usr/lib/gcc/${ARCH}/13-win32/
 
 # Install apt repository for wine
 RUN \
-  curl --fail --location https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
+  curl --fail --location https://dl.winehq.org/wine-builds/winehq.key | \
+  gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
   . /etc/os-release && \
   echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/wine.list
 

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -65,24 +65,24 @@ WORKDIR /tmp/
 # Install SDL libraries from binary packages
 RUN sdlVersion="2.32.10" && \
   curl --fail https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz | tar --extract --gunzip && \
-  make -C SDL2-${sdlVersion}/ cross && \
+  make --directory SDL2-${sdlVersion}/ cross && \
   rm -rf SDL2-${sdlVersion}/
 RUN sdlImageVersion="2.8.12" && \
   curl --fail https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz | tar --extract --gunzip && \
-  make -C SDL2_image-${sdlImageVersion}/ cross && \
+  make --directory SDL2_image-${sdlImageVersion}/ cross && \
   rm -rf SDL2_image-${sdlImageVersion}/
 RUN sdlMixerVersion="2.8.2" && \
   curl --fail https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz | tar --extract --gunzip && \
-  make -C SDL2_mixer-${sdlMixerVersion}/ cross && \
+  make --directory SDL2_mixer-${sdlMixerVersion}/ cross && \
   rm -rf SDL2_mixer-${sdlMixerVersion}/
 RUN sdlTtfVersion="2.24.0" && \
   curl --fail https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz | tar --extract --gunzip && \
-  make -C SDL2_ttf-${sdlTtfVersion}/ cross && \
+  make --directory SDL2_ttf-${sdlTtfVersion}/ cross && \
   rm -rf SDL2_ttf-${sdlTtfVersion}/
 # Install dependencies from source packages
 RUN glewVersion="2.3.1" && \
   curl --fail --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | tar --extract --gunzip && \
-  make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 install && \
+  make --directory glew-${glewVersion}/ SYSTEM=linux-mingw64 install && \
   rm -rf glew-${glewVersion}/ glew.*
 
 # Set custom variables for build script convenience

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -31,9 +31,10 @@ ENV \
   AR=${TARGET_TRIPLET}-ar \
   STRIP=${TARGET_TRIPLET}-strip
 
-ENV GCC_RUNTIME_PATH=/usr/lib/gcc/${TARGET_TRIPLET}/13-win32/
-# Set default install location for source built packages
-ENV LOCAL_PACKAGE_PATH=/usr/local/${TARGET_TRIPLET}/
+# Custom variables describing the cross compile environment
+ENV \
+  GCC_RUNTIME_PATH=/usr/lib/gcc/${TARGET_TRIPLET}/13-win32/ \
+  LOCAL_PACKAGE_PATH=/usr/local/${TARGET_TRIPLET}/
 
 # Install apt repository for wine
 RUN \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -23,7 +23,7 @@ RUN \
     gzip=1.14-* \
     ca-certificates=*
 
-ARG TARGET_TRIPLET=x86_64-w64-mingw32
+ENV TARGET_TRIPLET=x86_64-w64-mingw32
 ENV \
   CXX=${TARGET_TRIPLET}-g++ \
   CC=${TARGET_TRIPLET}-gcc \
@@ -49,7 +49,7 @@ RUN \
     wine=10.0~repack-12ubuntu1
 
 # Set default install location for source built packages
-ARG LOCAL_PACKAGE_PATH=/usr/local/${TARGET_TRIPLET}/
+ENV LOCAL_PACKAGE_PATH=/usr/local/${TARGET_TRIPLET}/
 
 # Setup compiler and tooling default folders
 ENV WINEPATH="${LOCAL_PACKAGE_PATH}bin/;${GCC_RUNTIME_PATH}"

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -56,7 +56,7 @@ ENV WINEPATH="${LOCAL_PACKAGE_PATH}bin/;${GCC_RUNTIME_PATH}"
 
 # Download, compile, and install Google Test source package
 RUN \
-  cmake -B/tmp/gtest/ -S/usr/src/googletest/ -DCMAKE_INSTALL_PREFIX="${LOCAL_PACKAGE_PATH}" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && \
+  cmake -B/tmp/gtest/ -S/usr/src/googletest/ -DCMAKE_INSTALL_PREFIX="${LOCAL_PACKAGE_PATH}" -DCMAKE_SYSTEM_NAME="Windows" -DCMAKE_BUILD_TYPE=Release -Dgtest_disable_pthreads=ON && \
   cmake --build /tmp/gtest/ && \
   cmake --install /tmp/gtest/ && \
   rm --force --recursive /tmp/gtest/

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -35,7 +35,7 @@ ENV GCC_RUNTIME_PATH=/usr/lib/gcc/${ARCH}/13-win32/
 
 # Install apt repository for wine
 RUN \
-  curl --location https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
+  curl --fail --location https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
   . /etc/os-release && \
   echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/wine.list
 
@@ -64,24 +64,24 @@ RUN \
 WORKDIR /tmp/
 # Install SDL libraries from binary packages
 RUN sdlVersion="2.32.10" && \
-  curl https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz | tar -xz && \
+  curl --fail https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz | tar -xz && \
   make -C SDL2-${sdlVersion}/ cross && \
   rm -rf SDL2-${sdlVersion}/
 RUN sdlImageVersion="2.8.12" && \
-  curl https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz | tar -xz && \
+  curl --fail https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz | tar -xz && \
   make -C SDL2_image-${sdlImageVersion}/ cross && \
   rm -rf SDL2_image-${sdlImageVersion}/
 RUN sdlMixerVersion="2.8.2" && \
-  curl https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz | tar -xz && \
+  curl --fail https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz | tar -xz && \
   make -C SDL2_mixer-${sdlMixerVersion}/ cross && \
   rm -rf SDL2_mixer-${sdlMixerVersion}/
 RUN sdlTtfVersion="2.24.0" && \
-  curl https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz | tar -xz && \
+  curl --fail https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz | tar -xz && \
   make -C SDL2_ttf-${sdlTtfVersion}/ cross && \
   rm -rf SDL2_ttf-${sdlTtfVersion}/
 # Install dependencies from source packages
 RUN glewVersion="2.3.1" && \
-  curl --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | tar -xz && \
+  curl --fail --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | tar -xz && \
   make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 install && \
   rm -rf glew-${glewVersion}/ glew.*
 

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -64,24 +64,29 @@ RUN \
 WORKDIR /tmp/
 # Install SDL libraries from binary packages
 RUN sdlVersion="2.32.10" && \
-  curl --fail https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz | tar --extract --gunzip && \
+  curl --fail https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz | \
+  tar --extract --gunzip && \
   make --directory SDL2-${sdlVersion}/ cross && \
   rm -rf SDL2-${sdlVersion}/
 RUN sdlImageVersion="2.8.12" && \
-  curl --fail https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz | tar --extract --gunzip && \
+  curl --fail https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz | \
+  tar --extract --gunzip && \
   make --directory SDL2_image-${sdlImageVersion}/ cross && \
   rm -rf SDL2_image-${sdlImageVersion}/
 RUN sdlMixerVersion="2.8.2" && \
-  curl --fail https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz | tar --extract --gunzip && \
+  curl --fail https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz | \
+  tar --extract --gunzip && \
   make --directory SDL2_mixer-${sdlMixerVersion}/ cross && \
   rm -rf SDL2_mixer-${sdlMixerVersion}/
 RUN sdlTtfVersion="2.24.0" && \
-  curl --fail https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz | tar --extract --gunzip && \
+  curl --fail https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz | \
+  tar --extract --gunzip && \
   make --directory SDL2_ttf-${sdlTtfVersion}/ cross && \
   rm -rf SDL2_ttf-${sdlTtfVersion}/
 # Install dependencies from source packages
 RUN glewVersion="2.3.1" && \
-  curl --fail --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | tar --extract --gunzip && \
+  curl --fail --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | \
+  tar --extract --gunzip && \
   make --directory glew-${glewVersion}/ SYSTEM=linux-mingw64 install && \
   rm -rf glew-${glewVersion}/ glew.*
 

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -35,7 +35,7 @@ ENV GCC_RUNTIME_PATH=/usr/lib/gcc/${ARCH}/13-win32/
 
 # Install apt repository for wine
 RUN \
-  curl -L https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
+  curl --location https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
   . /etc/os-release && \
   echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/wine.list
 

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -59,7 +59,7 @@ RUN \
   cmake -B/tmp/gtest/ -S/usr/src/googletest/ -DCMAKE_INSTALL_PREFIX="${LOCAL_PACKAGE_PATH}" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON && \
   cmake --build /tmp/gtest/ && \
   cmake --install /tmp/gtest/ && \
-  rm -rf /tmp/gtest/
+  rm --force --recursive /tmp/gtest/
 
 # Install NAS2D specific dependencies
 WORKDIR /tmp/
@@ -68,28 +68,28 @@ RUN sdlVersion="2.32.10" && \
   curl --fail https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz | \
   tar --extract --gunzip && \
   make --directory SDL2-${sdlVersion}/ cross && \
-  rm -rf SDL2-${sdlVersion}/
+  rm --force --recursive SDL2-${sdlVersion}/
 RUN sdlImageVersion="2.8.12" && \
   curl --fail https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz | \
   tar --extract --gunzip && \
   make --directory SDL2_image-${sdlImageVersion}/ cross && \
-  rm -rf SDL2_image-${sdlImageVersion}/
+  rm --force --recursive SDL2_image-${sdlImageVersion}/
 RUN sdlMixerVersion="2.8.2" && \
   curl --fail https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz | \
   tar --extract --gunzip && \
   make --directory SDL2_mixer-${sdlMixerVersion}/ cross && \
-  rm -rf SDL2_mixer-${sdlMixerVersion}/
+  rm --force --recursive SDL2_mixer-${sdlMixerVersion}/
 RUN sdlTtfVersion="2.24.0" && \
   curl --fail https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz | \
   tar --extract --gunzip && \
   make --directory SDL2_ttf-${sdlTtfVersion}/ cross && \
-  rm -rf SDL2_ttf-${sdlTtfVersion}/
+  rm --force --recursive SDL2_ttf-${sdlTtfVersion}/
 # Install dependencies from source packages
 RUN glewVersion="2.3.1" && \
   curl --fail --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | \
   tar --extract --gunzip && \
   make --directory glew-${glewVersion}/ SYSTEM=linux-mingw64 install && \
-  rm -rf glew-${glewVersion}/ glew.*
+  rm --force --recursive glew-${glewVersion}/ glew.*
 
 # Set custom variables for build script convenience
 # Activate appropriate Toolchain settings

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -64,24 +64,24 @@ RUN \
 WORKDIR /tmp/
 # Install SDL libraries from binary packages
 RUN sdlVersion="2.32.10" && \
-  curl --fail https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz | tar -xz && \
+  curl --fail https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz | tar --extract --gunzip && \
   make -C SDL2-${sdlVersion}/ cross && \
   rm -rf SDL2-${sdlVersion}/
 RUN sdlImageVersion="2.8.12" && \
-  curl --fail https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz | tar -xz && \
+  curl --fail https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz | tar --extract --gunzip && \
   make -C SDL2_image-${sdlImageVersion}/ cross && \
   rm -rf SDL2_image-${sdlImageVersion}/
 RUN sdlMixerVersion="2.8.2" && \
-  curl --fail https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz | tar -xz && \
+  curl --fail https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz | tar --extract --gunzip && \
   make -C SDL2_mixer-${sdlMixerVersion}/ cross && \
   rm -rf SDL2_mixer-${sdlMixerVersion}/
 RUN sdlTtfVersion="2.24.0" && \
-  curl --fail https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz | tar -xz && \
+  curl --fail https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz | tar --extract --gunzip && \
   make -C SDL2_ttf-${sdlTtfVersion}/ cross && \
   rm -rf SDL2_ttf-${sdlTtfVersion}/
 # Install dependencies from source packages
 RUN glewVersion="2.3.1" && \
-  curl --fail --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | tar -xz && \
+  curl --fail --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | tar --extract --gunzip && \
   make -C glew-${glewVersion}/ SYSTEM=linux-mingw64 install && \
   rm -rf glew-${glewVersion}/ glew.*
 

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -32,6 +32,8 @@ ENV \
   STRIP=${TARGET_TRIPLET}-strip
 
 ENV GCC_RUNTIME_PATH=/usr/lib/gcc/${TARGET_TRIPLET}/13-win32/
+# Set default install location for source built packages
+ENV LOCAL_PACKAGE_PATH=/usr/local/${TARGET_TRIPLET}/
 
 # Install apt repository for wine
 RUN \
@@ -47,9 +49,6 @@ RUN \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     wine=10.0~repack-12ubuntu1
-
-# Set default install location for source built packages
-ENV LOCAL_PACKAGE_PATH=/usr/local/${TARGET_TRIPLET}/
 
 # Setup compiler and tooling default folders
 ENV WINEPATH="${LOCAL_PACKAGE_PATH}bin/;${GCC_RUNTIME_PATH}"

--- a/dockerBuildEnv/nas2d-mingw.version.mk
+++ b/dockerBuildEnv/nas2d-mingw.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_mingw := 2026-07-25
+ImageVersion_mingw := 2026-07-26


### PR DESCRIPTION
Usr `/etc/os-release` to remove dependence on `lsb-release` package, use `curl` flag `--fail` for better error handling, use long form options, split pipes to multiple lines, build GTest/GMock in `Release` mode (reducing size), rename variables, switch back to `ENV` rather than `ARG`.

Related:
- PR #1544
- PR #1543
- PR #1542
- PR #1541
- PR #1539
- Issue #1431
- Issue #1524
- Issue #1527

----

Intentionally not re-building the Docker image, or updating the builds to use an updated image, even though the version tag have been bumped. Changes feel too minor to create a new package. There's a plan to split the Dockerfile up into a multi-stage build, which will be a more substantial change worthy of a new image. Wanted to keep those changes separate from general cleanup though, so separate PRs.
