### PR TITLE
Update Mingw build environment - Multi-stage builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         - "build-env-nas2d-arch:2026-07-24"
         - "build-env-nas2d-clang:2026-07-24"
         - "build-env-nas2d-gcc:2026-07-24"
-        - "build-env-nas2d-mingw:2026-07-25"
+        - "build-env-nas2d-mingw:2026-07-28"
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -104,7 +104,7 @@ FROM build-tools
 # Install apt repository for wine
 RUN \
   --mount=type=bind,from=wine-apt-repo-key,source=/tmp,target=/wine-key \
-  cp /wine-key/apt.wine.gpg /etc/apt/keyrings/ && \
+  install -D --mode=644 /wine-key/apt.wine.gpg /etc/apt/keyrings/ && \
   . /etc/os-release && \
   echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/wine.list
 

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -96,7 +96,7 @@ RUN \
 
 # ----
 
-FROM build-tools AS dependencies
+FROM build-tools
 
 # Install apt repository for wine
 RUN \
@@ -132,11 +132,6 @@ RUN \
 
 # Install dependencies from source packages
 COPY --link --from=glew /glew /
-
-
-# ----
-
-FROM dependencies
 
 COPY --link --from=googletest /staging/googletest ${LOCAL_PACKAGE_PATH}
 

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -75,6 +75,27 @@ RUN make --directory /glew-package/glew-${glewVersion}/ SYSTEM=linux-mingw64 DES
 
 # ----
 
+FROM build-tools AS googletest
+
+RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+    cmake=4.2.3-* \
+    libgtest-dev=1.17.0-* \
+    libgmock-dev=1.17.0-*
+
+# Download, compile, and install Google Test source package
+RUN \
+  cmake -B/tmp/gtest/ -S/usr/src/googletest/ -DCMAKE_INSTALL_PREFIX="${LOCAL_PACKAGE_PATH}" -DCMAKE_SYSTEM_NAME="Windows" -DCMAKE_BUILD_TYPE=Release -Dgtest_disable_pthreads=ON && \
+  cmake --build /tmp/gtest/ && \
+  cmake --install /tmp/gtest/ --prefix=/staging/googletest && \
+  rm --force --recursive /tmp/gtest/
+
+
+# ----
+
 FROM build-tools AS dependencies
 
 # Install apt repository for wine
@@ -111,27 +132,6 @@ RUN \
 
 # Install dependencies from source packages
 COPY --link --from=glew /glew /
-
-
-# ----
-
-FROM build-tools AS googletest
-
-RUN \
-  --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-    cmake=4.2.3-* \
-    libgtest-dev=1.17.0-* \
-    libgmock-dev=1.17.0-*
-
-# Download, compile, and install Google Test source package
-RUN \
-  cmake -B/tmp/gtest/ -S/usr/src/googletest/ -DCMAKE_INSTALL_PREFIX="${LOCAL_PACKAGE_PATH}" -DCMAKE_SYSTEM_NAME="Windows" -DCMAKE_BUILD_TYPE=Release -Dgtest_disable_pthreads=ON && \
-  cmake --build /tmp/gtest/ && \
-  cmake --install /tmp/gtest/ --prefix=/staging/googletest && \
-  rm --force --recursive /tmp/gtest/
 
 
 # ----

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -39,6 +39,36 @@ RUN \
     gzip=1.14-* \
     ca-certificates=*
 
+# Install NAS2D specific dependencies
+WORKDIR /tmp/
+# Install SDL libraries from binary packages
+RUN sdlVersion="2.32.10" && \
+  curl --fail https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz | \
+  tar --extract --gunzip && \
+  make --directory SDL2-${sdlVersion}/ cross && \
+  rm --force --recursive SDL2-${sdlVersion}/
+RUN sdlImageVersion="2.8.12" && \
+  curl --fail https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz | \
+  tar --extract --gunzip && \
+  make --directory SDL2_image-${sdlImageVersion}/ cross && \
+  rm --force --recursive SDL2_image-${sdlImageVersion}/
+RUN sdlMixerVersion="2.8.2" && \
+  curl --fail https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz | \
+  tar --extract --gunzip && \
+  make --directory SDL2_mixer-${sdlMixerVersion}/ cross && \
+  rm --force --recursive SDL2_mixer-${sdlMixerVersion}/
+RUN sdlTtfVersion="2.24.0" && \
+  curl --fail https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz | \
+  tar --extract --gunzip && \
+  make --directory SDL2_ttf-${sdlTtfVersion}/ cross && \
+  rm --force --recursive SDL2_ttf-${sdlTtfVersion}/
+# Install dependencies from source packages
+RUN glewVersion="2.3.1" && \
+  curl --fail --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | \
+  tar --extract --gunzip && \
+  make --directory glew-${glewVersion}/ SYSTEM=linux-mingw64 install && \
+  rm --force --recursive glew-${glewVersion}/ glew.*
+
 # Install apt repository for wine
 RUN \
   curl --fail --location https://dl.winehq.org/wine-builds/winehq.key | \
@@ -72,36 +102,6 @@ RUN \
   cmake --build /tmp/gtest/ && \
   cmake --install /tmp/gtest/ && \
   rm --force --recursive /tmp/gtest/
-
-# Install NAS2D specific dependencies
-WORKDIR /tmp/
-# Install SDL libraries from binary packages
-RUN sdlVersion="2.32.10" && \
-  curl --fail https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz | \
-  tar --extract --gunzip && \
-  make --directory SDL2-${sdlVersion}/ cross && \
-  rm --force --recursive SDL2-${sdlVersion}/
-RUN sdlImageVersion="2.8.12" && \
-  curl --fail https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz | \
-  tar --extract --gunzip && \
-  make --directory SDL2_image-${sdlImageVersion}/ cross && \
-  rm --force --recursive SDL2_image-${sdlImageVersion}/
-RUN sdlMixerVersion="2.8.2" && \
-  curl --fail https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz | \
-  tar --extract --gunzip && \
-  make --directory SDL2_mixer-${sdlMixerVersion}/ cross && \
-  rm --force --recursive SDL2_mixer-${sdlMixerVersion}/
-RUN sdlTtfVersion="2.24.0" && \
-  curl --fail https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz | \
-  tar --extract --gunzip && \
-  make --directory SDL2_ttf-${sdlTtfVersion}/ cross && \
-  rm --force --recursive SDL2_ttf-${sdlTtfVersion}/
-# Install dependencies from source packages
-RUN glewVersion="2.3.1" && \
-  curl --fail --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | \
-  tar --extract --gunzip && \
-  make --directory glew-${glewVersion}/ SYSTEM=linux-mingw64 install && \
-  rm --force --recursive glew-${glewVersion}/ glew.*
 
 # Set custom variables for build script convenience
 # Activate appropriate Toolchain settings

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -28,6 +28,11 @@ ENV \
   GCC_RUNTIME_PATH=/usr/lib/gcc/${TARGET_TRIPLET}/13-win32/ \
   LOCAL_PACKAGE_PATH=/usr/local/${TARGET_TRIPLET}/
 
+
+# ----
+
+FROM build-tools AS dependencies
+
 RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
@@ -111,7 +116,7 @@ RUN \
 
 # ----
 
-FROM build-tools
+FROM dependencies
 
 COPY --from=googletest /staging/googletest ${LOCAL_PACKAGE_PATH}
 

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -77,16 +77,6 @@ RUN make --directory /glew-package/glew-${glewVersion}/ SYSTEM=linux-mingw64 DES
 
 FROM build-tools AS dependencies
 
-RUN \
-  --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-    curl=8.18.0-* \
-    tar=1.35+* \
-    gzip=1.14-* \
-    ca-certificates=*
-
 # Install SDL libraries from binary packages
 RUN \
   --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -118,7 +118,7 @@ RUN \
 
 FROM dependencies
 
-COPY --from=googletest /staging/googletest ${LOCAL_PACKAGE_PATH}
+COPY --link --from=googletest /staging/googletest ${LOCAL_PACKAGE_PATH}
 
 # Set custom variables for build script convenience
 # Activate appropriate Toolchain settings

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -1,6 +1,9 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM ubuntu:resolute-20260610 AS build-tools
+ARG baseImage=ubuntu:resolute-20260610
+
+
+FROM ${baseImage} AS build-tools
 
 # Remove automatic apt package cleanup so a local cache mount can be used
 RUN rm /etc/apt/apt.conf.d/docker-clean
@@ -31,7 +34,7 @@ ENV \
 
 # ----
 
-FROM ubuntu:resolute-20260610 AS wine-apt-repo-key
+FROM ${baseImage} AS wine-apt-repo-key
 
 RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -47,7 +50,7 @@ RUN gpg --output /tmp/apt.wine.gpg --dearmor /tmp/winehq.key
 
 # ----
 
-FROM ubuntu:resolute-20260610 AS sdl-packages
+FROM ${baseImage} AS sdl-packages
 
 ARG sdlVersion=2.32.10
 ADD --link --unpack=true https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz /sdl-packages

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -89,7 +89,7 @@ RUN \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-*
 
-# Download, compile, and install Google Test source package
+# Compile Google Test from source package and install to staging area
 RUN \
   cmake -B/tmp/gtest/ -S/usr/src/googletest/ -DCMAKE_INSTALL_PREFIX="${LOCAL_PACKAGE_PATH}" -DCMAKE_SYSTEM_NAME="Windows" -DCMAKE_BUILD_TYPE=Release -Dgtest_disable_pthreads=ON && \
   cmake --build /tmp/gtest/ && \
@@ -116,7 +116,7 @@ RUN \
   apt-get install -y --no-install-recommends \
     wine=10.0~repack-12ubuntu1
 
-# Setup compiler and tooling default folders
+# Set PATH for wine environment
 ENV WINEPATH="${LOCAL_PACKAGE_PATH}bin/;${GCC_RUNTIME_PATH}"
 
 # Install SDL libraries from binary packages
@@ -133,7 +133,6 @@ RUN \
   --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \
   make --directory /sdl-packages/SDL2_ttf-*/ cross
 
-# Install dependencies from source packages
 COPY --link --from=glew /glew /
 
 COPY --link --from=googletest /staging/googletest ${LOCAL_PACKAGE_PATH}

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -13,15 +13,7 @@ RUN \
   apt-get install -y --no-install-recommends \
     g++-mingw-w64-x86-64-win32=13.2.0-* \
     mingw-w64-tools \
-    make=4.4.1-* \
-    cmake=4.2.3-* \
-    libgtest-dev=1.17.0-* \
-    libgmock-dev=1.17.0-* \
-    curl=8.18.0-* \
-    gnupg=2.4.8-* \
-    tar=1.35+* \
-    gzip=1.14-* \
-    ca-certificates=*
+    make=4.4.1-*
 
 ENV TARGET_TRIPLET=x86_64-w64-mingw32
 ENV \
@@ -35,6 +27,17 @@ ENV \
 ENV \
   GCC_RUNTIME_PATH=/usr/lib/gcc/${TARGET_TRIPLET}/13-win32/ \
   LOCAL_PACKAGE_PATH=/usr/local/${TARGET_TRIPLET}/
+
+RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+    curl=8.18.0-* \
+    gnupg=2.4.8-* \
+    tar=1.35+* \
+    gzip=1.14-* \
+    ca-certificates=*
 
 # Install apt repository for wine
 RUN \
@@ -53,6 +56,15 @@ RUN \
 
 # Setup compiler and tooling default folders
 ENV WINEPATH="${LOCAL_PACKAGE_PATH}bin/;${GCC_RUNTIME_PATH}"
+
+RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+    cmake=4.2.3-* \
+    libgtest-dev=1.17.0-* \
+    libgmock-dev=1.17.0-*
 
 # Download, compile, and install Google Test source package
 RUN \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -31,6 +31,22 @@ ENV \
 
 # ----
 
+FROM ubuntu:resolute-20260610 AS wine-apt-repo-key
+
+RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+    gnupg=2.4.8-*
+
+ADD https://dl.winehq.org/wine-builds/winehq.key /tmp/winehq.key
+
+RUN gpg --output /tmp/apt.wine.gpg --dearmor /tmp/winehq.key
+
+
+# ----
+
 FROM build-tools AS dependencies
 
 RUN \
@@ -39,7 +55,6 @@ RUN \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     curl=8.18.0-* \
-    gnupg=2.4.8-* \
     tar=1.35+* \
     gzip=1.14-* \
     ca-certificates=*
@@ -76,8 +91,8 @@ RUN glewVersion="2.3.1" && \
 
 # Install apt repository for wine
 RUN \
-  curl --fail --location https://dl.winehq.org/wine-builds/winehq.key | \
-  gpg --dearmor > /etc/apt/keyrings/apt.wine.gpg - && \
+  --mount=type=bind,from=wine-apt-repo-key,source=/tmp,target=/wine-key \
+  cp /wine-key/apt.wine.gpg /etc/apt/keyrings/ && \
   . /etc/os-release && \
   echo "deb [signed-by=/etc/apt/keyrings/apt.wine.gpg] https://dl.winehq.org/wine-builds/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/wine.list
 

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -47,6 +47,23 @@ RUN gpg --output /tmp/apt.wine.gpg --dearmor /tmp/winehq.key
 
 # ----
 
+FROM ubuntu:resolute-20260610 AS sdl-packages
+
+ARG sdlVersion=2.32.10
+ADD --unpack=true https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz /sdl-packages
+
+ARG sdlImageVersion=2.8.12
+ADD --unpack=true https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz /sdl-packages
+
+ARG sdlMixerVersion=2.8.2
+ADD --unpack=true https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz /sdl-packages
+
+ARG sdlTtfVersion=2.24.0
+ADD --unpack=true https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz /sdl-packages
+
+
+# ----
+
 FROM build-tools AS dependencies
 
 RUN \
@@ -59,29 +76,20 @@ RUN \
     gzip=1.14-* \
     ca-certificates=*
 
-# Install NAS2D specific dependencies
-WORKDIR /tmp/
 # Install SDL libraries from binary packages
-RUN sdlVersion="2.32.10" && \
-  curl --fail https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz | \
-  tar --extract --gunzip && \
-  make --directory SDL2-${sdlVersion}/ cross && \
-  rm --force --recursive SDL2-${sdlVersion}/
-RUN sdlImageVersion="2.8.12" && \
-  curl --fail https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz | \
-  tar --extract --gunzip && \
-  make --directory SDL2_image-${sdlImageVersion}/ cross && \
-  rm --force --recursive SDL2_image-${sdlImageVersion}/
-RUN sdlMixerVersion="2.8.2" && \
-  curl --fail https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz | \
-  tar --extract --gunzip && \
-  make --directory SDL2_mixer-${sdlMixerVersion}/ cross && \
-  rm --force --recursive SDL2_mixer-${sdlMixerVersion}/
-RUN sdlTtfVersion="2.24.0" && \
-  curl --fail https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz | \
-  tar --extract --gunzip && \
-  make --directory SDL2_ttf-${sdlTtfVersion}/ cross && \
-  rm --force --recursive SDL2_ttf-${sdlTtfVersion}/
+RUN \
+  --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \
+  make --directory /sdl-packages/SDL2-*/ cross
+RUN \
+  --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \
+  make --directory /sdl-packages/SDL2_image-*/ cross
+RUN \
+  --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \
+  make --directory /sdl-packages/SDL2_mixer-*/ cross
+RUN \
+  --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \
+  make --directory /sdl-packages/SDL2_ttf-*/ cross
+
 # Install dependencies from source packages
 RUN glewVersion="2.3.1" && \
   curl --fail --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -40,7 +40,7 @@ RUN \
   apt-get install -y --no-install-recommends \
     gnupg=2.4.8-*
 
-ADD https://dl.winehq.org/wine-builds/winehq.key /tmp/winehq.key
+ADD --link https://dl.winehq.org/wine-builds/winehq.key /tmp/winehq.key
 
 RUN gpg --output /tmp/apt.wine.gpg --dearmor /tmp/winehq.key
 
@@ -50,16 +50,16 @@ RUN gpg --output /tmp/apt.wine.gpg --dearmor /tmp/winehq.key
 FROM ubuntu:resolute-20260610 AS sdl-packages
 
 ARG sdlVersion=2.32.10
-ADD --unpack=true https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz /sdl-packages
+ADD --link --unpack=true https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz /sdl-packages
 
 ARG sdlImageVersion=2.8.12
-ADD --unpack=true https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz /sdl-packages
+ADD --link --unpack=true https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-${sdlImageVersion}-mingw.tar.gz /sdl-packages
 
 ARG sdlMixerVersion=2.8.2
-ADD --unpack=true https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz /sdl-packages
+ADD --link --unpack=true https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-${sdlMixerVersion}-mingw.tar.gz /sdl-packages
 
 ARG sdlTtfVersion=2.24.0
-ADD --unpack=true https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz /sdl-packages
+ADD --link --unpack=true https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-${sdlTtfVersion}-mingw.tar.gz /sdl-packages
 
 
 # ----
@@ -67,7 +67,7 @@ ADD --unpack=true https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel
 FROM build-tools AS glew
 
 ARG glewVersion=2.3.1
-ADD --unpack=true https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz /glew-package
+ADD --link --unpack=true https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz /glew-package
 
 RUN make --directory /glew-package/glew-${glewVersion}/ SYSTEM=linux-mingw64
 RUN make --directory /glew-package/glew-${glewVersion}/ SYSTEM=linux-mingw64 DESTDIR=/glew install

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -77,23 +77,6 @@ RUN make --directory /glew-package/glew-${glewVersion}/ SYSTEM=linux-mingw64 DES
 
 FROM build-tools AS dependencies
 
-# Install SDL libraries from binary packages
-RUN \
-  --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \
-  make --directory /sdl-packages/SDL2-*/ cross
-RUN \
-  --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \
-  make --directory /sdl-packages/SDL2_image-*/ cross
-RUN \
-  --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \
-  make --directory /sdl-packages/SDL2_mixer-*/ cross
-RUN \
-  --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \
-  make --directory /sdl-packages/SDL2_ttf-*/ cross
-
-# Install dependencies from source packages
-COPY --link --from=glew /glew /
-
 # Install apt repository for wine
 RUN \
   --mount=type=bind,from=wine-apt-repo-key,source=/tmp,target=/wine-key \
@@ -111,6 +94,23 @@ RUN \
 
 # Setup compiler and tooling default folders
 ENV WINEPATH="${LOCAL_PACKAGE_PATH}bin/;${GCC_RUNTIME_PATH}"
+
+# Install SDL libraries from binary packages
+RUN \
+  --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \
+  make --directory /sdl-packages/SDL2-*/ cross
+RUN \
+  --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \
+  make --directory /sdl-packages/SDL2_image-*/ cross
+RUN \
+  --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \
+  make --directory /sdl-packages/SDL2_mixer-*/ cross
+RUN \
+  --mount=type=bind,from=sdl-packages,source=/sdl-packages,target=/sdl-packages \
+  make --directory /sdl-packages/SDL2_ttf-*/ cross
+
+# Install dependencies from source packages
+COPY --link --from=glew /glew /
 
 
 # ----

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -1,6 +1,6 @@
 # See Docker section of makefile in root project folder for usage commands.
 
-FROM ubuntu:resolute-20260610
+FROM ubuntu:resolute-20260610 AS build-tools
 
 # Remove automatic apt package cleanup so a local cache mount can be used
 RUN rm /etc/apt/apt.conf.d/docker-clean
@@ -87,6 +87,11 @@ RUN \
 # Setup compiler and tooling default folders
 ENV WINEPATH="${LOCAL_PACKAGE_PATH}bin/;${GCC_RUNTIME_PATH}"
 
+
+# ----
+
+FROM build-tools AS googletest
+
 RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
@@ -100,8 +105,15 @@ RUN \
 RUN \
   cmake -B/tmp/gtest/ -S/usr/src/googletest/ -DCMAKE_INSTALL_PREFIX="${LOCAL_PACKAGE_PATH}" -DCMAKE_SYSTEM_NAME="Windows" -DCMAKE_BUILD_TYPE=Release -Dgtest_disable_pthreads=ON && \
   cmake --build /tmp/gtest/ && \
-  cmake --install /tmp/gtest/ && \
+  cmake --install /tmp/gtest/ --prefix=/staging/googletest && \
   rm --force --recursive /tmp/gtest/
+
+
+# ----
+
+FROM build-tools
+
+COPY --from=googletest /staging/googletest ${LOCAL_PACKAGE_PATH}
 
 # Set custom variables for build script convenience
 # Activate appropriate Toolchain settings

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -50,7 +50,7 @@ RUN gpg --output /tmp/apt.wine.gpg --dearmor /tmp/winehq.key
 
 # ----
 
-FROM ${baseImage} AS sdl-packages
+FROM scratch AS sdl-packages
 
 ARG sdlVersion=2.32.10
 ADD --link --unpack=true https://libsdl.org/release/SDL2-devel-${sdlVersion}-mingw.tar.gz /sdl-packages

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.17
+
 # See Docker section of makefile in root project folder for usage commands.
 
 ARG baseImage=ubuntu:resolute-20260610

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -64,6 +64,17 @@ ADD --unpack=true https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel
 
 # ----
 
+FROM build-tools AS glew
+
+ARG glewVersion=2.3.1
+ADD --unpack=true https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz /glew-package
+
+RUN make --directory /glew-package/glew-${glewVersion}/ SYSTEM=linux-mingw64
+RUN make --directory /glew-package/glew-${glewVersion}/ SYSTEM=linux-mingw64 DESTDIR=/glew install
+
+
+# ----
+
 FROM build-tools AS dependencies
 
 RUN \
@@ -91,11 +102,7 @@ RUN \
   make --directory /sdl-packages/SDL2_ttf-*/ cross
 
 # Install dependencies from source packages
-RUN glewVersion="2.3.1" && \
-  curl --fail --location https://github.com/nigels-com/glew/releases/download/glew-${glewVersion}/glew-${glewVersion}.tgz | \
-  tar --extract --gunzip && \
-  make --directory glew-${glewVersion}/ SYSTEM=linux-mingw64 install && \
-  rm --force --recursive glew-${glewVersion}/ glew.*
+COPY --link --from=glew /glew /
 
 # Install apt repository for wine
 RUN \

--- a/dockerBuildEnv/nas2d-mingw.Dockerfile
+++ b/dockerBuildEnv/nas2d-mingw.Dockerfile
@@ -2,13 +2,16 @@
 
 # See Docker section of makefile in root project folder for usage commands.
 
-ARG baseImage=ubuntu:resolute-20260610
 
-
-FROM ${baseImage} AS build-tools
+FROM ubuntu:resolute-20260610 AS base-image
 
 # Remove automatic apt package cleanup so a local cache mount can be used
 RUN rm /etc/apt/apt.conf.d/docker-clean
+
+
+# ----
+
+FROM base-image AS build-tools
 
 # Install base development tools
 RUN \
@@ -36,7 +39,7 @@ ENV \
 
 # ----
 
-FROM ${baseImage} AS wine-apt-repo-key
+FROM base-image AS wine-apt-repo-key
 
 RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/dockerBuildEnv/nas2d-mingw.version.mk
+++ b/dockerBuildEnv/nas2d-mingw.version.mk
@@ -1,1 +1,1 @@
-ImageVersion_mingw := 2026-07-26
+ImageVersion_mingw := 2026-07-28


### PR DESCRIPTION
Update Mingw build environment Dockerfile to make use of multi-stage builds, which allows for a smaller final Docker image without bloat from intermediate tools used during the construction of the final image.

As a bonus, the multi-stage build allows for stages to be built in parallel, significantly reducing the total build time. The multi-stage build also has much better caching characteristics, where far few layers need to be rebuilt after an updated of an intermediate layer.

Related:
- Issue #1431
- Issue #1527
- Issue #1525
- PR #1543
- PR #1545
- PR #1544
- PR #1542
- PR #1538
- PR #1541
- PR #1522
