### PR TITLE
Docker version tag on publish

### DIFF
--- a/dockerBuildEnv/makefile
+++ b/dockerBuildEnv/makefile
@@ -25,9 +25,10 @@ DockerDebugRootRules := $(addprefix root-debug-image-, ${DockerEnvironments})
 .PHONY: ${DockerBuildRules} ${DockerPushRules} ${DockerRunRules} ${DockerDebugRules} ${DockerDebugRootRules}
 
 ${DockerBuildRules}: build-image-%:
-	docker build ${DockerBuildEnvFolder}/$*/ --tag ${DockerImageNameTagged} --tag ${DockerImageNameLatest}
+	docker build ${DockerBuildEnvFolder}/$*/ --tag ${DockerImageNameLatest}
 
 ${DockerPushRules}: push-image-%:
+	docker tag ${DockerImageNameLatest} ${DockerImageNameTagged}
 	docker push ${DockerImageNameTagged}
 	docker push ${DockerImageNameLatest}
 

--- a/dockerBuildEnv/makefile
+++ b/dockerBuildEnv/makefile
@@ -32,10 +32,10 @@ ${DockerPushRules}: push-image-%:
 	docker push ${DockerImageNameLatest}
 
 ${DockerRunRules}: run-image-%:
-	docker run ${DockerRunFlags} ${DockerUserFlags} ${DockerImageNameTagged}
+	docker run ${DockerRunFlags} ${DockerUserFlags} ${DockerImageNameLatest}
 
 ${DockerDebugRules}: debug-image-%:
-	docker run ${DockerRunFlags} --interactive ${DockerUserFlags} ${DockerImageNameTagged} bash
+	docker run ${DockerRunFlags} --interactive ${DockerUserFlags} ${DockerImageNameLatest} bash
 
 ${DockerDebugRootRules}: root-debug-image-%:
-	docker run ${DockerRunFlags} --interactive ${DockerImageNameTagged} bash
+	docker run ${DockerRunFlags} --interactive ${DockerImageNameLatest} bash


### PR DESCRIPTION
This prevents overwriting published version tags with development versions.

Development builds will only be tagged as `latest`. Tagging with a specific version tag only happens in the `makefile` rule to "push" the Docker image.

All of the `docker run` rules used to help with development and debugging have been switched to use the `latest` tag.

Related:
- Issue #1525
