### PR TITLE
Add multi-platform Docker builds - Speed up Arm64 CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,10 +145,11 @@ jobs:
 
   linux-arm:
     runs-on: ubuntu-24.04-arm
+    container:
+      image: "ghcr.io/${{ github.repository_owner }}/build-env-nas2d-gcc:2026-07-24"
+      options: --user=1001:1001
 
     steps:
-    - run: sudo apt update && sudo apt --yes install libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libsdl2-ttf-dev libglew-dev libgtest-dev libgmock-dev
-
     - uses: actions/checkout@v6
 
     - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"

--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -12,6 +12,11 @@ on:
           - clang
           - gcc
           - mingw
+      multiPlatform:
+        description: Multi-platform build
+        required: true
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       buildEnv:
@@ -27,7 +32,28 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Setup Docker
+        if: ${{ inputs.multiPlatform }}
+        uses: docker/setup-docker-action@v5
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Set up QEMU
+        if: ${{ inputs.multiPlatform }}
+        uses: docker/setup-qemu-action@v4
+
+      - name: Docker build (multi-platform)
+        if: ${{ inputs.multiPlatform }}
+        run: make multi-build-image-${{ env.buildEnv }}
+
       - name: Docker build
+        if: ${{ !inputs.multiPlatform }}
         run: make build-image-${{ env.buildEnv }}
 
       - name: Docker login

--- a/dockerBuildEnv/makefile
+++ b/dockerBuildEnv/makefile
@@ -7,6 +7,7 @@ DockerBuildEnvFolder := $(abspath $(dir $(lastword ${MAKEFILE_LIST})))
 
 DockerRunFlags = --volume ${CURDIR}:/code --workdir=/code --rm --tty ${DockerAdditionalFlags}
 DockerUserFlags = --user="$(shell id --user):$(shell id --group)"
+DockerMultiPlatformFlags = --platform linux/amd64,linux/arm64
 DockerRepository ?= ghcr.io/lairworks
 DockerImageName = ${DockerRepository}/build-env-nas2d-$*
 DockerImageNameTagged = ${DockerImageName}:${ImageVersion_$*}
@@ -17,6 +18,7 @@ DockerEnvironments := $(patsubst ${DockerBuildEnvFolder}/%/version.mk,%,${Docker
 include ${DockerVersionFiles}
 
 DockerBuildRules := $(addprefix build-image-, ${DockerEnvironments})
+DockerMultiBuildRules := $(addprefix multi-build-image-, ${DockerEnvironments})
 DockerPushRules := $(addprefix push-image-, ${DockerEnvironments})
 DockerRunRules := $(addprefix run-image-, ${DockerEnvironments})
 DockerDebugRules := $(addprefix debug-image-, ${DockerEnvironments})
@@ -26,6 +28,9 @@ DockerDebugRootRules := $(addprefix root-debug-image-, ${DockerEnvironments})
 
 ${DockerBuildRules}: build-image-%:
 	docker build ${DockerBuildEnvFolder}/$*/ --tag ${DockerImageNameLatest}
+
+${DockerMultiBuildRules}: multi-build-image-%:
+	docker build ${DockerBuildEnvFolder}/$*/ --tag ${DockerImageNameLatest} ${DockerMultiPlatformFlags}
 
 ${DockerPushRules}: push-image-%:
 	docker tag ${DockerImageNameLatest} ${DockerImageNameTagged}


### PR DESCRIPTION
Speed up Arm64 build by using a Docker image with dependencies pre-installed.

Related:
- Issue #1471
