### PR TITLE
Consolidate Linux build jobs - Combine jobs for `amd64` and `arm64`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,8 @@ jobs:
           runner: ubuntu-24.04-arm
         - image: build-env-nas2d-gcc:2026-07-24
           runner: ubuntu-24.04-arm
+        - image: build-env-nas2d-mingw:2026-07-28
+          runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,8 @@ jobs:
         runner:
         - ubuntu-latest
         include:
+        - image: build-env-nas2d-clang:2026-07-24
+          runner: ubuntu-24.04-arm
         - image: build-env-nas2d-gcc:2026-07-24
           runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,23 +130,14 @@ jobs:
         - build-env-nas2d-clang:2026-07-24
         - build-env-nas2d-gcc:2026-07-24
         - build-env-nas2d-mingw:2026-07-28
-    runs-on: ubuntu-latest
+        runner:
+        - ubuntu-latest
+        include:
+        - image: build-env-nas2d-gcc:2026-07-24
+          runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"
-      options: --user=1001:1001
-
-    steps:
-    - uses: actions/checkout@v6
-
-    - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror"
-    - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" test
-    - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" check
-    - run: make --keep-going --jobs 16 CXXFLAGS_EXTRA="-Werror" demoGraphics
-
-  linux-arm:
-    runs-on: ubuntu-24.04-arm
-    container:
-      image: "ghcr.io/${{ github.repository_owner }}/build-env-nas2d-gcc:2026-07-24"
       options: --user=1001:1001
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,10 +126,10 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - "build-env-nas2d-arch:2026-07-24"
-        - "build-env-nas2d-clang:2026-07-24"
-        - "build-env-nas2d-gcc:2026-07-24"
-        - "build-env-nas2d-mingw:2026-07-28"
+        - build-env-nas2d-arch:2026-07-24
+        - build-env-nas2d-clang:2026-07-24
+        - build-env-nas2d-gcc:2026-07-24
+        - build-env-nas2d-mingw:2026-07-28
     runs-on: ubuntu-latest
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,8 +137,6 @@ jobs:
           runner: ubuntu-24.04-arm
         - image: build-env-nas2d-gcc:2026-07-24
           runner: ubuntu-24.04-arm
-        - image: build-env-nas2d-mingw:2026-07-28
-          runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"


### PR DESCRIPTION
Build for both `amd64` and `arm64` using a single GitHub Actions job. This consolidates all Linux builds under a single job.

----

Add a build for Clang on `arm64`. Previously we only built with GCC on `arm64`.

----

The Mingw environment was also tested on `arm64`, where it was able to build a cross compiled executable for Windows x86_64, though it was not able to run the executable using `wine` from an `arm64` environment. Perhaps we can look into cross compiling for Windows Arm64 in the future.

----

The Arch Linux environment was also looked into, though it seems the base image does not have multi-architecture support, so building the build environment fails trying to pull the base image on the `FROM` line.

----

Related:
- Issue #1471
