### PR TITLE
Add `git` back to Docker environments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,16 +126,16 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - build-env-nas2d-arch:2026-08-08
-        - build-env-nas2d-clang:2026-08-08
-        - build-env-nas2d-gcc:2026-08-08
-        - build-env-nas2d-mingw:2026-08-08
+        - build-env-nas2d-arch:2026-08-09
+        - build-env-nas2d-clang:2026-08-09
+        - build-env-nas2d-gcc:2026-08-09
+        - build-env-nas2d-mingw:2026-08-09
         runner:
         - ubuntu-latest
         include:
-        - image: build-env-nas2d-clang:2026-08-08
+        - image: build-env-nas2d-clang:2026-08-09
           runner: ubuntu-24.04-arm
-        - image: build-env-nas2d-gcc:2026-08-08
+        - image: build-env-nas2d-gcc:2026-08-09
           runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     container:

--- a/dockerBuildEnv/arch/Dockerfile
+++ b/dockerBuildEnv/arch/Dockerfile
@@ -8,6 +8,8 @@ RUN \
   pacman --sync --refresh --noconfirm \
     gcc \
     make \
+    git \
+    ca-certificates \
     gtest
 
 RUN \

--- a/dockerBuildEnv/arch/version.mk
+++ b/dockerBuildEnv/arch/version.mk
@@ -1,1 +1,1 @@
-ImageVersion_arch := 2026-08-08
+ImageVersion_arch := 2026-08-09

--- a/dockerBuildEnv/clang/Dockerfile
+++ b/dockerBuildEnv/clang/Dockerfile
@@ -13,6 +13,8 @@ RUN \
   apt-get install -y --no-install-recommends \
     clang=1:21.1.6-* \
     make=4.4.1-* \
+    git=1:2.53.0-* \
+    ca-certificates=* \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-*
 

--- a/dockerBuildEnv/clang/Dockerfile
+++ b/dockerBuildEnv/clang/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends --quiet \
     clang=1:21.1.6-* \
     make=4.4.1-* \
     git=1:2.53.0-* \
@@ -26,7 +26,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends --quiet \
     libglew-dev=2.2.0-* \
     libsdl2-dev=2.32.10+* \
     libsdl2-image-dev=2.8.8+* \

--- a/dockerBuildEnv/clang/Dockerfile
+++ b/dockerBuildEnv/clang/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     clang=1:21.1.6-* \
     make=4.4.1-* \
     git=1:2.53.0-* \
@@ -26,7 +26,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     libglew-dev=2.2.0-* \
     libsdl2-dev=2.32.10+* \
     libsdl2-image-dev=2.8.8+* \

--- a/dockerBuildEnv/clang/Dockerfile
+++ b/dockerBuildEnv/clang/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     clang=1:21.1.6-* \
     make=4.4.1-* \
     git=1:2.53.0-* \
@@ -26,7 +26,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     libglew-dev=2.2.0-* \
     libsdl2-dev=2.32.10+* \
     libsdl2-image-dev=2.8.8+* \

--- a/dockerBuildEnv/clang/version.mk
+++ b/dockerBuildEnv/clang/version.mk
@@ -1,1 +1,1 @@
-ImageVersion_clang := 2026-08-08
+ImageVersion_clang := 2026-08-09

--- a/dockerBuildEnv/gcc/Dockerfile
+++ b/dockerBuildEnv/gcc/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     g++=4:15.2.0-* \
     make=4.4.1-* \
     git=1:2.53.0-* \
@@ -26,7 +26,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     libglew-dev=2.2.0-* \
     libsdl2-dev=2.32.10+* \
     libsdl2-image-dev=2.8.8+* \

--- a/dockerBuildEnv/gcc/Dockerfile
+++ b/dockerBuildEnv/gcc/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     g++=4:15.2.0-* \
     make=4.4.1-* \
     git=1:2.53.0-* \
@@ -26,7 +26,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     libglew-dev=2.2.0-* \
     libsdl2-dev=2.32.10+* \
     libsdl2-image-dev=2.8.8+* \

--- a/dockerBuildEnv/gcc/Dockerfile
+++ b/dockerBuildEnv/gcc/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends --quiet \
     g++=4:15.2.0-* \
     make=4.4.1-* \
     git=1:2.53.0-* \
@@ -26,7 +26,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends --quiet \
     libglew-dev=2.2.0-* \
     libsdl2-dev=2.32.10+* \
     libsdl2-image-dev=2.8.8+* \

--- a/dockerBuildEnv/gcc/Dockerfile
+++ b/dockerBuildEnv/gcc/Dockerfile
@@ -13,6 +13,8 @@ RUN \
   apt-get install -y --no-install-recommends \
     g++=4:15.2.0-* \
     make=4.4.1-* \
+    git=1:2.53.0-* \
+    ca-certificates=* \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-*
 

--- a/dockerBuildEnv/gcc/version.mk
+++ b/dockerBuildEnv/gcc/version.mk
@@ -1,1 +1,1 @@
-ImageVersion_gcc := 2026-08-08
+ImageVersion_gcc := 2026-08-09

--- a/dockerBuildEnv/mingw/Dockerfile
+++ b/dockerBuildEnv/mingw/Dockerfile
@@ -18,7 +18,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     g++-mingw-w64-x86-64-win32=13.2.0-* \
     mingw-w64-tools \
     make=4.4.1-* \
@@ -47,7 +47,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     gnupg=2.4.8-*
 
 ADD --link https://dl.winehq.org/wine-builds/winehq.key /tmp/winehq.key
@@ -91,7 +91,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     cmake=4.2.3-* \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-*
@@ -120,7 +120,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
     wine=10.0~repack-12ubuntu1
 
 # Set PATH for wine environment

--- a/dockerBuildEnv/mingw/Dockerfile
+++ b/dockerBuildEnv/mingw/Dockerfile
@@ -18,7 +18,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     g++-mingw-w64-x86-64-win32=13.2.0-* \
     mingw-w64-tools \
     make=4.4.1-* \
@@ -47,7 +47,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     gnupg=2.4.8-*
 
 ADD --link https://dl.winehq.org/wine-builds/winehq.key /tmp/winehq.key
@@ -91,7 +91,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     cmake=4.2.3-* \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-*
@@ -120,7 +120,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     wine=10.0~repack-12ubuntu1
 
 # Set PATH for wine environment

--- a/dockerBuildEnv/mingw/Dockerfile
+++ b/dockerBuildEnv/mingw/Dockerfile
@@ -18,7 +18,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends --quiet \
     g++-mingw-w64-x86-64-win32=13.2.0-* \
     mingw-w64-tools \
     make=4.4.1-* \
@@ -47,7 +47,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends --quiet \
     gnupg=2.4.8-*
 
 ADD --link https://dl.winehq.org/wine-builds/winehq.key /tmp/winehq.key
@@ -91,7 +91,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends --quiet \
     cmake=4.2.3-* \
     libgtest-dev=1.17.0-* \
     libgmock-dev=1.17.0-*
@@ -120,7 +120,7 @@ RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends --quiet \
     wine=10.0~repack-12ubuntu1
 
 # Set PATH for wine environment

--- a/dockerBuildEnv/mingw/Dockerfile
+++ b/dockerBuildEnv/mingw/Dockerfile
@@ -21,7 +21,9 @@ RUN \
   apt-get install -y --no-install-recommends \
     g++-mingw-w64-x86-64-win32=13.2.0-* \
     mingw-w64-tools \
-    make=4.4.1-*
+    make=4.4.1-* \
+    git=1:2.53.0-* \
+    ca-certificates=*
 
 ENV TARGET_TRIPLET=x86_64-w64-mingw32
 ENV \

--- a/dockerBuildEnv/mingw/version.mk
+++ b/dockerBuildEnv/mingw/version.mk
@@ -1,1 +1,1 @@
-ImageVersion_mingw := 2026-08-08
+ImageVersion_mingw := 2026-08-09


### PR DESCRIPTION
Include `ca-certificates` as well so `git` can access files over HTTPS.

----

Downstreams projects such as OPHD may need to checkout NAS2D as a submodule. That requires having access to `git`. Using `actions/checkout` doesn't allow for initializing and downloading of a specific submodule, it's all or nothing, so may not be suitable. Having `git` means we can download just the submodules we need for a build, without downloading any data assets that would only be needed to package or run downstream apps.

There may be other future reasons to have `git` available to CI workflows. For instance, it can be used to tag a release package with a `git` version tag. It can also be used to detect file changes on a branch.

----

Having `git` available also means that `actions/checkout` doesn't need to fallback to the GitHub REST API. Having `git` available means we get an actual git repository, rather than an unpacked archive of the repository contents.

----

Re-add `DEBIAN_FRONTEND=noninteractive` to silence `apt` install warnings about falling back to non-interactive mode.

----

Related:
- Issue #1527
- PR #1543
